### PR TITLE
Make it so that you can document the properties of the `getAccountInfo()` config

### DIFF
--- a/packages/accounts/src/rpc-api/getAccountInfo.ts
+++ b/packages/accounts/src/rpc-api/getAccountInfo.ts
@@ -21,6 +21,7 @@ type NestInRpcResponseOrNull<T> = Readonly<{
 type GetAccountInfoApiCommonConfig = Readonly<{
     // Defaults to `finalized`
     commitment?: Commitment;
+    encoding: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
     // The minimum slot that the request can be evaluated at
     minContextSlot?: Slot;
 }>;
@@ -67,6 +68,6 @@ export type GetAccountInfoApi = {
     ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithBase58EncodedData>;
     getAccountInfo(
         address: Address,
-        config?: GetAccountInfoApiCommonConfig,
+        config?: Omit<GetAccountInfoApiCommonConfig, 'encoding'>,
     ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithBase58Bytes>;
 };

--- a/packages/rpc-api/src/getAccountInfo.ts
+++ b/packages/rpc-api/src/getAccountInfo.ts
@@ -17,6 +17,7 @@ type GetAccountInfoApiResponse<T> = (AccountInfoBase & T) | null;
 type GetAccountInfoApiCommonConfig = Readonly<{
     // Defaults to `finalized`
     commitment?: Commitment;
+    encoding: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
     // The minimum slot that the request can be evaluated at
     minContextSlot?: Slot;
 }>;
@@ -63,6 +64,6 @@ export type GetAccountInfoApi = {
     ): SolanaRpcResponse<GetAccountInfoApiResponse<AccountInfoWithBase58EncodedData>>;
     getAccountInfo(
         address: Address,
-        config?: GetAccountInfoApiCommonConfig,
+        config?: Omit<GetAccountInfoApiCommonConfig, 'encoding'>,
     ): SolanaRpcResponse<GetAccountInfoApiResponse<AccountInfoWithBase58Bytes>>;
 };


### PR DESCRIPTION
#### Problem

Without a central location for this property, there's no one place to add JSDoc.

#### Summary of Changes

Reorganize the types so that you can add documentation in one place and have it inherited everywhere.
