### PR TITLE
chore: fix typo in transaction-signer docs

### DIFF
--- a/packages/signers/src/transaction-signer.ts
+++ b/packages/signers/src/transaction-signer.ts
@@ -30,7 +30,7 @@ export type TransactionSigner<TAddress extends string = string> =
  * import { isTransactionSigner } from '@solana/signers';
  *
  * const address = '1234..5678' as Address<'1234..5678'>;
- * isTransactionSigner({ address, signTransaction: async () => {} }); // true
+ * isTransactionSigner({ address, signTransactions: async () => {} }); // true
  * isTransactionSigner({ address, modifyAndSignTransaction: async () => {} }); // true
  * isTransactionSigner({ address, signAndSendTransaction: async () => {} }); // true
  * isTransactionSigner({ address }); // false

--- a/packages/signers/src/transaction-signer.ts
+++ b/packages/signers/src/transaction-signer.ts
@@ -31,8 +31,8 @@ export type TransactionSigner<TAddress extends string = string> =
  *
  * const address = '1234..5678' as Address<'1234..5678'>;
  * isTransactionSigner({ address, signTransactions: async () => {} }); // true
- * isTransactionSigner({ address, modifyAndSignTransaction: async () => {} }); // true
- * isTransactionSigner({ address, signAndSendTransaction: async () => {} }); // true
+ * isTransactionSigner({ address, modifyAndSignTransactions: async () => {} }); // true
+ * isTransactionSigner({ address, signAndSendTransactions: async () => {} }); // true
  * isTransactionSigner({ address }); // false
  * ```
  *


### PR DESCRIPTION
#### Problem

this doc line references `signTransaction`:

https://github.com/anza-xyz/kit/blob/ccf6b857b1fbbbccdf2bfd3524a0a72501de00e7/packages/signers/src/transaction-signer.ts#L33

instead of `signTransactions`, as seen in the assert method just after:

https://github.com/anza-xyz/kit/blob/ccf6b857b1fbbbccdf2bfd3524a0a72501de00e7/packages/signers/src/transaction-signer.ts#L61

checking the source, `signTransactions` appears to be the correct method name

https://github.com/anza-xyz/kit/blob/ccf6b857b1fbbbccdf2bfd3524a0a72501de00e7/packages/signers/src/transaction-partial-signer.ts#L78

#### Summary of Changes

fixes the `signTransactions` method reference in `transaction-signer.ts` doc string
