### PR TITLE
Strip the TransactionMessageWithDurableNonceLifetime type when prepending instructions to a TransactionMessage

### DIFF
--- a/.changeset/rich-taxis-ring.md
+++ b/.changeset/rich-taxis-ring.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-messages': patch
+---
+
+Strip the TransactionMessageWithDurableNonceLifetime type when prepending instructions to a TransactionMessage

--- a/packages/transaction-messages/src/__typetests__/instruction-typetests.ts
+++ b/packages/transaction-messages/src/__typetests__/instruction-typetests.ts
@@ -1,0 +1,70 @@
+import { TransactionMessageWithDurableNonceLifetime } from '../durable-nonce';
+import {
+    appendTransactionMessageInstruction,
+    appendTransactionMessageInstructions,
+    prependTransactionMessageInstruction,
+    prependTransactionMessageInstructions,
+} from '../instructions';
+import { BaseTransactionMessage } from '../transaction-message';
+
+type MyTransactionMessage = BaseTransactionMessage & {};
+
+type IInstruction = BaseTransactionMessage['instructions'][number];
+
+// [DESCRIBE] appendTransactionMessageInstruction
+{
+    // It returns the same TransactionMessage type
+    {
+        const message = null as unknown as MyTransactionMessage;
+        const newMessage = appendTransactionMessageInstruction(null as unknown as IInstruction, message);
+        newMessage satisfies MyTransactionMessage;
+    }
+}
+
+// [DESCRIBE] appendTransactionMessageInstructions
+{
+    // It returns the same TransactionMessage type
+    {
+        const message = null as unknown as MyTransactionMessage;
+        const newMessage = appendTransactionMessageInstructions(null as unknown as IInstruction[], message);
+        newMessage satisfies MyTransactionMessage;
+    }
+}
+
+// [DESCRIBE] prependTransactionMessageInstruction
+{
+    // It returns the same TransactionMessage type
+    {
+        const message = null as unknown as MyTransactionMessage;
+        const newMessage = prependTransactionMessageInstruction(null as unknown as IInstruction, message);
+        newMessage satisfies MyTransactionMessage;
+    }
+
+    // It strips the durable nonce transaction message type
+    {
+        const message = null as unknown as MyTransactionMessage & TransactionMessageWithDurableNonceLifetime;
+        const newMessage = prependTransactionMessageInstruction(null as unknown as IInstruction, message);
+        newMessage satisfies MyTransactionMessage;
+        // @ts-expect-error The durable nonce transaction message type should be stripped.
+        newMessage satisfies TransactionMessageWithDurableNonceLifetime;
+    }
+}
+
+// [DESCRIBE] prependTransactionMessageInstructions
+{
+    // It returns the same TransactionMessage type
+    {
+        const message = null as unknown as MyTransactionMessage;
+        const newMessage = prependTransactionMessageInstructions(null as unknown as IInstruction[], message);
+        newMessage satisfies MyTransactionMessage;
+    }
+
+    // It strips the durable nonce transaction message type
+    {
+        const message = null as unknown as MyTransactionMessage & TransactionMessageWithDurableNonceLifetime;
+        const newMessage = prependTransactionMessageInstructions(null as unknown as IInstruction[], message);
+        newMessage satisfies MyTransactionMessage;
+        // @ts-expect-error The durable nonce transaction message type should be stripped.
+        newMessage satisfies TransactionMessageWithDurableNonceLifetime;
+    }
+}

--- a/packages/transaction-messages/src/instructions.ts
+++ b/packages/transaction-messages/src/instructions.ts
@@ -1,3 +1,4 @@
+import { TransactionMessageWithDurableNonceLifetime } from './durable-nonce';
 import { BaseTransactionMessage } from './transaction-message';
 
 export function appendTransactionMessageInstruction<TTransaction extends BaseTransactionMessage>(
@@ -17,19 +18,25 @@ export function appendTransactionMessageInstructions<TTransaction extends BaseTr
     });
 }
 
+// Durable nonce advance instruction must be the first instruction in the transaction message
+// So if instructions are prepended, we strip the durable nonce transaction message type
+type ExcludeDurableNonce<T> = T extends TransactionMessageWithDurableNonceLifetime
+    ? BaseTransactionMessage & Omit<T, keyof TransactionMessageWithDurableNonceLifetime>
+    : T;
+
 export function prependTransactionMessageInstruction<TTransaction extends BaseTransactionMessage>(
     instruction: TTransaction['instructions'][number],
     transaction: TTransaction,
-): TTransaction {
+): ExcludeDurableNonce<TTransaction> {
     return prependTransactionMessageInstructions([instruction], transaction);
 }
 
 export function prependTransactionMessageInstructions<TTransaction extends BaseTransactionMessage>(
     instructions: ReadonlyArray<TTransaction['instructions'][number]>,
     transaction: TTransaction,
-): TTransaction {
+): ExcludeDurableNonce<TTransaction> {
     return Object.freeze({
         ...transaction,
         instructions: Object.freeze([...instructions, ...transaction.instructions]),
-    });
+    }) as ExcludeDurableNonce<TTransaction>;
 }


### PR DESCRIPTION
#### Problem

It's possible to create a `CompilableTransactionMessage` that actually is not. Take a valid durable nonce transaction message, and prepend any instruction with no accounts. This will remain a `CompilableTransactionMessage`, since prepending doesn't change the type, but when you attempt to compile it it'll throw an error trying to read accounts from the first instruction, which it expects to be a durable nonce advance instruction but is not.

See compile code: https://github.com/anza-xyz/kit/blob/0ffbfb63ac9898ce50a1d39da9ab360fde83b967/packages/transactions/src/compile-transaction.ts#L42-L52

#### Summary of Changes

While we could add error checking to that compile code, the root cause is that `prependTransactionMessageInstruction(s)` should never return a `TransactionMessageWithDurableNonceLifetime`. This PR modifies the types so that the `TransactionMessageWithDurableNonceLifetime` is stripped if present on the input type. 

This means that the returned transaction is no longer a `CompilableTransactionMessage` if it was previously a `TransactionMessageWithDurableNonceLifetime`, and you'll correctly get a type error if you attempt to compile it.

This does not fix the bad error message if you eg cast such an invalid message to `TransactionMessageWithDurableNonceLifetime`, so we might still decide to add runtime checks and errors. But since we've generally preferred type errors when possible, I think this is the best fix for now. 

Addresses #187 