### PR TITLE
Remove Webpack memory optimizations from docs build

### DIFF
--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -4,9 +4,6 @@ const withMDX = createMDX();
 
 /** @type {import('next').NextConfig} */
 const config = {
-    experimental: {
-        webpackMemoryOptimizations: true,
-    },
     reactStrictMode: true,
     serverExternalPackages: ['twoslash', 'typescript'],
 };

--- a/docs/src/app/api/[[...slug]]/page.tsx
+++ b/docs/src/app/api/[[...slug]]/page.tsx
@@ -40,13 +40,7 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
 }
 
 export async function generateStaticParams() {
-    return apiSource.generateParams().filter(
-        params =>
-            // FIXME(#405): Build times on Vercel are so long as to make deploys impossible. For
-            // now, let's let Vercel generate API reference pages as they're visited (ISR -
-            // Incremental Static Generation).
-            params.slug.length === 0, // Except for the index page; generate that statically.
-    );
+    return apiSource.generateParams();
 }
 
 export async function generateMetadata(props: { params: Promise<{ slug?: string[] }> }) {


### PR DESCRIPTION
This was only needed in Vercel CI because their runners have such low memory.
