### PR TITLE
Statically build all API docs reference pages

### DIFF
--- a/docs/src/app/api/[[...slug]]/page.tsx
+++ b/docs/src/app/api/[[...slug]]/page.tsx
@@ -40,13 +40,7 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
 }
 
 export async function generateStaticParams() {
-    return apiSource.generateParams().filter(
-        params =>
-            // FIXME(#405): Build times on Vercel are so long as to make deploys impossible. For
-            // now, let's let Vercel generate API reference pages as they're visited (ISR -
-            // Incremental Static Generation).
-            params.slug.length === 0, // Except for the index page; generate that statically.
-    );
+    return apiSource.generateParams();
 }
 
 export async function generateMetadata(props: { params: Promise<{ slug?: string[] }> }) {


### PR DESCRIPTION
Now that we're buliding docs with GitHub instead of the Vercel CI, let's see if GitHub runners have enough memory to build the _entire_ API section.
