### PR TITLE
Recommend installing prettier extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode"
+    ]
+}


### PR DESCRIPTION
#### Problem

The workspace settings (.vscode/settings.json) configures the default formatter to be the prettier extension, but it's not installed by default.

#### Summary of Changes

VS Code allows a workspace to recommend installing extensions when a user opens the workspace without having the extension. Let's take advantage of that and recommend any extensions we configure by default.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/jM95rf8CFFukIoiv3PSh/fdc7f113-ab74-4840-9d66-6a3ffb5b6e61.png)

Fixes n/a