### PR TITLE
Repair the return type for `getBlockProduction`

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-block-production-type-test.ts
+++ b/packages/rpc-api/src/__typetests__/get-block-production-type-test.ts
@@ -1,0 +1,23 @@
+import type { Address } from '@solana/addresses';
+import type { Rpc } from '@solana/rpc-spec';
+
+import type { GetBlockProductionApi } from '../getBlockProduction';
+
+const rpc = null as unknown as Rpc<GetBlockProductionApi>;
+const identity = 'Joe11111111111111111111111111111' as Address<'Joe11111111111111111111111111111'>;
+
+void (async () => {
+    // [DESCRIBE] getBlockProduction with no identity.
+    {
+        // Returns leader slot / blocks produced record, by validator.
+        const result = await rpc.getBlockProduction().send();
+        result.value.byIdentity satisfies Record<Address, [leaderSlots: bigint, blocksProduced: bigint]>;
+    }
+
+    // [DESCRIBE] getBlockProduction with an identity.
+    {
+        // Returns leader slot / blocks produced record, for exactly the validator specified.
+        const result = await rpc.getBlockProduction({ identity }).send();
+        result.value.byIdentity satisfies Record<typeof identity, [leaderSlots: bigint, blocksProduced: bigint]>;
+    }
+});

--- a/packages/rpc-api/src/getBlockProduction.ts
+++ b/packages/rpc-api/src/getBlockProduction.ts
@@ -24,16 +24,10 @@ type GetBlockProductionApiConfigBase = Readonly<{
 }>;
 
 type BlockProductionWithSingleIdentity<TIdentity extends string> = Readonly<{
-    value: Readonly<{
-        byIdentity: Readonly<{ [TAddress in TIdentity]?: [NumberOfLeaderSlots, NumberOfBlocksProduced] }>;
-    }>;
+    [TAddress in TIdentity]?: [NumberOfLeaderSlots, NumberOfBlocksProduced];
 }>;
 
-type BlockProductionWithAllIdentities = Readonly<{
-    value: Readonly<{
-        byIdentity: Record<Address, [NumberOfLeaderSlots, NumberOfBlocksProduced]>;
-    }>;
-}>;
+type BlockProductionWithAllIdentities = Record<Address, [NumberOfLeaderSlots, NumberOfBlocksProduced]>;
 
 type GetBlockProductionApiResponse<T> = Readonly<{
     byIdentity: T;


### PR DESCRIPTION
The intent here seems to have been to flatten this type into the response from the top level, but that's not how it was eventually written. This PR corrects the type and adds a type test to cover the `byIdentity` property.