### PR TITLE
Add transaction message Exclude type helpers

### DIFF
--- a/.changeset/tall-boxes-kick.md
+++ b/.changeset/tall-boxes-kick.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-messages': patch
+---
+
+Introduce a new `TransactionMessageWithLifetime` type and special Exclude type helpers to remove information from transaction messages

--- a/packages/kit/src/compute-limit-internal.ts
+++ b/packages/kit/src/compute-limit-internal.ts
@@ -143,7 +143,7 @@ export async function getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_
      *         - either a recent blockhash lifetime or a nonce.
      */
     const isDurableNonceTransactionMessage = isTransactionMessageWithDurableNonceLifetime(transactionMessage);
-    let compilableTransactionMessage;
+    let compilableTransactionMessage: CompilableTransactionMessage;
     if (isDurableNonceTransactionMessage || isTransactionMessageWithBlockhashLifetime(transactionMessage)) {
         compilableTransactionMessage = transactionMessage;
     } else {
@@ -163,7 +163,7 @@ export async function getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_
         compilableTransactionMessage = appendTransactionMessageInstruction(
             maxComputeUnitLimitInstruction,
             compilableTransactionMessage,
-        );
+        ) as CompilableTransactionMessage;
     } else {
         const nextInstructions = [...compilableTransactionMessage.instructions];
         nextInstructions.splice(existingSetComputeUnitLimitInstructionIndex, 1, maxComputeUnitLimitInstruction);

--- a/packages/transaction-messages/src/compilable-transaction-message.ts
+++ b/packages/transaction-messages/src/compilable-transaction-message.ts
@@ -1,8 +1,7 @@
 import { IInstruction } from '@solana/instructions';
 
-import { TransactionMessageWithBlockhashLifetime } from './blockhash';
-import { TransactionMessageWithDurableNonceLifetime } from './durable-nonce';
 import { TransactionMessageWithFeePayer } from './fee-payer';
+import { TransactionMessageWithLifetime } from './lifetime';
 import { BaseTransactionMessage, TransactionVersion } from './transaction-message';
 
 /**
@@ -13,6 +12,4 @@ import { BaseTransactionMessage, TransactionVersion } from './transaction-messag
 export type CompilableTransactionMessage<
     TVersion extends TransactionVersion = TransactionVersion,
     TInstruction extends IInstruction = IInstruction,
-> = BaseTransactionMessage<TVersion, TInstruction> &
-    TransactionMessageWithFeePayer &
-    (TransactionMessageWithBlockhashLifetime | TransactionMessageWithDurableNonceLifetime);
+> = BaseTransactionMessage<TVersion, TInstruction> & TransactionMessageWithFeePayer & TransactionMessageWithLifetime;

--- a/packages/transaction-messages/src/durable-nonce.ts
+++ b/packages/transaction-messages/src/durable-nonce.ts
@@ -8,6 +8,7 @@ import {
     createAdvanceNonceAccountInstruction,
     isAdvanceNonceAccountInstruction,
 } from './durable-nonce-instruction';
+import { ExcludeTransactionMessageLifetime } from './lifetime';
 import { BaseTransactionMessage } from './transaction-message';
 
 type DurableNonceConfig<
@@ -59,6 +60,14 @@ export interface TransactionMessageWithDurableNonceLifetime<
     ];
     readonly lifetimeConstraint: NonceLifetimeConstraint<TNonceValue>;
 }
+
+/**
+ * A helper type to exclude the durable nonce lifetime constraint from a transaction message.
+ */
+export type ExcludeTransactionMessageDurableNonceLifetime<TTransactionMessage extends BaseTransactionMessage> =
+    TTransactionMessage extends TransactionMessageWithDurableNonceLifetime
+        ? ExcludeTransactionMessageLifetime<TTransactionMessage>
+        : TTransactionMessage;
 
 /**
  * A type guard that returns `true` if the transaction message conforms to the

--- a/packages/transaction-messages/src/fee-payer.ts
+++ b/packages/transaction-messages/src/fee-payer.ts
@@ -11,6 +11,14 @@ export interface TransactionMessageWithFeePayer<TAddress extends string = string
 }
 
 /**
+ * A helper type to exclude the fee payer from a transaction message.
+ */
+type ExcludeTransactionMessageFeePayer<TTransactionMessage extends BaseTransactionMessage> = Omit<
+    TTransactionMessage,
+    'feePayer'
+>;
+
+/**
  * Given a base58-encoded address of a system account, this method will return a new transaction
  * message having the same type as the one supplied plus the {@link TransactionMessageWithFeePayer}
  * type.
@@ -30,7 +38,7 @@ export function setTransactionMessageFeePayer<
 >(
     feePayer: Address<TFeePayerAddress>,
     transactionMessage: TTransactionMessage,
-): Omit<TTransactionMessage, 'feePayer'> & TransactionMessageWithFeePayer<TFeePayerAddress> {
+): ExcludeTransactionMessageFeePayer<TTransactionMessage> & TransactionMessageWithFeePayer<TFeePayerAddress> {
     if (
         'feePayer' in transactionMessage &&
         feePayer === transactionMessage.feePayer?.address &&

--- a/packages/transaction-messages/src/instructions.ts
+++ b/packages/transaction-messages/src/instructions.ts
@@ -1,5 +1,14 @@
-import { TransactionMessageWithDurableNonceLifetime } from './durable-nonce';
+import { ExcludeTransactionMessageDurableNonceLifetime } from './durable-nonce';
 import { BaseTransactionMessage } from './transaction-message';
+
+/**
+ * A helper type to reset the instructions of a transaction message to a new array of instructions.
+ */
+type ResetTransactionMessageInstructions<TTransactionMessage extends BaseTransactionMessage> = Omit<
+    TTransactionMessage,
+    'instructions'
+> &
+    Pick<BaseTransactionMessage, 'instructions'>;
 
 /**
  * Given an instruction, this method will return a new transaction message with that instruction
@@ -25,7 +34,7 @@ import { BaseTransactionMessage } from './transaction-message';
 export function appendTransactionMessageInstruction<TTransactionMessage extends BaseTransactionMessage>(
     instruction: TTransactionMessage['instructions'][number],
     transactionMessage: TTransactionMessage,
-): TTransactionMessage {
+): ResetTransactionMessageInstructions<TTransactionMessage> {
     return appendTransactionMessageInstructions([instruction], transactionMessage);
 }
 
@@ -59,18 +68,12 @@ export function appendTransactionMessageInstruction<TTransactionMessage extends 
 export function appendTransactionMessageInstructions<TTransactionMessage extends BaseTransactionMessage>(
     instructions: ReadonlyArray<TTransactionMessage['instructions'][number]>,
     transactionMessage: TTransactionMessage,
-): TTransactionMessage {
+): ResetTransactionMessageInstructions<TTransactionMessage> {
     return Object.freeze({
         ...transactionMessage,
         instructions: Object.freeze([...transactionMessage.instructions, ...instructions]),
     });
 }
-
-// Durable nonce advance instruction must be the first instruction in the transaction message
-// So if instructions are prepended, we strip the durable nonce transaction message type
-type ExcludeDurableNonce<T> = T extends TransactionMessageWithDurableNonceLifetime
-    ? BaseTransactionMessage & Omit<T, keyof TransactionMessageWithDurableNonceLifetime>
-    : T;
 
 /**
  * Given an instruction, this method will return a new transaction message with that instruction
@@ -96,7 +99,7 @@ type ExcludeDurableNonce<T> = T extends TransactionMessageWithDurableNonceLifeti
 export function prependTransactionMessageInstruction<TTransactionMessage extends BaseTransactionMessage>(
     instruction: TTransactionMessage['instructions'][number],
     transactionMessage: TTransactionMessage,
-): ExcludeDurableNonce<TTransactionMessage> {
+): ExcludeTransactionMessageDurableNonceLifetime<ResetTransactionMessageInstructions<TTransactionMessage>> {
     return prependTransactionMessageInstructions([instruction], transactionMessage);
 }
 
@@ -130,9 +133,9 @@ export function prependTransactionMessageInstruction<TTransactionMessage extends
 export function prependTransactionMessageInstructions<TTransactionMessage extends BaseTransactionMessage>(
     instructions: ReadonlyArray<TTransactionMessage['instructions'][number]>,
     transactionMessage: TTransactionMessage,
-): ExcludeDurableNonce<TTransactionMessage> {
+): ExcludeTransactionMessageDurableNonceLifetime<ResetTransactionMessageInstructions<TTransactionMessage>> {
     return Object.freeze({
         ...transactionMessage,
         instructions: Object.freeze([...instructions, ...transactionMessage.instructions]),
-    }) as ExcludeDurableNonce<TTransactionMessage>;
+    }) as ExcludeTransactionMessageDurableNonceLifetime<TTransactionMessage>;
 }

--- a/packages/transaction-messages/src/lifetime.ts
+++ b/packages/transaction-messages/src/lifetime.ts
@@ -1,0 +1,18 @@
+import { TransactionMessageWithBlockhashLifetime } from './blockhash';
+import { TransactionMessageWithDurableNonceLifetime } from './durable-nonce';
+import { BaseTransactionMessage } from './transaction-message';
+
+/**
+ * A transaction message with any valid lifetime constraint.
+ */
+export type TransactionMessageWithLifetime =
+    | TransactionMessageWithBlockhashLifetime
+    | TransactionMessageWithDurableNonceLifetime;
+
+/**
+ * A helper type to exclude any lifetime constraint from a transaction message.
+ */
+export type ExcludeTransactionMessageLifetime<TTransactionMessage extends BaseTransactionMessage> = Omit<
+    TTransactionMessage,
+    'lifetimeConstraint'
+>;


### PR DESCRIPTION
This PR introduce a `TransactionMessageWithLifetime` type that describes a transaction message with any lifetime set.

It also introduce `ExcludeTransactionMessageX<TTransactionMessage>` types for most `TransactionMessageWithX` types. This means we can simplify the return type of most of our setters by `ExcludeTransactionMessageX<T> & TransactionMessageWithX` to ensure the old state is not kept.

For instance, see how this PR makes the `setTransactionMessageLifetimeUsingBlockhash` function use a single function signature. This will be useful when we'll need to chain more type exclusions to setters such as `ExcludeTransactionMessageUnderSizeLimit`.