### PR TITLE
Rename Solana Kit to Kit in docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
-# Solana Kit documentation
+# Kit documentation
 
-Documentation website for Solana Kit, built with [Fumadocs](<(https://github.com/fuma-nama/fumadocs)>).
+Documentation website for Kit, built with [Fumadocs](<(https://github.com/fuma-nama/fumadocs)>).
 
 ## Install dependencies
 

--- a/docs/content/docs/compatible-clients.mdx
+++ b/docs/content/docs/compatible-clients.mdx
@@ -1,9 +1,9 @@
 ---
 title: Compatible clients
-description: A list of program clients compatible with Solana Kit
+description: A list of program clients compatible with Kit
 ---
 
-The table below provides a list of JavaScript program clients that you can use with Solana Kit. Make sure to install the library of each program your app interacts with to access its API.
+The table below provides a list of JavaScript program clients that you can use with Kit. Make sure to install the library of each program your app interacts with to access its API.
 
 Note that program clients are generated using [Codama](https://github.com/codama-idl/codama) and you can do the same for your own program clients.
 

--- a/docs/content/docs/concepts/codecs.mdx
+++ b/docs/content/docs/concepts/codecs.mdx
@@ -5,7 +5,7 @@ description: Encode and decode anything
 
 ## Introduction
 
-Solana Kit includes a powerful serialisation system called Codecs. Whether you're working with account data, instruction arguments, or custom binary layouts, Codecs give you the tools to transform structured data into bytes — and back again.
+Kit includes a powerful serialisation system called Codecs. Whether you're working with account data, instruction arguments, or custom binary layouts, Codecs give you the tools to transform structured data into bytes — and back again.
 
 Codecs are composable, type-safe, and environment-agnostic. They are designed to provide a flexible and consistent foundation for handling binary data across the Solana stack.
 

--- a/docs/content/docs/getting-started/build-transaction.mdx
+++ b/docs/content/docs/getting-started/build-transaction.mdx
@@ -44,7 +44,7 @@ person satisfies { name: string; age: number; wallet: Address };
 
 But as you can see, even after updating our variable, TypeScript still believes the `person` variable is of type `{ name: string }`. This is because TypeScript doesn't re-assign types to variables when they are mutated.
 
-Fortunately, the Solana Kit library offers a functional API which means its types are designed to be immutable. So, instead of trying to grow the `person` variable by mutating it, it creates new variables with new types at each step.
+Fortunately, the Kit library offers a functional API which means its types are designed to be immutable. So, instead of trying to grow the `person` variable by mutating it, it creates new variables with new types at each step.
 
 ```ts twoslash
 import { address, Address } from "@solana/kit";

--- a/docs/content/docs/getting-started/fetch-account.mdx
+++ b/docs/content/docs/getting-started/fetch-account.mdx
@@ -25,7 +25,7 @@ Having so many possible return values makes it harder to work with the retrieved
 
 Additionally, when trying to fetch an account that does not exist on-chain, the `null` value is returned which is particularly inconvenient when dealing with multiple accounts as it requires zipping the address array with the account array to determine which ones are missing.
 
-Therefore, Solana Kit offers a set of types and helpers that aim to unify these APIs and make them easier to work with. For instance, the `fetchEncodedAccount` and `fetchEncodedAccounts` helpers can be used to fetch one or multiple accounts and return them in a unified format.
+Therefore, Kit offers a set of types and helpers that aim to unify these APIs and make them easier to work with. For instance, the `fetchEncodedAccount` and `fetchEncodedAccounts` helpers can be used to fetch one or multiple accounts and return them in a unified format.
 
 ```ts twoslash
 import { Rpc, SolanaRpcApi } from "@solana/kit";
@@ -77,7 +77,7 @@ account satisfies EncodedAccount;
 
 So far, we have been dealing with encoded accounts, meaning the `data` field of the fetched account is a byte array — i.e. a `Uint8Array`. But we are realistically going to need to decode that data into a more usable format.
 
-Solana Kit ships with a set of serialization libraries called Codecs. These libraries offer types and functions to create Codec objects that can be composed together to create more complex serialization and deserialization logic.
+Kit ships with a set of serialization libraries called Codecs. These libraries offer types and functions to create Codec objects that can be composed together to create more complex serialization and deserialization logic.
 
 You can [read more about Codecs here](/docs/concepts/codecs), but let's quickly see how we can create a Codec object to decode our `Mint` account.
 
@@ -248,12 +248,12 @@ Mint supply: 0.
 
 ## Next steps
 
-Congrats on completing this tutorial! You've learned how to get started with the Solana Kit library by:
+Congrats on completing this tutorial! You've learned how to get started with the Kit library by:
 
-- Creating a `Client` object containing all the bits from Solana Kit that matter for your application — ensuring the rest can be tree-shaken away.
+- Creating a `Client` object containing all the bits from Kit that matter for your application — ensuring the rest can be tree-shaken away.
 - Building instructions and transaction messages.
 - Generating signer objects and using them to sign transactions.
 - Sending transactions and waiting for them to be confirmed.
 - Fetching and decoding on-chain accounts that were created by your transactions.
 
-If you'd like to dig deeper into the Solana Kit library, you may be interested in the [Core concepts](/docs/concepts) section of the documentation. There, you'll find in-depth articles about specific parts of the library such as [Codecs](/docs/concepts/codecs), [Signers](/docs/concepts/signers), and [RPCs](/docs/concepts/rpc).
+If you'd like to dig deeper into the Kit library, you may be interested in the [Core concepts](/docs/concepts) section of the documentation. There, you'll find in-depth articles about specific parts of the library such as [Codecs](/docs/concepts/codecs), [Signers](/docs/concepts/signers), and [RPCs](/docs/concepts/rpc).

--- a/docs/content/docs/getting-started/index.mdx
+++ b/docs/content/docs/getting-started/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: Getting started with Solana Kit
-description: A step-by-step guide to grasp the basics of Solana Kit
+title: Getting started with Kit
+description: A step-by-step guide to grasp the basics of Kit
 ---
 
-In this series of articles, we'll build a simple application that creates a new Solana token and retrieves its information. Along the way, we'll explore some of the core concepts of the Solana Kit library and learn how to use it to send transactions and read data from the Solana blockchain.
+In this series of articles, we'll build a simple application that creates a new Solana token and retrieves its information. Along the way, we'll explore some of the core concepts of the Kit library and learn how to use it to send transactions and read data from the Solana blockchain.
 
 Let's start by [setting up our project](/docs/getting-started/setup)!
 

--- a/docs/content/docs/getting-started/send-transaction.mdx
+++ b/docs/content/docs/getting-started/send-transaction.mdx
@@ -22,7 +22,7 @@ const encodedTransaction = getBase64EncodedWireTransaction(signedTransaction);
 await rpc.sendTransaction(encodedTransaction, { preflightCommitment: "confirmed", encoding: "base64" }).send();
 ```
 
-However, Solana Kit offers a helper function that does that for us whilst providing some sensible default values. This function is called `sendTransactionWithoutConfirmingFactory` and, given an RPC object, it returns a function that sends transactions without waiting for confirmation.
+However, Kit offers a helper function that does that for us whilst providing some sensible default values. This function is called `sendTransactionWithoutConfirmingFactory` and, given an RPC object, it returns a function that sends transactions without waiting for confirmation.
 
 ```ts twoslash
 import { FullySignedTransaction, TransactionWithBlockhashLifetime, Rpc, SolanaRpcApi } from "@solana/kit";
@@ -41,7 +41,7 @@ Sending transactions is one thing but, more often than not, we'll want to make s
 
 There are several ways to ensure a transaction was confirmed by the network. For instance, we could poll the network at regular intervals to check the status of the transaction until it has the required commitment level. Another way would be to listen for network events and use them to determine the status of the sent transaction.
 
-Sometimes it may be useful to dig deeper into confirmation strategies and create custom ones that make the most sense for our applications. But for all other cases, Solana Kit provides helpers that abstract this complexity away from us. Namely, it provides two helper functions that both send and confirm transactions. Which function to use depends on the lifetime set on the transaction.
+Sometimes it may be useful to dig deeper into confirmation strategies and create custom ones that make the most sense for our applications. But for all other cases, Kit provides helpers that abstract this complexity away from us. Namely, it provides two helper functions that both send and confirm transactions. Which function to use depends on the lifetime set on the transaction.
 
 - `sendAndConfirmTransactionFactory` is used for transactions using a blockhash strategy for its lifetime.
 - `sendAndConfirmDurableNonceTransactionFactory` is used for transactions using a durable nonce strategy for its lifetime.
@@ -73,7 +73,7 @@ If you hover on top of the `sendTransaction` or `sendAndConfirmTransaction` func
 
 This is because there is a common misconception that one must wait for the transaction to be sent to the network before obtaining its signature. However, that's not the case. The transaction signature is accessible as soon as the transaction is signed by its fee payer. This is because the signature that uniquely identifies a transaction is none other than the fee payer's signature for that transaction.
 
-As such, Solana Kit decouples these two distinct concepts by offering a `getSignatureFromTransaction` function that returns the signature of a transaction that can be used even before it is sent to the network.
+As such, Kit decouples these two distinct concepts by offering a `getSignatureFromTransaction` function that returns the signature of a transaction that can be used even before it is sent to the network.
 
 ```ts twoslash
 import {

--- a/docs/content/docs/getting-started/setup.mdx
+++ b/docs/content/docs/getting-started/setup.mdx
@@ -5,7 +5,7 @@ description: Set up the environment and prepare a personalised client object
 
 ## Install dependencies
 
-First things first, set up a new TypeScript project with a `src/index.ts` file and install the `@solana/kit` library. Additionally, to keep this tutorial focused on the Solana Kit library, we'll use `tsx` to compile and run our TypeScript code.
+First things first, set up a new TypeScript project with a `src/index.ts` file and install the `@solana/kit` library. Additionally, to keep this tutorial focused on the Kit library, we'll use `tsx` to compile and run our TypeScript code.
 
 ```package-install
 @solana/kit tsx

--- a/docs/content/docs/getting-started/signers.mdx
+++ b/docs/content/docs/getting-started/signers.mdx
@@ -7,7 +7,7 @@ Before we can start crafting transactions, we're going to need a wallet that can
 
 ## Generate a new `CryptoKeypair`
 
-The Solana Kit library uses the [native Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Crypto) for cryptographic tasks like generating key pairs and signing or verifying messages. This improves security by leveraging the browser's built-in functions instead of third-party libraries.
+The Kit library uses the [native Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Crypto) for cryptographic tasks like generating key pairs and signing or verifying messages. This improves security by leveraging the browser's built-in functions instead of third-party libraries.
 
 To create a new keypair, you can use the `generateKeyPair` helper function. This will return an instance of the native `CryptoKeyPair` type.
 
@@ -17,7 +17,7 @@ import { generateKeyPair } from "@solana/kit";
 const wallet: CryptoKeyPair = await generateKeyPair();
 ```
 
-And just like that, we have a wallet that can be used to sign transactions. However, Solana Kit provides a useful abstraction on top of anything that can sign messages and/or transactions called `Signers`.
+And just like that, we have a wallet that can be used to sign transactions. However, Kit provides a useful abstraction on top of anything that can sign messages and/or transactions called `Signers`.
 
 ## Generate a new `KeyPairSigner`
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -18,7 +18,7 @@ Follow these simple steps to install and get started with Kit:
  
 ### Install Kit
 
-Install Solana Kit using the main `@solana/kit` library. It includes many smaller packages — such as `@solana/rpc` or `@solana/transactions` — that can also be used individually for more granular imports.
+Install Kit using the main `@solana/kit` library. It includes many smaller packages — such as `@solana/rpc` or `@solana/transactions` — that can also be used individually for more granular imports.
 
 ```package-install
 @solana/kit
@@ -30,7 +30,7 @@ Install Solana Kit using the main `@solana/kit` library. It includes many smalle
 
 ### Install program clients
 
-Install Solana Kit compatible clients for any program you want to interact with. For example, to interact with the System program, install the `@solana-program/system` package. You can find a [list of available program clients here](/docs/compatible-clients).
+Install Kit compatible clients for any program you want to interact with. For example, to interact with the System program, install the `@solana-program/system` package. You can find a [list of available program clients here](/docs/compatible-clients).
 
 ```package-install
 npm install @solana-program/system \
@@ -45,7 +45,7 @@ npm install @solana-program/system \
 
 ### Set up your project
 
-Use primitives provided by Solana Kit to set up your project and start interacting with Solana!
+Use primitives provided by Kit to set up your project and start interacting with Solana!
 
 For example, if you are planning on sending transactions, you will likely need an RPC API, an RPC Subscriptions API and a "send and confirm" strategy.
 
@@ -57,7 +57,7 @@ const rpcSubscriptions = createSolanaRpcSubscriptions("wss://api.devnet.solana.c
 const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
 ```
 
-Check out our [Getting started](/docs/getting-started) tutorial and our [Core concepts](/docs/concepts) guides to learn more about how to use Solana Kit.
+Check out our [Getting started](/docs/getting-started) tutorial and our [Core concepts](/docs/concepts) guides to learn more about how to use Kit.
 
 </Step>
 </Steps>

--- a/docs/content/docs/upgrade-guide.mdx
+++ b/docs/content/docs/upgrade-guide.mdx
@@ -5,21 +5,21 @@ description: Upgrade your Web3.js project to Kit
 
 ## Why upgrade?
 
-Solana Kit (formerly Web3.js v2) is a complete rewrite of [the Web3.js library](https://github.com/solana-labs/solana-web3.js/). It is designed to be more composable, customizable, and efficient than its predecessor. Its functional design enables the entire library to be tree-shaken, drastically reducing your bundle size. It also takes advantage of modern JavaScript features — such as native Ed25519 key support and `bigint` for large values — resulting in an even smaller bundle, better performance and most importantly, a reduced attack surface for your application.
+Kit (formerly Web3.js v2) is a complete rewrite of [the Web3.js library](https://github.com/solana-labs/solana-web3.js/). It is designed to be more composable, customizable, and efficient than its predecessor. Its functional design enables the entire library to be tree-shaken, drastically reducing your bundle size. It also takes advantage of modern JavaScript features — such as native Ed25519 key support and `bigint` for large values — resulting in an even smaller bundle, better performance and most importantly, a reduced attack surface for your application.
 
 <Spread>
   ![Tree-shaking illustration. The left side shows a bunch of imports from Web3.js all being bundled despite only a
-  couple being used. The right side shows an equivalent set of imports for Solana Kit but only the used functions are
+  couple being used. The right side shows an equivalent set of imports for Kit but only the used functions are
   bundled.](./tree-shaking.svg)
 </Spread>
 
-Unlike Web3.js, Solana Kit doesn't rely on JavaScript classes or other non-tree-shakeable features. This brings us to our first key difference.
+Unlike Web3.js, Kit doesn't rely on JavaScript classes or other non-tree-shakeable features. This brings us to our first key difference.
 
 ## Where's my `Connection` class?
 
 In Web3.js, the `Connection` class serves as a central entry point, making the library's API easier to discover via a single object. However, this comes at a cost: using the `Connection` class forces you to bundle every method it provides, even if you only use a few. As a result, your users must download the entire library, even when most of it goes unused.
 
-To avoid this, **Solana Kit does not include a single entry-point class like `Connection`**. Instead, it offers a set of functions that you can import and use as needed. Two key functions replace most of the `Connection` class's functionality: `createSolanaRpc` and `createSolanaRpcSubscriptions`.
+To avoid this, **Kit does not include a single entry-point class like `Connection`**. Instead, it offers a set of functions that you can import and use as needed. Two key functions replace most of the `Connection` class's functionality: `createSolanaRpc` and `createSolanaRpcSubscriptions`.
 
 The former, `createSolanaRpc`, returns an `Rpc` object for making RPC requests to a specified endpoint. [Read more about RPCs here](/docs/concepts/rpc).
 
@@ -39,7 +39,7 @@ const wallet = new PublicKey("1234..5678");
 const balance = await connection.getBalance(wallet);
 ```
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import { address, createSolanaRpc } from "@solana/kit";
 
 // Create an RPC proxy object.
@@ -74,7 +74,7 @@ connection.onAccountChange(wallet, (accountInfo) => {
 });
 ```
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import { address, createSolanaRpcSubscriptions } from "@solana/kit";
 
 // Create an RPC subscriptions proxy object.
@@ -118,7 +118,7 @@ const wallet = new PublicKey("1234..5678");
 const account = await connection.getAccountInfo(wallet);
 ```
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import { address } from "@solana/kit";
 // ---cut-start---
 import { createSolanaRpc } from "@solana/kit";
@@ -132,9 +132,9 @@ const { value: account } = await rpc.getAccountInfo(wallet).send();
 </div>
 </Spread>
 
-Solana Kit also provides helper functions like `fetchEncodedAccount` and `fetchEncodedAccounts`, which return `MaybeAccount` objects. These objects store the account's address and include an `exists` boolean to indicate whether the account is present on-chain. If `exists` is `true`, the object also contains the expected account info. These helpers also unify the return type of accounts, ensuring consistency regardless of the encoding used to fetch them.
+Kit also provides helper functions like `fetchEncodedAccount` and `fetchEncodedAccounts`, which return `MaybeAccount` objects. These objects store the account's address and include an `exists` boolean to indicate whether the account is present on-chain. If `exists` is `true`, the object also contains the expected account info. These helpers also unify the return type of accounts, ensuring consistency regardless of the encoding used to fetch them.
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import { address, assertAccountExists, fetchEncodedAccount } from "@solana/kit";
 // ---cut-start---
 import { createSolanaRpc } from "@solana/kit";
@@ -147,9 +147,9 @@ assertAccountExists(account);
 account.data satisfies Uint8Array;
 ```
 
-In addition, Solana Kit introduces a new serialization library called `codecs`. Codecs are composable objects for encoding and decoding any type to and from a `Uint8Array`. For example, here's how you can define a codec for a `Person` account by combining multiple codec primitives:
+In addition, Kit introduces a new serialization library called `codecs`. Codecs are composable objects for encoding and decoding any type to and from a `Uint8Array`. For example, here's how you can define a codec for a `Person` account by combining multiple codec primitives:
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import {
   address,
   Address,
@@ -188,7 +188,7 @@ const bytes = personCodec.encode({
 
 Once you have a codec for an account's data, you can use the `decodeAccount` function to transform an encoded account into a decoded account.
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import { address, Codec, decodeAccount, fetchEncodedAccount } from "@solana/kit";
 // ---cut-start---
 import {
@@ -227,11 +227,11 @@ if (decodedAccount.exists) {
 
 ## Using program libraries
 
-Fortunately, you don't need to create a custom codec every time you decode an account. Solana Kit provides client libraries for many popular Solana programs that can help with that. For example, System program helpers are available in the `@solana-program/system` library.
+Fortunately, you don't need to create a custom codec every time you decode an account. Kit provides client libraries for many popular Solana programs that can help with that. For example, System program helpers are available in the `@solana-program/system` library.
 
 These libraries are [generated via Codama](https://github.com/codama-idl/codama), ensuring consistent structure across them. For instance, the `fetchNonce` function from `@solana-program/system` can be used to fetch and decode a `Nonce` account from its address.
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import { Account, address } from "@solana/kit";
 import { fetchNonce, Nonce } from "@solana-program/system";
 // ---cut-start---
@@ -242,13 +242,13 @@ const rpc = createSolanaRpc("https://api.devnet.solana.com");
 const account: Account<Nonce> = await fetchNonce(rpc, address("1234..5678"));
 ```
 
-[Check out the "Compatible clients" page](/docs/compatible-clients) for a list of available program libraries compatible with Solana Kit.
+[Check out the "Compatible clients" page](/docs/compatible-clients) for a list of available program libraries compatible with Kit.
 
 ## Creating instructions
 
 In addition to fetching and decoding accounts, generated program clients also provide functions for creating instructions. These functions follow the `getXInstruction` naming convention, where `X` is the name of the instruction.
 
-For example, here's how to create a `CreateAccount` instruction using the `SystemProgram` class in Web3.js, followed by the Solana Kit equivalent using the `@solana-program/system` library.
+For example, here's how to create a `CreateAccount` instruction using the `SystemProgram` class in Web3.js, followed by the Kit equivalent using the `@solana-program/system` library.
 
 <Spread>
 <div className="2xl:flex 2xl:*:flex-1 2xl:items-start 2xl:gap-4">
@@ -263,7 +263,7 @@ const transferSol = SystemProgram.transfer({
 });
 ```
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import { address, createNoopSigner } from "@solana/kit";
 import { getTransferSolInstruction } from "@solana-program/system";
 
@@ -278,10 +278,10 @@ const transferSol = getTransferSolInstruction({
 </Spread>
 
 <Callout title="Transaction signers">
-  Notice the `createNoopSigner` function in the Solana Kit example. Unlike Web3.js, Solana Kit uses `TransactionSigner`
-  objects when an account needs to act as a signer for an instruction. This allows signers to be extracted from built
-  transactions, enabling automatic transaction signing without manually scanning instructions to find required signers.
-  We'll explore this further in the ["Signing transactions" section below](#signing-transactions).
+  Notice the `createNoopSigner` function in the Kit example. Unlike Web3.js, Kit uses `TransactionSigner` objects when
+  an account needs to act as a signer for an instruction. This allows signers to be extracted from built transactions,
+  enabling automatic transaction signing without manually scanning instructions to find required signers. We'll explore
+  this further in the ["Signing transactions" section below](#signing-transactions).
 </Callout>
 
 Now that we know how to create instructions, let's see how to use them to build transactions.
@@ -290,9 +290,9 @@ Now that we know how to create instructions, let's see how to use them to build 
 
 Web3.js makes a number of assumptions when creating transactions. For example, it defaults to the latest transaction version and uses a recent blockhash for the transaction lifetime. While this improves the developer experience by providing sensible defaults, it comes at the cost of tree-shakeability. If an application only relies on durable nonce lifetimes, it will still be forced to bundle logic related to blockhash lifetimes, even if it's never used.
 
-Solana Kit, on the other hand, makes no assumptions about transactions. Instead, it requires developers to explicitly provide all necessary information using a series of helper functions. These functions progressively transform an empty transaction message into a fully compiled and signed transaction, ready to be sent to the network. This approach ensures strong type safety, allowing helper functions to enforce valid transaction states at compile time.
+Kit, on the other hand, makes no assumptions about transactions. Instead, it requires developers to explicitly provide all necessary information using a series of helper functions. These functions progressively transform an empty transaction message into a fully compiled and signed transaction, ready to be sent to the network. This approach ensures strong type safety, allowing helper functions to enforce valid transaction states at compile time.
 
-Since TypeScript cannot re-declare the type of an existing variable, each transaction helper returns a new immutable transaction object with an updated type. To streamline this, Solana Kit provides a `pipe` function, allowing developers to chain transaction helpers together efficiently.
+Since TypeScript cannot re-declare the type of an existing variable, each transaction helper returns a new immutable transaction object with an updated type. To streamline this, Kit provides a `pipe` function, allowing developers to chain transaction helpers together efficiently.
 
 <Spread>
 <div className="2xl:flex 2xl:*:flex-1 2xl:items-start 2xl:gap-4">
@@ -308,7 +308,7 @@ const initializeMint = createInitializeMintInstruction(initializeMintInput);
 const transaction = new Transaction({ feePayer, ...latestBlockhash }).add(createAccount).add(initializeMint);
 ```
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import {
   appendTransactionMessageInstructions,
   createTransactionMessage,
@@ -343,7 +343,7 @@ const transactionMessage = pipe(
 
 ## Signing transactions
 
-Both Web3.js and Solana Kit allow keypairs to sign or partially sign transactions. However, Solana Kit leverages the native [`CryptoKeyPair`](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKeyPair) API to generate and export keypairs securely, without exposing private keys to the environment.
+Both Web3.js and Kit allow keypairs to sign or partially sign transactions. However, Kit leverages the native [`CryptoKeyPair`](https://developer.mozilla.org/en-US/docs/Web/API/CryptoKeyPair) API to generate and export keypairs securely, without exposing private keys to the environment.
 
 <Spread>
 <div className="2xl:flex 2xl:*:flex-1 2xl:items-start 2xl:gap-4">
@@ -357,7 +357,7 @@ const authority = Keypair.generate();
 transaction.sign([payer, authority]);
 ```
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import { compileTransaction, generateKeyPair, signTransaction } from "@solana/kit";
 // ---cut-start---
 import { CompilableTransactionMessage, TransactionMessageWithBlockhashLifetime } from "@solana/kit";
@@ -373,9 +373,9 @@ const signedTransaction = await signTransaction([payer, authority], transaction)
 </div>
 </Spread>
 
-Additionally, as mentioned in the ["Creating instructions"](#creating-instructions) section, Solana Kit introduces **signer objects**. These objects handle transaction and message signing while abstracting away the underlying signing mechanism. This could be using a Crypto KeyPair, a wallet adapter in the browser, a Noop signer, or anything we want. Here are some examples of how signers can be created:
+Additionally, as mentioned in the ["Creating instructions"](#creating-instructions) section, Kit introduces **signer objects**. These objects handle transaction and message signing while abstracting away the underlying signing mechanism. This could be using a Crypto KeyPair, a wallet adapter in the browser, a Noop signer, or anything we want. Here are some examples of how signers can be created:
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import { address, createNoopSigner, generateKeyPairSigner } from "@solana/kit";
 import { useWalletAccountTransactionSendingSigner } from "@solana/react";
 // ---cut-start---
@@ -397,7 +397,7 @@ One key advantage of using signers is that they can be passed directly when crea
 
 Here's an example of passing signers to both instructions and the transaction fee payer. Notice that `signTransactionMessageWithSigners` doesn't require additional signers to be passed in — it already knows which ones are needed.
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import { signTransactionMessageWithSigners } from "@solana/kit";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import { getInitializeMintInstruction, TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
@@ -449,7 +449,7 @@ const signedTransaction = await signTransactionMessageWithSigners(transactionMes
 
 ## Sending and confirming transactions
 
-Finally, we can send our signed transaction to the network and wait for confirmation. While there are multiple ways to confirm transactions (e.g., polling, listening for events, etc.), both Web3.js and Solana Kit provide a default strategy that works for most use cases.
+Finally, we can send our signed transaction to the network and wait for confirmation. While there are multiple ways to confirm transactions (e.g., polling, listening for events, etc.), both Web3.js and Kit provide a default strategy that works for most use cases.
 
 <Spread>
 <div className="2xl:flex 2xl:*:flex-1 2xl:items-start 2xl:gap-4">
@@ -465,7 +465,7 @@ const mint = Keypair.generate();
 const transactionSignature = await sendAndConfirmTransaction(connection, transaction, [feePayer, mint]);
 ```
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import { sendAndConfirmTransactionFactory, getSignatureFromTransaction } from "@solana/kit";
 // ---cut-start---
 import {
@@ -490,7 +490,7 @@ await sendAndConfirm(signedTransaction, { commitment: "confirmed" });
 </div>
 </Spread>
 
-Notice that the `sendAndConfirm` function does not return the transaction signature. This is because a transaction signature is deterministically known before it is sent. To access it, Solana Kit provides a separate `getSignatureFromTransaction` helper as illustrated in the code snippet above.
+Notice that the `sendAndConfirm` function does not return the transaction signature. This is because a transaction signature is deterministically known before it is sent. To access it, Kit provides a separate `getSignatureFromTransaction` helper as illustrated in the code snippet above.
 
 Additionally, the `sendAndConfirmTransactionFactory` function requires both an RPC and an RPC Subscriptions object. However, this does not mean that the full RPC and RPC Subscriptions implementations are needed. Only the following API methods must be implemented:
 
@@ -499,11 +499,11 @@ Additionally, the `sendAndConfirmTransactionFactory` function requires both an R
 
 ## Closing words
 
-We've now explored the key differences between Web3.js and Solana Kit, giving you a solid foundation for upgrading your project. Since Solana Kit is a complete rewrite, there's no simple step-by-step migration guide, and the process may take some time.
+We've now explored the key differences between Web3.js and Kit, giving you a solid foundation for upgrading your project. Since Kit is a complete rewrite, there's no simple step-by-step migration guide, and the process may take some time.
 
-To ease the transition, Solana Kit provides a `@solana/compat` package, which allows for incremental migration. This package includes functions that convert core types — such as public keys and transactions — between Web3.js and Solana Kit. This means you can start integrating Solana Kit without having to refactor your entire project at once.
+To ease the transition, Kit provides a `@solana/compat` package, which allows for incremental migration. This package includes functions that convert core types — such as public keys and transactions — between Web3.js and Kit. This means you can start integrating Kit without having to refactor your entire project at once.
 
-```ts twoslash title="Solana Kit"
+```ts twoslash title="Kit"
 import { Keypair, PublicKey } from "@solana/web3.js";
 import { createSignerFromKeyPair } from "@solana/kit";
 import {
@@ -531,4 +531,4 @@ const instruction = fromLegacyTransactionInstruction(transactionInstruction);
 const transaction = fromVersionedTransaction(versionedTransaction);
 ```
 
-For more details on how Solana Kit differs from Web3.js and its design principles, check out the [Solana Kit README](https://github.com/anza-xyz/kit/blob/main/README.md).
+For more details on how Kit differs from Web3.js and its design principles, check out the [Kit README](https://github.com/anza-xyz/kit/blob/main/README.md).

--- a/docs/src/app/layout.config.tsx
+++ b/docs/src/app/layout.config.tsx
@@ -33,7 +33,7 @@ export const baseOptions: BaseLayoutProps = {
                         fill="currentColor"
                     />
                 </svg>
-                Solana Kit
+                Kit
             </>
         ),
     },


### PR DESCRIPTION
This PR replaces instances of `"Solana Kit"` to `"Kit"` within the documentation website — i.e. in the `docs` folder.