### PR TITLE
Harmonize program filter type between RPC and RPC Subscriptions

### DIFF
--- a/packages/rpc-api/src/__tests__/get-program-accounts-test.ts
+++ b/packages/rpc-api/src/__tests__/get-program-accounts-test.ts
@@ -4,7 +4,7 @@ import type { Address } from '@solana/addresses';
 import { getBase58Decoder } from '@solana/codecs-strings';
 import { SOLANA_ERROR__JSON_RPC__SERVER_ERROR_MIN_CONTEXT_SLOT_NOT_REACHED, SolanaError } from '@solana/errors';
 import type { Rpc } from '@solana/rpc-spec';
-import type { Commitment } from '@solana/rpc-types';
+import type { Base58EncodedBytes, Commitment } from '@solana/rpc-types';
 import path from 'path';
 
 import { GetProgramAccountsApi } from '../index';
@@ -2339,7 +2339,7 @@ describe('getProgramAccounts', () => {
                     filters: [
                         {
                             memcmp: {
-                                bytes: mint,
+                                bytes: mint as unknown as Base58EncodedBytes,
                                 encoding: 'base58',
                                 offset: 0n,
                             },
@@ -2400,7 +2400,7 @@ describe('getProgramAccounts', () => {
                         },
                         {
                             memcmp: {
-                                bytes: mint,
+                                bytes: mint as unknown as Base58EncodedBytes,
                                 encoding: 'base58',
                                 offset: 0n,
                             },

--- a/packages/rpc-graphql/src/loaders/loader.ts
+++ b/packages/rpc-graphql/src/loaders/loader.ts
@@ -2,7 +2,12 @@ import type { Address } from '@solana/addresses';
 import stringify from '@solana/fast-stable-stringify';
 import type { Signature } from '@solana/keys';
 import type { GetAccountInfoApi, GetBlockApi, GetProgramAccountsApi, GetTransactionApi } from '@solana/rpc';
-import type { Commitment, Slot } from '@solana/rpc-types';
+import type {
+    Commitment,
+    GetProgramAccountsDatasizeFilter,
+    GetProgramAccountsMemcmpFilter,
+    Slot,
+} from '@solana/rpc-types';
 
 export type BatchLoadPromiseCallback<T> = Readonly<{
     reject: (reason?: unknown) => void;
@@ -65,18 +70,7 @@ export type ProgramAccountsLoaderArgsBase = {
     commitment?: Commitment;
     dataSlice?: { length: number; offset: number };
     encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
-    filters?: (
-        | {
-              dataSize: bigint;
-          }
-        | {
-              memcmp: {
-                  bytes: string;
-                  encoding: 'base58' | 'base64';
-                  offset: bigint;
-              };
-          }
-    )[];
+    filters?: (GetProgramAccountsDatasizeFilter | GetProgramAccountsMemcmpFilter)[];
     /**
      * Prevents accessing stale data by enforcing that the RPC node has processed transactions up to
      * this slot

--- a/packages/rpc-graphql/src/resolvers/program-accounts.ts
+++ b/packages/rpc-graphql/src/resolvers/program-accounts.ts
@@ -1,5 +1,5 @@
 import { Address } from '@solana/addresses';
-import { Commitment, Slot } from '@solana/rpc-types';
+import { Commitment, GetProgramAccountsDatasizeFilter, GetProgramAccountsMemcmpFilter, Slot } from '@solana/rpc-types';
 import type { GraphQLResolveInfo } from 'graphql';
 
 import { RpcGraphQLContext } from '../context';
@@ -21,8 +21,8 @@ export function resolveProgramAccounts(fieldName?: string) {
              * on the client, the default commitment applied by the server is `"finalized"`.
              */
             commitment?: Commitment;
-            dataSizeFilters?: { dataSize: bigint }[];
-            memcmpFilters?: { bytes: string; encoding: 'base58' | 'base64'; offset: bigint }[];
+            dataSizeFilters?: GetProgramAccountsDatasizeFilter[];
+            memcmpFilters?: GetProgramAccountsMemcmpFilter['memcmp'][];
             /**
              * Prevents accessing stale data by enforcing that the RPC node has processed
              * transactions up to this slot
@@ -34,20 +34,7 @@ export function resolveProgramAccounts(fieldName?: string) {
         info: GraphQLResolveInfo,
     ): Promise<AccountResult[] | null> => {
         const programAddress = fieldName ? parent[fieldName] : args.programAddress;
-        let filters:
-            | (
-                  | {
-                        dataSize: bigint;
-                    }
-                  | {
-                        memcmp: {
-                            bytes: string;
-                            encoding: 'base58' | 'base64';
-                            offset: bigint;
-                        };
-                    }
-              )[]
-            | undefined = [];
+        let filters: (GetProgramAccountsDatasizeFilter | GetProgramAccountsMemcmpFilter)[] | undefined = [];
         if (args.memcmpFilters) {
             filters.concat(
                 args.memcmpFilters.map(memcmpFilter => ({

--- a/packages/rpc-graphql/src/resolvers/resolve-info/program-accounts.ts
+++ b/packages/rpc-graphql/src/resolvers/resolve-info/program-accounts.ts
@@ -1,5 +1,5 @@
 import { Address } from '@solana/addresses';
-import { Commitment, Slot } from '@solana/rpc-types';
+import { Commitment, GetProgramAccountsDatasizeFilter, GetProgramAccountsMemcmpFilter, Slot } from '@solana/rpc-types';
 import { GraphQLResolveInfo } from 'graphql';
 
 import { ProgramAccountsLoaderArgs } from '../../loaders';
@@ -21,18 +21,7 @@ export function buildProgramAccountsLoaderArgSetFromResolveInfo(
          * the client, the default commitment applied by the server is `"finalized"`.
          */
         commitment?: Commitment;
-        filters?: (
-            | {
-                  dataSize: bigint;
-              }
-            | {
-                  memcmp: {
-                      bytes: string;
-                      encoding: 'base58' | 'base64';
-                      offset: bigint;
-                  };
-              }
-        )[];
+        filters?: (GetProgramAccountsDatasizeFilter | GetProgramAccountsMemcmpFilter)[];
         /**
          * Prevents accessing stale data by enforcing that the RPC node has processed transactions
          * up to this slot

--- a/packages/rpc-subscriptions-api/src/program-notifications.ts
+++ b/packages/rpc-subscriptions-api/src/program-notifications.ts
@@ -6,25 +6,11 @@ import type {
     AccountInfoWithBase64EncodedData,
     AccountInfoWithBase64EncodedZStdCompressedData,
     AccountInfoWithJsonData,
-    Base58EncodedBytes,
-    Base64EncodedBytes,
     Commitment,
+    GetProgramAccountsDatasizeFilter,
+    GetProgramAccountsMemcmpFilter,
     SolanaRpcResponse,
 } from '@solana/rpc-types';
-
-type ProgramNotificationsMemcmpFilterBase58 = Readonly<{
-    bytes: Base58EncodedBytes;
-    encoding: 'base58';
-    offset: bigint;
-}>;
-
-type ProgramNotificationsMemcmpFilterBase64 = Readonly<{
-    bytes: Base64EncodedBytes;
-    encoding: 'base64';
-    offset: bigint;
-}>;
-
-type ProgramNotificationsDatasizeFilter = bigint;
 
 type ProgramNotificationsApiNotificationBase<TData> = SolanaRpcResponse<
     Readonly<{
@@ -36,10 +22,7 @@ type ProgramNotificationsApiNotificationBase<TData> = SolanaRpcResponse<
 type ProgramNotificationsApiCommonConfig = Readonly<{
     commitment?: Commitment;
     // The resultant account must meet ALL filter criteria to be included in the returned results
-    filters?: readonly Readonly<
-        | { dataSize: ProgramNotificationsDatasizeFilter }
-        | { memcmp: ProgramNotificationsMemcmpFilterBase58 | ProgramNotificationsMemcmpFilterBase64 }
-    >[];
+    filters?: readonly Readonly<GetProgramAccountsDatasizeFilter | GetProgramAccountsMemcmpFilter>[];
 }>;
 
 export type ProgramNotificationsApi = {

--- a/packages/rpc-types/src/account-filters.ts
+++ b/packages/rpc-types/src/account-filters.ts
@@ -1,3 +1,5 @@
+import { Base58EncodedBytes, Base64EncodedBytes } from './encoded-bytes';
+
 export type DataSlice = Readonly<{
     /** The number of bytes to return */
     length: number;
@@ -5,22 +7,37 @@ export type DataSlice = Readonly<{
     offset: number;
 }>;
 
+type ProgramNotificationsMemcmpFilterBase58 = Readonly<{
+    /**
+     * The bytes to match, as a base-58 encoded string.
+     *
+     * Data is limited to a maximum of 128 decoded bytes.
+     */
+    bytes: Base58EncodedBytes;
+    /** The encoding to use when decoding the supplied byte string */
+    encoding: 'base58';
+    /** The byte offset into the account data from which to start the comparison */
+    offset: bigint;
+}>;
+
+type ProgramNotificationsMemcmpFilterBase64 = Readonly<{
+    /**
+     * The bytes to match, as a base-64 encoded string.
+     *
+     * Data is limited to a maximum of 128 decoded bytes.
+     */
+    bytes: Base64EncodedBytes;
+    /** The encoding to use when decoding the supplied byte string */
+    encoding: 'base64';
+    /** The byte offset into the account data from which to start the comparison */
+    offset: bigint;
+}>;
+
 export type GetProgramAccountsMemcmpFilter = Readonly<{
     /**
      * This filter matches when the bytes supplied are equal to the account data at the given offset
      */
-    memcmp: Readonly<{
-        /**
-         * The bytes to match, encoded as a string using the specified encoding.
-         *
-         * Data is limited to a maximum of 128 decoded bytes.
-         */
-        bytes: string;
-        /** The encoding to use when decoding the supplied byte string */
-        encoding: 'base58' | 'base64';
-        /** The byte offset into the account data from which to start the comparison */
-        offset: bigint;
-    }>;
+    memcmp: ProgramNotificationsMemcmpFilterBase58 | ProgramNotificationsMemcmpFilterBase64;
 }>;
 
 export type GetProgramAccountsDatasizeFilter = Readonly<{


### PR DESCRIPTION
#### Problem

The RPC API specifies a `Base58EncodedData | Base64EncodedData` where the RPC Subscriptions API specifies only `string`. Granted the more restrictive type is less ergonomic, but the friction it adds can prevent – at build time – someone from mixing up their encodings.

#### Summary of Changes

Use the common type definition for both.
