### PR TITLE
chore: fix invalid links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This is the JavaScript SDK for building Solana apps for Node, web, and React Nat
 > [!NOTE]
 > Did you expect to find `@solana/web3.js` here? You're in the right place! We have renamed the 2.x line of `@solana/web3.js` to `@solana/kit`.
 >
-> The code for the 1.x line of `@solana/web3.js` can be found [here](https://github.com/solana-labs/solana-web3.js/tree/maintenance/v1.x) and the documentation [here](https://solana-labs.github.io/solana-web3.js/).
+> The code for the 1.x line of `@solana/web3.js` can be found [here](https://github.com/solana-labs/solana-web3.js/tree/maintenance/v1.x) and the documentation [here](https://solana-foundation.github.io/solana-web3.js/).
 
 # Installation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Kit documentation
 
-Documentation website for Kit, built with [Fumadocs](<(https://github.com/fuma-nama/fumadocs)>).
+Documentation website for Kit, built with [Fumadocs](https://github.com/fuma-nama/fumadocs).
 
 ## Install dependencies
 

--- a/packages/compat/src/address.ts
+++ b/packages/compat/src/address.ts
@@ -2,7 +2,7 @@ import { Address } from '@solana/addresses';
 import { PublicKey } from '@solana/web3.js';
 
 /**
- * Converts a legacy [PublicKey](https://solana-labs.github.io/solana-web3.js/classes/PublicKey.html)
+ * Converts a legacy [PublicKey](https://solana-foundation.github.io/solana-web3.js/classes/PublicKey.html)
  * object to an {@link Address}.
  *
  * @example

--- a/packages/compat/src/instruction.ts
+++ b/packages/compat/src/instruction.ts
@@ -4,7 +4,7 @@ import { TransactionInstruction } from '@solana/web3.js';
 import { fromLegacyPublicKey } from './address';
 
 /**
- * This can be used to convert a legacy [`TransactionInstruction`](https://solana-labs.github.io/solana-web3.js/classes/TransactionInstruction.html)
+ * This can be used to convert a legacy [`TransactionInstruction`](https://solana-foundation.github.io/solana-web3.js/classes/TransactionInstruction.html)
  * object to an {@link IInstruction}.
  *
  * @example

--- a/packages/compat/src/keypair.ts
+++ b/packages/compat/src/keypair.ts
@@ -2,7 +2,7 @@ import { createKeyPairFromBytes } from '@solana/keys';
 import { Keypair } from '@solana/web3.js';
 
 /**
- * Converts a legacy [Keypair](https://solana-labs.github.io/solana-web3.js/classes/Keypair.html)
+ * Converts a legacy [Keypair](https://solana-foundation.github.io/solana-web3.js/classes/Keypair.html)
  * object to a native Ed25519 {@link CryptoKeyPair} object.
  *
  * @example

--- a/packages/compat/src/transaction.ts
+++ b/packages/compat/src/transaction.ts
@@ -19,7 +19,7 @@ function convertSignatures(transaction: VersionedTransaction, staticAccountKeys:
 }
 
 /**
- * This can be used to convert a legacy [VersionedTransaction](https://solana-labs.github.io/solana-web3.js/classes/VersionedTransaction.html)
+ * This can be used to convert a legacy [VersionedTransaction](https://solana-foundation.github.io/solana-web3.js/classes/VersionedTransaction.html)
  * object to a {@link Transaction}.
  *
  * @example


### PR DESCRIPTION
#### Problem
Invalid links in files


#### Summary of Changes
1. README.md 
(https://solana-labs.github.io/solana-web3.js/) is invalid. 
'solana-labs' is changd to 'solana-foundation'

2. docs/README.md
[Fumadocs] (<(https://github.com/fuma-nama/fumadocs)>) is changed to [Fumadocs](https://github.com/fuma-nama/fumadocs)
Corrected malformed markdown link syntax for proper rendering.

3. Additionally, URLs like solana-labs changed to solana-foundation.


Fixes #