### PR TITLE
Don't run the docs preview CI step for dependabot PRs

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -21,6 +21,7 @@ env:
 
 jobs:
   preview-docs:
+    if: github.actor != 'dependabot[bot]'
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Problem

TIL that Dependabot doesn't share any of the same secrets as GitHub Actions. This is why the Vercel deploy is failing on all Dependabot PRs – no access token.

#### Summary of Changes

Disable the docs preview for dependabot PRs.
