### PR TITLE
Prevent hanging task in `rpc-subscriptions-functional-test`

### DIFF
--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-functional-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-functional-test.ts
@@ -25,15 +25,19 @@ describe('accountNotifications', () => {
 
     it('can subscribe to account notifications', async () => {
         expect.hasAssertions();
-        const abortSignal = new AbortController().signal;
-        const subscriptionPromise = rpcSubscriptions
-            .accountNotifications('4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc' as Address)
-            .subscribe({ abortSignal });
+        const abortController = new AbortController();
+        try {
+            const subscriptionPromise = rpcSubscriptions
+                .accountNotifications('4nTLDQiSTRHbngKZWPMfYnZdWTbKiNeuuPcX7yFUpSAc' as Address)
+                .subscribe({ abortSignal: abortController.signal });
 
-        await expect(subscriptionPromise).resolves.toEqual(
-            expect.objectContaining({
-                [Symbol.asyncIterator]: expect.any(Function),
-            }),
-        );
+            await expect(subscriptionPromise).resolves.toEqual(
+                expect.objectContaining({
+                    [Symbol.asyncIterator]: expect.any(Function),
+                }),
+            );
+        } finally {
+            abortController.abort();
+        }
     });
 });


### PR DESCRIPTION
#### Problem

This recently started to hang my local tests. I'm not sure how this ever worked, or why it succeeds in CI.

#### Summary of Changes

Unsubscribe from the subscription after the test is complete.
