### PR TITLE
Document `commitment` property in RPC API

### DIFF
--- a/packages/accounts/src/fetch-account.ts
+++ b/packages/accounts/src/fetch-account.ts
@@ -13,6 +13,15 @@ import type { GetAccountInfoApi, GetMultipleAccountsApi } from './rpc-api';
  */
 export type FetchAccountConfig = {
     abortSignal?: AbortSignal;
+    /**
+     * Fetch the details of the account as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     minContextSlot?: Slot;
 };
@@ -94,6 +103,15 @@ export async function fetchJsonParsedAccount<TData extends object, TAddress exte
  */
 export type FetchAccountsConfig = {
     abortSignal?: AbortSignal;
+    /**
+     * Fetch the details of the accounts as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     minContextSlot?: Slot;
 };

--- a/packages/accounts/src/rpc-api/getAccountInfo.ts
+++ b/packages/accounts/src/rpc-api/getAccountInfo.ts
@@ -19,7 +19,15 @@ type NestInRpcResponseOrNull<T> = Readonly<{
 }>;
 
 type GetAccountInfoApiCommonConfig = Readonly<{
-    // Defaults to `finalized`
+    /**
+     * Fetch the details of the account as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     encoding: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
     // The minimum slot that the request can be evaluated at

--- a/packages/accounts/src/rpc-api/getMultipleAccounts.ts
+++ b/packages/accounts/src/rpc-api/getMultipleAccounts.ts
@@ -14,7 +14,15 @@ import type {
 type GetMultipleAccountsApiResponseBase = AccountInfoBase | null;
 
 type GetMultipleAccountsApiCommonConfig = Readonly<{
-    /** Defaults to `finalized` */
+    /**
+     * Fetch the details of the accounts as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     /** The minimum slot that the request can be evaluated at */
     minContextSlot?: Slot;

--- a/packages/kit/src/compute-limit-internal.ts
+++ b/packages/kit/src/compute-limit-internal.ts
@@ -27,6 +27,14 @@ import { compileTransaction, getBase64EncodedWireTransaction } from '@solana/tra
 
 type ComputeUnitEstimateForTransactionMessageConfig = Readonly<{
     abortSignal?: AbortSignal;
+    /**
+     * Compute the estimate as of the highest slot that has reached this level of commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     minContextSlot?: Slot;
     rpc: Rpc<SimulateTransactionApi>;

--- a/packages/rpc-api/src/getAccountInfo.ts
+++ b/packages/rpc-api/src/getAccountInfo.ts
@@ -15,7 +15,15 @@ import type {
 type GetAccountInfoApiResponse<T> = (AccountInfoBase & T) | null;
 
 type GetAccountInfoApiCommonConfig = Readonly<{
-    // Defaults to `finalized`
+    /**
+     * Fetch the details of the account as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     encoding: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
     // The minimum slot that the request can be evaluated at

--- a/packages/rpc-api/src/getBalance.ts
+++ b/packages/rpc-api/src/getBalance.ts
@@ -10,6 +10,15 @@ export type GetBalanceApi = {
     getBalance(
         address: Address,
         config?: Readonly<{
+            /**
+             * Fetch the balance of the account as of the highest slot that has reached this level
+             * of commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
             minContextSlot?: Slot;
         }>,

--- a/packages/rpc-api/src/getBlock.ts
+++ b/packages/rpc-api/src/getBlock.ts
@@ -45,7 +45,14 @@ type GetBlockApiResponseWithTransactions<TTransaction> = Readonly<{
 // API parameter types
 
 type GetBlockCommonConfig = Readonly<{
-    /** @defaultValue finalized */
+    /**
+     * Fetch blocks from slots that have reached at least this level of commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Omit<Commitment, 'processed'>;
     encoding?: GetBlockEncoding;
     maxSupportedTransactionVersion?: GetBlockMaxSupportedTransactionVersion;

--- a/packages/rpc-api/src/getBlockHeight.ts
+++ b/packages/rpc-api/src/getBlockHeight.ts
@@ -8,7 +8,15 @@ export type GetBlockHeightApi = {
      */
     getBlockHeight(
         config?: Readonly<{
-            // Defaults to `finalized`
+            /**
+             * Fetch the block height as of the highest slot that has reached this level of
+             * commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
             // The minimum slot that the request can be evaluated at
             minContextSlot?: Slot;

--- a/packages/rpc-api/src/getBlockProduction.ts
+++ b/packages/rpc-api/src/getBlockProduction.ts
@@ -10,6 +10,15 @@ type SlotRange = Readonly<{
 }>;
 
 type GetBlockProductionApiConfigBase = Readonly<{
+    /**
+     * Fetch the block production information as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     range?: SlotRange;
 }>;

--- a/packages/rpc-api/src/getBlocks.ts
+++ b/packages/rpc-api/src/getBlocks.ts
@@ -10,7 +10,14 @@ export type GetBlocksApi = {
         startSlot: Slot,
         endSlotInclusive?: Slot,
         config?: Readonly<{
-            // Defaults to `finalized`
+            /**
+             * Include only blocks at slots that have reached at least this level of commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Exclude<Commitment, 'processed'>;
         }>,
     ): GetBlocksApiResponse;

--- a/packages/rpc-api/src/getBlocksWithLimit.ts
+++ b/packages/rpc-api/src/getBlocksWithLimit.ts
@@ -13,7 +13,14 @@ export type GetBlocksWithLimitApi = {
         // Note: 0 will return an empty array
         limit: number,
         config?: Readonly<{
-            // Defaults to `finalized`
+            /**
+             * Include only blocks at slots that have reached at least this level of commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Exclude<Commitment, 'processed'>;
         }>,
     ): GetBlocksWithLimitApiResponse;

--- a/packages/rpc-api/src/getEpochInfo.ts
+++ b/packages/rpc-api/src/getEpochInfo.ts
@@ -21,6 +21,15 @@ export type GetEpochInfoApi = {
      */
     getEpochInfo(
         config?: Readonly<{
+            /**
+             * Fetch epoch information as of the highest slot that has reached this level of
+             * commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
             minContextSlot?: Slot;
         }>,

--- a/packages/rpc-api/src/getFeeForMessage.ts
+++ b/packages/rpc-api/src/getFeeForMessage.ts
@@ -11,6 +11,15 @@ export type GetFeeForMessageApi = {
     getFeeForMessage(
         message: TransactionMessageBytesBase64,
         config?: Readonly<{
+            /**
+             * Fetch the fee information as of the highest slot that has reached this level of
+             * commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
             minContextSlot?: Slot;
         }>,

--- a/packages/rpc-api/src/getInflationGovernor.ts
+++ b/packages/rpc-api/src/getInflationGovernor.ts
@@ -23,7 +23,15 @@ export type GetInflationGovernorApi = {
      */
     getInflationGovernor(
         config?: Readonly<{
-            // Defaults to `finalized`
+            /**
+             * Return the inflation governor as of the highest slot that has reached this level of
+             * commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
         }>,
     ): GetInflationGovernorApiResponse;

--- a/packages/rpc-api/src/getInflationReward.ts
+++ b/packages/rpc-api/src/getInflationReward.ts
@@ -2,7 +2,15 @@ import type { Address } from '@solana/addresses';
 import type { Commitment, Lamports, Slot } from '@solana/rpc-types';
 
 type GetInflationRewardApiConfig = Readonly<{
-    // Defaults to `finalized`
+    /**
+     * Fetch the inflation reward details as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     // An epoch for which the reward occurs.
     // If omitted, the previous epoch will be used

--- a/packages/rpc-api/src/getLargestAccounts.ts
+++ b/packages/rpc-api/src/getLargestAccounts.ts
@@ -17,6 +17,15 @@ export type GetLargestAccountsApi = {
      */
     getLargestAccounts(
         config?: Readonly<{
+            /**
+             * Fetch the largest accounts as of the highest slot that has reached this level of
+             * commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
             /** Filter results by account type */
             filter?: 'circulating' | 'nonCirculating';

--- a/packages/rpc-api/src/getLatestBlockhash.ts
+++ b/packages/rpc-api/src/getLatestBlockhash.ts
@@ -13,6 +13,15 @@ export type GetLatestBlockhashApi = {
      */
     getLatestBlockhash(
         config?: Readonly<{
+            /**
+             * Fetch the latest blockhash as of the highest slot that has reached this level of
+             * commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
             minContextSlot?: Slot;
         }>,

--- a/packages/rpc-api/src/getLeaderSchedule.ts
+++ b/packages/rpc-api/src/getLeaderSchedule.ts
@@ -2,6 +2,14 @@ import type { Address } from '@solana/addresses';
 import type { Commitment, Slot } from '@solana/rpc-types';
 
 type GetLeaderScheduleApiConfigBase = Readonly<{
+    /**
+     * Fetch the leader schedule as of the highest slot that has reached this level of commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
 }>;
 

--- a/packages/rpc-api/src/getMultipleAccounts.ts
+++ b/packages/rpc-api/src/getMultipleAccounts.ts
@@ -14,7 +14,15 @@ import type {
 type GetMultipleAccountsApiResponseBase = AccountInfoBase | null;
 
 type GetMultipleAccountsApiCommonConfig = Readonly<{
-    /** Defaults to `finalized` */
+    /**
+     * Fetch the details of the accounts as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     /** The minimum slot that the request can be evaluated at */
     minContextSlot?: Slot;

--- a/packages/rpc-api/src/getProgramAccounts.ts
+++ b/packages/rpc-api/src/getProgramAccounts.ts
@@ -16,7 +16,15 @@ import type {
 } from '@solana/rpc-types';
 
 type GetProgramAccountsApiCommonConfig = Readonly<{
-    /** @defaultValue "finalized" */
+    /**
+     * Fetch the details of the accounts as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     /** filter results (up to 4 filters allowed) @see https://docs.solana.com/api/http#filter-criteria */
     filters?: (GetProgramAccountsDatasizeFilter | GetProgramAccountsMemcmpFilter)[];

--- a/packages/rpc-api/src/getSignaturesForAddress.ts
+++ b/packages/rpc-api/src/getSignaturesForAddress.ts
@@ -24,6 +24,14 @@ type AllowedCommitmentForGetSignaturesForAddress = Exclude<Commitment, 'processe
 type GetSignaturesForAddressConfig = Readonly<{
     /** start searching backwards from this transaction signature. If not provided the search starts from the top of the highest max confirmed block. */
     before?: Signature;
+    /**
+     * Fetch the signatures as of the highest slot that has reached this level of commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: AllowedCommitmentForGetSignaturesForAddress;
     /** maximum transaction signatures to return (between 1 and 1,000). Default: 1000 */
     limit?: number;

--- a/packages/rpc-api/src/getSlot.ts
+++ b/packages/rpc-api/src/getSlot.ts
@@ -8,6 +8,14 @@ export type GetSlotApi = {
      */
     getSlot(
         config?: Readonly<{
+            /**
+             * Fetch the highest slot that has reached this level of commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
             minContextSlot?: Slot;
         }>,

--- a/packages/rpc-api/src/getSlotLeader.ts
+++ b/packages/rpc-api/src/getSlotLeader.ts
@@ -9,6 +9,14 @@ export type GetSlotLeaderApi = {
      */
     getSlotLeader(
         config?: Readonly<{
+            /**
+             * Fetch the leader as of the highest slot that has reached this level of commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
             minContextSlot?: Slot;
         }>,

--- a/packages/rpc-api/src/getStakeMinimumDelegation.ts
+++ b/packages/rpc-api/src/getStakeMinimumDelegation.ts
@@ -8,6 +8,15 @@ export type GetStakeMinimumDelegationApi = {
      */
     getStakeMinimumDelegation(
         config?: Readonly<{
+            /**
+             * Fetch the minimum delegation as of  highest slot that has reached this level of
+             * commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
         }>,
     ): SolanaRpcResponse<GetStakeMinimumDelegationApiResponse>;

--- a/packages/rpc-api/src/getSupply.ts
+++ b/packages/rpc-api/src/getSupply.ts
@@ -2,6 +2,14 @@ import type { Address } from '@solana/addresses';
 import type { Commitment, Lamports, SolanaRpcResponse } from '@solana/rpc-types';
 
 type GetSupplyConfig = Readonly<{
+    /**
+     * Fetch the supply as of the highest slot that has reached this level of commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
 }>;
 

--- a/packages/rpc-api/src/getTokenAccountBalance.ts
+++ b/packages/rpc-api/src/getTokenAccountBalance.ts
@@ -11,6 +11,14 @@ export type GetTokenAccountBalanceApi = {
         /** Pubkey of Token account to query, as base-58 encoded string */
         address: Address,
         config?: Readonly<{
+            /**
+             * Fetch the balance as of the highest slot that has reached this level of commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
         }>,
     ): SolanaRpcResponse<GetTokenAccountBalanceApiResponse>;

--- a/packages/rpc-api/src/getTokenAccountsByDelegate.ts
+++ b/packages/rpc-api/src/getTokenAccountsByDelegate.ts
@@ -40,7 +40,15 @@ type ProgramIdFilter = Readonly<{
 type AccountsFilter = MintFilter | ProgramIdFilter;
 
 type GetTokenAccountsByDelegateApiCommonConfig = Readonly<{
-    /** @defaultValue "finalized" */
+    /**
+     * Fetch the details of the accounts as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     /** The minimum slot that the request can be evaluated at */
     minContextSlot?: Slot;

--- a/packages/rpc-api/src/getTokenAccountsByOwner.ts
+++ b/packages/rpc-api/src/getTokenAccountsByOwner.ts
@@ -40,7 +40,15 @@ type ProgramIdFilter = Readonly<{
 type AccountsFilter = MintFilter | ProgramIdFilter;
 
 type GetTokenAccountsByOwnerApiCommonConfig = Readonly<{
-    /** @defaultValue "finalized" */
+    /**
+     * Fetch the details of the accounts as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     /** The minimum slot that the request can be evaluated at */
     minContextSlot?: Slot;

--- a/packages/rpc-api/src/getTokenLargestAccounts.ts
+++ b/packages/rpc-api/src/getTokenLargestAccounts.ts
@@ -12,6 +12,15 @@ export type GetTokenLargestAccountsApi = {
     getTokenLargestAccounts(
         tokenMint: Address,
         config?: Readonly<{
+            /**
+             * Fetch the largest accounts as of the highest slot that has reached this level of
+             * commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
         }>,
     ): SolanaRpcResponse<GetTokenLargestAccountsApiResponse>;

--- a/packages/rpc-api/src/getTokenSupply.ts
+++ b/packages/rpc-api/src/getTokenSupply.ts
@@ -11,6 +11,14 @@ export type GetTokenSupplyApi = {
         /** Pubkey of the token Mint to query, as base-58 encoded string */
         address: Address,
         config?: Readonly<{
+            /**
+             * Fetch the supply as of the highest slot that has reached this level of commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
         }>,
     ): SolanaRpcResponse<GetTokenSupplyApiResponse>;

--- a/packages/rpc-api/src/getTransaction.ts
+++ b/packages/rpc-api/src/getTransaction.ts
@@ -120,6 +120,15 @@ type TransactionJsonParsed = Readonly<{
     TransactionBase;
 
 type GetTransactionCommonConfig<TMaxSupportedTransactionVersion> = Readonly<{
+    /**
+     * Fetch the transaction details as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     maxSupportedTransactionVersion?: TMaxSupportedTransactionVersion;
 }>;

--- a/packages/rpc-api/src/getTransactionCount.ts
+++ b/packages/rpc-api/src/getTransactionCount.ts
@@ -8,7 +8,15 @@ export type GetTransactionCountApi = {
      */
     getTransactionCount(
         config?: Readonly<{
-            // Defaults to `finalized`
+            /**
+             * Fetch the transaction count as of the highest slot that has reached this level of
+             * commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
             // The minimum slot that the request can be evaluated at
             minContextSlot?: Slot;

--- a/packages/rpc-api/src/getVoteAccounts.ts
+++ b/packages/rpc-api/src/getVoteAccounts.ts
@@ -31,6 +31,15 @@ type GetVoteAccountsApiResponse<TVotePubkey extends Address> = Readonly<{
 }>;
 
 type GetVoteAccountsConfig<TVotePubkey extends Address> = Readonly<{
+    /**
+     * Fetch the details of the vote accounts as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     /** Specify the number of slots behind the tip that a validator must fall to be considered delinquent. **NOTE:** For the sake of consistency between ecosystem products, _it is **not** recommended that this argument be specified._ */
     delinquentSlotDistance?: bigint;

--- a/packages/rpc-api/src/isBlockhashValid.ts
+++ b/packages/rpc-api/src/isBlockhashValid.ts
@@ -10,7 +10,15 @@ export type IsBlockhashValidApi = {
         /** query blockhash, as a base-58 encoded string */
         blockhash: Blockhash,
         config?: Readonly<{
-            /** Defaults to `finalized` */
+            /**
+             * Evaluate whether the blockhash is valid as of the highest slot that has reached this
+             * level of commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
             /** The minimum slot that the request can be evaluated at */
             minContextSlot?: Slot;

--- a/packages/rpc-api/src/requestAirdrop.ts
+++ b/packages/rpc-api/src/requestAirdrop.ts
@@ -3,6 +3,14 @@ import type { Signature } from '@solana/keys';
 import type { Commitment, Lamports } from '@solana/rpc-types';
 
 type RequestAirdropConfig = Readonly<{
+    /**
+     * Evaluate the request as of the highest slot that has reached this level of commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
 }>;
 

--- a/packages/rpc-api/src/sendTransaction.ts
+++ b/packages/rpc-api/src/sendTransaction.ts
@@ -5,6 +5,16 @@ import type { Base64EncodedWireTransaction } from '@solana/transactions';
 type SendTransactionConfig = Readonly<{
     maxRetries?: bigint;
     minContextSlot?: Slot;
+    /**
+     * Simulate the transaction as of the highest slot that has reached this level of commitment.
+     *
+     * Has no effect when `skipPreflight` is set to `true`.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     preflightCommitment?: Commitment;
     skipPreflight?: boolean;
 }>;

--- a/packages/rpc-api/src/simulateTransaction.ts
+++ b/packages/rpc-api/src/simulateTransaction.ts
@@ -17,9 +17,13 @@ import type { Base64EncodedWireTransaction, TransactionBlockhashLifetime } from 
 
 type SimulateTransactionConfigBase = Readonly<{
     /**
-     * Commitment level to simulate the transaction at
-     * @defaultValue finalized
-     * */
+     * Simulate the transaction as of the highest slot that has reached this level of commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     /**
      * If `true` the response will include inner instructions. These inner instructions will be

--- a/packages/rpc-graphql/src/loaders/loader.ts
+++ b/packages/rpc-graphql/src/loaders/loader.ts
@@ -15,6 +15,15 @@ export type LoadManyFn<TArgs, T> = (args: TArgs[]) => Promise<(Error | T)[]>;
 export type Loader<TArgs, T> = { load: LoadFn<TArgs, T>; loadMany: LoadManyFn<TArgs, T> };
 
 export type AccountLoaderArgsBase = {
+    /**
+     * Fetch the details of the account as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     dataSlice?: { length: number; offset: number };
     encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
@@ -40,6 +49,15 @@ export type MultipleAccountsLoaderValue = AccountLoaderValue[];
 export type MultipleAccountsLoader = Loader<MultipleAccountsLoaderArgs, MultipleAccountsLoaderValue>;
 
 export type ProgramAccountsLoaderArgsBase = {
+    /**
+     * Fetch the details of the accounts as of the highest slot that has reached this level of
+     * commitment.
+     *
+     * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+     * example, when using an API created by a `createSolanaRpc*()` helper, the default commitment
+     * is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on the client, the
+     * default commitment applied by the server is `"finalized"`.
+     */
     commitment?: Commitment;
     dataSlice?: { length: number; offset: number };
     encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -39,7 +39,20 @@ export const resolveAccountData = () => {
 export const resolveAccount = (fieldName?: string) => {
     return async (
         parent: { [x: string]: Address },
-        args: { address?: Address; commitment?: Commitment; minContextSlot?: Slot },
+        args: {
+            address?: Address;
+            /**
+             * Fetch the details of the account as of the highest slot that has reached this level
+             * of commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
+            commitment?: Commitment;
+            minContextSlot?: Slot;
+        },
         context: RpcGraphQLContext,
         info: GraphQLResolveInfo,
     ): Promise<AccountResult | null> => {

--- a/packages/rpc-graphql/src/resolvers/program-accounts.ts
+++ b/packages/rpc-graphql/src/resolvers/program-accounts.ts
@@ -11,6 +11,15 @@ export function resolveProgramAccounts(fieldName?: string) {
     return async (
         parent: { [x: string]: Address },
         args: {
+            /**
+             * Fetch the details of the accounts as of the highest slot that has reached this level
+             * of commitment.
+             *
+             * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use.
+             * For example, when using an API created by a `createSolanaRpc*()` helper, the default
+             * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer
+             * on the client, the default commitment applied by the server is `"finalized"`.
+             */
             commitment?: Commitment;
             dataSizeFilters?: { dataSize: bigint }[];
             memcmpFilters?: { bytes: string; encoding: 'base58' | 'base64'; offset: bigint }[];

--- a/packages/rpc-graphql/src/resolvers/resolve-info/account.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/account.ts
@@ -119,6 +119,15 @@ export function buildAccountArgSetWithVisitor<TArgs extends AccountLoaderArgs | 
 export function buildAccountLoaderArgSetFromResolveInfo(
     args: {
         address: Address;
+        /**
+         * Fetch the details of the account as of the highest slot that has reached this level of
+         * commitment.
+         *
+         * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+         * example, when using an API created by a `createSolanaRpc*()` helper, the default
+         * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on
+         * the client, the default commitment applied by the server is `"finalized"`.
+         */
         commitment?: Commitment;
         minContextSlot?: Slot;
     },

--- a/packages/rpc-graphql/src/resolvers/resolve-info/block.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/block.ts
@@ -11,6 +11,14 @@ import { injectableRootVisitor } from './visitor';
  */
 export function buildBlockLoaderArgSetFromResolveInfo(
     args: {
+        /**
+         * Fetch blocks from slots that have reached at least this level of commitment.
+         *
+         * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+         * example, when using an API created by a `createSolanaRpc*()` helper, the default
+         * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on
+         * the client, the default commitment applied by the server is `"finalized"`.
+         */
         commitment?: Omit<Commitment, 'processed'>;
         minContextSlot?: Slot;
         slot: Slot;

--- a/packages/rpc-graphql/src/resolvers/resolve-info/program-accounts.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/program-accounts.ts
@@ -11,6 +11,15 @@ import { buildAccountArgSetWithVisitor } from './account';
  */
 export function buildProgramAccountsLoaderArgSetFromResolveInfo(
     args: {
+        /**
+         * Fetch the details of the accounts as of the highest slot that has reached this level of
+         * commitment.
+         *
+         * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+         * example, when using an API created by a `createSolanaRpc*()` helper, the default
+         * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on
+         * the client, the default commitment applied by the server is `"finalized"`.
+         */
         commitment?: Commitment;
         filters?: (
             | {

--- a/packages/rpc-graphql/src/resolvers/resolve-info/transaction.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/transaction.ts
@@ -78,6 +78,15 @@ export function buildTransactionArgSetWithVisitor<TArgs extends BlockLoaderArgs 
  */
 export function buildTransactionLoaderArgSetFromResolveInfo(
     args: {
+        /**
+         * Fetch the transaction details as of the highest slot that has reached this level of
+         * commitment.
+         *
+         * @defaultValue Whichever default is applied by the underlying {@link RpcApi} in use. For
+         * example, when using an API created by a `createSolanaRpc*()` helper, the default
+         * commitment is `"confirmed"` unless configured otherwise. Unmitigated by an API layer on
+         * the client, the default commitment applied by the server is `"finalized"`.
+         */
         commitment?: Omit<Commitment, 'processed'>;
         minContextSlot?: Slot;
         signature: Signature;


### PR DESCRIPTION
Everywhere `commitment` appears in the code, I added this new description, trying my best to indicate the implication of setting one.
