### PR TITLE
Remove I prefixes before Transaction types

### DIFF
--- a/.changeset/swift-socks-doubt.md
+++ b/.changeset/swift-socks-doubt.md
@@ -1,0 +1,13 @@
+---
+'@solana/transaction-messages': minor
+'@solana/transactions': minor
+'@solana/signers': minor
+'@solana/errors': minor
+'@solana/kit': minor
+---
+
+Deprecate the `I` prefix of four transaction message types to stay consistent with the rest of them. Namely, the following types are renamed and their old names are marked as deprecated:
+- `ITransactionMessageWithFeePayer` -> `TransactionMessageWithFeePayer`
+- `ITransactionMessageWithFeePayerSigner` -> `TransactionMessageWithFeePayerSigner`
+- `ITransactionMessageWithSigners` -> `TransactionMessageWithSigners`
+- `ITransactionMessageWithSingleSendingSigner` -> `TransactionMessageWithSingleSendingSigner`

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ The object-oriented design of the web3.js (1.x) API prevents optimizing compiler
 
 Read more about tree-shaking here:
 
--   [Mozilla Developer Docs: Tree Shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking)
--   [WebPack Docs: Tree Shaking](https://webpack.js.org/guides/tree-shaking/)
--   [Web.Dev Blog Article: Reduce JavaScript Payloads with Tree Shaking](https://web.dev/articles/reduce-javascript-payloads-with-tree-shaking)
+- [Mozilla Developer Docs: Tree Shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking)
+- [WebPack Docs: Tree Shaking](https://webpack.js.org/guides/tree-shaking/)
+- [Web.Dev Blog Article: Reduce JavaScript Payloads with Tree Shaking](https://web.dev/articles/reduce-javascript-payloads-with-tree-shaking)
 
 One example of an API that can’t be tree-shaken is the `Connection` class. It has dozens of methods, but because it’s a _class_ you have no choice but to include every method in your application’s final bundle, no matter how many you _actually_ use.
 
@@ -62,16 +62,16 @@ Kit is fully tree-shakable and will remain so, enforced by build-time checks. Op
 
 Kit is comprised of several smaller, modular packages under the `@solana` organization, including:
 
--   `@solana/accounts`: For fetching and decoding accounts
--   `@solana/codecs`: For composing data (de)serializers from a set of primitives or building custom ones
--   `@solana/errors`: For identifying and refining coded errors thrown in the `@solana` namespace
--   `@solana/rpc`: For sending RPC requests
--   `@solana/rpc-subscriptions`: For subscribing to RPC notifications
--   `@solana/signers`: For building message and/or transaction signer objects
--   `@solana/sysvars`: For fetching and decoding sysvar accounts
--   `@solana/transaction-messages`: For building and transforming Solana transaction message objects
--   `@solana/transactions`: For compiling and signing transactions for submission to the network
--   And many more!
+- `@solana/accounts`: For fetching and decoding accounts
+- `@solana/codecs`: For composing data (de)serializers from a set of primitives or building custom ones
+- `@solana/errors`: For identifying and refining coded errors thrown in the `@solana` namespace
+- `@solana/rpc`: For sending RPC requests
+- `@solana/rpc-subscriptions`: For subscribing to RPC notifications
+- `@solana/signers`: For building message and/or transaction signer objects
+- `@solana/sysvars`: For fetching and decoding sysvar accounts
+- `@solana/transaction-messages`: For building and transforming Solana transaction message objects
+- `@solana/transactions`: For compiling and signing transactions for submission to the network
+- And many more!
 
 Some of these packages are themselves composed of smaller packages. For instance, `@solana/rpc` is composed of `@solana/rpc-spec` (for core JSON RPC specification types), `@solana/rpc-api` (for the Solana-specific RPC methods), `@solana/rpc-transport-http` (for the default HTTP transport) and so on.
 
@@ -83,10 +83,10 @@ Depending on your use case and your tolerance for certain application behaviours
 
 The inability to customize web3.js up until now has been a source of frustration:
 
--   The Mango team wanted to customize the transaction confirmation strategy, but all of that functionality is hidden away behind `confirmTransaction` – a static method of `Connection`. [Here’s the code for `confirmTransaction` on GitHub](https://github.com/solana-labs/solana-web3.js/blob/69a8ad25ef09f9e6d5bff1ffa8428d9be0bd32ac/packages/library-legacy/src/connection.ts#L3734).
--   Solana developer ‘mPaella’ [wanted us to add a feature in the RPC](https://github.com/solana-labs/solana-web3.js/issues/1143#issuecomment-1435927152) that would failover to a set of backup URLs in case the primary one failed.
--   Solana developer ‘epicfaace’ wanted first-class support for automatic time-windowed batching in the RPC transport. [Here’s their pull request](https://github.com/solana-labs/solana/pull/23628).
--   Multiple folks have expressed the need for custom retry logic for failed requests or transactions. [Here’s a pull request from ‘dafyddd’](https://github.com/solana-labs/solana/pull/11811) and [another from ‘abrkn’](https://github.com/solana-labs/solana-web3.js/issues/1041) attempting to modify retry logic to suit their individual use cases.
+- The Mango team wanted to customize the transaction confirmation strategy, but all of that functionality is hidden away behind `confirmTransaction` – a static method of `Connection`. [Here’s the code for `confirmTransaction` on GitHub](https://github.com/solana-labs/solana-web3.js/blob/69a8ad25ef09f9e6d5bff1ffa8428d9be0bd32ac/packages/library-legacy/src/connection.ts#L3734).
+- Solana developer ‘mPaella’ [wanted us to add a feature in the RPC](https://github.com/solana-labs/solana-web3.js/issues/1143#issuecomment-1435927152) that would failover to a set of backup URLs in case the primary one failed.
+- Solana developer ‘epicfaace’ wanted first-class support for automatic time-windowed batching in the RPC transport. [Here’s their pull request](https://github.com/solana-labs/solana/pull/23628).
+- Multiple folks have expressed the need for custom retry logic for failed requests or transactions. [Here’s a pull request from ‘dafyddd’](https://github.com/solana-labs/solana/pull/11811) and [another from ‘abrkn’](https://github.com/solana-labs/solana-web3.js/issues/1041) attempting to modify retry logic to suit their individual use cases.
 
 Kit exposes far more of its internals, particularly where communication with an RPC is concerned, and allows willing developers the ability to compose new implementations from the default ones that manifest a nearly limitless array of customizations.
 
@@ -114,7 +114,7 @@ Class-based architecture also presents unique risks to developers who trigger th
 
 Read more about dual-package hazard:
 
--   [NodeJS: Dual Package Hazard](https://nodejs.org/api/packages.html#dual-package-hazard)
+- [NodeJS: Dual Package Hazard](https://nodejs.org/api/packages.html#dual-package-hazard)
 
 Kit implements no classes (with the notable exception of the `SolanaError` class) and implements the thinnest possible interfaces at function boundaries.
 
@@ -145,12 +145,12 @@ Kit ships with an implementation of the [JSON RPC specification](https://www.jso
 
 The main package responsible for managing communication with an RPC is `@solana/rpc`. However, this package makes use of more granular packages to break down the RPC logic into smaller pieces. Namely, these packages are:
 
--   `@solana/rpc`: Contains all logic related to sending Solana RPC calls.
--   `@solana/rpc-api`: Describes all Solana RPC methods using types.
--   `@solana/rpc-transport-http`: Provides a concrete implementation of an RPC transport using HTTP requests.
--   `@solana/rpc-spec`: Defines the JSON RPC spec for sending RPC requests.
--   `@solana/rpc-spec-types`: Shared JSON RPC specifications types and helpers that are used by both `@solana/rpc` and `@solana/rpc-subscriptions` (described in the next section).
--   `@solana/rpc-types`: Shared Solana RPC types and helpers that are used by both `@solana/rpc` and `@solana/rpc-subscriptions`.
+- `@solana/rpc`: Contains all logic related to sending Solana RPC calls.
+- `@solana/rpc-api`: Describes all Solana RPC methods using types.
+- `@solana/rpc-transport-http`: Provides a concrete implementation of an RPC transport using HTTP requests.
+- `@solana/rpc-spec`: Defines the JSON RPC spec for sending RPC requests.
+- `@solana/rpc-spec-types`: Shared JSON RPC specifications types and helpers that are used by both `@solana/rpc` and `@solana/rpc-subscriptions` (described in the next section).
+- `@solana/rpc-types`: Shared Solana RPC types and helpers that are used by both `@solana/rpc` and `@solana/rpc-subscriptions`.
 
 The main `@solana/kit` package re-exports the `@solana/rpc` package so, going forward, we will import RPC types and functions from the library directly.
 
@@ -481,9 +481,9 @@ const slot = await rpc.getSlot().send({ abortSignal: abortController.signal });
 
 Read more about `AbortController` here:
 
--   [Mozilla Developer Docs: `AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
--   [Mozilla Developer Docs: `AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
--   [JavaScript.info: Fetch: Abort](https://javascript.info/fetch-abort)
+- [Mozilla Developer Docs: `AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
+- [Mozilla Developer Docs: `AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+- [JavaScript.info: Fetch: Abort](https://javascript.info/fetch-abort)
 
 ## RPC Subscriptions
 
@@ -491,12 +491,12 @@ Subscriptions in the legacy library do not allow custom retry logic and do not a
 
 The main package responsible for managing communication with RPC subscriptions is `@solana/rpc-subscriptions`. However, similarly to `@solana/rpc`, this package also makes use of more granular packages. These packages are:
 
--   `@solana/rpc-subscriptions`: Contains all logic related to subscribing to Solana RPC notifications.
--   `@solana/rpc-subscriptions-api`: Describes all Solana RPC subscriptions using types.
--   `@solana/rpc-subscriptions-channel-websocket`: Provides a concrete implementation of an RPC Subscriptions channel using WebSockets.
--   `@solana/rpc-subscriptions-spec`: Defines the JSON RPC spec for subscribing to RPC notifications.
--   `@solana/rpc-spec-types`: Shared JSON RPC specifications types and helpers that are used by both `@solana/rpc` and `@solana/rpc-subscriptions`.
--   `@solana/rpc-types`: Shared Solana RPC types and helpers that are used by both `@solana/rpc` and `@solana/rpc-subscriptions`.
+- `@solana/rpc-subscriptions`: Contains all logic related to subscribing to Solana RPC notifications.
+- `@solana/rpc-subscriptions-api`: Describes all Solana RPC subscriptions using types.
+- `@solana/rpc-subscriptions-channel-websocket`: Provides a concrete implementation of an RPC Subscriptions channel using WebSockets.
+- `@solana/rpc-subscriptions-spec`: Defines the JSON RPC spec for subscribing to RPC notifications.
+- `@solana/rpc-spec-types`: Shared JSON RPC specifications types and helpers that are used by both `@solana/rpc` and `@solana/rpc-subscriptions`.
+- `@solana/rpc-types`: Shared Solana RPC types and helpers that are used by both `@solana/rpc` and `@solana/rpc-subscriptions`.
 
 Since the main `@solana/kit` library also re-exports the `@solana/rpc-subscriptions` package we will import RPC Subscriptions types and functions directly from the main library going forward.
 
@@ -546,8 +546,8 @@ try {
 
 You can read more about `AsyncIterator` at the following links:
 
--   [Mozilla Developer Docs: `AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator)
--   [Luciano Mammino (Blog): JavaScript Async Iterators](https://www.nodejsdesignpatterns.com/blog/javascript-async-iterators/)
+- [Mozilla Developer Docs: `AsyncIterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator)
+- [Luciano Mammino (Blog): JavaScript Async Iterators](https://www.nodejsdesignpatterns.com/blog/javascript-async-iterators/)
 
 ### Aborting RPC Subscriptions
 
@@ -579,9 +579,9 @@ console.log('Done.');
 
 Read more about `AbortController` at the following links:
 
--   [Mozilla Developer Docs: `AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
--   [Mozilla Developer Docs: `AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
--   [JavaScript.info: Fetch: Abort](https://javascript.info/fetch-abort)
+- [Mozilla Developer Docs: `AbortController`](https://developer.mozilla.org/en-US/docs/Web/API/AbortController)
+- [Mozilla Developer Docs: `AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal)
+- [JavaScript.info: Fetch: Abort](https://javascript.info/fetch-abort)
 
 #### Cancelling Subscriptions
 
@@ -868,10 +868,10 @@ const transactionMessage = createTransactionMessage({ version: 0 });
 
 // Set the fee payer
 const transactionMessageWithFeePayer = setTransactionMessageFeePayer(feePayer, transactionMessage);
-//    ^? V0TransactionMessage & ITransactionMessageWithFeePayer
+//    ^? V0TransactionMessage & TransactionMessageWithFeePayer
 
 const transactionMessageWithFeePayerAndLifetime = setTransactionMessageLifetimeUsingBlockhash(
-    // ^? V0TransactionMessage & ITransactionMessageWithFeePayer & TransactionMessageWithBlockhashLifetime
+    // ^? V0TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithBlockhashLifetime
     recentBlockhash,
     transactionMessageWithFeePayer,
 );
@@ -967,11 +967,11 @@ We have taken steps to make it easier to write data (de)serializers, especially 
 
 Solana’s codecs libraries are broken up into modular components so you only need to import the ones you need. They are:
 
--   `@solana/codecs-core`: The core codecs library for working with codecs serializers and creating custom ones
--   `@solana/codecs-numbers`: Used for serialization of numbers (little-endian and big-endian bytes, etc.)
--   `@solana/codecs-strings`: Used for serialization of strings
--   `@solana/codecs-data-structures`: Codecs and serializers for structs
--   `@solana/options`: Designed to build codecs and serializers for types that mimic Rust’s enums, which can include embedded data within their variants such as values, tuples, and structs
+- `@solana/codecs-core`: The core codecs library for working with codecs serializers and creating custom ones
+- `@solana/codecs-numbers`: Used for serialization of numbers (little-endian and big-endian bytes, etc.)
+- `@solana/codecs-strings`: Used for serialization of strings
+- `@solana/codecs-data-structures`: Codecs and serializers for structs
+- `@solana/options`: Designed to build codecs and serializers for types that mimic Rust’s enums, which can include embedded data within their variants such as values, tuples, and structs
 
 These packages are included in the main `@solana/kit` library but you may also import them from `@solana/codecs` if you only need the codecs.
 
@@ -1287,14 +1287,14 @@ const instruction = getCreateLookupTableInstruction({
 
 On top of instruction builders, these clients offer a variety of utilities such as:
 
--   Instruction codecs — e.g. `getTransferSolInstructionDataCodec`.
--   Account types — e.g. `AddressLookupTable`.
--   Account codecs — e.g. `getAddressLookupTableAccountDataCodec`.
--   Account helpers — e.g. `fetchAddressLookupTable`.
--   PDA helpers — e.g. `findAddressLookupTablePda`, `fetchAddressLookupTableFromSeeds`.
--   Defined types and their codecs — e.g. `NonceState`, `getNonceStateCodec`.
--   Program helpers — e.g. `SYSTEM_PROGRAM_ADDRESS`, `SystemAccount` enum, `identifySystemInstruction`.
--   And much more!
+- Instruction codecs — e.g. `getTransferSolInstructionDataCodec`.
+- Account types — e.g. `AddressLookupTable`.
+- Account codecs — e.g. `getAddressLookupTableAccountDataCodec`.
+- Account helpers — e.g. `fetchAddressLookupTable`.
+- PDA helpers — e.g. `findAddressLookupTablePda`, `fetchAddressLookupTableFromSeeds`.
+- Defined types and their codecs — e.g. `NonceState`, `getNonceStateCodec`.
+- Program helpers — e.g. `SYSTEM_PROGRAM_ADDRESS`, `SystemAccount` enum, `identifySystemInstruction`.
+- And much more!
 
 Here’s another example that fetches an `AddressLookupTable` PDA from its seeds.
 
@@ -1331,15 +1331,15 @@ pnpm create solana-program
 
 This [`create-solana-program`](https://github.com/solana-program/create-solana-program) installer will create a new repository including:
 
--   An example program using the framework of your choice (Anchor coming soon).
--   Generated clients for any of the selected clients.
--   A set of scripts that allows you to:
-    -   Start a local validator including all programs and accounts you depend on.
-    -   Build, lint and test your programs.
-    -   Generate IDLs from your programs.
-    -   Generate clients from the generated IDLs.
-    -   Build and test each of your clients.
--   GitHub Actions pipelines to test your program, test your clients, and even manually publish new packages or crates for your clients. (Coming soon).
+- An example program using the framework of your choice (Anchor coming soon).
+- Generated clients for any of the selected clients.
+- A set of scripts that allows you to:
+    - Start a local validator including all programs and accounts you depend on.
+    - Build, lint and test your programs.
+    - Generate IDLs from your programs.
+    - Generate clients from the generated IDLs.
+    - Build and test each of your clients.
+- GitHub Actions pipelines to test your program, test your clients, and even manually publish new packages or crates for your clients. (Coming soon).
 
 When selecting the JavaScript client, you will get a fully generated library compatible with Kit much like the `@solana-program` packages showcased above.
 
@@ -1454,12 +1454,12 @@ See more in the package’s [README on GitHub](https://github.com/anza-xyz/kit/t
 
 You can see all development of this library and associated GraphQL tooling in the Kit repository on GitHub.
 
--   https://github.com/anza-xyz/kit
+- https://github.com/anza-xyz/kit
 
 You can follow along with program client generator development in the `@solana-program` org and the `@codama-idl/codama` repository.
 
--   https://github.com/solana-program/
--   https://github.com/codama-idl/codama
+- https://github.com/solana-program/
+- https://github.com/codama-idl/codama
 
 Solana Labs develops these tools in public, as open source. We encourage any and all developers who would like to work on these tools to contribute to the codebase.
 

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -495,7 +495,7 @@ export const SolanaErrorMessages: Readonly<{
         'More than one `TransactionSendingSigner` was identified.',
     [SOLANA_ERROR__SIGNER__TRANSACTION_SENDING_SIGNER_MISSING]:
         'No `TransactionSendingSigner` was identified. Please provide a valid ' +
-        '`ITransactionWithSingleSendingSigner` transaction.',
+        '`TransactionWithSingleSendingSigner` transaction.',
     [SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED]:
         'Wallet account signers do not support signing multiple messages/transactions in a single operation',
     [SOLANA_ERROR__SUBTLE_CRYPTO__CANNOT_EXPORT_NON_EXTRACTABLE_KEY]: 'Cannot export a non-extractable key.',

--- a/packages/kit/src/__tests__/compute-limit-internal-test.ts
+++ b/packages/kit/src/__tests__/compute-limit-internal-test.ts
@@ -8,7 +8,7 @@ import {
 import { AccountRole } from '@solana/instructions';
 import { Rpc, SimulateTransactionApi } from '@solana/rpc';
 import { Blockhash, TransactionError } from '@solana/rpc-types';
-import { ITransactionMessageWithFeePayer, Nonce, TransactionMessage } from '@solana/transaction-messages';
+import { Nonce, TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
 import { getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPORT } from '../compute-limit-internal';
 
@@ -23,7 +23,7 @@ const MOCK_BLOCKHASH_LIFETIME_CONSTRAINT = {
 
 describe('getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPORT', () => {
     let sendSimulateTransactionRequest: jest.Mock;
-    let mockTransactionMessage: ITransactionMessageWithFeePayer & TransactionMessage;
+    let mockTransactionMessage: TransactionMessage & TransactionMessageWithFeePayer;
     let rpc: Rpc<SimulateTransactionApi>;
     let simulateTransaction: jest.Mock;
     beforeEach(() => {

--- a/packages/kit/src/compute-limit-internal.ts
+++ b/packages/kit/src/compute-limit-internal.ts
@@ -19,9 +19,9 @@ import {
     CompilableTransactionMessage,
     isDurableNonceTransaction,
     isTransactionMessageWithBlockhashLifetime,
-    ITransactionMessageWithFeePayer,
     setTransactionMessageLifetimeUsingBlockhash,
     TransactionMessage,
+    TransactionMessageWithFeePayer,
 } from '@solana/transaction-messages';
 import { compileTransaction, getBase64EncodedWireTransaction } from '@solana/transactions';
 
@@ -42,7 +42,7 @@ type ComputeUnitEstimateForTransactionMessageConfig = Readonly<{
      */
     minContextSlot?: Slot;
     rpc: Rpc<SimulateTransactionApi>;
-    transactionMessage: CompilableTransactionMessage | (ITransactionMessageWithFeePayer & TransactionMessage);
+    transactionMessage: CompilableTransactionMessage | (TransactionMessage & TransactionMessageWithFeePayer);
 }>;
 
 const COMPUTE_BUDGET_PROGRAM_ADDRESS =

--- a/packages/kit/src/compute-limit.ts
+++ b/packages/kit/src/compute-limit.ts
@@ -1,8 +1,8 @@
 import { Rpc, SimulateTransactionApi } from '@solana/rpc';
 import {
     CompilableTransactionMessage,
-    ITransactionMessageWithFeePayer,
     TransactionMessage,
+    TransactionMessageWithFeePayer,
 } from '@solana/transaction-messages';
 
 import { getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPORT } from './compute-limit-internal';
@@ -12,7 +12,7 @@ type ComputeUnitEstimateForTransactionMessageFactoryConfig = Readonly<{
     rpc: Rpc<SimulateTransactionApi>;
 }>;
 type ComputeUnitEstimateForTransactionMessageFunction = (
-    transactionMessage: CompilableTransactionMessage | (ITransactionMessageWithFeePayer & TransactionMessage),
+    transactionMessage: CompilableTransactionMessage | (TransactionMessage & TransactionMessageWithFeePayer),
     config?: Omit<
         Parameters<typeof getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
         'rpc' | 'transactionMessage'

--- a/packages/signers/README.md
+++ b/packages/signers/README.md
@@ -435,12 +435,12 @@ const myInstructionWithSigners: IInstruction & IInstructionWithSigners = {
 };
 ```
 
-#### `ITransactionMessageWithSigners`
+#### `TransactionMessageWithSigners`
 
 Composable type that allows `IAccountSignerMetas` to be used inside all of the transaction message's account metas.
 
 ```ts
-const myTransactionMessageWithSigners: BaseTransactionMessage & ITransactionMessageWithSigners = {
+const myTransactionMessageWithSigners: BaseTransactionMessage & TransactionMessageWithSigners = {
     instructions: [
         myInstructionA as IInstruction & IInstructionWithSigners,
         myInstructionB as IInstruction & IInstructionWithSigners,
@@ -552,7 +552,7 @@ const mySignedTransaction = await signTransactionMessageWithSigners(myTransactio
 });
 
 // We now know the transaction is fully signed.
-mySignedTransaction satisfies IFullySignedTransaction;
+mySignedTransaction satisfies FullySignedTransaction;
 ```
 
 #### `signAndSendTransactionMessageWithSigners()`

--- a/packages/signers/src/__tests__/__setup__.ts
+++ b/packages/signers/src/__tests__/__setup__.ts
@@ -9,7 +9,7 @@ import {
     setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/transaction-messages';
 
-import { IAccountSignerMeta, IInstructionWithSigners, ITransactionMessageWithSigners } from '../account-signer-meta';
+import { IAccountSignerMeta, IInstructionWithSigners, TransactionMessageWithSigners } from '../account-signer-meta';
 import { MessageModifyingSigner } from '../message-modifying-signer';
 import { MessagePartialSigner } from '../message-partial-signer';
 import { TransactionModifyingSigner } from '../transaction-modifying-signer';
@@ -29,7 +29,7 @@ export function createMockInstructionWithSigners(signers: TransactionSigner[]): 
 
 export function createMockTransactionMessageWithSigners(
     signers: TransactionSigner[],
-): CompilableTransactionMessage & ITransactionMessageWithSigners {
+): CompilableTransactionMessage & TransactionMessageWithSigners {
     const transaction = createTransactionMessage({ version: 0 });
     const transactionWithFeePayer = setTransactionMessageFeePayer(signers[0]?.address ?? '1111', transaction);
     const compilableTransaction = setTransactionMessageLifetimeUsingBlockhash(

--- a/packages/signers/src/__tests__/add-signers-test.ts
+++ b/packages/signers/src/__tests__/add-signers-test.ts
@@ -3,11 +3,11 @@ import '@solana/test-matchers/toBeFrozenObject';
 import { Address } from '@solana/addresses';
 import { SOLANA_ERROR__SIGNER__ADDRESS_CANNOT_HAVE_MULTIPLE_SIGNERS, SolanaError } from '@solana/errors';
 import { AccountRole, IInstruction } from '@solana/instructions';
-import { BaseTransactionMessage, ITransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
 import { IAccountSignerMeta, IInstructionWithSigners } from '../account-signer-meta';
 import { addSignersToInstruction, addSignersToTransactionMessage } from '../add-signers';
-import { ITransactionMessageWithFeePayerSigner } from '../fee-payer-signer';
+import { TransactionMessageWithFeePayerSigner } from '../fee-payer-signer';
 import { createMockTransactionModifyingSigner, createMockTransactionPartialSigner } from './__setup__';
 
 describe('addSignersToInstruction', () => {
@@ -193,7 +193,7 @@ describe('addSignersToTransactionMessage', () => {
 
     it('updates the fee payer if a matching signer is provided', () => {
         // Given a transaction with a fee payer address.
-        const transaction: BaseTransactionMessage & ITransactionMessageWithFeePayer = {
+        const transaction: BaseTransactionMessage & TransactionMessageWithFeePayer = {
             feePayer: { address: '1111' as Address },
             instructions: [],
             version: 0,
@@ -215,7 +215,7 @@ describe('addSignersToTransactionMessage', () => {
         const signerB = createMockTransactionModifyingSigner('1111' as Address);
 
         // And a transaction using fee payer signer A.
-        const transaction: BaseTransactionMessage & ITransactionMessageWithFeePayerSigner = {
+        const transaction: BaseTransactionMessage & TransactionMessageWithFeePayerSigner = {
             feePayer: signerA,
             instructions: [],
             version: 0,

--- a/packages/signers/src/__tests__/fee-payer-signer-test.ts
+++ b/packages/signers/src/__tests__/fee-payer-signer-test.ts
@@ -1,9 +1,9 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
 import { Address } from '@solana/addresses';
-import { BaseTransactionMessage, ITransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
-import { ITransactionMessageWithFeePayerSigner, setTransactionMessageFeePayerSigner } from '../fee-payer-signer';
+import { setTransactionMessageFeePayerSigner, TransactionMessageWithFeePayerSigner } from '../fee-payer-signer';
 import { TransactionSigner } from '../transaction-signer';
 import { createMockTransactionPartialSigner } from './__setup__';
 
@@ -21,7 +21,7 @@ describe('setTransactionMessageFeePayerSigner', () => {
         expect(txWithFeePayerA).toHaveProperty('feePayer', feePayerA);
     });
     describe('given a transaction with a fee payer signer already set', () => {
-        let txWithFeePayerA: BaseTransactionMessage & ITransactionMessageWithFeePayerSigner;
+        let txWithFeePayerA: BaseTransactionMessage & TransactionMessageWithFeePayerSigner;
         beforeEach(() => {
             txWithFeePayerA = { ...baseTx, feePayer: feePayerA };
         });
@@ -36,7 +36,7 @@ describe('setTransactionMessageFeePayerSigner', () => {
         });
     });
     describe('given a transaction with a non-signer fee payer already set', () => {
-        let txWithFeePayerA: BaseTransactionMessage & ITransactionMessageWithFeePayer;
+        let txWithFeePayerA: BaseTransactionMessage & TransactionMessageWithFeePayer;
         beforeEach(() => {
             txWithFeePayerA = { ...baseTx, feePayer: { address: feePayerA.address } };
         });

--- a/packages/signers/src/__tests__/sign-transaction-test.ts
+++ b/packages/signers/src/__tests__/sign-transaction-test.ts
@@ -23,7 +23,7 @@ import {
 } from '../sign-transaction';
 import {
     assertIsTransactionMessageWithSingleSendingSigner,
-    ITransactionMessageWithSingleSendingSigner,
+    TransactionMessageWithSingleSendingSigner,
 } from '../transaction-with-single-sending-signer';
 import {
     createMockTransactionCompositeSigner,
@@ -590,7 +590,7 @@ describe('signAndSendTransactionMessageWithSigners', () => {
 
         // When we try to force sign and send this transaction.
         const promise = signAndSendTransactionMessageWithSigners(
-            transactionMessage as ITransactionMessageWithSingleSendingSigner & typeof transactionMessage,
+            transactionMessage as TransactionMessageWithSingleSendingSigner & typeof transactionMessage,
         );
 
         // Then we expect an error letting us know no sending mechanism was provided.

--- a/packages/signers/src/__typetests__/add-signers-typetest.ts
+++ b/packages/signers/src/__typetests__/add-signers-typetest.ts
@@ -1,7 +1,7 @@
 import { IInstruction } from '@solana/instructions';
 import { TransactionMessage } from '@solana/transaction-messages';
 
-import { IInstructionWithSigners, ITransactionMessageWithSigners } from '../account-signer-meta';
+import { IInstructionWithSigners, TransactionMessageWithSigners } from '../account-signer-meta';
 import { addSignersToInstruction, addSignersToTransactionMessage } from '../add-signers';
 import { TransactionSigner } from '../transaction-signer';
 
@@ -25,6 +25,6 @@ const message = null as unknown as TransactionMessage;
     // It adds the `WithSigners` type expansion to the transaction message
     {
         const messageWithSigners = addSignersToTransactionMessage([aliceSigner, bobSigner], message);
-        messageWithSigners satisfies ITransactionMessageWithSigners;
+        messageWithSigners satisfies TransactionMessageWithSigners;
     }
 }

--- a/packages/signers/src/__typetests__/fee-payer-typetest.ts
+++ b/packages/signers/src/__typetests__/fee-payer-typetest.ts
@@ -1,6 +1,6 @@
-import { ITransactionMessageWithFeePayer, TransactionMessage } from '@solana/transaction-messages';
+import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
-import { ITransactionMessageWithFeePayerSigner, setTransactionMessageFeePayerSigner } from '../fee-payer-signer';
+import { setTransactionMessageFeePayerSigner, TransactionMessageWithFeePayerSigner } from '../fee-payer-signer';
 import { TransactionSigner } from '../transaction-signer';
 
 const aliceSigner = null as unknown as TransactionSigner<'alice'>;
@@ -13,29 +13,29 @@ const message = null as unknown as TransactionMessage;
     // It adds the fee payer signer to the new message
     {
         const messageWithFeePayer = setTransactionMessageFeePayerSigner(aliceSigner, message);
-        messageWithFeePayer satisfies ITransactionMessageWithFeePayerSigner<'alice'>;
+        messageWithFeePayer satisfies TransactionMessageWithFeePayerSigner<'alice'>;
     }
 
     // It *replaces* an existing fee payer signer with the new one
     {
-        const messageWithAliceFeePayerSigner = null as unknown as ITransactionMessageWithFeePayerSigner<'alice'> &
-            TransactionMessage;
+        const messageWithAliceFeePayerSigner = null as unknown as TransactionMessage &
+            TransactionMessageWithFeePayerSigner<'alice'>;
         const messageWithBobFeePayerSigner = setTransactionMessageFeePayerSigner(
             bobSigner,
             messageWithAliceFeePayerSigner,
         );
         // @ts-expect-error Alice should no longer be a payer.
-        messageWithBobFeePayerSigner satisfies ITransactionMessageWithFeePayerSigner<'alice'>;
-        messageWithBobFeePayerSigner satisfies ITransactionMessageWithFeePayerSigner<'bob'>;
+        messageWithBobFeePayerSigner satisfies TransactionMessageWithFeePayerSigner<'alice'>;
+        messageWithBobFeePayerSigner satisfies TransactionMessageWithFeePayerSigner<'bob'>;
     }
 
     // It *replaces* an existing fee payer address with the new signer
     {
-        const messageWithMalloryFeePayer = null as unknown as ITransactionMessageWithFeePayer<'mallory'> &
-            TransactionMessage;
+        const messageWithMalloryFeePayer = null as unknown as TransactionMessage &
+            TransactionMessageWithFeePayer<'mallory'>;
         const messageWithBobFeePayerSigner = setTransactionMessageFeePayerSigner(bobSigner, messageWithMalloryFeePayer);
         // @ts-expect-error Mallory should no longer be a payer.
-        messageWithBobFeePayerSigner satisfies ITransactionMessageWithFeePayer<'mallory'>;
-        messageWithBobFeePayerSigner satisfies ITransactionMessageWithFeePayerSigner<'bob'>;
+        messageWithBobFeePayerSigner satisfies TransactionMessageWithFeePayer<'mallory'>;
+        messageWithBobFeePayerSigner satisfies TransactionMessageWithFeePayerSigner<'bob'>;
     }
 }

--- a/packages/signers/src/__typetests__/sign-transaction-typetest.ts
+++ b/packages/signers/src/__typetests__/sign-transaction-typetest.ts
@@ -13,15 +13,15 @@ import {
     TransactionWithLifetime,
 } from '@solana/transactions';
 
-import { ITransactionMessageWithSigners } from '../account-signer-meta';
+import { TransactionMessageWithSigners } from '../account-signer-meta';
 import {
     partiallySignTransactionMessageWithSigners,
     signAndSendTransactionMessageWithSigners,
     signTransactionMessageWithSigners,
 } from '../sign-transaction';
-import { ITransactionMessageWithSingleSendingSigner } from '../transaction-with-single-sending-signer';
+import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-single-sending-signer';
 
-type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & ITransactionMessageWithSigners;
+type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & TransactionMessageWithSigners;
 
 {
     // [partiallySignTransactionMessageWithSigners]: returns a transaction with a blockhash lifetime
@@ -78,6 +78,6 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & IT
 {
     // [signAndSendTransactionMessageWithSigners]: returns a signature
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
-        ITransactionMessageWithSingleSendingSigner;
+        TransactionMessageWithSingleSendingSigner;
     signAndSendTransactionMessageWithSigners(transactionMessage) satisfies Promise<SignatureBytes>;
 }

--- a/packages/signers/src/account-signer-meta.ts
+++ b/packages/signers/src/account-signer-meta.ts
@@ -1,12 +1,12 @@
 import { AccountRole, IAccountLookupMeta, IAccountMeta, IInstruction } from '@solana/instructions';
 import {
     BaseTransactionMessage,
-    ITransactionMessageWithFeePayer,
+    TransactionMessageWithFeePayer,
     TransactionVersion,
 } from '@solana/transaction-messages';
 
 import { deduplicateSigners } from './deduplicate-signers';
-import { ITransactionMessageWithFeePayerSigner } from './fee-payer-signer';
+import { TransactionMessageWithFeePayerSigner } from './fee-payer-signer';
 import { isTransactionSigner, TransactionSigner } from './transaction-signer';
 
 /**
@@ -103,22 +103,22 @@ export type IInstructionWithSigners<
  * ```ts
  * import { IInstruction } from '@solana/instructions';
  * import { BaseTransactionMessage } from '@solana/transaction-messages';
- * import { generateKeyPairSigner, IInstructionWithSigners, ITransactionMessageWithSigners } from '@solana/signers';
+ * import { generateKeyPairSigner, IInstructionWithSigners, TransactionMessageWithSigners } from '@solana/signers';
  *
  * const signer = await generateKeyPairSigner();
  * const firstInstruction: IInstruction = { ... };
  * const secondInstruction: IInstructionWithSigners = { ... };
- * const transactionMessage: BaseTransactionMessage & ITransactionMessageWithSigners = {
+ * const transactionMessage: BaseTransactionMessage & TransactionMessageWithSigners = {
  *     feePayer: signer,
  *     instructions: [firstInstruction, secondInstruction],
  * }
  * ```
  */
-export type ITransactionMessageWithSigners<
+export type TransactionMessageWithSigners<
     TAddress extends string = string,
     TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
     TAccounts extends readonly IAccountMetaWithSigner<TSigner>[] = readonly IAccountMetaWithSigner<TSigner>[],
-> = Partial<ITransactionMessageWithFeePayer<TAddress> | ITransactionMessageWithFeePayerSigner<TAddress, TSigner>> &
+> = Partial<TransactionMessageWithFeePayer<TAddress> | TransactionMessageWithFeePayerSigner<TAddress, TSigner>> &
     Pick<
         BaseTransactionMessage<TransactionVersion, IInstruction & IInstructionWithSigners<TSigner, TAccounts>>,
         'instructions'
@@ -160,7 +160,7 @@ export function getSignersFromInstruction<TSigner extends TransactionSigner = Tr
 
 /**
  * Extracts and deduplicates all {@link TransactionSigner | TransactionSigners} stored
- * inside a given {@link ITransactionMessageWithSigners | transaction message}.
+ * inside a given {@link TransactionMessageWithSigners | transaction message}.
  *
  * This includes any {@link TransactionSigner | TransactionSigners} stored
  * as the fee payer or in the instructions of the transaction message.
@@ -174,7 +174,7 @@ export function getSignersFromInstruction<TSigner extends TransactionSigner = Tr
  * @example
  * ```ts
  * import { IInstruction } from '@solana/instructions';
- * import { IInstructionWithSigners, ITransactionMessageWithSigners, getSignersFromTransactionMessage } from '@solana/signers';
+ * import { IInstructionWithSigners, TransactionMessageWithSigners, getSignersFromTransactionMessage } from '@solana/signers';
  *
  * const signerA = { address: address('1111..1111'), signTransactions: async () => {} };
  * const signerB = { address: address('2222..2222'), signTransactions: async () => {} };
@@ -186,7 +186,7 @@ export function getSignersFromInstruction<TSigner extends TransactionSigner = Tr
  *     programAddress: address('1234..5678'),
  *     accounts: [{ address: signerB.address, signer: signerB, ... }],
  * };
- * const transactionMessage: ITransactionMessageWithSigners = {
+ * const transactionMessage: TransactionMessageWithSigners = {
  *     feePayer: signerA,
  *     instructions: [firstInstruction, secondInstruction],
  * }
@@ -198,7 +198,7 @@ export function getSignersFromInstruction<TSigner extends TransactionSigner = Tr
 export function getSignersFromTransactionMessage<
     TAddress extends string = string,
     TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
-    TTransactionMessage extends ITransactionMessageWithSigners<TAddress, TSigner> = ITransactionMessageWithSigners<
+    TTransactionMessage extends TransactionMessageWithSigners<TAddress, TSigner> = TransactionMessageWithSigners<
         TAddress,
         TSigner
     >,

--- a/packages/signers/src/add-signers.ts
+++ b/packages/signers/src/add-signers.ts
@@ -1,8 +1,8 @@
 import { Address } from '@solana/addresses';
 import { IInstruction, isSignerRole } from '@solana/instructions';
-import { BaseTransactionMessage, ITransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
-import { IAccountSignerMeta, IInstructionWithSigners, ITransactionMessageWithSigners } from './account-signer-meta';
+import { IAccountSignerMeta, IInstructionWithSigners, TransactionMessageWithSigners } from './account-signer-meta';
 import { deduplicateSigners } from './deduplicate-signers';
 import { isTransactionSigner, TransactionSigner } from './transaction-signer';
 
@@ -106,14 +106,14 @@ export function addSignersToInstruction<TInstruction extends IInstruction>(
  */
 export function addSignersToTransactionMessage<TTransactionMessage extends BaseTransactionMessage>(
     signers: TransactionSigner[],
-    transactionMessage: TTransactionMessage | (ITransactionMessageWithSigners & TTransactionMessage),
-): ITransactionMessageWithSigners & TTransactionMessage {
+    transactionMessage: TTransactionMessage | (TransactionMessageWithSigners & TTransactionMessage),
+): TransactionMessageWithSigners & TTransactionMessage {
     const feePayerSigner = hasAddressOnlyFeePayer(transactionMessage)
         ? signers.find(signer => signer.address === transactionMessage.feePayer.address)
         : undefined;
 
     if (!feePayerSigner && transactionMessage.instructions.length === 0) {
-        return transactionMessage as ITransactionMessageWithSigners & TTransactionMessage;
+        return transactionMessage as TransactionMessageWithSigners & TTransactionMessage;
     }
 
     return Object.freeze({
@@ -124,7 +124,7 @@ export function addSignersToTransactionMessage<TTransactionMessage extends BaseT
 }
 
 function hasAddressOnlyFeePayer(
-    message: BaseTransactionMessage & Partial<ITransactionMessageWithFeePayer>,
+    message: BaseTransactionMessage & Partial<TransactionMessageWithFeePayer>,
 ): message is BaseTransactionMessage & { feePayer: { address: Address } } {
     return (
         !!message &&

--- a/packages/signers/src/deprecated.ts
+++ b/packages/signers/src/deprecated.ts
@@ -1,0 +1,95 @@
+import type { IAccountLookupMeta, IAccountMeta } from '@solana/instructions';
+import type { Brand } from '@solana/nominal-types';
+
+import type { IAccountSignerMeta, TransactionMessageWithSigners } from './account-signer-meta';
+import type { TransactionSigner } from './transaction-signer';
+
+/**
+ * A {@link BaseTransactionMessage} type extension that accept {@link TransactionSigner | TransactionSigners}.
+ *
+ * Namely, it allows:
+ * - a {@link TransactionSigner} to be used as the fee payer and
+ * - {@link IInstructionWithSigners} to be used in its instructions.
+ *
+ * @deprecated Use {@link TransactionMessageWithSigners} instead. It was only renamed.
+ *
+ * @typeParam TAddress - Supply a string literal to define an account having a particular address.
+ * @typeParam TSigner - Optionally provide a narrower type for {@link TransactionSigner | TransactionSigners}.
+ * @typeParam TAccounts - Optionally provide a narrower type for the account metas.
+ *
+ * @example
+ * ```ts
+ * import { IInstruction } from '@solana/instructions';
+ * import { BaseTransactionMessage } from '@solana/transaction-messages';
+ * import { generateKeyPairSigner, IInstructionWithSigners, ITransactionMessageWithSigners } from '@solana/signers';
+ *
+ * const signer = await generateKeyPairSigner();
+ * const firstInstruction: IInstruction = { ... };
+ * const secondInstruction: IInstructionWithSigners = { ... };
+ * const transactionMessage: BaseTransactionMessage & ITransactionMessageWithSigners = {
+ *     feePayer: signer,
+ *     instructions: [firstInstruction, secondInstruction],
+ * }
+ * ```
+ */
+export type ITransactionMessageWithSigners<
+    TAddress extends string = string,
+    TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
+    TAccounts extends readonly IAccountMetaWithSigner<TSigner>[] = readonly IAccountMetaWithSigner<TSigner>[],
+> = TransactionMessageWithSigners<TAddress, TSigner, TAccounts>;
+
+type IAccountMetaWithSigner<TSigner extends TransactionSigner = TransactionSigner> =
+    | IAccountLookupMeta
+    | IAccountMeta
+    | IAccountSignerMeta<string, TSigner>;
+
+/**
+ * Alternative to {@link TransactionMessageWithFeePayer} that uses a {@link TransactionSigner} for the fee payer.
+ *
+ * @deprecated Use {@link TransactionMessageWithFeePayer} instead. It was only renamed.
+ *
+ * @typeParam TAddress - Supply a string literal to define a fee payer having a particular address.
+ * @typeParam TSigner - Optionally provide a narrower type for the {@link TransactionSigner}.
+ *
+ * @example
+ * ```ts
+ * import { BaseTransactionMessage } from '@solana/transaction-messages';
+ * import { generateKeyPairSigner, ITransactionMessageWithFeePayerSigner } from '@solana/signers';
+ *
+ * const transactionMessage: BaseTransactionMessage & ITransactionMessageWithFeePayerSigner = {
+ *     feePayer: await generateKeyPairSigner(),
+ *     instructions: [],
+ *     version: 0,
+ * };
+ * ```
+ */
+export interface ITransactionMessageWithFeePayerSigner<
+    TAddress extends string = string,
+    TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
+> {
+    readonly feePayer: TSigner;
+}
+
+/**
+ * Defines a transaction message with exactly one {@link TransactionSendingSigner}.
+ *
+ * This type is used to narrow the type of transaction messages that have been
+ * checked to have exactly one sending signer.
+ *
+ * @deprecated Use {@link TransactionMessageWithSingleSendingSigner} instead. It was only renamed.
+ *
+ * @example
+ * ```ts
+ * import { assertIsTransactionMessageWithSingleSendingSigner } from '@solana/signers';
+ *
+ * assertIsTransactionMessageWithSingleSendingSigner(transactionMessage);
+ * transactionMessage satisfies ITransactionMessageWithSingleSendingSigner;
+ * ```
+ *
+ * @see {@link isTransactionMessageWithSingleSendingSigner}
+ * @see {@link assertIsTransactionMessageWithSingleSendingSigner}
+ */
+export type ITransactionMessageWithSingleSendingSigner = Brand<
+    TransactionMessageWithSigners,
+    'TransactionMessageWithSingleSendingSigner'
+>;

--- a/packages/signers/src/fee-payer-signer.ts
+++ b/packages/signers/src/fee-payer-signer.ts
@@ -1,9 +1,9 @@
-import { BaseTransactionMessage, ITransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
 import { TransactionSigner } from './transaction-signer';
 
 /**
- * Alternative to {@link ITransactionMessageWithFeePayer} that uses a {@link TransactionSigner} for the fee payer.
+ * Alternative to {@link TransactionMessageWithFeePayer} that uses a {@link TransactionSigner} for the fee payer.
  *
  * @typeParam TAddress - Supply a string literal to define a fee payer having a particular address.
  * @typeParam TSigner - Optionally provide a narrower type for the {@link TransactionSigner}.
@@ -11,16 +11,16 @@ import { TransactionSigner } from './transaction-signer';
  * @example
  * ```ts
  * import { BaseTransactionMessage } from '@solana/transaction-messages';
- * import { generateKeyPairSigner, ITransactionMessageWithFeePayerSigner } from '@solana/signers';
+ * import { generateKeyPairSigner, TransactionMessageWithFeePayerSigner } from '@solana/signers';
  *
- * const transactionMessage: BaseTransactionMessage & ITransactionMessageWithFeePayerSigner = {
+ * const transactionMessage: BaseTransactionMessage & TransactionMessageWithFeePayerSigner = {
  *     feePayer: await generateKeyPairSigner(),
  *     instructions: [],
  *     version: 0,
  * };
  * ```
  */
-export interface ITransactionMessageWithFeePayerSigner<
+export interface TransactionMessageWithFeePayerSigner<
     TAddress extends string = string,
     TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
 > {
@@ -50,11 +50,11 @@ export interface ITransactionMessageWithFeePayerSigner<
 export function setTransactionMessageFeePayerSigner<
     TFeePayerAddress extends string,
     TTransactionMessage extends BaseTransactionMessage &
-        Partial<ITransactionMessageWithFeePayer | ITransactionMessageWithFeePayerSigner>,
+        Partial<TransactionMessageWithFeePayer | TransactionMessageWithFeePayerSigner>,
 >(
     feePayer: TransactionSigner<TFeePayerAddress>,
     transactionMessage: TTransactionMessage,
-): ITransactionMessageWithFeePayerSigner<TFeePayerAddress> & Omit<TTransactionMessage, 'feePayer'> {
+): Omit<TTransactionMessage, 'feePayer'> & TransactionMessageWithFeePayerSigner<TFeePayerAddress> {
     Object.freeze(feePayer);
     const out = { ...transactionMessage, feePayer };
     Object.freeze(out);

--- a/packages/signers/src/index.ts
+++ b/packages/signers/src/index.ts
@@ -90,3 +90,6 @@ export * from './transaction-sending-signer';
 export * from './transaction-signer';
 export * from './transaction-with-single-sending-signer';
 export * from './types';
+
+// Remove in the next major version.
+export * from './deprecated';

--- a/packages/signers/src/sign-transaction.ts
+++ b/packages/signers/src/sign-transaction.ts
@@ -15,7 +15,7 @@ import {
     TransactionWithLifetime,
 } from '@solana/transactions';
 
-import { getSignersFromTransactionMessage, ITransactionMessageWithSigners } from './account-signer-meta';
+import { getSignersFromTransactionMessage, TransactionMessageWithSigners } from './account-signer-meta';
 import { deduplicateSigners } from './deduplicate-signers';
 import {
     isTransactionModifyingSigner,
@@ -35,7 +35,7 @@ import {
 import { isTransactionSigner, TransactionSigner } from './transaction-signer';
 import { assertIsTransactionMessageWithSingleSendingSigner } from './transaction-with-single-sending-signer';
 
-type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & ITransactionMessageWithSigners;
+type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & TransactionMessageWithSigners;
 
 /**
  * Extracts all {@link TransactionSigner | TransactionSigners} inside the provided
@@ -135,7 +135,7 @@ export async function partiallySignTransactionMessageWithSigners<
  * });
  *
  * // We now know the transaction is fully signed.
- * mySignedTransaction satisfies IFullySignedTransaction;
+ * mySignedTransaction satisfies FullySignedTransaction;
  * ```
  *
  * @see {@link partiallySignTransactionMessageWithSigners}

--- a/packages/signers/src/transaction-with-single-sending-signer.ts
+++ b/packages/signers/src/transaction-with-single-sending-signer.ts
@@ -6,7 +6,7 @@ import {
 import { Brand } from '@solana/nominal-types';
 import { CompilableTransactionMessage } from '@solana/transaction-messages';
 
-import { getSignersFromTransactionMessage, ITransactionMessageWithSigners } from './account-signer-meta';
+import { getSignersFromTransactionMessage, TransactionMessageWithSigners } from './account-signer-meta';
 import { isTransactionModifyingSigner } from './transaction-modifying-signer';
 import { isTransactionPartialSigner } from './transaction-partial-signer';
 import { isTransactionSendingSigner } from './transaction-sending-signer';
@@ -22,14 +22,14 @@ import { isTransactionSendingSigner } from './transaction-sending-signer';
  * import { assertIsTransactionMessageWithSingleSendingSigner } from '@solana/signers';
  *
  * assertIsTransactionMessageWithSingleSendingSigner(transactionMessage);
- * transactionMessage satisfies ITransactionMessageWithSingleSendingSigner;
+ * transactionMessage satisfies TransactionMessageWithSingleSendingSigner;
  * ```
  *
  * @see {@link isTransactionMessageWithSingleSendingSigner}
  * @see {@link assertIsTransactionMessageWithSingleSendingSigner}
  */
-export type ITransactionMessageWithSingleSendingSigner = Brand<
-    ITransactionMessageWithSigners,
+export type TransactionMessageWithSingleSendingSigner = Brand<
+    TransactionMessageWithSigners,
     'TransactionMessageWithSingleSendingSigner'
 >;
 
@@ -65,7 +65,7 @@ export type ITransactionMessageWithSingleSendingSigner = Brand<
  */
 export function isTransactionMessageWithSingleSendingSigner<TTransactionMessage extends CompilableTransactionMessage>(
     transaction: TTransactionMessage,
-): transaction is ITransactionMessageWithSingleSendingSigner & TTransactionMessage {
+): transaction is TransactionMessageWithSingleSendingSigner & TTransactionMessage {
     try {
         assertIsTransactionMessageWithSingleSendingSigner(transaction);
         return true;
@@ -100,7 +100,7 @@ export function assertIsTransactionMessageWithSingleSendingSigner<
     TTransactionMessage extends CompilableTransactionMessage,
 >(
     transaction: TTransactionMessage,
-): asserts transaction is ITransactionMessageWithSingleSendingSigner & TTransactionMessage {
+): asserts transaction is TransactionMessageWithSingleSendingSigner & TTransactionMessage {
     const signers = getSignersFromTransactionMessage(transaction);
     const sendingSigners = signers.filter(isTransactionSendingSigner);
 

--- a/packages/transaction-messages/README.md
+++ b/packages/transaction-messages/README.md
@@ -56,7 +56,7 @@ const message = createTransactionMessage({ version: 0 });
 
 ### Types
 
-#### `ITransactionMessageWithFeePayer`
+#### `TransactionMessageWithFeePayer`
 
 This type represents a transaction message for which a fee payer has been declared. A transaction must conform to this type to be compiled and landed on the network.
 
@@ -64,7 +64,7 @@ This type represents a transaction message for which a fee payer has been declar
 
 #### `setTransactionMessageFeePayer()`
 
-Given a base58-encoded address of a system account, this method will return a new transaction message having the same type as the one supplied plus the `ITransactionMessageWithFeePayer` type.
+Given a base58-encoded address of a system account, this method will return a new transaction message having the same type as the one supplied plus the `TransactionMessageWithFeePayer` type.
 
 ```ts
 import { address } from '@solana/addresses';

--- a/packages/transaction-messages/src/__tests__/fee-payer-test.ts
+++ b/packages/transaction-messages/src/__tests__/fee-payer-test.ts
@@ -2,7 +2,7 @@ import '@solana/test-matchers/toBeFrozenObject';
 
 import { Address } from '@solana/addresses';
 
-import { ITransactionMessageWithFeePayer, setTransactionMessageFeePayer } from '../fee-payer';
+import { setTransactionMessageFeePayer, TransactionMessageWithFeePayer } from '../fee-payer';
 import { BaseTransactionMessage } from '../transaction-message';
 
 const EXAMPLE_FEE_PAYER_A =
@@ -23,7 +23,7 @@ describe('setTransactionMessageFeePayer', () => {
         expect(txWithFeePayerA).toHaveProperty('feePayer', { address: EXAMPLE_FEE_PAYER_A });
     });
     describe('given a transaction with a fee payer already set', () => {
-        let txWithFeePayerA: BaseTransactionMessage & ITransactionMessageWithFeePayer;
+        let txWithFeePayerA: BaseTransactionMessage & TransactionMessageWithFeePayer;
         beforeEach(() => {
             txWithFeePayerA = {
                 ...baseTx,

--- a/packages/transaction-messages/src/__typetests__/fee-payer-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/fee-payer-typetest.ts
@@ -1,6 +1,6 @@
 import { Address } from '@solana/addresses';
 
-import { ITransactionMessageWithFeePayer, setTransactionMessageFeePayer } from '../fee-payer';
+import { setTransactionMessageFeePayer, TransactionMessageWithFeePayer } from '../fee-payer';
 import { TransactionMessage } from '../transaction-message';
 
 const aliceAddress = 'alice' as Address<'alice'>;
@@ -13,16 +13,16 @@ const message = null as unknown as TransactionMessage;
     // It adds the fee payer to the new message
     {
         const messageWithFeePayer = setTransactionMessageFeePayer(aliceAddress, message);
-        messageWithFeePayer satisfies ITransactionMessageWithFeePayer<'alice'>;
+        messageWithFeePayer satisfies TransactionMessageWithFeePayer<'alice'>;
     }
 
     // It *replaces* an existing fee payer with the new one
     {
-        const messageWithAliceFeePayer = null as unknown as ITransactionMessageWithFeePayer<'alice'> &
-            TransactionMessage;
+        const messageWithAliceFeePayer = null as unknown as TransactionMessage &
+            TransactionMessageWithFeePayer<'alice'>;
         const messageWithBobFeePayer = setTransactionMessageFeePayer(bobAddress, messageWithAliceFeePayer);
         // @ts-expect-error Alice should no longer be a payer.
-        messageWithBobFeePayer satisfies ITransactionMessageWithFeePayer<'alice'>;
-        messageWithBobFeePayer satisfies ITransactionMessageWithFeePayer<'bob'>;
+        messageWithBobFeePayer satisfies TransactionMessageWithFeePayer<'alice'>;
+        messageWithBobFeePayer satisfies TransactionMessageWithFeePayer<'bob'>;
     }
 }

--- a/packages/transaction-messages/src/__typetests__/transaction-message-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/transaction-message-typetest.ts
@@ -13,7 +13,7 @@ import {
     setTransactionMessageLifetimeUsingDurableNonce,
     TransactionMessageWithDurableNonceLifetime,
 } from '../durable-nonce';
-import { ITransactionMessageWithFeePayer, setTransactionMessageFeePayer } from '../fee-payer';
+import { setTransactionMessageFeePayer, TransactionMessageWithFeePayer } from '../fee-payer';
 import { appendTransactionMessageInstruction, prependTransactionMessageInstruction } from '../instructions';
 import { BaseTransactionMessage, TransactionMessage } from '../transaction-message';
 
@@ -120,79 +120,79 @@ setTransactionMessageLifetimeUsingDurableNonce(
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }>,
-) satisfies Extract<TransactionMessage, { version: 'legacy' }> & ITransactionMessageWithFeePayer<'feePayer'>;
+) satisfies Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithFeePayer<'feePayer'>;
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }> &
-        ITransactionMessageWithFeePayer<'NOTfeePayer'>,
-) satisfies Extract<TransactionMessage, { version: 'legacy' }> & ITransactionMessageWithFeePayer<'feePayer'>;
+        TransactionMessageWithFeePayer<'NOTfeePayer'>,
+) satisfies Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithFeePayer<'feePayer'>;
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }>,
     // @ts-expect-error Version should match
-) satisfies Extract<TransactionMessage, { version: 0 }> & ITransactionMessageWithFeePayer<'feePayer'>;
+) satisfies Extract<TransactionMessage, { version: 0 }> & TransactionMessageWithFeePayer<'feePayer'>;
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 0 }>,
-) satisfies Extract<TransactionMessage, { version: 0 }> & ITransactionMessageWithFeePayer<'feePayer'>;
+) satisfies Extract<TransactionMessage, { version: 0 }> & TransactionMessageWithFeePayer<'feePayer'>;
 
 // (blockhash)
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithBlockhashLifetime,
 ) satisfies Extract<TransactionMessage, { version: 'legacy' }> &
-    ITransactionMessageWithFeePayer<'feePayer'> &
-    TransactionMessageWithBlockhashLifetime;
+    TransactionMessageWithBlockhashLifetime &
+    TransactionMessageWithFeePayer<'feePayer'>;
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }> &
-        ITransactionMessageWithFeePayer<'NOTfeePayer'> &
-        TransactionMessageWithBlockhashLifetime,
+        TransactionMessageWithBlockhashLifetime &
+        TransactionMessageWithFeePayer<'NOTfeePayer'>,
 ) satisfies Extract<TransactionMessage, { version: 'legacy' }> &
-    ITransactionMessageWithFeePayer<'feePayer'> &
-    TransactionMessageWithBlockhashLifetime;
+    TransactionMessageWithBlockhashLifetime &
+    TransactionMessageWithFeePayer<'feePayer'>;
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithBlockhashLifetime,
     // @ts-expect-error Version should match
 ) satisfies Extract<TransactionMessage, { version: 0 }> &
-    ITransactionMessageWithFeePayer<'feePayer'> &
-    TransactionMessageWithBlockhashLifetime;
+    TransactionMessageWithBlockhashLifetime &
+    TransactionMessageWithFeePayer<'feePayer'>;
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 0 }> & TransactionMessageWithBlockhashLifetime,
 ) satisfies Extract<TransactionMessage, { version: 0 }> &
-    ITransactionMessageWithFeePayer<'feePayer'> &
-    TransactionMessageWithBlockhashLifetime;
+    TransactionMessageWithBlockhashLifetime &
+    TransactionMessageWithFeePayer<'feePayer'>;
 
 // (durable nonce)
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithDurableNonceLifetime,
 ) satisfies Extract<TransactionMessage, { version: 'legacy' }> &
-    ITransactionMessageWithFeePayer<'feePayer'> &
-    TransactionMessageWithDurableNonceLifetime;
+    TransactionMessageWithDurableNonceLifetime &
+    TransactionMessageWithFeePayer<'feePayer'>;
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }> &
-        ITransactionMessageWithFeePayer<'NOTfeePayer'> &
-        TransactionMessageWithDurableNonceLifetime,
+        TransactionMessageWithDurableNonceLifetime &
+        TransactionMessageWithFeePayer<'NOTfeePayer'>,
 ) satisfies Extract<TransactionMessage, { version: 'legacy' }> &
-    ITransactionMessageWithFeePayer<'feePayer'> &
-    TransactionMessageWithDurableNonceLifetime;
+    TransactionMessageWithDurableNonceLifetime &
+    TransactionMessageWithFeePayer<'feePayer'>;
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithDurableNonceLifetime,
     // @ts-expect-error Version should match
 ) satisfies Extract<TransactionMessage, { version: 0 }> &
-    ITransactionMessageWithFeePayer<'feePayer'> &
-    TransactionMessageWithDurableNonceLifetime;
+    TransactionMessageWithDurableNonceLifetime &
+    TransactionMessageWithFeePayer<'feePayer'>;
 setTransactionMessageFeePayer(
     mockFeePayer,
     null as unknown as Extract<TransactionMessage, { version: 0 }> & TransactionMessageWithDurableNonceLifetime,
 ) satisfies Extract<TransactionMessage, { version: 0 }> &
-    ITransactionMessageWithFeePayer<'feePayer'> &
-    TransactionMessageWithDurableNonceLifetime;
+    TransactionMessageWithDurableNonceLifetime &
+    TransactionMessageWithFeePayer<'feePayer'>;
 
 // appendTransactionMessageInstruction
 appendTransactionMessageInstruction(
@@ -203,9 +203,9 @@ appendTransactionMessageInstruction(
 };
 appendTransactionMessageInstruction(
     mockInstruction,
-    null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & ITransactionMessageWithFeePayer<'feePayer'>,
+    null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithFeePayer<'feePayer'>,
 ) satisfies Extract<TransactionMessage, { version: 'legacy' }> &
-    ITransactionMessageWithFeePayer<'feePayer'> & {
+    TransactionMessageWithFeePayer<'feePayer'> & {
         instructions: TransactionMessage['instructions'];
     };
 
@@ -218,9 +218,9 @@ prependTransactionMessageInstruction(
 };
 prependTransactionMessageInstruction(
     mockInstruction,
-    null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & ITransactionMessageWithFeePayer<'feePayer'>,
+    null as unknown as Extract<TransactionMessage, { version: 'legacy' }> & TransactionMessageWithFeePayer<'feePayer'>,
 ) satisfies Extract<TransactionMessage, { version: 'legacy' }> &
-    ITransactionMessageWithFeePayer<'feePayer'> & {
+    TransactionMessageWithFeePayer<'feePayer'> & {
         instructions: TransactionMessage['instructions'];
     };
 
@@ -228,7 +228,7 @@ prependTransactionMessageInstruction(
 // @ts-expect-error missing fee payer + lifetime token
 null as unknown as BaseTransactionMessage satisfies CompilableTransactionMessage;
 // @ts-expect-error missing lifetime token
-null as unknown as BaseTransactionMessage & ITransactionMessageWithFeePayer satisfies CompilableTransactionMessage;
+null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer satisfies CompilableTransactionMessage;
 null as unknown as BaseTransactionMessage &
     // @ts-expect-error missing fee payer
     TransactionMessageWithBlockhashLifetime satisfies CompilableTransactionMessage;
@@ -238,8 +238,8 @@ null as unknown as BaseTransactionMessage &
     transactionMessage satisfies CompilableTransactionMessage;
 }
 null as unknown as BaseTransactionMessage &
-    ITransactionMessageWithFeePayer &
-    TransactionMessageWithBlockhashLifetime satisfies CompilableTransactionMessage;
+    TransactionMessageWithBlockhashLifetime &
+    TransactionMessageWithFeePayer satisfies CompilableTransactionMessage;
 null as unknown as BaseTransactionMessage &
-    ITransactionMessageWithFeePayer &
-    TransactionMessageWithDurableNonceLifetime satisfies CompilableTransactionMessage;
+    TransactionMessageWithDurableNonceLifetime &
+    TransactionMessageWithFeePayer satisfies CompilableTransactionMessage;

--- a/packages/transaction-messages/src/compilable-transaction-message.ts
+++ b/packages/transaction-messages/src/compilable-transaction-message.ts
@@ -2,7 +2,7 @@ import { IInstruction } from '@solana/instructions';
 
 import { TransactionMessageWithBlockhashLifetime } from './blockhash';
 import { TransactionMessageWithDurableNonceLifetime } from './durable-nonce';
-import { ITransactionMessageWithFeePayer } from './fee-payer';
+import { TransactionMessageWithFeePayer } from './fee-payer';
 import { BaseTransactionMessage, TransactionVersion } from './transaction-message';
 
 /**
@@ -14,5 +14,5 @@ export type CompilableTransactionMessage<
     TVersion extends TransactionVersion = TransactionVersion,
     TInstruction extends IInstruction = IInstruction,
 > = BaseTransactionMessage<TVersion, TInstruction> &
-    ITransactionMessageWithFeePayer &
+    TransactionMessageWithFeePayer &
     (TransactionMessageWithBlockhashLifetime | TransactionMessageWithDurableNonceLifetime);

--- a/packages/transaction-messages/src/deprecated.ts
+++ b/packages/transaction-messages/src/deprecated.ts
@@ -1,0 +1,11 @@
+import type { Address } from '@solana/addresses';
+
+/**
+ * Represents a transaction message for which a fee payer has been declared. A transaction must
+ * conform to this type to be compiled and landed on the network.
+ *
+ * @deprecated Use {@link TransactionMessageWithFeePayer} instead. It was only renamed.
+ */
+export interface ITransactionMessageWithFeePayer<TAddress extends string = string> {
+    readonly feePayer: Readonly<{ address: Address<TAddress> }>;
+}

--- a/packages/transaction-messages/src/fee-payer.ts
+++ b/packages/transaction-messages/src/fee-payer.ts
@@ -6,13 +6,13 @@ import { BaseTransactionMessage } from './transaction-message';
  * Represents a transaction message for which a fee payer has been declared. A transaction must
  * conform to this type to be compiled and landed on the network.
  */
-export interface ITransactionMessageWithFeePayer<TAddress extends string = string> {
+export interface TransactionMessageWithFeePayer<TAddress extends string = string> {
     readonly feePayer: Readonly<{ address: Address<TAddress> }>;
 }
 
 /**
  * Given a base58-encoded address of a system account, this method will return a new transaction
- * message having the same type as the one supplied plus the {@link ITransactionMessageWithFeePayer}
+ * message having the same type as the one supplied plus the {@link TransactionMessageWithFeePayer}
  * type.
  *
  * @example
@@ -26,18 +26,18 @@ export interface ITransactionMessageWithFeePayer<TAddress extends string = strin
  */
 export function setTransactionMessageFeePayer<
     TFeePayerAddress extends string,
-    TTransactionMessage extends BaseTransactionMessage & Partial<ITransactionMessageWithFeePayer>,
+    TTransactionMessage extends BaseTransactionMessage & Partial<TransactionMessageWithFeePayer>,
 >(
     feePayer: Address<TFeePayerAddress>,
     transactionMessage: TTransactionMessage,
-): ITransactionMessageWithFeePayer<TFeePayerAddress> & Omit<TTransactionMessage, 'feePayer'> {
+): Omit<TTransactionMessage, 'feePayer'> & TransactionMessageWithFeePayer<TFeePayerAddress> {
     if (
         'feePayer' in transactionMessage &&
         feePayer === transactionMessage.feePayer?.address &&
         isAddressOnlyFeePayer(transactionMessage.feePayer)
     ) {
-        return transactionMessage as unknown as ITransactionMessageWithFeePayer<TFeePayerAddress> &
-            Omit<TTransactionMessage, 'feePayer'>;
+        return transactionMessage as unknown as Omit<TTransactionMessage, 'feePayer'> &
+            TransactionMessageWithFeePayer<TFeePayerAddress>;
     }
     const out = {
         ...transactionMessage,
@@ -48,7 +48,7 @@ export function setTransactionMessageFeePayer<
 }
 
 function isAddressOnlyFeePayer(
-    feePayer: Partial<ITransactionMessageWithFeePayer>['feePayer'],
+    feePayer: Partial<TransactionMessageWithFeePayer>['feePayer'],
 ): feePayer is { address: Address } {
     return (
         !!feePayer &&

--- a/packages/transaction-messages/src/index.ts
+++ b/packages/transaction-messages/src/index.ts
@@ -39,3 +39,6 @@ export * from './durable-nonce';
 export * from './fee-payer';
 export * from './instructions';
 export * from './transaction-message';
+
+// Remove in the next major version.
+export * from './deprecated';

--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -26,7 +26,7 @@ Given a `TransactionMessage`, this function returns a `Transaction` object. This
 Whether a transaction message is ready to be compiled or not is enforced for you at the type level. In order to be signable, a transaction message must:
 
 - have a version and a list of zero or more instructions (ie. conform to `BaseTransactionMessage`)
-- have a fee payer set (ie. conform to `ITransactionMessageWithFeePayer`)
+- have a fee payer set (ie. conform to `TransactionMessageWithFeePayer`)
 - have a lifetime specified (ie. conform to `TransactionMessageWithBlockhashLifetime | TransactionMessageWithDurableNonceLifetime`)
 
 ## Signing transactions

--- a/packages/transactions/src/__typetests__/compile-transaction-typetest.ts
+++ b/packages/transactions/src/__typetests__/compile-transaction-typetest.ts
@@ -2,10 +2,10 @@ import { Blockhash } from '@solana/rpc-types';
 import {
     BaseTransactionMessage,
     CompilableTransactionMessage,
-    ITransactionMessageWithFeePayer,
     Nonce,
     TransactionMessageWithBlockhashLifetime,
     TransactionMessageWithDurableNonceLifetime,
+    TransactionMessageWithFeePayer,
 } from '@solana/transaction-messages';
 
 import { compileTransaction } from '../compile-transaction';
@@ -21,35 +21,35 @@ import { Transaction } from '../transaction';
 // transaction message with blockhash lifetime
 compileTransaction(
     null as unknown as BaseTransactionMessage &
-        ITransactionMessageWithFeePayer &
-        TransactionMessageWithBlockhashLifetime,
+        TransactionMessageWithBlockhashLifetime &
+        TransactionMessageWithFeePayer,
 ) satisfies Readonly<Transaction & TransactionWithLifetime>;
 compileTransaction(
     null as unknown as BaseTransactionMessage &
-        ITransactionMessageWithFeePayer &
-        TransactionMessageWithBlockhashLifetime,
+        TransactionMessageWithBlockhashLifetime &
+        TransactionMessageWithFeePayer,
 ) satisfies Readonly<Transaction & TransactionWithBlockhashLifetime>;
 compileTransaction(
     null as unknown as BaseTransactionMessage &
-        ITransactionMessageWithFeePayer &
-        TransactionMessageWithBlockhashLifetime,
+        TransactionMessageWithBlockhashLifetime &
+        TransactionMessageWithFeePayer,
 ).lifetimeConstraint.blockhash satisfies Blockhash;
 
 // transaction message with durable nonce lifetime
 compileTransaction(
     null as unknown as BaseTransactionMessage &
-        ITransactionMessageWithFeePayer &
-        TransactionMessageWithDurableNonceLifetime,
+        TransactionMessageWithDurableNonceLifetime &
+        TransactionMessageWithFeePayer,
 ) satisfies Readonly<Transaction & TransactionWithLifetime>;
 compileTransaction(
     null as unknown as BaseTransactionMessage &
-        ITransactionMessageWithFeePayer &
-        TransactionMessageWithDurableNonceLifetime,
+        TransactionMessageWithDurableNonceLifetime &
+        TransactionMessageWithFeePayer,
 ) satisfies Readonly<Transaction & TransactionWithDurableNonceLifetime>;
 compileTransaction(
     null as unknown as BaseTransactionMessage &
-        ITransactionMessageWithFeePayer &
-        TransactionMessageWithDurableNonceLifetime,
+        TransactionMessageWithDurableNonceLifetime &
+        TransactionMessageWithFeePayer,
 ).lifetimeConstraint.nonce satisfies Nonce;
 
 // transaction message with unknown lifetime

--- a/packages/transactions/src/compile-transaction.ts
+++ b/packages/transactions/src/compile-transaction.ts
@@ -26,7 +26,7 @@ import { SignaturesMap, Transaction, TransactionMessageBytes } from './transacti
  *
  * - have a version and a list of zero or more instructions (ie. conform to
  *   {@link BaseTransactionMessage})
- * - have a fee payer set (ie. conform to {@link ITransactionMessageWithFeePayer})
+ * - have a fee payer set (ie. conform to {@link TransactionMessageWithFeePayer})
  * - have a lifetime specified (ie. conform to {@link TransactionMessageWithBlockhashLifetime} or
  *   {@link TransactionMessageWithDurableNonceLifetime})
  */


### PR DESCRIPTION
Most of the types in the `transactions` and `transaction-messages` are not prefixed by the letter `I` apart from four of them. This PR makes them more consistent with the rest of the library by removing that prefix.