### PR TITLE
s/readableIndexes/readonlyIndexes/ in `AddressLookupTable` type

### DIFF
--- a/.changeset/nice-clouds-roll.md
+++ b/.changeset/nice-clouds-roll.md
@@ -1,0 +1,7 @@
+---
+'@solana/rpc-api': patch
+'@solana/rpc-graphql': patch
+'@solana/rpc-types': patch
+---
+
+Corrected a misspelling of `readonlyIndexes` in the `AddressLookupTable` type. This fixes the return type of the `getTransaction` RPC call.

--- a/.changeset/old-chefs-win.md
+++ b/.changeset/old-chefs-win.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-messages': patch
+---
+
+Deprecated the `writableIndices`/`readableIndices` spellings in transaction messages in favour of `readonlyIndexes`/`writableIndexes`. This will make this shape compatible with the output of the `getTransaction` API that uses those spellings for address lookup table data.

--- a/packages/kit/src/__tests__/decompile-transaction-message-fetching-lookup-tables-test.ts
+++ b/packages/kit/src/__tests__/decompile-transaction-message-fetching-lookup-tables-test.ts
@@ -232,15 +232,17 @@ describe('decompileTransactionMessageFetchingLookupTables', () => {
 
         const compiledTransactionMessage: CompiledTransactionMessage = {
             addressTableLookups: [
+                // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                 {
                     lookupTableAddress: lookupTableAddress1,
-                    readableIndices: [0],
-                    writableIndices: [],
+                    readonlyIndexes: [0],
+                    writableIndexes: [],
                 },
+                // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                 {
                     lookupTableAddress: lookupTableAddress2,
-                    readableIndices: [0],
-                    writableIndices: [],
+                    readonlyIndexes: [0],
+                    writableIndexes: [],
                 },
             ],
             header: {

--- a/packages/rpc-api/src/getTransaction.ts
+++ b/packages/rpc-api/src/getTransaction.ts
@@ -63,9 +63,9 @@ type TransactionMetaBase = Readonly<{
 type AddressTableLookup = Readonly<{
     /** The address of the address lookup table account. */
     accountKey: Address;
-    /** Indices of accounts in a lookup table to load as read-only. */
-    readableIndexes: readonly number[];
-    /** Indices of accounts in a lookup table to load as writable. */
+    /** Indexes of accounts in a lookup table to load as read-only. */
+    readonlyIndexes: readonly number[];
+    /** Indexes of accounts in a lookup table to load as writable. */
     writableIndexes: readonly number[];
 }>;
 

--- a/packages/rpc-graphql/src/schema/type-defs/transaction.ts
+++ b/packages/rpc-graphql/src/schema/type-defs/transaction.ts
@@ -42,7 +42,7 @@ export const transactionTypeDefs = /* GraphQL */ `
 
     type TransactionMessageAddressTableLookup {
         accountKey: Address
-        readableIndexes: [Int]
+        readonlyIndexes: [Int]
         writableIndexes: [Int]
     }
 

--- a/packages/rpc-types/src/transaction.ts
+++ b/packages/rpc-types/src/transaction.ts
@@ -12,9 +12,9 @@ type TransactionVersion = 'legacy' | 0;
 type AddressTableLookup = Readonly<{
     /** Address of the address lookup table account. */
     accountKey: Address;
-    /** Indices of accounts in a lookup table to load as read-only. */
-    readableIndexes: readonly number[];
-    /** Indices of accounts in a lookup table to load as writable. */
+    /** Indexes of accounts in a lookup table to load as read-only. */
+    readonlyIndexes: readonly number[];
+    /** Indexes of accounts in a lookup table to load as writable. */
     writableIndexes: readonly number[];
 }>;
 

--- a/packages/transaction-messages/src/__tests__/decompile-message-test.ts
+++ b/packages/transaction-messages/src/__tests__/decompile-message-test.ts
@@ -643,10 +643,11 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress,
-                            readableIndices: [0],
-                            writableIndices: [],
+                            readonlyIndexes: [0],
+                            writableIndexes: [],
                         },
                     ],
                     header: {
@@ -697,10 +698,11 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress,
-                            readableIndices: [0, 2],
-                            writableIndices: [],
+                            readonlyIndexes: [0, 2],
+                            writableIndexes: [],
                         },
                     ],
                     header: {
@@ -754,10 +756,11 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress,
-                            readableIndices: [],
-                            writableIndices: [0],
+                            readonlyIndexes: [],
+                            writableIndexes: [0],
                         },
                     ],
                     header: {
@@ -808,10 +811,11 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress,
-                            readableIndices: [],
-                            writableIndices: [0, 2],
+                            readonlyIndexes: [],
+                            writableIndexes: [0, 2],
                         },
                     ],
                     header: {
@@ -870,10 +874,11 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress,
-                            readableIndices: [0],
-                            writableIndices: [2],
+                            readonlyIndexes: [0],
+                            writableIndexes: [2],
                         },
                     ],
                     header: {
@@ -930,10 +935,11 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress,
-                            readableIndices: [0],
-                            writableIndices: [],
+                            readonlyIndexes: [0],
+                            writableIndexes: [],
                         },
                     ],
                     header: {
@@ -989,10 +995,11 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress,
-                            readableIndices: [0],
-                            writableIndices: [2],
+                            readonlyIndexes: [0],
+                            writableIndexes: [2],
                         },
                     ],
                     header: {
@@ -1050,10 +1057,11 @@ describe('decompileTransactionMessage', () => {
             it('throws if the lookup table is not passed in', () => {
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress,
-                            readableIndices: [0],
-                            writableIndices: [],
+                            readonlyIndexes: [0],
+                            writableIndexes: [],
                         },
                     ],
                     header: {
@@ -1091,10 +1099,11 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress,
-                            readableIndices: [1],
-                            writableIndices: [],
+                            readonlyIndexes: [1],
+                            writableIndexes: [],
                         },
                     ],
                     header: {
@@ -1135,10 +1144,11 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress,
-                            readableIndices: [],
-                            writableIndices: [1],
+                            readonlyIndexes: [],
+                            writableIndexes: [1],
                         },
                     ],
                     header: {
@@ -1187,15 +1197,17 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress: lookupTableAddress1,
-                            readableIndices: [0],
-                            writableIndices: [],
+                            readonlyIndexes: [0],
+                            writableIndexes: [],
                         },
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress: lookupTableAddress2,
-                            readableIndices: [0],
-                            writableIndices: [],
+                            readonlyIndexes: [0],
+                            writableIndexes: [],
                         },
                     ],
                     header: {
@@ -1251,15 +1263,17 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress: lookupTableAddress1,
-                            readableIndices: [],
-                            writableIndices: [0],
+                            readonlyIndexes: [],
+                            writableIndexes: [0],
                         },
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress: lookupTableAddress2,
-                            readableIndices: [],
-                            writableIndices: [0],
+                            readonlyIndexes: [],
+                            writableIndexes: [0],
                         },
                     ],
                     header: {
@@ -1318,15 +1332,17 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress: lookupTableAddress1,
-                            readableIndices: [0],
-                            writableIndices: [1],
+                            readonlyIndexes: [0],
+                            writableIndexes: [1],
                         },
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress: lookupTableAddress2,
-                            readableIndices: [0],
-                            writableIndices: [1],
+                            readonlyIndexes: [0],
+                            writableIndexes: [1],
                         },
                     ],
                     header: {
@@ -1406,15 +1422,17 @@ describe('decompileTransactionMessage', () => {
 
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress: lookupTableAddress1,
-                            readableIndices: [0],
-                            writableIndices: [1],
+                            readonlyIndexes: [0],
+                            writableIndexes: [1],
                         },
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress: lookupTableAddress2,
-                            readableIndices: [0],
-                            writableIndices: [1],
+                            readonlyIndexes: [0],
+                            writableIndexes: [1],
                         },
                     ],
                     header: {
@@ -1499,15 +1517,17 @@ describe('decompileTransactionMessage', () => {
             it('throws if multiple lookup tables are not passed in', () => {
                 const compiledTransaction: CompiledTransactionMessage = {
                     addressTableLookups: [
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress: lookupTableAddress1,
-                            readableIndices: [0],
-                            writableIndices: [],
+                            readonlyIndexes: [0],
+                            writableIndexes: [],
                         },
+                        // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
                             lookupTableAddress: lookupTableAddress2,
-                            readableIndices: [0],
-                            writableIndices: [],
+                            readonlyIndexes: [0],
+                            writableIndexes: [],
                         },
                     ],
                     header: {

--- a/packages/transaction-messages/src/codecs/__tests__/address-table-lookup-test.ts
+++ b/packages/transaction-messages/src/codecs/__tests__/address-table-lookup-test.ts
@@ -19,10 +19,11 @@ describe('Address table lookup codec', () => {
             });
             it('serializes an `AddressTableLookup` according to the spec', () => {
                 expect(
+                    // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                     addressTableLookup.encode({
                         lookupTableAddress: 'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address, // decodes to [11{32}]
-                        readableIndices: [33, 22],
-                        writableIndices: [44],
+                        readonlyIndexes: [33, 22],
+                        writableIndexes: [44],
                     } as AddressTableLookup),
                 ).toEqual(
                     // prettier-ignore
@@ -65,8 +66,8 @@ describe('Address table lookup codec', () => {
                 const [lookup, offset] = addressTableLookup.read(byteArray, 0);
                 expect(lookup).toEqual({
                     lookupTableAddress: 'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address, // decodes to [11{32}]
-                    readableIndices: [33, 22],
-                    writableIndices: [44],
+                    readonlyIndexes: [33, 22],
+                    writableIndexes: [44],
                 });
                 // Expect the entire byte array to have been consumed.
                 expect(offset).toBe(byteArray.byteLength);

--- a/packages/transaction-messages/src/codecs/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/codecs/__tests__/message-test.ts
@@ -18,10 +18,11 @@ describe.each([getCompiledTransactionMessageCodec, getCompiledTransactionMessage
         it('serializes a transaction according to the spec', () => {
             const byteArray = compiledMessage.encode({
                 addressTableLookups: [
+                    // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                     {
                         lookupTableAddress: '3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7' as Address, // decodes to [44{32}]
-                        readableIndices: [77],
-                        writableIndices: [66, 55],
+                        readonlyIndexes: [77],
+                        writableIndexes: [66, 55],
                     },
                 ],
                 header: {
@@ -252,8 +253,8 @@ describe.each([getCompiledTransactionMessageCodec, getCompiledTransactionMessage
                 addressTableLookups: [
                     {
                         lookupTableAddress: '3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7' as Address, // decodes to [44{32}]
-                        readableIndices: [77],
-                        writableIndices: [66, 55],
+                        readonlyIndexes: [77],
+                        writableIndexes: [66, 55],
                     },
                 ],
                 header: {

--- a/packages/transaction-messages/src/codecs/address-table-lookup.ts
+++ b/packages/transaction-messages/src/codecs/address-table-lookup.ts
@@ -16,16 +16,17 @@ type AddressTableLookup = ReturnType<typeof getCompiledAddressTableLookups>[numb
 let memoizedAddressTableLookupEncoder: VariableSizeEncoder<AddressTableLookup> | undefined;
 export function getAddressTableLookupEncoder(): VariableSizeEncoder<AddressTableLookup> {
     if (!memoizedAddressTableLookupEncoder) {
+        const indexEncoder = getArrayEncoder(getU8Encoder(), { size: getShortU16Encoder() }) as Encoder<
+            readonly number[]
+        >;
         memoizedAddressTableLookupEncoder = getStructEncoder([
             ['lookupTableAddress', getAddressEncoder()],
-            [
-                'writableIndices',
-                getArrayEncoder(getU8Encoder(), { size: getShortU16Encoder() }) as Encoder<readonly number[]>,
-            ],
-            [
-                'readableIndices',
-                getArrayEncoder(getU8Encoder(), { size: getShortU16Encoder() }) as Encoder<readonly number[]>,
-            ],
+            /** @deprecated Remove in a future major version */
+            ['readableIndices', indexEncoder],
+            ['readonlyIndexes', indexEncoder],
+            ['writableIndexes', indexEncoder],
+            /** @deprecated Remove in a future major version */
+            ['writableIndices', indexEncoder],
         ]);
     }
 
@@ -35,10 +36,15 @@ export function getAddressTableLookupEncoder(): VariableSizeEncoder<AddressTable
 let memoizedAddressTableLookupDecoder: VariableSizeDecoder<AddressTableLookup> | undefined;
 export function getAddressTableLookupDecoder(): VariableSizeDecoder<AddressTableLookup> {
     if (!memoizedAddressTableLookupDecoder) {
+        const indexEncoder = getArrayDecoder(getU8Decoder(), { size: getShortU16Decoder() });
         memoizedAddressTableLookupDecoder = getStructDecoder([
             ['lookupTableAddress', getAddressDecoder()],
-            ['writableIndices', getArrayDecoder(getU8Decoder(), { size: getShortU16Decoder() })],
-            ['readableIndices', getArrayDecoder(getU8Decoder(), { size: getShortU16Decoder() })],
+            /** @deprecated Remove in a future major version */
+            ['readableIndices', indexEncoder],
+            ['readonlyIndexes', indexEncoder],
+            ['writableIndexes', indexEncoder],
+            /** @deprecated Remove in a future major version */
+            ['writableIndices', indexEncoder],
         ]);
     }
 

--- a/packages/transaction-messages/src/compile/__tests__/address-table-lookups-test.ts
+++ b/packages/transaction-messages/src/compile/__tests__/address-table-lookups-test.ts
@@ -94,7 +94,7 @@ describe('getCompiledAddressTableLookups', () => {
             },
         ] as OrderedAccounts;
         const compiledAddressTableLookups = getCompiledAddressTableLookups(orderedAccounts);
-        expect(compiledAddressTableLookups).toHaveProperty('0.readableIndices', [30, 50, 40]);
-        expect(compiledAddressTableLookups).toHaveProperty('0.writableIndices', [20, 10]);
+        expect(compiledAddressTableLookups).toHaveProperty('0.readonlyIndexes', [30, 50, 40]);
+        expect(compiledAddressTableLookups).toHaveProperty('0.writableIndexes', [20, 10]);
     });
 });

--- a/packages/transaction-messages/src/compile/address-table-lookups.ts
+++ b/packages/transaction-messages/src/compile/address-table-lookups.ts
@@ -6,26 +6,43 @@ import { OrderedAccounts } from '../compile/accounts';
 type AddressTableLookup = Readonly<{
     /** The address of the address lookup table account. */
     lookupTableAddress: Address;
-    /** Indices of accounts in a lookup table to load as read-only. */
+    /** @deprecated Use `readonlyIndexes` */
     readableIndices: readonly number[];
-    /** Indices of accounts in a lookup table to load as writable. */
+    /** Indexes of accounts in a lookup table to load as read-only. */
+    readonlyIndexes: readonly number[];
+    /** Indexes of accounts in a lookup table to load as writable. */
+    writableIndexes: readonly number[];
+    /** @deprecated Use `writableIndexes` */
     writableIndices: readonly number[];
 }>;
 
 export function getCompiledAddressTableLookups(orderedAccounts: OrderedAccounts): AddressTableLookup[] {
-    const index: Record<Address, { readonly readableIndices: number[]; readonly writableIndices: number[] }> = {};
+    const index: Record<
+        Address,
+        Readonly<{
+            [K in keyof Omit<AddressTableLookup, 'lookupTableAddress'>]: number[];
+        }>
+    > = {};
     for (const account of orderedAccounts) {
         if (!('lookupTableAddress' in account)) {
             continue;
         }
         const entry = (index[account.lookupTableAddress] ||= {
+            /** @deprecated Remove in a future major version */
             readableIndices: [],
+            readonlyIndexes: [],
+            writableIndexes: [],
+            /** @deprecated Remove in a future major version */
             writableIndices: [],
         });
         if (account.role === AccountRole.WRITABLE) {
+            entry.writableIndexes.push(account.addressIndex);
+            /** @deprecated Remove in a future major version */
             entry.writableIndices.push(account.addressIndex);
         } else {
+            /** @deprecated Remove in a future major version */
             entry.readableIndices.push(account.addressIndex);
+            entry.readonlyIndexes.push(account.addressIndex);
         }
     }
     return Object.keys(index)

--- a/packages/transaction-messages/src/decompile-message.ts
+++ b/packages/transaction-messages/src/decompile-message.ts
@@ -88,8 +88,16 @@ function getAddressLookupMetas(
     // we know that for each lookup, knownLookups[lookup.lookupTableAddress] is defined
     for (const lookup of compiledAddressTableLookups) {
         const addresses = addressesByLookupTableAddress[lookup.lookupTableAddress];
+        const readonlyIndexes =
+            lookup.readonlyIndexes ??
+            /** @deprecated Remove in a future major version */
+            lookup.readableIndices;
+        const writableIndexes =
+            lookup.writableIndexes ??
+            /** @deprecated Remove in a future major version */
+            lookup.writableIndices;
 
-        const highestIndex = Math.max(...lookup.readableIndices, ...lookup.writableIndices);
+        const highestIndex = Math.max(...readonlyIndexes, ...writableIndexes);
         if (highestIndex >= addresses.length) {
             throw new SolanaError(
                 SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_INDEX_OUT_OF_RANGE,
@@ -101,7 +109,7 @@ function getAddressLookupMetas(
             );
         }
 
-        const readOnlyForLookup: IAccountLookupMeta[] = lookup.readableIndices.map(r => ({
+        const readOnlyForLookup: IAccountLookupMeta[] = readonlyIndexes.map(r => ({
             address: addresses[r],
             addressIndex: r,
             lookupTableAddress: lookup.lookupTableAddress,
@@ -109,7 +117,7 @@ function getAddressLookupMetas(
         }));
         readOnlyMetas.push(...readOnlyForLookup);
 
-        const writableForLookup: IAccountLookupMeta[] = lookup.writableIndices.map(w => ({
+        const writableForLookup: IAccountLookupMeta[] = writableIndexes.map(w => ({
             address: addresses[w],
             addressIndex: w,
             lookupTableAddress: lookup.lookupTableAddress,


### PR DESCRIPTION
#### Problem

1. These were misspelled in the return type of `getTransaction()`
2. Because of the misspelling, the data structure from the `getTransaction()` API and the `CompiledTransactionMessage` type were incompatible.

#### Summary of Changes

1. The misspelling was corrected in the return type of the `getTransaction()` API
2. The alternate spellings in `CompiledTransactionMessage` were deprecated, and duplicated as the API's spellings. We can remove the `*Indices` spellings in a future major version.

Fixes #412.
