### PR TITLE
Remove `NO_CONFIG` hack in RPC methods with no parameters

### DIFF
--- a/.changeset/beige-tips-kiss.md
+++ b/.changeset/beige-tips-kiss.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-api': patch
+---
+
+RPC methods that take no parameters no longer rely on having a placeholder `NO_CONFIG` argument. Removing it will save you from wondering why it exists.

--- a/.changeset/silent-berries-know.md
+++ b/.changeset/silent-berries-know.md
@@ -1,0 +1,42 @@
+---
+'@solana/rpc-subscriptions-channel-websocket': patch
+'@solana/webcrypto-ed25519-polyfill': patch
+'@solana/transaction-confirmation': patch
+'@solana/codecs-data-structures': patch
+'@solana/rpc-subscriptions-spec': patch
+'@solana/fast-stable-stringify': patch
+'@solana/rpc-subscriptions-api': patch
+'@solana/transaction-messages': patch
+'@solana/rpc-transport-http': patch
+'@solana/rpc-subscriptions': patch
+'@solana/rpc-parsed-types': patch
+'@solana/rpc-transformers': patch
+'@solana/codecs-numbers': patch
+'@solana/codecs-strings': patch
+'@solana/rpc-spec-types': patch
+'@solana/instructions': patch
+'@solana/subscribable': patch
+'@solana/transactions': patch
+'@solana/codecs-core': patch
+'@solana/rpc-graphql': patch
+'@solana/assertions': patch
+'@solana/functional': patch
+'@solana/addresses': patch
+'@solana/rpc-types': patch
+'@solana/accounts': patch
+'@solana/programs': patch
+'@solana/promises': patch
+'@solana/rpc-spec': patch
+'@solana/options': patch
+'@solana/rpc-api': patch
+'@solana/signers': patch
+'@solana/sysvars': patch
+'@solana/codecs': patch
+'@solana/compat': patch
+'@solana/errors': patch
+'@solana/keys': patch
+'@solana/kit': patch
+'@solana/rpc': patch
+---
+
+The minimum TypeScript version is now 5.3.3

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -79,7 +79,7 @@
         "@solana/rpc-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -77,7 +77,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -74,7 +74,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -78,7 +78,7 @@
         "tinybench": "^4.0.1"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -79,7 +79,7 @@
         "@solana/codecs-strings": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -75,7 +75,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -82,7 +82,7 @@
     },
     "peerDependencies": {
         "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -76,7 +76,7 @@
         "@solana/options": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -83,7 +83,7 @@
         "@solana/web3.js": "^1"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -76,7 +76,7 @@
         "commander": "^13.1.0"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/fast-stable-stringify/package.json
+++ b/packages/fast-stable-stringify/package.json
@@ -78,7 +78,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -71,7 +71,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -78,7 +78,7 @@
         "@solana/addresses": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -78,7 +78,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "devDependencies": {
         "tinybench": "^4.0.1"

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -94,7 +94,7 @@
         "@solana/transactions": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -78,7 +78,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/programs/package.json
+++ b/packages/programs/package.json
@@ -79,7 +79,7 @@
         "@solana/transaction-messages": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/promises/package.json
+++ b/packages/promises/package.json
@@ -71,7 +71,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-api/package.json
+++ b/packages/rpc-api/package.json
@@ -88,7 +88,7 @@
         "@solana/rpc-transport-http": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-api/src/getClusterNodes.ts
+++ b/packages/rpc-api/src/getClusterNodes.ts
@@ -42,10 +42,6 @@ type GetClusterNodesApiResponse = readonly ClusterNode[];
 export type GetClusterNodesApi = {
     /**
      * Returns information about all the nodes participating in the cluster
-     * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
      */
-    getClusterNodes(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): GetClusterNodesApiResponse;
+    getClusterNodes(): GetClusterNodesApiResponse;
 };

--- a/packages/rpc-api/src/getEpochSchedule.ts
+++ b/packages/rpc-api/src/getEpochSchedule.ts
@@ -14,10 +14,6 @@ type GetEpochScheduleApiResponse = Readonly<{
 export type GetEpochScheduleApi = {
     /**
      * Returns the epoch schedule information from this cluster's genesis config
-     * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
      */
-    getEpochSchedule(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): GetEpochScheduleApiResponse;
+    getEpochSchedule(): GetEpochScheduleApiResponse;
 };

--- a/packages/rpc-api/src/getFirstAvailableBlock.ts
+++ b/packages/rpc-api/src/getFirstAvailableBlock.ts
@@ -5,10 +5,6 @@ type GetFirstAvailableBlockApiResponse = Slot;
 export type GetFirstAvailableBlockApi = {
     /**
      * Returns the slot of the lowest confirmed block that has not been purged from the ledger
-     * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
      */
-    getFirstAvailableBlock(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): GetFirstAvailableBlockApiResponse;
+    getFirstAvailableBlock(): GetFirstAvailableBlockApiResponse;
 };

--- a/packages/rpc-api/src/getGenesisHash.ts
+++ b/packages/rpc-api/src/getGenesisHash.ts
@@ -6,8 +6,5 @@ export type GetGenesisHashApi = {
     /**
      * Returns the genesis hash
      */
-    getGenesisHash(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): GetGenesisHashApiResponse;
+    getGenesisHash(): GetGenesisHashApiResponse;
 };

--- a/packages/rpc-api/src/getHealth.ts
+++ b/packages/rpc-api/src/getHealth.ts
@@ -4,8 +4,5 @@ export type GetHealthApi = {
     /**
      * Returns the health status of the node ("ok" if healthy).
      */
-    getHealth(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): GetHealthApiResponse;
+    getHealth(): GetHealthApiResponse;
 };

--- a/packages/rpc-api/src/getHighestSnapshotSlot.ts
+++ b/packages/rpc-api/src/getHighestSnapshotSlot.ts
@@ -13,8 +13,5 @@ export type GetHighestSnapshotSlotApi = {
      * incremental snapshot slot based on the full snapshot slot, if there
      * is one.
      */
-    getHighestSnapshotSlot(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): GetHighestSnapshotSlotApiResponse;
+    getHighestSnapshotSlot(): GetHighestSnapshotSlotApiResponse;
 };

--- a/packages/rpc-api/src/getIdentity.ts
+++ b/packages/rpc-api/src/getIdentity.ts
@@ -8,8 +8,5 @@ export type GetIdentityApi = {
     /**
      * Returns the identity pubkey for the current node
      */
-    getIdentity(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): GetIdentityApiResponse;
+    getIdentity(): GetIdentityApiResponse;
 };

--- a/packages/rpc-api/src/getInflationRate.ts
+++ b/packages/rpc-api/src/getInflationRate.ts
@@ -15,8 +15,5 @@ export type GetInflationRateApi = {
     /**
      * Returns the specific inflation values for the current epoch
      */
-    getInflationRate(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): GetInflationRateApiResponse;
+    getInflationRate(): GetInflationRateApiResponse;
 };

--- a/packages/rpc-api/src/getMaxRetransmitSlot.ts
+++ b/packages/rpc-api/src/getMaxRetransmitSlot.ts
@@ -5,10 +5,6 @@ type GetMaxRetransmitSlotApiResponse = Slot;
 export type GetMaxRetransmitSlotApi = {
     /**
      * Get the max slot seen from retransmit stage.
-     * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
      */
-    getMaxRetransmitSlot(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): GetMaxRetransmitSlotApiResponse;
+    getMaxRetransmitSlot(): GetMaxRetransmitSlotApiResponse;
 };

--- a/packages/rpc-api/src/getMaxShredInsertSlot.ts
+++ b/packages/rpc-api/src/getMaxShredInsertSlot.ts
@@ -5,10 +5,6 @@ type GetMaxShredInsertSlotApiResponse = Slot;
 export type GetMaxShredInsertSlotApi = {
     /**
      * Get the max slot seen from after shred insert.
-     * Note that the optional NO_CONFIG object is ignored. See https://github.com/solana-labs/solana-web3.js/issues/1389
      */
-    getMaxShredInsertSlot(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): GetMaxShredInsertSlotApiResponse;
+    getMaxShredInsertSlot(): GetMaxShredInsertSlotApiResponse;
 };

--- a/packages/rpc-api/src/getVersion.ts
+++ b/packages/rpc-api/src/getVersion.ts
@@ -9,8 +9,5 @@ export type GetVersionApi = {
     /**
      * Returns the current Solana version running on the node
      */
-    getVersion(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): GetVersionApiResponse;
+    getVersion(): GetVersionApiResponse;
 };

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -85,7 +85,7 @@
         "@solana/transactions": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-parsed-types/package.json
+++ b/packages/rpc-parsed-types/package.json
@@ -73,7 +73,7 @@
         "@solana/rpc-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-spec-types/package.json
+++ b/packages/rpc-spec-types/package.json
@@ -71,7 +71,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-spec/package.json
+++ b/packages/rpc-spec/package.json
@@ -75,7 +75,7 @@
         "@solana/rpc-spec-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -83,7 +83,7 @@
         "@solana/rpc-subscriptions-channel-websocket": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-subscriptions-api/src/root-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/root-notifications.ts
@@ -6,8 +6,5 @@ export type RootNotificationsApi = {
     /**
      * Subscribe to receive notification anytime a new root is set by the validator
      */
-    rootNotifications(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): RootNotificationsApiNotification;
+    rootNotifications(): RootNotificationsApiNotification;
 };

--- a/packages/rpc-subscriptions-api/src/slot-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/slot-notifications.ts
@@ -10,8 +10,5 @@ export type SlotNotificationsApi = {
     /**
      * Subscribe to receive notification anytime a slot is processed by the validator
      */
-    slotNotifications(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): SlotNotificationsApiNotification;
+    slotNotifications(): SlotNotificationsApiNotification;
 };

--- a/packages/rpc-subscriptions-api/src/slots-updates-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/slots-updates-notifications.ts
@@ -39,8 +39,5 @@ export type SlotsUpdatesNotificationsApi = {
     /**
      * Subscribe to receive a notification from the validator on a variety of updates on every slot
      */
-    slotsUpdatesNotifications(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): SlotsUpdatesNotificationsApiNotification;
+    slotsUpdatesNotifications(): SlotsUpdatesNotificationsApiNotification;
 };

--- a/packages/rpc-subscriptions-api/src/vote-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/vote-notifications.ts
@@ -14,8 +14,5 @@ export type VoteNotificationsApi = {
     /**
      * Subscribe to receive a notification from the validator on a variety of updates on every slot
      */
-    voteNotifications(
-        // FIXME: https://github.com/solana-labs/solana-web3.js/issues/1389
-        NO_CONFIG?: Record<string, never>,
-    ): VoteNotificationsApiNotification;
+    voteNotifications(): VoteNotificationsApiNotification;
 };

--- a/packages/rpc-subscriptions-channel-websocket/package.json
+++ b/packages/rpc-subscriptions-channel-websocket/package.json
@@ -82,7 +82,7 @@
         "jest-websocket-mock": "^2.5.0"
     },
     "peerDependencies": {
-        "typescript": ">=5",
+        "typescript": ">=5.3.3",
         "ws": "^8.18.0"
     },
     "engines": {

--- a/packages/rpc-subscriptions-spec/package.json
+++ b/packages/rpc-subscriptions-spec/package.json
@@ -80,7 +80,7 @@
         "@solana/event-target-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -88,7 +88,7 @@
         "@solana/event-target-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -77,7 +77,7 @@
         "@solana/rpc-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-transport-http/package.json
+++ b/packages/rpc-transport-http/package.json
@@ -83,7 +83,7 @@
         "zx": "^8.4.1"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -78,7 +78,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -85,7 +85,7 @@
         "@solana/event-target-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -84,7 +84,7 @@
         "@solana/text-encoding-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/subscribable/package.json
+++ b/packages/subscribable/package.json
@@ -77,7 +77,7 @@
         "@solana/event-target-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -84,7 +84,7 @@
         "@solana/rpc-transport-http": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -87,7 +87,7 @@
         "@solana/instructions": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/transaction-messages/package.json
+++ b/packages/transaction-messages/package.json
@@ -84,7 +84,7 @@
         "@solana/codecs-strings": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -84,7 +84,7 @@
         "@solana/transaction-messages": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -74,7 +74,7 @@
         "@solana/crypto-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.3.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,8 +315,8 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/addresses:
     dependencies:
@@ -333,8 +333,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/assertions:
     dependencies:
@@ -342,8 +342,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/build-scripts:
     devDependencies:
@@ -375,8 +375,8 @@ importers:
         specifier: workspace:*
         version: link:../options
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/codecs-core:
     dependencies:
@@ -384,8 +384,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       tinybench:
         specifier: ^4.0.1
@@ -403,8 +403,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/codecs-strings':
         specifier: workspace:*
@@ -419,8 +419,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/codecs-strings:
     dependencies:
@@ -437,8 +437,8 @@ importers:
         specifier: ^1.0.22
         version: 1.0.22
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/text-encoding-impl':
         specifier: workspace:*
@@ -468,8 +468,8 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/web3.js':
         specifier: ^1
@@ -486,16 +486,16 @@ importers:
         specifier: ^13.1.0
         version: 13.1.0
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/event-target-impl: {}
 
   packages/fast-stable-stringify:
     dependencies:
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@types/json-stable-stringify':
         specifier: ^1.2.0
@@ -516,8 +516,8 @@ importers:
   packages/functional:
     dependencies:
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/instructions:
     dependencies:
@@ -528,8 +528,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -550,8 +550,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       tinybench:
         specifier: ^4.0.1
@@ -614,7 +614,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5'
+        specifier: '>=5.3.3'
         version: 5.7.3
 
   packages/options:
@@ -635,8 +635,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/programs:
     dependencies:
@@ -647,8 +647,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/functional':
         specifier: workspace:*
@@ -660,8 +660,8 @@ importers:
   packages/promises:
     dependencies:
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/react:
     dependencies:
@@ -748,8 +748,8 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/event-target-impl':
         specifier: workspace:*
@@ -791,8 +791,8 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/rpc-spec-types':
         specifier: workspace:*
@@ -819,8 +819,8 @@ importers:
         specifier: ^16.10.0
         version: 16.10.0
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -841,8 +841,8 @@ importers:
   packages/rpc-parsed-types:
     dependencies:
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -860,14 +860,14 @@ importers:
         specifier: workspace:*
         version: link:../rpc-spec-types
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/rpc-spec-types:
     dependencies:
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/rpc-subscriptions:
     dependencies:
@@ -905,8 +905,8 @@ importers:
         specifier: workspace:*
         version: link:../subscribable
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -939,8 +939,8 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/rpc-subscriptions-channel-websocket':
         specifier: workspace:*
@@ -961,8 +961,8 @@ importers:
         specifier: workspace:*
         version: link:../subscribable
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
       ws:
         specifier: ^8.18.0
         version: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -992,8 +992,8 @@ importers:
         specifier: workspace:*
         version: link:../subscribable
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/event-target-impl':
         specifier: workspace:*
@@ -1014,8 +1014,8 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/rpc-transport-http:
     dependencies:
@@ -1029,8 +1029,8 @@ importers:
         specifier: workspace:*
         version: link:../rpc-spec-types
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
       undici-types:
         specifier: ^7.5.0
         version: 7.5.0
@@ -1063,8 +1063,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/signers:
     dependencies:
@@ -1090,8 +1090,8 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/rpc-types':
         specifier: workspace:*
@@ -1106,8 +1106,8 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/event-target-impl':
         specifier: workspace:*
@@ -1128,8 +1128,8 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -1208,8 +1208,8 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/codecs-core':
         specifier: workspace:*
@@ -1248,8 +1248,8 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/codecs-strings':
         specifier: workspace:*
@@ -1291,8 +1291,8 @@ importers:
         specifier: workspace:*
         version: link:../transaction-messages
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
 
   packages/tsconfig: {}
 
@@ -1302,8 +1302,8 @@ importers:
         specifier: ^2.2.3
         version: 2.2.3
       typescript:
-        specifier: '>=5'
-        version: 5.7.2
+        specifier: '>=5.3.3'
+        version: 5.7.3
     devDependencies:
       '@solana/crypto-impl':
         specifier: workspace:*
@@ -6940,11 +6940,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  typescript@5.7.2:
-    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
@@ -13796,8 +13791,6 @@ snapshots:
       typescript: 5.7.3
     transitivePeerDependencies:
       - supports-color
-
-  typescript@5.7.2: {}
 
   typescript@5.7.3: {}
 


### PR DESCRIPTION
#### Problem

TypeScript used to have a problem inferring the type of overloads with no arguments (https://github.com/microsoft/TypeScript/issues/53508). This has been fixed as of TypeScript 5.3.3.

#### Summary of Changes

Remove `NO_CONFIG` placeholder argument hack.

Fixes https://github.com/solana-labs/solana-web3.js/issues/1389.
