### PR TITLE
Loosen lifetime constraint on sendAndConfirmTransaction to only require lastValidBlockHeight

### DIFF
--- a/.changeset/nine-weeks-shop.md
+++ b/.changeset/nine-weeks-shop.md
@@ -1,0 +1,6 @@
+---
+'@solana/transaction-confirmation': patch
+'@solana/kit': patch
+---
+
+Loosen lifetime constraint on sendAndConfirmTransaction to only require lastValidBlockHeight

--- a/packages/kit/src/__tests__/send-transaction-internal-test.ts
+++ b/packages/kit/src/__tests__/send-transaction-internal-test.ts
@@ -11,7 +11,7 @@ import {
 
 import {
     sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT,
-    sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT,
+    sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT,
 } from '../send-transaction-internal';
 
 jest.mock('@solana/transactions');
@@ -39,7 +39,7 @@ describe('sendAndConfirmTransaction', () => {
         );
     });
     it('encodes the transaction into wire format before sending', () => {
-        sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
+        sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             confirmRecentTransaction,
@@ -56,7 +56,7 @@ describe('sendAndConfirmTransaction', () => {
             preflightCommitment: 'confirmed' as Commitment,
             skipPreflight: false,
         } as Parameters<SendTransactionApi['sendTransaction']>[1];
-        sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
+        sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...sendTransactionConfig,
             abortSignal: new AbortController().signal,
             commitment: 'finalized' as Commitment,
@@ -80,7 +80,7 @@ describe('sendAndConfirmTransaction', () => {
         } as Parameters<SendTransactionApi['sendTransaction']>[1];
         sendTransaction.mockResolvedValue('abc' as Signature);
         const abortSignal = new AbortController().signal;
-        sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
+        sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...sendTransactionConfig,
             abortSignal,
             commitment: 'finalized' as Commitment,
@@ -102,7 +102,7 @@ describe('sendAndConfirmTransaction', () => {
     `(
         'when missing a `preflightCommitment` and the commitment is $commitment, applies a downgraded `preflightCommitment`',
         ({ commitment, expectedPreflightCommitment }) => {
-            sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
+            sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
                 abortSignal: new AbortController().signal,
                 commitment,
                 confirmRecentTransaction,
@@ -131,7 +131,7 @@ describe('sendAndConfirmTransaction', () => {
     `(
         'honours the explicit `preflightCommitment` no matter that the commitment is $commitment',
         ({ commitment, preflightCommitment, expectedPreflightCommitment }) => {
-            sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
+            sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
                 abortSignal: new AbortController().signal,
                 commitment,
                 confirmRecentTransaction,
@@ -149,7 +149,7 @@ describe('sendAndConfirmTransaction', () => {
     );
     it('when missing a `preflightCommitment` and the commitment is the same as the server default for `preflightCommitment`, does not apply a `preflightCommitment`', () => {
         expect.assertions(1);
-        sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
+        sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             confirmRecentTransaction,
@@ -163,7 +163,7 @@ describe('sendAndConfirmTransaction', () => {
         sendTransaction.mockResolvedValue('abc');
         confirmRecentTransaction.mockResolvedValue(undefined);
         await expect(
-            sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
+            sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
                 abortSignal: new AbortController().signal,
                 commitment: 'finalized',
                 confirmRecentTransaction,

--- a/packages/kit/src/__tests__/send-transaction-internal-test.ts
+++ b/packages/kit/src/__tests__/send-transaction-internal-test.ts
@@ -11,7 +11,7 @@ import {
 
 import {
     sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT_EXPORT,
-    sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT,
+    sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT,
 } from '../send-transaction-internal';
 
 jest.mock('@solana/transactions');
@@ -39,7 +39,7 @@ describe('sendAndConfirmTransaction', () => {
         );
     });
     it('encodes the transaction into wire format before sending', () => {
-        sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
+        sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             confirmRecentTransaction,
@@ -56,7 +56,7 @@ describe('sendAndConfirmTransaction', () => {
             preflightCommitment: 'confirmed' as Commitment,
             skipPreflight: false,
         } as Parameters<SendTransactionApi['sendTransaction']>[1];
-        sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
+        sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...sendTransactionConfig,
             abortSignal: new AbortController().signal,
             commitment: 'finalized' as Commitment,
@@ -80,7 +80,7 @@ describe('sendAndConfirmTransaction', () => {
         } as Parameters<SendTransactionApi['sendTransaction']>[1];
         sendTransaction.mockResolvedValue('abc' as Signature);
         const abortSignal = new AbortController().signal;
-        sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
+        sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...sendTransactionConfig,
             abortSignal,
             commitment: 'finalized' as Commitment,
@@ -102,7 +102,7 @@ describe('sendAndConfirmTransaction', () => {
     `(
         'when missing a `preflightCommitment` and the commitment is $commitment, applies a downgraded `preflightCommitment`',
         ({ commitment, expectedPreflightCommitment }) => {
-            sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
+            sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
                 abortSignal: new AbortController().signal,
                 commitment,
                 confirmRecentTransaction,
@@ -131,7 +131,7 @@ describe('sendAndConfirmTransaction', () => {
     `(
         'honours the explicit `preflightCommitment` no matter that the commitment is $commitment',
         ({ commitment, preflightCommitment, expectedPreflightCommitment }) => {
-            sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
+            sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
                 abortSignal: new AbortController().signal,
                 commitment,
                 confirmRecentTransaction,
@@ -149,7 +149,7 @@ describe('sendAndConfirmTransaction', () => {
     );
     it('when missing a `preflightCommitment` and the commitment is the same as the server default for `preflightCommitment`, does not apply a `preflightCommitment`', () => {
         expect.assertions(1);
-        sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
+        sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
             abortSignal: new AbortController().signal,
             commitment: 'finalized',
             confirmRecentTransaction,
@@ -163,7 +163,7 @@ describe('sendAndConfirmTransaction', () => {
         sendTransaction.mockResolvedValue('abc');
         confirmRecentTransaction.mockResolvedValue(undefined);
         await expect(
-            sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
+            sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
                 abortSignal: new AbortController().signal,
                 commitment: 'finalized',
                 confirmRecentTransaction,

--- a/packages/kit/src/send-and-confirm-transaction.ts
+++ b/packages/kit/src/send-and-confirm-transaction.ts
@@ -3,21 +3,22 @@ import type { RpcSubscriptions, SignatureNotificationsApi, SlotNotificationsApi 
 import {
     createBlockHeightExceedencePromiseFactory,
     createRecentSignatureConfirmationPromiseFactory,
+    TransactionWithLastValidBlockHeight,
     waitForRecentTransactionConfirmation,
 } from '@solana/transaction-confirmation';
-import { FullySignedTransaction, TransactionWithBlockhashLifetime } from '@solana/transactions';
+import { FullySignedTransaction } from '@solana/transactions';
 
-import { sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT } from './send-transaction-internal';
+import { sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT } from './send-transaction-internal';
 
-type SendAndConfirmTransactionWithBlockhashLifetimeFunction = (
-    transaction: FullySignedTransaction & TransactionWithBlockhashLifetime,
+type SendAndConfirmTransactionWithLastValidBlockHeightFunction = (
+    transaction: FullySignedTransaction & TransactionWithLastValidBlockHeight,
     config: Omit<
-        Parameters<typeof sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
+        Parameters<typeof sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
         'confirmRecentTransaction' | 'rpc' | 'transaction'
     >,
 ) => Promise<void>;
 
-type SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<TCluster> = {
+type SendAndConfirmTransactionWithLastValidBlockHeightFactoryConfig<TCluster> = {
     /** An object that supports the {@link GetSignatureStatusesApi} and the {@link SendTransactionApi} of the Solana RPC API */
     rpc: Rpc<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi> & { '~cluster'?: TCluster };
     /** An object that supports the {@link SignatureNotificationsApi} and the {@link SlotNotificationsApi} of the Solana RPC Subscriptions API */
@@ -50,19 +51,19 @@ type SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<TCluster> = {
 export function sendAndConfirmTransactionFactory({
     rpc,
     rpcSubscriptions,
-}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<'devnet'>): SendAndConfirmTransactionWithBlockhashLifetimeFunction;
+}: SendAndConfirmTransactionWithLastValidBlockHeightFactoryConfig<'devnet'>): SendAndConfirmTransactionWithLastValidBlockHeightFunction;
 export function sendAndConfirmTransactionFactory({
     rpc,
     rpcSubscriptions,
-}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<'testnet'>): SendAndConfirmTransactionWithBlockhashLifetimeFunction;
+}: SendAndConfirmTransactionWithLastValidBlockHeightFactoryConfig<'testnet'>): SendAndConfirmTransactionWithLastValidBlockHeightFunction;
 export function sendAndConfirmTransactionFactory({
     rpc,
     rpcSubscriptions,
-}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<'mainnet'>): SendAndConfirmTransactionWithBlockhashLifetimeFunction;
+}: SendAndConfirmTransactionWithLastValidBlockHeightFactoryConfig<'mainnet'>): SendAndConfirmTransactionWithLastValidBlockHeightFunction;
 export function sendAndConfirmTransactionFactory<TCluster extends 'devnet' | 'mainnet' | 'testnet' | void = void>({
     rpc,
     rpcSubscriptions,
-}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<TCluster>): SendAndConfirmTransactionWithBlockhashLifetimeFunction {
+}: SendAndConfirmTransactionWithLastValidBlockHeightFactoryConfig<TCluster>): SendAndConfirmTransactionWithLastValidBlockHeightFunction {
     const getBlockHeightExceedencePromise = createBlockHeightExceedencePromiseFactory({
         rpc,
         rpcSubscriptions,
@@ -84,7 +85,7 @@ export function sendAndConfirmTransactionFactory<TCluster extends 'devnet' | 'ma
         });
     }
     return async function sendAndConfirmTransaction(transaction, config) {
-        await sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
+        await sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...config,
             confirmRecentTransaction,
             rpc,

--- a/packages/kit/src/send-and-confirm-transaction.ts
+++ b/packages/kit/src/send-and-confirm-transaction.ts
@@ -8,17 +8,17 @@ import {
 } from '@solana/transaction-confirmation';
 import { FullySignedTransaction } from '@solana/transactions';
 
-import { sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT } from './send-transaction-internal';
+import { sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT } from './send-transaction-internal';
 
-type SendAndConfirmTransactionWithLastValidBlockHeightFunction = (
+type SendAndConfirmTransactionWithBlockhashLifetimeFunction = (
     transaction: FullySignedTransaction & TransactionWithLastValidBlockHeight,
     config: Omit<
-        Parameters<typeof sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
+        Parameters<typeof sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
         'confirmRecentTransaction' | 'rpc' | 'transaction'
     >,
 ) => Promise<void>;
 
-type SendAndConfirmTransactionWithLastValidBlockHeightFactoryConfig<TCluster> = {
+type SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<TCluster> = {
     /** An object that supports the {@link GetSignatureStatusesApi} and the {@link SendTransactionApi} of the Solana RPC API */
     rpc: Rpc<GetEpochInfoApi & GetSignatureStatusesApi & SendTransactionApi> & { '~cluster'?: TCluster };
     /** An object that supports the {@link SignatureNotificationsApi} and the {@link SlotNotificationsApi} of the Solana RPC Subscriptions API */
@@ -51,19 +51,19 @@ type SendAndConfirmTransactionWithLastValidBlockHeightFactoryConfig<TCluster> = 
 export function sendAndConfirmTransactionFactory({
     rpc,
     rpcSubscriptions,
-}: SendAndConfirmTransactionWithLastValidBlockHeightFactoryConfig<'devnet'>): SendAndConfirmTransactionWithLastValidBlockHeightFunction;
+}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<'devnet'>): SendAndConfirmTransactionWithBlockhashLifetimeFunction;
 export function sendAndConfirmTransactionFactory({
     rpc,
     rpcSubscriptions,
-}: SendAndConfirmTransactionWithLastValidBlockHeightFactoryConfig<'testnet'>): SendAndConfirmTransactionWithLastValidBlockHeightFunction;
+}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<'testnet'>): SendAndConfirmTransactionWithBlockhashLifetimeFunction;
 export function sendAndConfirmTransactionFactory({
     rpc,
     rpcSubscriptions,
-}: SendAndConfirmTransactionWithLastValidBlockHeightFactoryConfig<'mainnet'>): SendAndConfirmTransactionWithLastValidBlockHeightFunction;
+}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<'mainnet'>): SendAndConfirmTransactionWithBlockhashLifetimeFunction;
 export function sendAndConfirmTransactionFactory<TCluster extends 'devnet' | 'mainnet' | 'testnet' | void = void>({
     rpc,
     rpcSubscriptions,
-}: SendAndConfirmTransactionWithLastValidBlockHeightFactoryConfig<TCluster>): SendAndConfirmTransactionWithLastValidBlockHeightFunction {
+}: SendAndConfirmTransactionWithBlockhashLifetimeFactoryConfig<TCluster>): SendAndConfirmTransactionWithBlockhashLifetimeFunction {
     const getBlockHeightExceedencePromise = createBlockHeightExceedencePromiseFactory({
         rpc,
         rpcSubscriptions,
@@ -85,7 +85,7 @@ export function sendAndConfirmTransactionFactory<TCluster extends 'devnet' | 'ma
         });
     }
     return async function sendAndConfirmTransaction(transaction, config) {
-        await sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
+        await sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
             ...config,
             confirmRecentTransaction,
             rpc,

--- a/packages/kit/src/send-transaction-internal.ts
+++ b/packages/kit/src/send-transaction-internal.ts
@@ -24,7 +24,7 @@ interface SendAndConfirmDurableNonceTransactionConfig
     transaction: FullySignedTransaction & TransactionWithDurableNonceLifetime;
 }
 
-interface SendAndConfirmTransactionWithLastValidBlockHeightConfig
+interface SendAndConfirmTransactionWithBlockhashLifetimeConfig
     extends SendTransactionBaseConfig,
         SendTransactionConfigWithoutEncoding {
     confirmRecentTransaction: (
@@ -111,14 +111,14 @@ export async function sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT
     return transactionSignature;
 }
 
-export async function sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
+export async function sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
     abortSignal,
     commitment,
     confirmRecentTransaction,
     rpc,
     transaction,
     ...sendTransactionConfig
-}: SendAndConfirmTransactionWithLastValidBlockHeightConfig): Promise<Signature> {
+}: SendAndConfirmTransactionWithBlockhashLifetimeConfig): Promise<Signature> {
     const transactionSignature = await sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
         ...sendTransactionConfig,
         abortSignal,

--- a/packages/kit/src/send-transaction-internal.ts
+++ b/packages/kit/src/send-transaction-internal.ts
@@ -2,13 +2,13 @@ import type { Signature } from '@solana/keys';
 import type { Rpc, SendTransactionApi } from '@solana/rpc';
 import { Commitment, commitmentComparator } from '@solana/rpc-types';
 import {
+    TransactionWithLastValidBlockHeight,
     waitForDurableNonceTransactionConfirmation,
     waitForRecentTransactionConfirmation,
 } from '@solana/transaction-confirmation';
 import {
     FullySignedTransaction,
     getBase64EncodedWireTransaction,
-    TransactionWithBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
 } from '@solana/transactions';
 
@@ -24,7 +24,7 @@ interface SendAndConfirmDurableNonceTransactionConfig
     transaction: FullySignedTransaction & TransactionWithDurableNonceLifetime;
 }
 
-interface SendAndConfirmTransactionWithBlockhashLifetimeConfig
+interface SendAndConfirmTransactionWithLastValidBlockHeightConfig
     extends SendTransactionBaseConfig,
         SendTransactionConfigWithoutEncoding {
     confirmRecentTransaction: (
@@ -33,7 +33,7 @@ interface SendAndConfirmTransactionWithBlockhashLifetimeConfig
             'getBlockHeightExceedencePromise' | 'getRecentSignatureConfirmationPromise'
         >,
     ) => Promise<void>;
-    transaction: FullySignedTransaction & TransactionWithBlockhashLifetime;
+    transaction: FullySignedTransaction & TransactionWithLastValidBlockHeight;
 }
 
 interface SendTransactionBaseConfig extends SendTransactionConfigWithoutEncoding {
@@ -111,14 +111,14 @@ export async function sendAndConfirmDurableNonceTransaction_INTERNAL_ONLY_DO_NOT
     return transactionSignature;
 }
 
-export async function sendAndConfirmTransactionWithBlockhashLifetime_INTERNAL_ONLY_DO_NOT_EXPORT({
+export async function sendAndConfirmTransactionWithLastValidBlockHeight_INTERNAL_ONLY_DO_NOT_EXPORT({
     abortSignal,
     commitment,
     confirmRecentTransaction,
     rpc,
     transaction,
     ...sendTransactionConfig
-}: SendAndConfirmTransactionWithBlockhashLifetimeConfig): Promise<Signature> {
+}: SendAndConfirmTransactionWithLastValidBlockHeightConfig): Promise<Signature> {
     const transactionSignature = await sendTransaction_INTERNAL_ONLY_DO_NOT_EXPORT({
         ...sendTransactionConfig,
         abortSignal,

--- a/packages/transaction-confirmation/src/confirmation-strategy-blockheight.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-blockheight.ts
@@ -10,7 +10,7 @@ type GetBlockHeightExceedencePromiseFn = (config: {
     lastValidBlockHeight: bigint;
 }) => Promise<void>;
 
-type CreateBlockHeightExceedencePromiseFactoryyConfig<TCluster> = {
+type CreateBlockHeightExceedencePromiseFactoryConfig<TCluster> = {
     rpc: Rpc<GetEpochInfoApi> & { '~cluster'?: TCluster };
     rpcSubscriptions: RpcSubscriptions<SlotNotificationsApi> & { '~cluster'?: TCluster };
 };
@@ -18,21 +18,21 @@ type CreateBlockHeightExceedencePromiseFactoryyConfig<TCluster> = {
 export function createBlockHeightExceedencePromiseFactory({
     rpc,
     rpcSubscriptions,
-}: CreateBlockHeightExceedencePromiseFactoryyConfig<'devnet'>): GetBlockHeightExceedencePromiseFn;
+}: CreateBlockHeightExceedencePromiseFactoryConfig<'devnet'>): GetBlockHeightExceedencePromiseFn;
 export function createBlockHeightExceedencePromiseFactory({
     rpc,
     rpcSubscriptions,
-}: CreateBlockHeightExceedencePromiseFactoryyConfig<'testnet'>): GetBlockHeightExceedencePromiseFn;
+}: CreateBlockHeightExceedencePromiseFactoryConfig<'testnet'>): GetBlockHeightExceedencePromiseFn;
 export function createBlockHeightExceedencePromiseFactory({
     rpc,
     rpcSubscriptions,
-}: CreateBlockHeightExceedencePromiseFactoryyConfig<'mainnet'>): GetBlockHeightExceedencePromiseFn;
+}: CreateBlockHeightExceedencePromiseFactoryConfig<'mainnet'>): GetBlockHeightExceedencePromiseFn;
 export function createBlockHeightExceedencePromiseFactory<
     TCluster extends 'devnet' | 'mainnet' | 'testnet' | void = void,
 >({
     rpc,
     rpcSubscriptions,
-}: CreateBlockHeightExceedencePromiseFactoryyConfig<TCluster>): GetBlockHeightExceedencePromiseFn {
+}: CreateBlockHeightExceedencePromiseFactoryConfig<TCluster>): GetBlockHeightExceedencePromiseFn {
     return async function getBlockHeightExceedencePromise({
         abortSignal: callerAbortSignal,
         commitment,

--- a/packages/transaction-confirmation/src/waiters.ts
+++ b/packages/transaction-confirmation/src/waiters.ts
@@ -2,7 +2,7 @@ import { Signature } from '@solana/keys';
 import {
     getSignatureFromTransaction,
     Transaction,
-    TransactionBlockhashLifetime,
+    TransactionWithBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
 } from '@solana/transactions';
 
@@ -11,8 +11,8 @@ import { createNonceInvalidationPromiseFactory } from './confirmation-strategy-n
 import { BaseTransactionConfirmationStrategyConfig, raceStrategies } from './confirmation-strategy-racer';
 import { getTimeoutPromise } from './confirmation-strategy-timeout';
 
-export type TransactionWithLastValidBlockHeight = {
-    readonly lifetimeConstraint: Pick<TransactionBlockhashLifetime, 'lastValidBlockHeight'>;
+export type TransactionWithLastValidBlockHeight = Omit<TransactionWithBlockhashLifetime, 'lifetimeConstraint'> & {
+    lifetimeConstraint: Omit<TransactionWithBlockhashLifetime['lifetimeConstraint'], 'blockhash'>;
 };
 
 interface WaitForDurableNonceTransactionConfirmationConfig extends BaseTransactionConfirmationStrategyConfig {

--- a/packages/transaction-confirmation/src/waiters.ts
+++ b/packages/transaction-confirmation/src/waiters.ts
@@ -2,7 +2,7 @@ import { Signature } from '@solana/keys';
 import {
     getSignatureFromTransaction,
     Transaction,
-    TransactionWithBlockhashLifetime,
+    TransactionBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
 } from '@solana/transactions';
 
@@ -10,6 +10,10 @@ import { createBlockHeightExceedencePromiseFactory } from './confirmation-strate
 import { createNonceInvalidationPromiseFactory } from './confirmation-strategy-nonce';
 import { BaseTransactionConfirmationStrategyConfig, raceStrategies } from './confirmation-strategy-racer';
 import { getTimeoutPromise } from './confirmation-strategy-timeout';
+
+export type TransactionWithLastValidBlockHeight = {
+    readonly lifetimeConstraint: Pick<TransactionBlockhashLifetime, 'lastValidBlockHeight'>;
+};
 
 interface WaitForDurableNonceTransactionConfirmationConfig extends BaseTransactionConfirmationStrategyConfig {
     getNonceInvalidationPromise: ReturnType<typeof createNonceInvalidationPromiseFactory>;
@@ -19,7 +23,7 @@ interface WaitForDurableNonceTransactionConfirmationConfig extends BaseTransacti
 interface WaitForRecentTransactionWithBlockhashLifetimeConfirmationConfig
     extends BaseTransactionConfirmationStrategyConfig {
     getBlockHeightExceedencePromise: ReturnType<typeof createBlockHeightExceedencePromiseFactory>;
-    transaction: Readonly<Transaction & TransactionWithBlockhashLifetime>;
+    transaction: Readonly<Transaction & TransactionWithLastValidBlockHeight>;
 }
 
 interface WaitForRecentTransactionWithTimeBasedLifetimeConfirmationConfig


### PR DESCRIPTION
#### Problem

If you receive a serialized blockhash transaction and want to send it using the Kit `sendAndConfirmTransaction` then you currently need to produce a `TransactionWithBlockhashLifetime` type to attach to the transaction, ie `{blockhash, lastValidBlockHeight}`. But the confirm logic only cares about the `lastValidBlockHeight`, so the blockhash part is unnecessary.

This encourages decompiling the transaction message unnecessarily to obtain the blockhash, which is ignored but required to satisfy the type.

#### Summary of Changes

You can now send and confirm a fully signed transaction with this shape:

```ts
{
  messageBytes: TransactionMessageBytes;
  signatures: SignaturesMap;
  lifetimeConstraint: {
    lastValidBlockHeight: Slot
  }
} 
```

In the case where you're using Kit to sign and we return `FullySignedTransaction & TransactionWithBlockhashLifetime` this is still satisfied.

But in the case where you have a deserialized Transaction `{messageBytes, signatures}` you now only need to attach a `lastValidBlockHeight`. As this is unavailable on the transaction message, this makes it clear that you don't need to parse the transaction in any way to confirm it, and nor should you for instance make an RPC call to fetch a new blockhash.