### PR TITLE
Always compare the current PR's bundle size to main

### DIFF
--- a/.github/workflows/bundlesize.yml
+++ b/.github/workflows/bundlesize.yml
@@ -35,3 +35,7 @@ jobs:
 
       - name: BundleMon
         uses: lironer/bundlemon-action@v1
+        env:
+          # Always compare to the main branch; prevents stacked PRs from being
+          # compared to the wrong mergebase (ie. the PR beneath the current one)
+          CI_TARGET_BRANCH: main


### PR DESCRIPTION
Regardless of what the mergebase of the current PR is, this will cause Bundlemon to _always_ compare the size from the perspective of the last known `main` size.

This prevents stacked PRs from trying (and failing) to find the size of the PR branch directly underneath them.

Fixes #70

# Test Plan

Works on #72.
