### PR TITLE
Make example code in `Rpc*<...>` types runnable

### DIFF
--- a/packages/rpc/README.md
+++ b/packages/rpc/README.md
@@ -48,13 +48,13 @@ This is useful in cases where you need to make assertions about the suitability 
 ```ts
 async function getSpecialAccountInfo(
     address: Address<'ReAL1111111111111111111111111111'>,
-    rpc: RpcMainnet,
+    rpc: RpcMainnet<unknown>,
 ): Promise<SpecialAccountInfo>;
 async function getSpecialAccountInfo(
     address: Address<'TeST1111111111111111111111111111'>,
-    rpc: RpcDevnet | RpcTestnet,
+    rpc: RpcDevnet<unknown> | RpcTestnet<unknown>,
 ): Promise<SpecialAccountInfo>;
-async function getSpecialAccountInfo(address: Address, rpc: Rpc): Promise<SpecialAccountInfo> {
+async function getSpecialAccountInfo(address: Address, rpc: Rpc<unknown>): Promise<SpecialAccountInfo> {
     /* ... */
 }
 const rpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));

--- a/packages/rpc/src/rpc-clusters.ts
+++ b/packages/rpc/src/rpc-clusters.ts
@@ -72,13 +72,13 @@ export type RpcTransportFromClusterUrl<TClusterUrl extends ClusterUrl> = TCluste
  * ```ts
  * async function getSpecialAccountInfo(
  *     address: Address<'ReAL1111111111111111111111111111'>,
- *     rpc: RpcMainnet,
+ *     rpc: RpcMainnet<unknown>,
  * ): Promise<SpecialAccountInfo>;
  * async function getSpecialAccountInfo(
  *     address: Address<'TeST1111111111111111111111111111'>,
- *     rpc: RpcDevnet | RpcTestnet,
+ *     rpc: RpcDevnet<unknown> | RpcTestnet<unknown>,
  * ): Promise<SpecialAccountInfo>;
- * async function getSpecialAccountInfo(address: Address, rpc: Rpc): Promise<SpecialAccountInfo> {
+ * async function getSpecialAccountInfo(address: Address, rpc: Rpc<unknown>): Promise<SpecialAccountInfo> {
  *     /* ... *\/
  * }
  * const rpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
@@ -97,13 +97,13 @@ export type RpcDevnet<TRpcMethods> = Rpc<TRpcMethods> & { '~cluster': 'devnet' }
  * ```ts
  * async function getSpecialAccountInfo(
  *     address: Address<'ReAL1111111111111111111111111111'>,
- *     rpc: RpcMainnet,
+ *     rpc: RpcMainnet<unknown>,
  * ): Promise<SpecialAccountInfo>;
  * async function getSpecialAccountInfo(
  *     address: Address<'TeST1111111111111111111111111111'>,
- *     rpc: RpcDevnet | RpcTestnet,
+ *     rpc: RpcDevnet<unknown> | RpcTestnet<unknown>,
  * ): Promise<SpecialAccountInfo>;
- * async function getSpecialAccountInfo(address: Address, rpc: Rpc): Promise<SpecialAccountInfo> {
+ * async function getSpecialAccountInfo(address: Address, rpc: Rpc<unknown>): Promise<SpecialAccountInfo> {
  *     /* ... *\/
  * }
  * const rpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));
@@ -122,13 +122,13 @@ export type RpcTestnet<TRpcMethods> = Rpc<TRpcMethods> & { '~cluster': 'testnet'
  * ```ts
  * async function getSpecialAccountInfo(
  *     address: Address<'ReAL1111111111111111111111111111'>,
- *     rpc: RpcMainnet,
+ *     rpc: RpcMainnet<unknown>,
  * ): Promise<SpecialAccountInfo>;
  * async function getSpecialAccountInfo(
  *     address: Address<'TeST1111111111111111111111111111'>,
- *     rpc: RpcDevnet | RpcTestnet,
+ *     rpc: RpcDevnet<unknown> | RpcTestnet<unknown>,
  * ): Promise<SpecialAccountInfo>;
- * async function getSpecialAccountInfo(address: Address, rpc: Rpc): Promise<SpecialAccountInfo> {
+ * async function getSpecialAccountInfo(address: Address, rpc: Rpc<unknown>): Promise<SpecialAccountInfo> {
  *     /* ... *\/
  * }
  * const rpc = createSolanaRpc(devnet('https://api.devnet.solana.com'));


### PR DESCRIPTION
#### Problem

These are missing type parameters.

#### Summary of Changes

It's enough to match on `unknown`: https://codesandbox.io/p/sandbox/ydjvcr
