### PR TITLE
Repair the `StakeHistory` sysvar fetcher

### DIFF
--- a/.changeset/public-terms-prove.md
+++ b/.changeset/public-terms-prove.md
@@ -1,0 +1,5 @@
+---
+'@solana/sysvars': patch
+---
+
+The `SysvarStakeHistory` encoder/decoder no longer produces malformed data

--- a/packages/sysvars/src/__tests__/stake-history-test.ts
+++ b/packages/sysvars/src/__tests__/stake-history-test.ts
@@ -12,10 +12,12 @@ describe('stake history', () => {
     it('decode', () => {
         // prettier-ignore
         const stakeHistoryState = new Uint8Array([
-            2, 0, 0, 0,                     // array length 
+            2, 0, 0, 0, 0, 0, 0, 0,         // array length 
+            1, 0, 0, 0, 0, 0, 0, 0,         // epoch
             0, 208, 237, 144, 46, 0, 0, 0,  // effective
             0, 160, 219, 33, 93, 0, 0, 0,   // activating
             0, 112, 201, 178, 139, 0, 0, 0, // deactivating
+            2, 0, 0, 0, 0, 0, 0, 0,         // epoch
             0, 160, 219, 33, 93, 0, 0, 0,   // effective
             0, 112, 201, 178, 139, 0, 0, 0, // activating
             0, 64, 183, 67, 186, 0, 0, 0,   // deactivating
@@ -23,14 +25,20 @@ describe('stake history', () => {
         expect(getSysvarStakeHistoryCodec().decode(stakeHistoryState)).toMatchObject(
             expect.arrayContaining([
                 {
-                    activating: 400_000_000_000n,
-                    deactivating: 600_000_000_000n,
-                    effective: 200_000_000_000n,
+                    epoch: 1n,
+                    stakeHistory: {
+                        activating: 400_000_000_000n,
+                        deactivating: 600_000_000_000n,
+                        effective: 200_000_000_000n,
+                    },
                 },
                 {
-                    activating: 600_000_000_000n,
-                    deactivating: 800_000_000_000n,
-                    effective: 400_000_000_000n,
+                    epoch: 2n,
+                    stakeHistory: {
+                        activating: 600_000_000_000n,
+                        deactivating: 800_000_000_000n,
+                        effective: 400_000_000_000n,
+                    },
                 },
             ]),
         );

--- a/packages/sysvars/src/stake-history.ts
+++ b/packages/sysvars/src/stake-history.ts
@@ -5,20 +5,25 @@ import {
     getArrayEncoder,
     getStructDecoder,
     getStructEncoder,
+    getU64Decoder,
+    getU64Encoder,
     type VariableSizeCodec,
     type VariableSizeDecoder,
     type VariableSizeEncoder,
 } from '@solana/codecs';
 import type { GetAccountInfoApi } from '@solana/rpc-api';
 import type { Rpc } from '@solana/rpc-spec';
-import { getDefaultLamportsDecoder, getDefaultLamportsEncoder, type Lamports } from '@solana/rpc-types';
+import { Epoch, getDefaultLamportsDecoder, getDefaultLamportsEncoder, type Lamports } from '@solana/rpc-types';
 
 import { fetchEncodedSysvarAccount, SYSVAR_STAKE_HISTORY_ADDRESS } from './sysvar';
 
 type Entry = Readonly<{
-    activating: Lamports;
-    deactivating: Lamports;
-    effective: Lamports;
+    epoch: Epoch;
+    stakeHistory: Readonly<{
+        activating: Lamports;
+        deactivating: Lamports;
+        effective: Lamports;
+    }>;
 }>;
 
 /**
@@ -31,20 +36,34 @@ export type SysvarStakeHistory = Entry[];
 export function getSysvarStakeHistoryEncoder(): VariableSizeEncoder<SysvarStakeHistory> {
     return getArrayEncoder(
         getStructEncoder([
-            ['effective', getDefaultLamportsEncoder()],
-            ['activating', getDefaultLamportsEncoder()],
-            ['deactivating', getDefaultLamportsEncoder()],
+            ['epoch', getU64Encoder()],
+            [
+                'stakeHistory',
+                getStructEncoder([
+                    ['effective', getDefaultLamportsEncoder()],
+                    ['activating', getDefaultLamportsEncoder()],
+                    ['deactivating', getDefaultLamportsEncoder()],
+                ]),
+            ],
         ]),
+        { size: getU64Encoder() },
     );
 }
 
 export function getSysvarStakeHistoryDecoder(): VariableSizeDecoder<SysvarStakeHistory> {
     return getArrayDecoder(
         getStructDecoder([
-            ['effective', getDefaultLamportsDecoder()],
-            ['activating', getDefaultLamportsDecoder()],
-            ['deactivating', getDefaultLamportsDecoder()],
+            ['epoch', getU64Decoder()],
+            [
+                'stakeHistory',
+                getStructDecoder([
+                    ['effective', getDefaultLamportsDecoder()],
+                    ['activating', getDefaultLamportsDecoder()],
+                    ['deactivating', getDefaultLamportsDecoder()],
+                ]),
+            ],
         ]),
+        { size: getU64Decoder() },
     );
 }
 


### PR DESCRIPTION
#### Problem

The data from this decoder is malformed.

#### Test Plan

```shell
$ pnpm dlx bun repl
> import {fetchSysvarStakeHistory} from './packages/sysvars';
undefined
> import {createSolanaRpc} from './packages/kit'
undefined
> const r = createSolanaRpc('https://api.mainnet-beta.solana.com')
undefined
> await fetchSysvarStakeHistory(r);
[
  {
    epoch: 769n,
    stakeHistory: {
      effective: 383590604902523127n,
      activating: 4044071834618951n,
      deactivating: 4656615498818574n
    }
  },
  /* ... */
]
```

Compare that to:

```shell
$ curl https://api.mainnet-beta.solana.com -s -X   POST -H "Content-Type: application/json" -d '
  {
    "jsonrpc": "2.0",
    "id": 1,
    "method": "getAccountInfo",
    "params": [
      "SysvarStakeHistory1111111111111111111111111",
      {
        "encoding": "jsonParsed"
      }
    ]
  }
' | jq
{
  "jsonrpc": "2.0",
  "result": {
    "context": {
      "apiVersion": "2.1.16",
      "slot": 332640417
    },
    "value": {
      "data": {
        "parsed": {
          "info": [
            {
              "epoch": 769,
              "stakeHistory": {
                "activating": 4044071834618951,
                "deactivating": 4656615498818574,
                "effective": 383590604902523127
              }
              /* ... */
```
