### PR TITLE
Upload docs build products as an archive to reduce upload API usage

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -52,4 +52,4 @@ jobs:
         run: |
           vercel pull --token="$VERCEL_TOKEN" --yes --environment=production
           vercel build --token="$VERCEL_TOKEN" --prod
-          vercel deploy --token="$VERCEL_TOKEN" --prebuilt --prod
+          vercel deploy --token="$VERCEL_TOKEN" --archive=tgz --prebuilt --prod

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           vercel pull --token="$VERCEL_TOKEN" --yes --environment=preview
           vercel build --token="$VERCEL_TOKEN" --prod=false
-          DEPLOY_URL=$(vercel deploy --token="$VERCEL_TOKEN" --env GITHUB_PR_NUMBER="$PR_NUMBER" --env GITHUB_PR_BRANCH="$BRANCH_NAME" --prebuilt --prod=false 2>&1 | grep -o 'https://[a-zA-Z0-9.-]*\.vercel\.app' | tail -1)
+          DEPLOY_URL=$(vercel deploy --token="$VERCEL_TOKEN" --archive=tgz --env GITHUB_PR_NUMBER="$PR_NUMBER" --env GITHUB_PR_BRANCH="$BRANCH_NAME" --prebuilt --prod=false 2>&1 | grep -o 'https://[a-zA-Z0-9.-]*\.vercel\.app' | tail -1)
           echo "preview_url=$DEPLOY_URL" >> $GITHUB_OUTPUT
 
       - name: Comment on PR with Preview URL


### PR DESCRIPTION
#### Problem

We blew the ‘number of uploads’ API limit for deploying the docs site.

Example: https://github.com/anza-xyz/kit/actions/runs/14841857940/job/41666500045

#### Summary of Changes

Archiving it first reduces the number of upload API requests to 1 per deployment.
