### PR TITLE
Docs preview action no longer fails to create PR comment

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -59,4 +59,4 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PREVIEW_URL: '${{ steps.vercel_deploy.outputs.preview_url }}'
         run: |
-          gh pr comment $PR_NUMBER --body "Documentation Preview: $PREVIEW_URL" --edit-last
+          gh pr comment $PR_NUMBER --body "Documentation Preview: $PREVIEW_URL" --create-if-none --edit-last


### PR DESCRIPTION
If you want to use `--edit-last`, they changed this to require `--create-if-none` if the comment doesn't already exists
