### PR TITLE
Document `@solana/rpc-parsed-types` with TypeDoc

### DIFF
--- a/packages/rpc-parsed-types/README.md
+++ b/packages/rpc-parsed-types/README.md
@@ -10,4 +10,4 @@
 
 # @solana/rpc-parsed-types
 
-This package defines types for Parsed objects used in the [Solana JSON-RPC](https://docs.solana.com/api/http). It can be used standalone, but it is also exported as part of Kit [`@solana/kit`](https://github.com/anza-xyz/kit/tree/main/packages/kit).
+This package defines types for parsed objects returned by methods of the [Solana JSON-RPC](https://docs.solana.com/api/http). It can be used standalone, but it is also exported as part of Kit [`@solana/kit`](https://github.com/anza-xyz/kit/tree/main/packages/kit).

--- a/packages/rpc-parsed-types/src/index.ts
+++ b/packages/rpc-parsed-types/src/index.ts
@@ -1,3 +1,10 @@
+/**
+ * This package defines types for parsed objects returned by methods of the
+ * [Solana JSON-RPC](https://docs.solana.com/api/http). It can be used standalone, but it is also
+ * exported as part of Kit [`@solana/kit`](https://github.com/anza-xyz/kit/tree/main/packages/kit).
+ *
+ * @packageDocumentation
+ */
 export * from './address-lookup-table-accounts';
 export * from './bpf-upgradeable-loader-accounts';
 export * from './config-accounts';


### PR DESCRIPTION
I ultimately punted on documenting the _actual_ parsed types (eg. vote account, stake account).
