### PR TITLE
Only re-request reviews from non-core members when PR changes

### DIFF
--- a/.github/workflows/dismiss-stale-pr-reviews.yml
+++ b/.github/workflows/dismiss-stale-pr-reviews.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Dismiss Stale PR Reviews
+        if: ${{ !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association) }}
         uses: withgraphite/dismiss-stale-approvals@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Problem

The real problem that ‘dismiss on change’ tries to protect against is:

1. Person submits PR
2. Core member approves PR
3. Person updates PR with malicious or broken code
4. Core member presses merge

There exists time between ‘approve’ and ‘merge’ for someone to sneak code in.

#### Summary of Changes

Presume that the contributions of core team members do not have to be protected against. Only run this workflow for non-core contributors.
