### PR TITLE
Repair the `SysvarEpochRewards` fetcher/decoder/encoder

### DIFF
--- a/.changeset/better-masks-tease.md
+++ b/.changeset/better-masks-tease.md
@@ -1,0 +1,5 @@
+---
+'@solana/sysvars': patch
+---
+
+The `SysvarEpochRewards` encoder/decoder no longer produces malformed data

--- a/packages/sysvars/src/__tests__/epoch-rewards-test.ts
+++ b/packages/sysvars/src/__tests__/epoch-rewards-test.ts
@@ -4,14 +4,29 @@ describe('epoch rewards', () => {
     it('decode', () => {
         // prettier-ignore
         const epochRewardsState = new Uint8Array([
-            0, 45, 49, 1, 0, 0, 0, 0,    // distributionCompleteBlockHeight
-            134, 74, 2, 0, 0, 0, 0, 0,   // distributedRewards
-            0, 132, 215, 23, 0, 0, 0, 0, // totalRewards
+            // distributionStartingBlockHeight
+            0xab, 0xa8, 0x87, 0x12, 0x00, 0x00, 0x00, 0x00,
+            // numPartitions
+            0x3a, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            // parentBlockhash
+            0x67, 0x8b, 0xd4, 0xe4, 0xc8, 0x5c, 0x10, 0x87, 0xa8, 0x0a, 0xfb, 0x2f, 0x0d, 0xbb, 0x13, 0x27, 0x16, 0x11, 0x3a, 0xc7, 0xc7, 0xb0, 0xc7, 0xe4, 0x99, 0x51, 0x4d, 0x42, 0xdb, 0x43, 0xd7, 0x1c,
+            // totalPoints
+            0x10, 0xbe, 0x90, 0x99, 0x7a, 0x16, 0x9e, 0xa5, 0xc2, 0x2d, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 
+            // totalRewards
+            0x00, 0xb3, 0x04, 0x4e, 0xd0, 0x20, 0x89, 0x00,
+            // distributedRewards
+            0x00, 0xb8, 0xea, 0x37, 0xd0, 0x20, 0x89, 0x00,
+            // active
+            0x00,
         ]);
-        expect(getSysvarEpochRewardsCodec().decode(epochRewardsState)).toMatchObject({
-            distributedRewards: 150_150n,
-            distributionCompleteBlockHeight: 20_000_000n,
-            totalRewards: 400_000_000n,
+        expect(getSysvarEpochRewardsCodec().decode(epochRewardsState)).toStrictEqual({
+            active: false,
+            distributedRewards: 38598150472775680n,
+            distributionStartingBlockHeight: 310880427n,
+            numPartitions: 314n,
+            parentBlockhash: '7yCfKTaamnrmkAfefSgsonQ6rtwCfVaxQJircWb9K4Qj',
+            totalPoints: 2633948733309470433656336n,
+            totalRewards: 38598150843577088n,
         });
     });
     // TODO: This account does not seem to exist on-chain yet.

--- a/packages/sysvars/src/epoch-rewards.ts
+++ b/packages/sysvars/src/epoch-rewards.ts
@@ -4,17 +4,29 @@ import {
     type FixedSizeCodec,
     type FixedSizeDecoder,
     type FixedSizeEncoder,
+    getBooleanDecoder,
+    getBooleanEncoder,
     getStructDecoder,
     getStructEncoder,
     getU64Decoder,
     getU64Encoder,
+    getU128Decoder,
+    getU128Encoder,
 } from '@solana/codecs';
 import type { GetAccountInfoApi } from '@solana/rpc-api';
 import type { Rpc } from '@solana/rpc-spec';
+import {
+    Blockhash,
+    getBlockhashDecoder,
+    getBlockhashEncoder,
+    getDefaultLamportsDecoder,
+    getDefaultLamportsEncoder,
+    Lamports,
+} from '@solana/rpc-types';
 
 import { fetchEncodedSysvarAccount, SYSVAR_EPOCH_REWARDS_ADDRESS } from './sysvar';
 
-type SysvarEpochRewardsSize = 24;
+type SysvarEpochRewardsSize = 81;
 
 /**
  * The `EpochRewards` sysvar.
@@ -30,24 +42,36 @@ type SysvarEpochRewardsSize = 24;
  * See https://github.com/anza-xyz/agave/blob/e0203f22dc83cb792fa97f91dbe6e924cbd08af1/docs/src/runtime/sysvars.md?plain=1#L155-L168
  */
 export type SysvarEpochRewards = Readonly<{
-    distributedRewards: bigint;
-    distributionCompleteBlockHeight: bigint;
-    totalRewards: bigint;
+    active: boolean;
+    distributedRewards: Lamports;
+    distributionStartingBlockHeight: bigint;
+    numPartitions: bigint;
+    parentBlockhash: Blockhash;
+    totalPoints: bigint;
+    totalRewards: Lamports;
 }>;
 
 export function getSysvarEpochRewardsEncoder(): FixedSizeEncoder<SysvarEpochRewards, SysvarEpochRewardsSize> {
     return getStructEncoder([
-        ['distributionCompleteBlockHeight', getU64Encoder()],
-        ['distributedRewards', getU64Encoder()],
-        ['totalRewards', getU64Encoder()],
+        ['distributionStartingBlockHeight', getU64Encoder()],
+        ['numPartitions', getU64Encoder()],
+        ['parentBlockhash', getBlockhashEncoder()],
+        ['totalPoints', getU128Encoder()],
+        ['totalRewards', getDefaultLamportsEncoder()],
+        ['distributedRewards', getDefaultLamportsEncoder()],
+        ['active', getBooleanEncoder()],
     ]) as FixedSizeEncoder<SysvarEpochRewards, SysvarEpochRewardsSize>;
 }
 
 export function getSysvarEpochRewardsDecoder(): FixedSizeDecoder<SysvarEpochRewards, SysvarEpochRewardsSize> {
     return getStructDecoder([
-        ['distributionCompleteBlockHeight', getU64Decoder()],
-        ['distributedRewards', getU64Decoder()],
-        ['totalRewards', getU64Decoder()],
+        ['distributionStartingBlockHeight', getU64Decoder()],
+        ['numPartitions', getU64Decoder()],
+        ['parentBlockhash', getBlockhashDecoder()],
+        ['totalPoints', getU128Decoder()],
+        ['totalRewards', getDefaultLamportsDecoder()],
+        ['distributedRewards', getDefaultLamportsDecoder()],
+        ['active', getBooleanDecoder()],
     ]) as FixedSizeDecoder<SysvarEpochRewards, SysvarEpochRewardsSize>;
 }
 


### PR DESCRIPTION
#### Problem

This fell out of sync as of https://github.com/anza-xyz/agave/pull/428 and is now reporting incorrect data.

#### Test Plan

```shell
pnpm dlx bun repl
> import {fetchSysvarEpochRewards} from './packages/sysvars';
undefined
> import {createSolanaRpc} from './packages/kit'
undefined
> const r = createSolanaRpc('https://api.mainnet-beta.solana.com')
undefined
> await fetchSysvarEpochRewards(r);
{
  distributionStartingBlockHeight: 310449729n,
  numPartitions: 319n,
  parentBlockhash: 'GYMCsbMsLA1AnsXPaPAA7pAbbA5vEBLTgM3QgBvdBUxF',
  totalPoints: 2643849320321396387655516n,
  totalRewards: 150870678501792n,
  distributedRewards: 150870677130403n,
  active: false
}
```

Compare to:

```shell
curl https://api.mainnet-beta.solana.com -s -X \
  POST -H "Content-Type: application/json" -d '
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "getAccountInfo",
    "params": [
      "SysvarEpochRewards1111111111111111111111111",
      {
        "encoding": "jsonParsed"
      }
    ]
  }
' | jq
```

```json
{
  "jsonrpc": "2.0",
  "result": {
    "context": {
      "apiVersion": "2.1.16",
      "slot": 332620574
    },
    "value": {
      "data": {
        "parsed": {
          "info": {
            "active": false,
            "distributedRewards": "150870677130403",
            "distributionStartingBlockHeight": 310449729,
            "numPartitions": 319,
            "parentBlockhash": "GYMCsbMsLA1AnsXPaPAA7pAbbA5vEBLTgM3QgBvdBUxF",
            "totalPoints": "2643849320321396387655516",
            "totalRewards": "150870678501792"
          },
          "type": "epochRewards"
        },
        "program": "sysvar",
        "space": 81
      },
      "executable": false,
      "lamports": 1454640,
      "owner": "Sysvar1111111111111111111111111111111111111",
      "rentEpoch": 18446744073709551615,
      "space": 81
    }
  },
  "id": 1
}
```
