### PR TITLE
Rename core concept pages

### DIFF
--- a/docs/content/docs/concepts/codecs.mdx
+++ b/docs/content/docs/concepts/codecs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Encode and decode data
-description: TODO
+title: Codecs
+description: Encode and decode anything
 ---
 
 TODO

--- a/docs/content/docs/concepts/keypairs.mdx
+++ b/docs/content/docs/concepts/keypairs.mdx
@@ -1,6 +1,6 @@
 ---
-title: Use native keypairs
-description: TODO
+title: Key pairs
+description: Generate and manage native cryptographic key pairs
 ---
 
 TODO

--- a/docs/content/docs/concepts/rpc-subscriptions.mdx
+++ b/docs/content/docs/concepts/rpc-subscriptions.mdx
@@ -1,6 +1,6 @@
 ---
-title: Subscribe to RPC Events
-description: TODO
+title: RPC subscriptions
+description: Configure RPC subscription clients to receive RPC notifications
 ---
 
 TODO

--- a/docs/content/docs/concepts/rpc.mdx
+++ b/docs/content/docs/concepts/rpc.mdx
@@ -1,6 +1,6 @@
 ---
-title: Send RPC requests
-description: TODO
+title: RPC requests
+description: Configure RPC clients to send RPC requests
 ---
 
 TODO

--- a/docs/content/docs/concepts/signers.mdx
+++ b/docs/content/docs/concepts/signers.mdx
@@ -1,6 +1,6 @@
 ---
-title: Sign transactions and messages
-description: TODO
+title: Signers
+description: Sign transactions and messages however you like
 ---
 
 TODO

--- a/docs/content/docs/concepts/transactions.mdx
+++ b/docs/content/docs/concepts/transactions.mdx
@@ -1,6 +1,6 @@
 ---
-title: Build transactions
-description: TODO
+title: Transactions
+description: Build and compile transaction messages
 ---
 
 TODO


### PR DESCRIPTION
This PR renames the titles and descriptions of the core concept pages so they can easily be identified by name.