### PR TITLE
Rename DurableNonceLifetime helpers

### DIFF
--- a/.changeset/fast-ghosts-cover.md
+++ b/.changeset/fast-ghosts-cover.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-messages': minor
+---
+
+Rename `isDurableNonceTransaction` to `isTransactionMessageWithDurableNonceLifetime` and `assertIsDurableNonceTransactionMessage` to `assertIsTransactionMessageWithDurableNonceLifetime` for consistency with the blockhash lifetime. The old names are kept as aliases but marked as deprecated.

--- a/packages/kit/src/compute-limit-internal.ts
+++ b/packages/kit/src/compute-limit-internal.ts
@@ -17,8 +17,8 @@ import { Blockhash, Commitment, Slot } from '@solana/rpc-types';
 import {
     appendTransactionMessageInstruction,
     CompilableTransactionMessage,
-    isDurableNonceTransaction,
     isTransactionMessageWithBlockhashLifetime,
+    isTransactionMessageWithDurableNonceLifetime,
     setTransactionMessageLifetimeUsingBlockhash,
     TransactionMessage,
     TransactionMessageWithFeePayer,
@@ -142,7 +142,7 @@ export async function getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_
      * STEP 1: Make sure the transaction message will not fail in simulation for lack of a lifetime
      *         - either a recent blockhash lifetime or a nonce.
      */
-    const isDurableNonceTransactionMessage = isDurableNonceTransaction(transactionMessage);
+    const isDurableNonceTransactionMessage = isTransactionMessageWithDurableNonceLifetime(transactionMessage);
     let compilableTransactionMessage;
     if (isDurableNonceTransactionMessage || isTransactionMessageWithBlockhashLifetime(transactionMessage)) {
         compilableTransactionMessage = transactionMessage;

--- a/packages/transaction-messages/README.md
+++ b/packages/transaction-messages/README.md
@@ -171,9 +171,9 @@ function handleSubmit() {
 }
 ```
 
-#### `assertIsDurableNonceTransactionMessage()`
+#### `assertIsTransactionMessageWithDurableNonceLifetime()`
 
-From time to time you might acquire a transaction message that you expect to be a durable nonce transaction, from an untrusted network API or user input. To assert that such an arbitrary transaction is in fact a durable nonce transaction, use the `assertIsDurableNonceTransactionMessage` function.
+From time to time you might acquire a transaction message that you expect to be a durable nonce transaction, from an untrusted network API or user input. To assert that such an arbitrary transaction is in fact a durable nonce transaction, use the `assertIsTransactionMessageWithDurableNonceLifetime` function.
 
 See [`assertIsBlockhash()`](#assertisblockhash) for an example of how to use an assertion function.
 

--- a/packages/transaction-messages/src/__tests__/durable-nonce-test.ts
+++ b/packages/transaction-messages/src/__tests__/durable-nonce-test.ts
@@ -6,7 +6,7 @@ import type { Blockhash } from '@solana/rpc-types';
 
 import { TransactionMessageWithBlockhashLifetime } from '../blockhash';
 import {
-    assertIsDurableNonceTransactionMessage,
+    assertIsTransactionMessageWithDurableNonceLifetime,
     Nonce,
     setTransactionMessageLifetimeUsingDurableNonce,
     TransactionMessageWithDurableNonceLifetime,
@@ -59,7 +59,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
     });
     it('throws when supplied a transaction with a nonce lifetime constraint but no instructions', () => {
         expect(() => {
-            assertIsDurableNonceTransactionMessage({
+            assertIsTransactionMessageWithDurableNonceLifetime({
                 ...durableNonceTx,
                 instructions: [],
             });
@@ -67,7 +67,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
     });
     it('throws when supplied a transaction with a nonce lifetime constraint but an instruction at index 0 for a program other than the system program', () => {
         expect(() => {
-            assertIsDurableNonceTransactionMessage({
+            assertIsTransactionMessageWithDurableNonceLifetime({
                 ...durableNonceTx,
                 instructions: [
                     {
@@ -83,7 +83,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
     });
     it('throws when supplied a transaction with a nonce lifetime constraint but a system program instruction at index 0 for something other than the `AdvanceNonceAccount` instruction', () => {
         expect(() => {
-            assertIsDurableNonceTransactionMessage({
+            assertIsTransactionMessageWithDurableNonceLifetime({
                 ...durableNonceTx,
                 instructions: [
                     {
@@ -99,7 +99,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
     });
     it('throws when supplied a transaction with a nonce lifetime constraint but a system program instruction at index 0 with malformed accounts', () => {
         expect(() => {
-            assertIsDurableNonceTransactionMessage({
+            assertIsTransactionMessageWithDurableNonceLifetime({
                 ...durableNonceTx,
                 instructions: [
                     {
@@ -115,7 +115,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
     });
     it('throws when supplied a transaction with an `AdvanceNonceAccount` instruction at index 0 but no lifetime constraint', () => {
         expect(() => {
-            assertIsDurableNonceTransactionMessage({
+            assertIsTransactionMessageWithDurableNonceLifetime({
                 ...durableNonceTx,
                 lifetimeConstraint: undefined,
             });
@@ -123,7 +123,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
     });
     it('throws when supplied a transaction with an `AdvanceNonceAccount` instruction at index 0 but a blockhash lifetime constraint', () => {
         expect(() => {
-            assertIsDurableNonceTransactionMessage({
+            assertIsTransactionMessageWithDurableNonceLifetime({
                 ...durableNonceTx,
                 lifetimeConstraint: {
                     blockhash: '123' as Blockhash,
@@ -134,7 +134,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
     });
     it('does not throw when supplied a durable nonce transaction', () => {
         expect(() => {
-            assertIsDurableNonceTransactionMessage({ ...durableNonceTx });
+            assertIsTransactionMessageWithDurableNonceLifetime({ ...durableNonceTx });
         }).not.toThrow();
     });
     it('does not throw when the nonce authority is a writable signer', () => {
@@ -159,7 +159,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
             version: 0,
         } as const;
         expect(() => {
-            assertIsDurableNonceTransactionMessage({ ...transaction });
+            assertIsTransactionMessageWithDurableNonceLifetime({ ...transaction });
         }).not.toThrow();
     });
 });

--- a/packages/transaction-messages/src/deprecated.ts
+++ b/packages/transaction-messages/src/deprecated.ts
@@ -1,5 +1,10 @@
 import type { Address } from '@solana/addresses';
 
+import {
+    assertIsTransactionMessageWithDurableNonceLifetime,
+    isTransactionMessageWithDurableNonceLifetime,
+} from './durable-nonce';
+
 /**
  * Represents a transaction message for which a fee payer has been declared. A transaction must
  * conform to this type to be compiled and landed on the network.
@@ -9,3 +14,56 @@ import type { Address } from '@solana/addresses';
 export interface ITransactionMessageWithFeePayer<TAddress extends string = string> {
     readonly feePayer: Readonly<{ address: Address<TAddress> }>;
 }
+
+/**
+ * From time to time you might acquire a transaction message, that you expect to have a
+ * nonce-based lifetime, from an untrusted network API or user input. Use this function to assert
+ * that such a transaction message actually has a nonce-based lifetime.
+ *
+ * @deprecated Use {@link assertIsTransactionMessageWithDurableNonceLifetime} instead. It was only renamed.
+ *
+ * @example
+ * ```ts
+ * import { assertIsDurableNonceTransactionMessage } from '@solana/transaction-messages';
+ *
+ * try {
+ *     // If this type assertion function doesn't throw, then
+ *     // Typescript will upcast `message` to `TransactionMessageWithDurableNonceLifetime`.
+ *     assertIsDurableNonceTransactionMessage(message);
+ *     // At this point, `message` is a `TransactionMessageWithDurableNonceLifetime` that can be used
+ *     // with the RPC.
+ *     const { nonce, nonceAccountAddress } = message.lifetimeConstraint;
+ *     const { data: { blockhash: actualNonce } } = await fetchNonce(nonceAccountAddress);
+ * } catch (e) {
+ *     // `message` turned out not to have a nonce-based lifetime
+ * }
+ * ```
+ */
+export const assertIsDurableNonceTransactionMessage = assertIsTransactionMessageWithDurableNonceLifetime;
+
+/**
+ * A type guard that returns `true` if the transaction message conforms to the
+ * {@link TransactionMessageWithDurableNonceLifetime} type, and refines its type for use in your
+ * program.
+ *
+ * @deprecated Use {@link isTransactionMessageWithDurableNonceLifetime} instead. It was only renamed.
+ *
+ * @example
+ * ```ts
+ * import { isDurableNonceTransaction } from '@solana/transaction-messages';
+ * import { fetchNonce } from "@solana-program/system";
+ *
+ * if (isDurableNonceTransaction(message)) {
+ *     // At this point, `message` has been refined to a
+ *     // `TransactionMessageWithDurableNonceLifetime`.
+ *     const { nonce, nonceAccountAddress } = message.lifetimeConstraint;
+ *     const { data: { blockhash: actualNonce } } = await fetchNonce(nonceAccountAddress);
+ *     setNonceIsValid(nonce === actualNonce);
+ * } else {
+ *     setError(
+ *         `${getSignatureFromTransaction(transaction)} does not have a nonce-based lifetime`,
+ *     );
+ * }
+ * ```
+ */
+export const isDurableNonceTransaction = isTransactionMessageWithDurableNonceLifetime;

--- a/packages/transaction-messages/src/durable-nonce.ts
+++ b/packages/transaction-messages/src/durable-nonce.ts
@@ -88,12 +88,12 @@ export interface TransactionMessageWithDurableNonceLifetime<
  *
  * @example
  * ```ts
- * import { assertIsDurableNonceTransactionMessage } from '@solana/transaction-messages';
+ * import { assertIsTransactionMessageWithDurableNonceLifetime } from '@solana/transaction-messages';
  *
  * try {
  *     // If this type assertion function doesn't throw, then
  *     // Typescript will upcast `message` to `TransactionMessageWithDurableNonceLifetime`.
- *     assertIsDurableNonceTransactionMessage(message);
+ *     assertIsTransactionMessageWithDurableNonceLifetime(message);
  *     // At this point, `message` is a `TransactionMessageWithDurableNonceLifetime` that can be used
  *     // with the RPC.
  *     const { nonce, nonceAccountAddress } = message.lifetimeConstraint;
@@ -103,10 +103,10 @@ export interface TransactionMessageWithDurableNonceLifetime<
  * }
  * ```
  */
-export function assertIsDurableNonceTransactionMessage(
+export function assertIsTransactionMessageWithDurableNonceLifetime(
     transactionMessage: BaseTransactionMessage | (BaseTransactionMessage & TransactionMessageWithDurableNonceLifetime),
 ): asserts transactionMessage is BaseTransactionMessage & TransactionMessageWithDurableNonceLifetime {
-    if (!isDurableNonceTransaction(transactionMessage)) {
+    if (!isTransactionMessageWithDurableNonceLifetime(transactionMessage)) {
         throw new SolanaError(SOLANA_ERROR__TRANSACTION__EXPECTED_NONCE_LIFETIME);
     }
 }
@@ -212,7 +212,7 @@ function isAdvanceNonceAccountInstructionData(data: ReadonlyUint8Array): data is
  * }
  * ```
  */
-export function isDurableNonceTransaction(
+export function isTransactionMessageWithDurableNonceLifetime(
     transactionMessage: BaseTransactionMessage | (BaseTransactionMessage & TransactionMessageWithDurableNonceLifetime),
 ): transactionMessage is BaseTransactionMessage & TransactionMessageWithDurableNonceLifetime {
     return (
@@ -299,7 +299,7 @@ export function setTransactionMessageLifetimeUsingDurableNonce<
     if (firstInstruction && isAdvanceNonceAccountInstruction(firstInstruction)) {
         if (isAdvanceNonceAccountInstructionForNonce(firstInstruction, nonceAccountAddress, nonceAuthorityAddress)) {
             if (
-                isDurableNonceTransaction(transactionMessage) &&
+                isTransactionMessageWithDurableNonceLifetime(transactionMessage) &&
                 transactionMessage.lifetimeConstraint.nonce === nonce
             ) {
                 return transactionMessage as TransactionMessageWithDurableNonceLifetime<


### PR DESCRIPTION
#### Context

This library uses the following naming convention for types and helpers:

```ts
type MyType;
function isMyType;
function assertIsMyType;
```

For instance, the `TransactionMessageWithBlockhashLifetime` follows this convention:

```ts
type TransactionMessageWithBlockhashLifetime;
function isTransactionMessageWithBlockhashLifetime;
function assertIsTransactionMessageWithBlockhashLifetime;
```

#### Problem

The durable nonce helpers do not follow this convention:

```ts
type TransactionMessageWithDurableNonceLifetime;
function isDurableNonceTransaction;
function assertIsDurableNonceTransactionMessage;
```

#### Summary of Changes

Rename the durable nonce helpers so they follow the same naming convention.

```ts
type TransactionMessageWithDurableNonceLifetime;
function isTransactionMessageWithDurableNonceLifetime;
function assertIsTransactionMessageWithDurableNonceLifetime;
```