### PR TITLE
Enable experimental peak-memory optimizations in docs build

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -4,6 +4,9 @@ const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
 const config = {
+    experimental: {
+        webpackMemoryOptimizations: true,
+    },
     reactStrictMode: true,
     serverExternalPackages: ['twoslash', 'typescript'],
 };


### PR DESCRIPTION
This is an effort to make the docs buildable on Vercel's low-memory CI, of which we're currently using >96% of the memory before dying.

https://nextjs.org/docs/app/guides/memory-usage#try-experimentalwebpackmemoryoptimizations
