### PR TITLE
Use `TransactionMessageWithinSizeLimit` in helper functions

### DIFF
--- a/.changeset/better-crabs-taste.md
+++ b/.changeset/better-crabs-taste.md
@@ -1,0 +1,7 @@
+---
+'@solana/transaction-messages': minor
+'@solana/transactions': minor
+'@solana/signers': minor
+---
+
+Add, remove and forward the `TransactionMessageWithinSizeLimit` and `TransactionWithinSizeLimit` types in all helpers that may affect the size of a transaction or transaction message.

--- a/packages/signers/src/__typetests__/sign-transaction-typetest.ts
+++ b/packages/signers/src/__typetests__/sign-transaction-typetest.ts
@@ -4,12 +4,14 @@ import {
     CompilableTransactionMessage,
     TransactionMessageWithBlockhashLifetime,
     TransactionMessageWithDurableNonceLifetime,
+    TransactionMessageWithinSizeLimit,
 } from '@solana/transaction-messages';
 import {
     FullySignedTransaction,
     Transaction,
     TransactionWithBlockhashLifetime,
     TransactionWithDurableNonceLifetime,
+    TransactionWithinSizeLimit,
     TransactionWithLifetime,
 } from '@solana/transactions';
 
@@ -50,6 +52,15 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & Tr
 }
 
 {
+    // [partiallySignTransactionMessageWithSigners]: returns a transaction with a `TransactionWithinSizeLimit` flag
+    const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
+        TransactionMessageWithinSizeLimit;
+    partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
+        Readonly<Transaction & TransactionWithinSizeLimit>
+    >;
+}
+
+{
     // [signTransactionMessageWithSigners]: returns a fully signed transaction with a blockhash lifetime
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
         TransactionMessageWithBlockhashLifetime;
@@ -72,6 +83,15 @@ type CompilableTransactionMessageWithSigners = CompilableTransactionMessage & Tr
     const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners;
     signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
         Readonly<FullySignedTransaction & TransactionWithLifetime>
+    >;
+}
+
+{
+    // [signTransactionMessageWithSigners]: returns a transaction with a `TransactionWithinSizeLimit` flag
+    const transactionMessage = null as unknown as CompilableTransactionMessageWithSigners &
+        TransactionMessageWithinSizeLimit;
+    signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
+        Readonly<FullySignedTransaction & Transaction & TransactionWithinSizeLimit>
     >;
 }
 

--- a/packages/transaction-messages/src/__typetests__/create-transaction-message-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/create-transaction-message-typetest.ts
@@ -1,5 +1,6 @@
 import { createTransactionMessage } from '../create-transaction-message';
 import { TransactionMessage } from '../transaction-message';
+import { TransactionMessageWithinSizeLimit } from '../transaction-message-size';
 
 type LegacyTransactionMessage = Extract<TransactionMessage, { version: 'legacy' }>;
 type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
@@ -18,4 +19,10 @@ type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
     message satisfies V0TransactionMessage;
     // @ts-expect-error Should not be legacy.
     message satisfies LegacyTransactionMessage;
+}
+
+// It returns an empty transaction message with size limit type safety.
+{
+    createTransactionMessage({ version: 'legacy' }) satisfies TransactionMessageWithinSizeLimit;
+    createTransactionMessage({ version: 0 }) satisfies TransactionMessageWithinSizeLimit;
 }

--- a/packages/transaction-messages/src/__typetests__/instructions-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/instructions-typetest.ts
@@ -17,6 +17,7 @@ import {
     prependTransactionMessageInstructions,
 } from '../instructions';
 import { BaseTransactionMessage } from '../transaction-message';
+import { TransactionMessageWithinSizeLimit } from '../transaction-message-size';
 
 type IInstruction = BaseTransactionMessage['instructions'][number];
 type InstructionA = IInstruction & { identifier: 'A' };
@@ -81,6 +82,14 @@ type InstructionC = IInstruction & { identifier: 'C' };
         message satisfies BaseTransactionMessage & TransactionMessageWithDurableNonceLifetime;
         message.instructions satisfies readonly [AdvanceNonceAccountInstruction, InstructionA];
     }
+
+    // It removes the size limit type safety.
+    {
+        const message = null as unknown as BaseTransactionMessage & TransactionMessageWithinSizeLimit;
+        const newMessage = appendTransactionMessageInstruction(null as unknown as IInstruction, message);
+        // @ts-expect-error Potentially no longer within size limit.
+        newMessage satisfies TransactionMessageWithinSizeLimit;
+    }
 }
 
 // [DESCRIBE] appendTransactionMessageInstructions
@@ -114,6 +123,14 @@ type InstructionC = IInstruction & { identifier: 'C' };
             message,
         );
         newMessage.instructions satisfies readonly [...IInstruction[], InstructionA, InstructionB];
+    }
+
+    // It removes the size limit type safety.
+    {
+        const message = null as unknown as BaseTransactionMessage & TransactionMessageWithinSizeLimit;
+        const newMessage = appendTransactionMessageInstructions([null as unknown as IInstruction], message);
+        // @ts-expect-error Potentially no longer within size limit.
+        newMessage satisfies TransactionMessageWithinSizeLimit;
     }
 }
 
@@ -195,6 +212,14 @@ type InstructionC = IInstruction & { identifier: 'C' };
         // @ts-expect-error No longer a durable nonce lifetime.
         message satisfies BaseTransactionMessage & TransactionMessageWithDurableNonceLifetime;
     }
+
+    // It removes the size limit type safety.
+    {
+        const message = null as unknown as BaseTransactionMessage & TransactionMessageWithinSizeLimit;
+        const newMessage = prependTransactionMessageInstruction(null as unknown as IInstruction, message);
+        // @ts-expect-error Potentially no longer within size limit.
+        newMessage satisfies TransactionMessageWithinSizeLimit;
+    }
 }
 
 // [DESCRIBE] prependTransactionMessageInstructions
@@ -238,5 +263,13 @@ type InstructionC = IInstruction & { identifier: 'C' };
             message,
         );
         newMessage.instructions satisfies readonly [InstructionA, InstructionB, ...IInstruction[]];
+    }
+
+    // It removes the size limit type safety.
+    {
+        const message = null as unknown as BaseTransactionMessage & TransactionMessageWithinSizeLimit;
+        const newMessage = prependTransactionMessageInstructions([null as unknown as IInstruction], message);
+        // @ts-expect-error Potentially no longer within size limit.
+        newMessage satisfies TransactionMessageWithinSizeLimit;
     }
 }

--- a/packages/transaction-messages/src/create-transaction-message.ts
+++ b/packages/transaction-messages/src/create-transaction-message.ts
@@ -1,8 +1,15 @@
 import { TransactionMessage, TransactionVersion } from './transaction-message';
+import { TransactionMessageWithinSizeLimit } from './transaction-message-size';
 
 type TransactionConfig<TVersion extends TransactionVersion> = Readonly<{
     version: TVersion;
 }>;
+
+type EmptyTransactionMessage<TVersion extends TransactionVersion> = Omit<
+    Extract<TransactionMessage, { version: TVersion }>,
+    'instructions'
+> &
+    TransactionMessageWithinSizeLimit & { instructions: readonly [] };
 
 /**
  * Given a {@link TransactionVersion} this method will return an empty transaction having the
@@ -17,12 +24,9 @@ type TransactionConfig<TVersion extends TransactionVersion> = Readonly<{
  */
 export function createTransactionMessage<TVersion extends TransactionVersion>(
     config: TransactionConfig<TVersion>,
-): Omit<Extract<TransactionMessage, { version: TVersion }>, 'instructions'> & { instructions: readonly [] };
-export function createTransactionMessage<TVersion extends TransactionVersion>({
-    version,
-}: TransactionConfig<TVersion>): TransactionMessage {
+): EmptyTransactionMessage<TVersion> {
     return Object.freeze({
         instructions: Object.freeze([]),
-        version,
-    }) as TransactionMessage;
+        version: config.version,
+    }) as EmptyTransactionMessage<TVersion>;
 }

--- a/packages/transaction-messages/src/index.ts
+++ b/packages/transaction-messages/src/index.ts
@@ -39,6 +39,7 @@ export * from './durable-nonce';
 export { isAdvanceNonceAccountInstruction } from './durable-nonce-instruction';
 export * from './fee-payer';
 export * from './instructions';
+export * from './transaction-message-size';
 export * from './transaction-message';
 
 // Remove in the next major version.

--- a/packages/transaction-messages/src/instructions.ts
+++ b/packages/transaction-messages/src/instructions.ts
@@ -2,6 +2,7 @@ import { IInstruction } from '@solana/instructions';
 
 import { ExcludeTransactionMessageDurableNonceLifetime } from './durable-nonce';
 import { BaseTransactionMessage } from './transaction-message';
+import { ExcludeTransactionMessageWithinSizeLimit } from './transaction-message-size';
 
 /**
  * A helper type to append instructions to a transaction message
@@ -10,7 +11,7 @@ import { BaseTransactionMessage } from './transaction-message';
 type AppendTransactionMessageInstructions<
     TTransactionMessage extends BaseTransactionMessage,
     TInstructions extends readonly IInstruction[],
-> = Omit<TTransactionMessage, 'instructions'> & {
+> = Omit<ExcludeTransactionMessageWithinSizeLimit<TTransactionMessage>, 'instructions'> & {
     readonly instructions: readonly [...TTransactionMessage['instructions'], ...TInstructions];
 };
 
@@ -21,7 +22,10 @@ type AppendTransactionMessageInstructions<
 type PrependTransactionMessageInstructions<
     TTransactionMessage extends BaseTransactionMessage,
     TInstructions extends readonly IInstruction[],
-> = Omit<TTransactionMessage, 'instructions'> & {
+> = Omit<
+    ExcludeTransactionMessageWithinSizeLimit<ExcludeTransactionMessageDurableNonceLifetime<TTransactionMessage>>,
+    'instructions'
+> & {
     readonly instructions: readonly [...TInstructions, ...TTransactionMessage['instructions']];
 };
 
@@ -126,10 +130,7 @@ export function prependTransactionMessageInstruction<
 >(
     instruction: TInstruction,
     transactionMessage: TTransactionMessage,
-): PrependTransactionMessageInstructions<
-    ExcludeTransactionMessageDurableNonceLifetime<TTransactionMessage>,
-    [TInstruction]
-> {
+): PrependTransactionMessageInstructions<TTransactionMessage, [TInstruction]> {
     return prependTransactionMessageInstructions([instruction], transactionMessage);
 }
 
@@ -166,10 +167,7 @@ export function prependTransactionMessageInstructions<
 >(
     instructions: TInstructions,
     transactionMessage: TTransactionMessage,
-): PrependTransactionMessageInstructions<
-    ExcludeTransactionMessageDurableNonceLifetime<TTransactionMessage>,
-    TInstructions
-> {
+): PrependTransactionMessageInstructions<TTransactionMessage, TInstructions> {
     return Object.freeze({
         ...(transactionMessage as ExcludeTransactionMessageDurableNonceLifetime<TTransactionMessage>),
         instructions: Object.freeze([

--- a/packages/transaction-messages/src/transaction-message-size.ts
+++ b/packages/transaction-messages/src/transaction-message-size.ts
@@ -1,0 +1,18 @@
+import type { NominalType } from '@solana/nominal-types';
+
+import type { BaseTransactionMessage } from './transaction-message';
+
+/**
+ * A type guard that checks if a transaction message is within the size limit
+ * when compiled into a transaction.
+ */
+export type TransactionMessageWithinSizeLimit = NominalType<'transactionSize', 'withinLimit'>;
+
+/**
+ * Helper type that removes the `TransactionMessageWithinSizeLimit` flag
+ * from a transaction message.
+ */
+export type ExcludeTransactionMessageWithinSizeLimit<TTransactionMessage extends BaseTransactionMessage> = Omit<
+    TTransactionMessage,
+    '__transactionSize:@solana/kit'
+>;

--- a/packages/transactions/src/__typetests__/compile-transaction-typetest.ts
+++ b/packages/transactions/src/__typetests__/compile-transaction-typetest.ts
@@ -6,6 +6,7 @@ import {
     TransactionMessageWithBlockhashLifetime,
     TransactionMessageWithDurableNonceLifetime,
     TransactionMessageWithFeePayer,
+    TransactionMessageWithinSizeLimit,
 } from '@solana/transaction-messages';
 
 import { compileTransaction } from '../compile-transaction';
@@ -17,59 +18,59 @@ import {
     TransactionWithLifetime,
 } from '../lifetime';
 import { Transaction } from '../transaction';
+import { TransactionWithinSizeLimit } from '../transaction-size';
 
-// transaction message with blockhash lifetime
-compileTransaction(
-    null as unknown as BaseTransactionMessage &
-        TransactionMessageWithBlockhashLifetime &
-        TransactionMessageWithFeePayer,
-) satisfies Readonly<Transaction & TransactionWithLifetime>;
-compileTransaction(
-    null as unknown as BaseTransactionMessage &
-        TransactionMessageWithBlockhashLifetime &
-        TransactionMessageWithFeePayer,
-) satisfies Readonly<Transaction & TransactionWithBlockhashLifetime>;
-compileTransaction(
-    null as unknown as BaseTransactionMessage &
-        TransactionMessageWithBlockhashLifetime &
-        TransactionMessageWithFeePayer,
-).lifetimeConstraint.blockhash satisfies Blockhash;
+// [DESCRIBE] compileTransaction.
+{
+    // It forwards the blockhash lifetime constraint from the transaction message to the transaction.
+    {
+        const transaction = compileTransaction(
+            null as unknown as BaseTransactionMessage &
+                TransactionMessageWithBlockhashLifetime &
+                TransactionMessageWithFeePayer,
+        );
 
-// transaction message with durable nonce lifetime
-compileTransaction(
-    null as unknown as BaseTransactionMessage &
-        TransactionMessageWithDurableNonceLifetime &
-        TransactionMessageWithFeePayer,
-) satisfies Readonly<Transaction & TransactionWithLifetime>;
-compileTransaction(
-    null as unknown as BaseTransactionMessage &
-        TransactionMessageWithDurableNonceLifetime &
-        TransactionMessageWithFeePayer,
-) satisfies Readonly<Transaction & TransactionWithDurableNonceLifetime>;
-compileTransaction(
-    null as unknown as BaseTransactionMessage &
-        TransactionMessageWithDurableNonceLifetime &
-        TransactionMessageWithFeePayer,
-).lifetimeConstraint.nonce satisfies Nonce;
+        transaction satisfies Readonly<Transaction & TransactionWithLifetime>;
+        transaction satisfies Readonly<Transaction & TransactionWithBlockhashLifetime>;
+        transaction.lifetimeConstraint.blockhash satisfies Blockhash;
+    }
 
-// transaction message with unknown lifetime
-compileTransaction(null as unknown as CompilableTransactionMessage) satisfies Readonly<
-    Transaction & TransactionWithLifetime
->;
-// @ts-expect-error not known to have blockhash lifetime
-compileTransaction(null as unknown as CompilableTransactionMessage) satisfies Readonly<
-    Transaction & TransactionBlockhashLifetime
->;
-// @ts-expect-error not known to have durable nonce lifetime
-compileTransaction(null as unknown as CompilableTransactionMessage) satisfies Readonly<
-    Transaction & TransactionDurableNonceLifetime
->;
-compileTransaction(null as unknown as CompilableTransactionMessage).lifetimeConstraint satisfies
-    | { blockhash: Blockhash }
-    | { nonce: Nonce };
-// @ts-expect-error not known to have blockhash lifetime
-compileTransaction(null as unknown as CompilableTransactionMessage).lifetimeConstraint satisfies {
-    blockhash: Blockhash;
-};
-// @ts-expect-error not known to have durable nonce lifetime
-compileTransaction(null as unknown as CompilableTransactionMessage).lifetimeConstraint satisfies { nonce: Nonce };
+    // It forwards the durable nonce lifetime constraint from the transaction message to the transaction.
+    {
+        const transaction = compileTransaction(
+            null as unknown as BaseTransactionMessage &
+                TransactionMessageWithDurableNonceLifetime &
+                TransactionMessageWithFeePayer,
+        );
+
+        transaction satisfies Readonly<Transaction & TransactionWithLifetime>;
+        transaction satisfies Readonly<Transaction & TransactionWithDurableNonceLifetime>;
+        transaction.lifetimeConstraint.nonce satisfies Nonce;
+    }
+
+    // It returns a transaction with a lifetime constraint even if we don't know which one it is.
+    {
+        const transaction = compileTransaction(null as unknown as CompilableTransactionMessage);
+
+        transaction satisfies Readonly<Transaction & TransactionWithLifetime>;
+        // @ts-expect-error not known to have blockhash lifetime
+        transaction satisfies Readonly<Transaction & TransactionBlockhashLifetime>;
+        // @ts-expect-error not known to have durable nonce lifetime
+        transaction satisfies Readonly<Transaction & TransactionDurableNonceLifetime>;
+
+        transaction.lifetimeConstraint satisfies { blockhash: Blockhash } | { nonce: Nonce };
+        // @ts-expect-error not known to have blockhash lifetime
+        transaction.lifetimeConstraint satisfies { blockhash: Blockhash };
+        // @ts-expect-error not known to have durable nonce lifetime
+        transaction.lifetimeConstraint satisfies { nonce: Nonce };
+    }
+
+    // It forwards the within size limit flag from the transaction message to the transaction.
+    {
+        const transaction = compileTransaction(
+            null as unknown as CompilableTransactionMessage & TransactionMessageWithinSizeLimit,
+        );
+
+        transaction satisfies Readonly<Transaction & TransactionWithinSizeLimit>;
+    }
+}

--- a/packages/transactions/src/__typetests__/lifetime-typetest.ts
+++ b/packages/transactions/src/__typetests__/lifetime-typetest.ts
@@ -1,0 +1,53 @@
+import type {
+    CompilableTransactionMessage,
+    TransactionMessageWithBlockhashLifetime,
+    TransactionMessageWithDurableNonceLifetime,
+} from '@solana/transaction-messages';
+
+import type {
+    SetTransactionLifetimeFromCompilableTransactionMessage,
+    TransactionWithBlockhashLifetime,
+    TransactionWithDurableNonceLifetime,
+    TransactionWithLifetime,
+} from '../lifetime';
+import { Transaction } from '../transaction';
+
+// [DESCRIBE] SetTransactionLifetimeFromCompilableTransactionMessage.
+{
+    // It augments the provided transaction with a lifetime constraint.
+    {
+        type Result = SetTransactionLifetimeFromCompilableTransactionMessage<Transaction, CompilableTransactionMessage>;
+        null as unknown as Result satisfies Readonly<Transaction & TransactionWithLifetime>;
+    }
+
+    // It keeps extra properties from the transaction but not from the transaction message.
+    {
+        type Result = SetTransactionLifetimeFromCompilableTransactionMessage<
+            Transaction & { _from_transaction: 1 },
+            CompilableTransactionMessage & { _from_transaction_message: 1 }
+        >;
+        null as unknown as Result satisfies Readonly<{ _from_transaction: 1 }>;
+        // @ts-expect-error Does not keep extra properties from transaction messages.
+        null as unknown as Result satisfies Readonly<{ _from_transaction_message: 1 }>;
+    }
+
+    // It forwards the blockhash lifetime constraint from the transaction message to the transaction.
+    {
+        type Result = SetTransactionLifetimeFromCompilableTransactionMessage<
+            Transaction,
+            CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime
+        >;
+        null as unknown as Result satisfies Readonly<Transaction & TransactionWithBlockhashLifetime>;
+        null as unknown as Result satisfies Readonly<Transaction & TransactionWithLifetime>;
+    }
+
+    // It forwards the durable nonce lifetime constraint from the transaction message to the transaction.
+    {
+        type Result = SetTransactionLifetimeFromCompilableTransactionMessage<
+            Transaction,
+            CompilableTransactionMessage & TransactionMessageWithDurableNonceLifetime
+        >;
+        null as unknown as Result satisfies Readonly<Transaction & TransactionWithDurableNonceLifetime>;
+        null as unknown as Result satisfies Readonly<Transaction & TransactionWithLifetime>;
+    }
+}

--- a/packages/transactions/src/__typetests__/transaction-message-size-typetest.ts
+++ b/packages/transactions/src/__typetests__/transaction-message-size-typetest.ts
@@ -1,22 +1,42 @@
-import { CompilableTransactionMessage } from '@solana/transaction-messages';
+import { CompilableTransactionMessage, TransactionMessageWithinSizeLimit } from '@solana/transaction-messages';
 
 import {
     assertIsTransactionMessageWithinSizeLimit,
     isTransactionMessageWithinSizeLimit,
-    TransactionMessageWithinSizeLimit,
 } from '../transaction-message-size';
 
-// isTransactionMessageWithinSizeLimit
+// [DESCRIBE] isTransactionMessageWithinSizeLimit.
 {
-    const transactionMessage = null as unknown as CompilableTransactionMessage & { some: 1 };
-    if (isTransactionMessageWithinSizeLimit(transactionMessage)) {
-        transactionMessage satisfies CompilableTransactionMessage & TransactionMessageWithinSizeLimit & { some: 1 };
+    // It narrows the type of the transaction message to include the `TransactionMessageWithinSizeLimit` flag.
+    {
+        const transactionMessage = null as unknown as CompilableTransactionMessage;
+        if (isTransactionMessageWithinSizeLimit(transactionMessage)) {
+            transactionMessage satisfies CompilableTransactionMessage & TransactionMessageWithinSizeLimit;
+        }
+    }
+
+    // It keeps any extra properties from the transaction message.
+    {
+        const transactionMessage = null as unknown as CompilableTransactionMessage & { some: 1 };
+        if (isTransactionMessageWithinSizeLimit(transactionMessage)) {
+            transactionMessage satisfies CompilableTransactionMessage & { some: 1 };
+        }
     }
 }
 
-// assertIsTransactionMessageWithinSizeLimit
+// [DESCRIBE] assertIsTransactionMessageWithinSizeLimit.
 {
-    const transactionMessage = null as unknown as CompilableTransactionMessage & { some: 1 };
-    assertIsTransactionMessageWithinSizeLimit(transactionMessage);
-    transactionMessage satisfies CompilableTransactionMessage & TransactionMessageWithinSizeLimit & { some: 1 };
+    // It narrows the type of the transaction message to include the `TransactionMessageWithinSizeLimit` flag.
+    {
+        const transactionMessage = null as unknown as CompilableTransactionMessage;
+        assertIsTransactionMessageWithinSizeLimit(transactionMessage);
+        transactionMessage satisfies CompilableTransactionMessage & TransactionMessageWithinSizeLimit;
+    }
+
+    // It keeps any extra properties from the transaction message.
+    {
+        const transactionMessage = null as unknown as CompilableTransactionMessage & { some: 1 };
+        assertIsTransactionMessageWithinSizeLimit(transactionMessage);
+        transactionMessage satisfies CompilableTransactionMessage & { some: 1 };
+    }
 }

--- a/packages/transactions/src/__typetests__/transaction-size-typetest.ts
+++ b/packages/transactions/src/__typetests__/transaction-size-typetest.ts
@@ -1,21 +1,77 @@
+import type { BaseTransactionMessage, TransactionMessageWithinSizeLimit } from '@solana/transaction-messages';
+
 import { Transaction } from '../transaction';
 import {
     assertIsTransactionWithinSizeLimit,
     isTransactionWithinSizeLimit,
+    SetTransactionWithinSizeLimitFromTransactionMessage,
     TransactionWithinSizeLimit,
 } from '../transaction-size';
 
-// isTransactionWithinSizeLimit
+// [DESCRIBE] isTransactionWithinSizeLimit.
 {
-    const transaction = null as unknown as Transaction & { some: 1 };
-    if (isTransactionWithinSizeLimit(transaction)) {
-        transaction satisfies Transaction & TransactionWithinSizeLimit & { some: 1 };
+    // It narrows the type of the transaction to include the `TransactionWithinSizeLimit` flag.
+    {
+        const transaction = null as unknown as Transaction;
+        if (isTransactionWithinSizeLimit(transaction)) {
+            transaction satisfies Transaction & TransactionWithinSizeLimit;
+        }
+    }
+
+    // It keeps any extra properties from the transaction.
+    {
+        const transaction = null as unknown as Transaction & { some: 1 };
+        if (isTransactionWithinSizeLimit(transaction)) {
+            transaction satisfies Transaction & { some: 1 };
+        }
     }
 }
 
-// assertIsTransactionWithinSizeLimit
+// [DESCRIBE] assertIsTransactionWithinSizeLimit.
 {
-    const transaction = null as unknown as Transaction & { some: 1 };
-    assertIsTransactionWithinSizeLimit(transaction);
-    transaction satisfies Transaction & TransactionWithinSizeLimit & { some: 1 };
+    // It narrows the type of the transaction to include the `TransactionWithinSizeLimit` flag.
+    {
+        const transaction = null as unknown as Transaction;
+        assertIsTransactionWithinSizeLimit(transaction);
+        transaction satisfies Transaction & TransactionWithinSizeLimit;
+    }
+
+    // It keeps any extra properties from the transaction.
+    {
+        const transaction = null as unknown as Transaction & { some: 1 };
+        assertIsTransactionWithinSizeLimit(transaction);
+        transaction satisfies Transaction & { some: 1 };
+    }
+}
+
+// [DESCRIBE] SetTransactionWithinSizeLimitFromTransactionMessage.
+{
+    // It augments the provided transaction with the `TransactionWithinSizeLimit` flag.
+    {
+        type Result = SetTransactionWithinSizeLimitFromTransactionMessage<
+            Transaction,
+            BaseTransactionMessage & TransactionMessageWithinSizeLimit
+        >;
+        null as unknown as Result satisfies Transaction & TransactionWithinSizeLimit;
+    }
+
+    // It keeps any extra properties from the transaction but not from the transaction message.
+    {
+        type Result = SetTransactionWithinSizeLimitFromTransactionMessage<
+            Transaction & { _from_transaction: 1 },
+            BaseTransactionMessage & TransactionMessageWithinSizeLimit & { _from_transaction_message: 1 }
+        >;
+        null as unknown as Result satisfies { _from_transaction: 1 };
+        // @ts-expect-error Does not keep extra properties from transaction messages.
+        null as unknown as Result satisfies { _from_transaction_message: 1 };
+    }
+
+    // It returns the transaction as-is if the transaction message is not within size limit.
+    {
+        type Result = SetTransactionWithinSizeLimitFromTransactionMessage<
+            Transaction & { some: 1 },
+            BaseTransactionMessage
+        >;
+        null as unknown as Result satisfies Transaction & { some: 1 };
+    }
 }

--- a/packages/transactions/src/__typetests__/transaction-typetest.ts
+++ b/packages/transactions/src/__typetests__/transaction-typetest.ts
@@ -1,0 +1,57 @@
+import type {
+    CompilableTransactionMessage,
+    TransactionMessageWithBlockhashLifetime,
+    TransactionMessageWithDurableNonceLifetime,
+    TransactionMessageWithinSizeLimit,
+} from '@solana/transaction-messages';
+
+import type {
+    TransactionWithBlockhashLifetime,
+    TransactionWithDurableNonceLifetime,
+    TransactionWithLifetime,
+} from '../lifetime';
+import type { Transaction, TransactionFromCompilableTransactionMessage } from '../transaction';
+import { TransactionWithinSizeLimit } from '../transaction-size';
+
+// [DESCRIBE] TransactionFromCompilableTransactionMessage.
+{
+    // It returns a transaction with a lifetime constraint.
+    {
+        type Result = TransactionFromCompilableTransactionMessage<CompilableTransactionMessage>;
+        null as unknown as Result satisfies Readonly<Transaction & TransactionWithLifetime>;
+    }
+
+    // It does not keep extra properties from the transaction message.
+    {
+        type Result = TransactionFromCompilableTransactionMessage<CompilableTransactionMessage & { some: 1 }>;
+        null as unknown as Result satisfies Readonly<Transaction>;
+        // @ts-expect-error Does not keep extra properties from transaction messages.
+        null as unknown as Result satisfies Readonly<{ some: 1 }>;
+    }
+
+    // It forwards the blockhash lifetime constraint from the transaction message to the transaction.
+    {
+        type Result = TransactionFromCompilableTransactionMessage<
+            CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime
+        >;
+        null as unknown as Result satisfies Readonly<Transaction & TransactionWithBlockhashLifetime>;
+        null as unknown as Result satisfies Readonly<Transaction & TransactionWithLifetime>;
+    }
+
+    // It forwards the durable nonce lifetime constraint from the transaction message to the transaction.
+    {
+        type Result = TransactionFromCompilableTransactionMessage<
+            CompilableTransactionMessage & TransactionMessageWithDurableNonceLifetime
+        >;
+        null as unknown as Result satisfies Readonly<Transaction & TransactionWithDurableNonceLifetime>;
+        null as unknown as Result satisfies Readonly<Transaction & TransactionWithLifetime>;
+    }
+
+    // It forwards the within size limit flag from the transaction message to the transaction.
+    {
+        type Result = TransactionFromCompilableTransactionMessage<
+            CompilableTransactionMessage & TransactionMessageWithinSizeLimit
+        >;
+        null as unknown as Result satisfies Readonly<Transaction & TransactionWithinSizeLimit>;
+    }
+}

--- a/packages/transactions/src/compile-transaction.ts
+++ b/packages/transactions/src/compile-transaction.ts
@@ -3,16 +3,14 @@ import {
     compileTransactionMessage,
     getCompiledTransactionMessageEncoder,
     isTransactionMessageWithBlockhashLifetime,
-    TransactionMessageWithBlockhashLifetime,
-    TransactionMessageWithDurableNonceLifetime,
 } from '@solana/transaction-messages';
 
-import {
-    TransactionWithBlockhashLifetime,
-    TransactionWithDurableNonceLifetime,
-    TransactionWithLifetime,
-} from './lifetime';
-import { SignaturesMap, Transaction, TransactionMessageBytes } from './transaction';
+import type { TransactionWithLifetime } from './lifetime';
+import type {
+    SignaturesMap,
+    TransactionFromCompilableTransactionMessage,
+    TransactionMessageBytes,
+} from './transaction';
 
 /**
  * Returns a {@link Transaction} object for a given {@link TransactionMessage}.
@@ -30,21 +28,11 @@ import { SignaturesMap, Transaction, TransactionMessageBytes } from './transacti
  * - have a lifetime specified (ie. conform to {@link TransactionMessageWithBlockhashLifetime} or
  *   {@link TransactionMessageWithDurableNonceLifetime})
  */
-export function compileTransaction(
-    transactionMessage: CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime,
-): Readonly<Transaction & TransactionWithBlockhashLifetime>;
+export function compileTransaction<TTransactionMessage extends CompilableTransactionMessage>(
+    transactionMessage: TTransactionMessage,
+): Readonly<TransactionFromCompilableTransactionMessage<TTransactionMessage>> {
+    type ReturnType = Readonly<TransactionFromCompilableTransactionMessage<TTransactionMessage>>;
 
-export function compileTransaction(
-    transactionMessage: CompilableTransactionMessage & TransactionMessageWithDurableNonceLifetime,
-): Readonly<Transaction & TransactionWithDurableNonceLifetime>;
-
-export function compileTransaction(
-    transactionMessage: CompilableTransactionMessage,
-): Readonly<Transaction & TransactionWithLifetime>;
-
-export function compileTransaction(
-    transactionMessage: CompilableTransactionMessage,
-): Readonly<Transaction & TransactionWithLifetime> {
     const compiledMessage = compileTransactionMessage(transactionMessage);
     const messageBytes = getCompiledTransactionMessageEncoder().encode(compiledMessage) as TransactionMessageBytes;
 
@@ -67,11 +55,9 @@ export function compileTransaction(
         };
     }
 
-    const transaction: Transaction & TransactionWithLifetime = {
+    return Object.freeze({
         lifetimeConstraint,
         messageBytes: messageBytes,
         signatures: Object.freeze(signatures),
-    };
-
-    return Object.freeze(transaction);
+    }) as ReturnType;
 }

--- a/packages/transactions/src/lifetime.ts
+++ b/packages/transactions/src/lifetime.ts
@@ -1,6 +1,13 @@
-import { Address } from '@solana/addresses';
-import { Blockhash, Slot } from '@solana/rpc-types';
-import { Nonce } from '@solana/transaction-messages';
+import type { Address } from '@solana/addresses';
+import type { Blockhash, Slot } from '@solana/rpc-types';
+import type {
+    CompilableTransactionMessage,
+    Nonce,
+    TransactionMessageWithBlockhashLifetime,
+    TransactionMessageWithDurableNonceLifetime,
+} from '@solana/transaction-messages';
+
+import type { Transaction } from './transaction';
 
 /**
  * A constraint which, when applied to a transaction, makes that transaction eligible to land on the
@@ -78,3 +85,20 @@ export type TransactionWithBlockhashLifetime = {
 export type TransactionWithDurableNonceLifetime = {
     readonly lifetimeConstraint: TransactionDurableNonceLifetime;
 };
+
+/**
+ * Helper type that sets the lifetime constraint of a transaction message to be the same as the
+ * lifetime constraint of the provided transaction message.
+ */
+export type SetTransactionLifetimeFromCompilableTransactionMessage<
+    TTransaction extends Transaction,
+    TTransactionMessage extends CompilableTransactionMessage,
+> =
+    // Note that we have to compare the `lifetimeConstraint` properties explicitly because the
+    // `CompilableTransactionMessage` contains the union of all possible lifetime constraints
+    // and therefore would always match the first condition.
+    TTransactionMessage['lifetimeConstraint'] extends TransactionMessageWithBlockhashLifetime['lifetimeConstraint']
+        ? TransactionWithBlockhashLifetime & TTransaction
+        : TTransactionMessage['lifetimeConstraint'] extends TransactionMessageWithDurableNonceLifetime['lifetimeConstraint']
+          ? TransactionWithDurableNonceLifetime & TTransaction
+          : TransactionWithLifetime & TTransaction;

--- a/packages/transactions/src/transaction-message-size.ts
+++ b/packages/transactions/src/transaction-message-size.ts
@@ -1,6 +1,5 @@
 import { SOLANA_ERROR__TRANSACTION__EXCEEDS_SIZE_LIMIT, SolanaError } from '@solana/errors';
-import type { NominalType } from '@solana/nominal-types';
-import type { CompilableTransactionMessage } from '@solana/transaction-messages';
+import type { CompilableTransactionMessage, TransactionMessageWithinSizeLimit } from '@solana/transaction-messages';
 
 import { compileTransaction } from './compile-transaction';
 import { getTransactionSize, TRANSACTION_SIZE_LIMIT } from './transaction-size';
@@ -16,12 +15,6 @@ import { getTransactionSize, TRANSACTION_SIZE_LIMIT } from './transaction-size';
 export function getTransactionMessageSize(transactionMessage: CompilableTransactionMessage): number {
     return getTransactionSize(compileTransaction(transactionMessage));
 }
-
-/**
- * A type guard that checks if a transaction message is within the size limit
- * when compiled into a transaction.
- */
-export type TransactionMessageWithinSizeLimit = NominalType<'transactionSize', 'withinLimit'>;
 
 /**
  * Checks if a transaction message is within the size limit

--- a/packages/transactions/src/transaction-size.ts
+++ b/packages/transactions/src/transaction-size.ts
@@ -1,5 +1,6 @@
 import { SOLANA_ERROR__TRANSACTION__EXCEEDS_SIZE_LIMIT, SolanaError } from '@solana/errors';
 import type { NominalType } from '@solana/nominal-types';
+import type { BaseTransactionMessage, TransactionMessageWithinSizeLimit } from '@solana/transaction-messages';
 
 import { getTransactionEncoder } from './codecs';
 import { Transaction } from './transaction';
@@ -40,6 +41,18 @@ export function getTransactionSize(transaction: Transaction): number {
  * A type guard that checks if a transaction is within the size limit.
  */
 export type TransactionWithinSizeLimit = NominalType<'transactionSize', 'withinLimit'>;
+
+/**
+ * Helper type that adds the `TransactionWithinSizeLimit` flag to
+ * a transaction if and only if the provided transaction message
+ * is also within the size limit.
+ */
+export type SetTransactionWithinSizeLimitFromTransactionMessage<
+    TTransaction extends Transaction,
+    TTransactionMessage extends BaseTransactionMessage,
+> = TTransactionMessage extends TransactionMessageWithinSizeLimit
+    ? TransactionWithinSizeLimit & TTransaction
+    : TTransaction;
 
 /**
  * Checks if a transaction is within the size limit.

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -1,7 +1,11 @@
-import { Address } from '@solana/addresses';
-import { ReadonlyUint8Array } from '@solana/codecs-core';
-import { SignatureBytes } from '@solana/keys';
-import { Brand, EncodedString } from '@solana/nominal-types';
+import type { Address } from '@solana/addresses';
+import type { ReadonlyUint8Array } from '@solana/codecs-core';
+import type { SignatureBytes } from '@solana/keys';
+import type { Brand, EncodedString } from '@solana/nominal-types';
+import type { CompilableTransactionMessage } from '@solana/transaction-messages';
+
+import type { SetTransactionLifetimeFromCompilableTransactionMessage } from './lifetime';
+import type { SetTransactionWithinSizeLimitFromTransactionMessage } from './transaction-size';
 
 export type TransactionMessageBytes = Brand<ReadonlyUint8Array, 'TransactionMessageBytes'>;
 export type TransactionMessageBytesBase64 = Brand<EncodedString<string, 'base64'>, 'TransactionMessageBytesBase64'>;
@@ -18,3 +22,13 @@ export type Transaction = Readonly<{
      */
     signatures: SignaturesMap;
 }>;
+
+/**
+ * Helper type that creates a `Transaction` type as narrow as possible
+ * from the provided `CompilableTransactionMessage` type.
+ */
+export type TransactionFromCompilableTransactionMessage<TTransactionMessage extends CompilableTransactionMessage> =
+    SetTransactionWithinSizeLimitFromTransactionMessage<
+        SetTransactionLifetimeFromCompilableTransactionMessage<Transaction, TTransactionMessage>,
+        TTransactionMessage
+    >;


### PR DESCRIPTION
This PR adds, removes or forwards the `TransactionMessageWithinSizeLimit` and `TransactionWithinSizeLimit` types in all helpers that may affect the size of a transaction.

Namely it does the following:
- Moves the `TransactionMessageWithinSizeLimit` type to `@solana/transaction-messages` so it can be used within transaction message helpers (not we cannot move the other helper functions since they rely on compiling the transaction to get its size).
- Adds a `ExcludeTransactionMessageWithinSizeLimit` type helper to remove the size limit type safety from a message.
- Removes the size limit type safety when appending or prepending instruction.
- Removes the size limit type safety when setting a durable nonce lifetime if and only if the current lifetime of the message isn't already using a durable nonce constraint.
- Adds size limit type safety to the `createTransactionMessage` return type since it always returns empty messages.
- Adds a `SetTransactionWithinSizeLimitFromTransactionMessage` type helper that forwards the size limit type safety from a message to a transaction, if any.
- Adds a `SetTransactionLifetimeFromCompilableTransactionMessage ` type helper that forwards the lifetime constraint from a message to a transaction, if any.
- Adds a `TransactionFromCompilableTransactionMessage` type helper that creates a `Transaction` type with all the appropriate flags based on the provided message. This helper is then used in the following helpers to significantly simplify their function signatures (they now only require one):
  - `compileTransaction`
  - `signTransactionMessageWithSigners `
  - `partiallySignTransactionMessageWithSigners`
- Adds type tests for all of this.