### PR TITLE
Fix vercel docs deployments

### DIFF
--- a/docs/build-api-docs.sh
+++ b/docs/build-api-docs.sh
@@ -9,5 +9,8 @@ find $API_DIR -mindepth 1 -maxdepth 1 -type d -exec rm -rf {} +
 mkdir -p "$API_DIR"
 
 for DOC_PATH in packages/*/.docs; do
-    (cd $DOC_PATH && rsync -a . $API_DIR/ --exclude "index.mdx")
+    (cd "$DOC_PATH" && find . -type f ! -name "index.mdx" | while read -r file; do
+        mkdir -p "$API_DIR/$(dirname "$file")"
+        cp "$file" "$API_DIR/$file"
+    done)
 done

--- a/docs/package.json
+++ b/docs/package.json
@@ -39,5 +39,6 @@
         "postcss": "^8.5.3",
         "tailwindcss": "^4.0.9",
         "typescript": "^5.8.2"
-    }
+    },
+    "packageManager": "pnpm@10.4.1"
 }


### PR DESCRIPTION
This PR tries to fix vercel deployments with the addition of the `/api` pages by:
- Adding a `"packageManager"` field to the `package.json` of the `docs` folder.
- Replacing `rsync` (unsupported in Vercel build environments) with a combination of `find`, `mkdir` and `cp`.

Vercel settings were also change this make this work:
- Enabled the "Include files outside the root directory in the Build Step" option.
- Changed the "install" command to: `(cd .. && pnpm install) && pnpm install --ignore-workspace`.