### PR TITLE
Collect all of the types for the build-time constants in a common place

### DIFF
--- a/packages/accounts/src/types/global.d.ts
+++ b/packages/accounts/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/accounts/tsconfig.declarations.json
+++ b/packages/accounts/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/accounts/tsconfig.json
+++ b/packages/accounts/tsconfig.json
@@ -2,5 +2,5 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "@solana/accounts",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/addresses/src/types/global.d.ts
+++ b/packages/addresses/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/addresses/tsconfig.declarations.json
+++ b/packages/addresses/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/addresses/tsconfig.json
+++ b/packages/addresses/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/addresses",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/assertions/src/types/global.d.ts
+++ b/packages/assertions/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/assertions/tsconfig.declarations.json
+++ b/packages/assertions/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/assertions/tsconfig.json
+++ b/packages/assertions/tsconfig.json
@@ -2,7 +2,7 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "@solana/addresses",
     "extends": "../tsconfig/base.json",
-    "include": ["src"],
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"],
     "compilerOptions": {
         "lib": ["DOM", "ES2015"]
     }

--- a/packages/build-scripts/build-time-constants.d.ts
+++ b/packages/build-scripts/build-time-constants.d.ts
@@ -1,0 +1,13 @@
+// Build time constant roughly equivalent to `NODE_ENV !== 'production'`
+// See build-scripts/dev-flag.ts
+declare const __DEV__: boolean;
+
+// Build targets; mutually exclusive (only one can be true)
+// See build-scripts/getBaseConfig.ts
+declare const __BROWSER__: boolean;
+declare const __NODEJS__: boolean;
+declare const __REACTNATIVE__: boolean;
+
+// Build-time constant representing the version of the npm package
+// See build-scripts/getBaseConfig.ts
+declare const __VERSION__: string;

--- a/packages/codecs-core/src/types/global.d.ts
+++ b/packages/codecs-core/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/codecs-core/tsconfig.declarations.json
+++ b/packages/codecs-core/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/codecs-core/tsconfig.json
+++ b/packages/codecs-core/tsconfig.json
@@ -2,7 +2,7 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "@solana/codecs-core",
     "extends": "../tsconfig/base.json",
-    "include": ["src"],
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"],
     "compilerOptions": {
         "lib": ["DOM", "ES2020", "ES2022.Error"]
     }

--- a/packages/codecs-data-structures/src/types/global.d.ts
+++ b/packages/codecs-data-structures/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/codecs-data-structures/tsconfig.declarations.json
+++ b/packages/codecs-data-structures/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/codecs-data-structures/tsconfig.json
+++ b/packages/codecs-data-structures/tsconfig.json
@@ -2,7 +2,7 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "@solana/codecs-data-structures",
     "extends": "../tsconfig/base.json",
-    "include": ["src"],
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"],
     "compilerOptions": {
         "lib": ["DOM", "ES2019", "ES2022.Error"]
     }

--- a/packages/codecs-numbers/src/types/global.d.ts
+++ b/packages/codecs-numbers/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/codecs-numbers/tsconfig.declarations.json
+++ b/packages/codecs-numbers/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/codecs-numbers/tsconfig.json
+++ b/packages/codecs-numbers/tsconfig.json
@@ -2,7 +2,7 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "@solana/codecs-numbers",
     "extends": "../tsconfig/base.json",
-    "include": ["src"],
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"],
     "compilerOptions": {
         "lib": ["DOM", "ES2015", "ES2017.String", "ES2020.BigInt", "ES2022.Error"]
     }

--- a/packages/codecs-strings/src/types/global.d.ts
+++ b/packages/codecs-strings/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/codecs-strings/tsconfig.declarations.json
+++ b/packages/codecs-strings/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/codecs-strings/tsconfig.json
+++ b/packages/codecs-strings/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/codecs-strings",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/codecs/tsconfig.declarations.json
+++ b/packages/codecs/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/codecs/tsconfig.json
+++ b/packages/codecs/tsconfig.json
@@ -2,5 +2,5 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "@solana/codecs",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/compat/src/types/global.d.ts
+++ b/packages/compat/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/compat/tsconfig.declarations.json
+++ b/packages/compat/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/compat/tsconfig.json
+++ b/packages/compat/tsconfig.json
@@ -6,5 +6,5 @@
     },
     "display": "@solana/compat",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/crypto-impl/tsconfig.declarations.json
+++ b/packages/crypto-impl/tsconfig.declarations.json
@@ -7,5 +7,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.browser.ts"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.browser.ts"]
 }

--- a/packages/crypto-impl/tsconfig.json
+++ b/packages/crypto-impl/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "Crypto Implementation",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/errors/src/types/global.d.ts
+++ b/packages/errors/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/errors/tsconfig.declarations.json
+++ b/packages/errors/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/errors/tsconfig.json
+++ b/packages/errors/tsconfig.json
@@ -6,5 +6,5 @@
     },
     "display": "@solana/errors",
     "extends": "../tsconfig/base.json",
-    "include": ["bin", "src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "bin", "src"]
 }

--- a/packages/event-target-impl/tsconfig.declarations.json
+++ b/packages/event-target-impl/tsconfig.declarations.json
@@ -7,5 +7,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.browser.ts"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.browser.ts"]
 }

--- a/packages/event-target-impl/tsconfig.json
+++ b/packages/event-target-impl/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "EventTarget Implementation",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/fast-stable-stringify/tsconfig.declarations.json
+++ b/packages/fast-stable-stringify/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/fast-stable-stringify/tsconfig.json
+++ b/packages/fast-stable-stringify/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/fast-stable-stringify",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/fetch-impl/tsconfig.json
+++ b/packages/fetch-impl/tsconfig.json
@@ -6,5 +6,5 @@
     },
     "display": "Fetch Implementation",
     "extends": "@solana/tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/functional/tsconfig.declarations.json
+++ b/packages/functional/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/functional/tsconfig.json
+++ b/packages/functional/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/functional",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/instructions/src/types/global.d.ts
+++ b/packages/instructions/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/instructions/tsconfig.declarations.json
+++ b/packages/instructions/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/instructions/tsconfig.json
+++ b/packages/instructions/tsconfig.json
@@ -2,5 +2,5 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "@solana/instructions",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/keys/src/types/global.d.ts
+++ b/packages/keys/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/keys/tsconfig.declarations.json
+++ b/packages/keys/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/keys/tsconfig.json
+++ b/packages/keys/tsconfig.json
@@ -2,7 +2,7 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "@solana/keys",
     "extends": "../tsconfig/base.json",
-    "include": ["src"],
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"],
     "compilerOptions": {
         "lib": ["DOM", "ES2015", "ES2022.Error"]
     }

--- a/packages/kit/src/types/global.d.ts
+++ b/packages/kit/src/types/global.d.ts
@@ -1,5 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;
-declare const __VERSION__: string;

--- a/packages/kit/tsconfig.declarations.json
+++ b/packages/kit/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/kit/tsconfig.json
+++ b/packages/kit/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/kit",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/options/src/types/global.d.ts
+++ b/packages/options/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/options/tsconfig.declarations.json
+++ b/packages/options/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/options/tsconfig.json
+++ b/packages/options/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/options",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/programs/src/types/global.d.ts
+++ b/packages/programs/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/programs/tsconfig.declarations.json
+++ b/packages/programs/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/programs/tsconfig.json
+++ b/packages/programs/tsconfig.json
@@ -2,5 +2,5 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "@solana/instructions",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/promises/tsconfig.declarations.json
+++ b/packages/promises/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/promises/tsconfig.json
+++ b/packages/promises/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/promises",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/react/src/types/global.d.ts
+++ b/packages/react/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/react/tsconfig.declarations.json
+++ b/packages/react/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -6,5 +6,5 @@
     },
     "display": "@solana/react",
     "extends": "../tsconfig/base.json",
-    "include": ["./eslint.config.mjs", "src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "./eslint.config.mjs", "src"]
 }

--- a/packages/rpc-api/src/types/global.d.ts
+++ b/packages/rpc-api/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/rpc-api/tsconfig.declarations.json
+++ b/packages/rpc-api/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc-api/tsconfig.json
+++ b/packages/rpc-api/tsconfig.json
@@ -2,5 +2,5 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "@solana/rpc-api",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/rpc-graphql/src/types/global.d.ts
+++ b/packages/rpc-graphql/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/rpc-graphql/tsconfig.declarations.json
+++ b/packages/rpc-graphql/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc-graphql/tsconfig.json
+++ b/packages/rpc-graphql/tsconfig.json
@@ -6,5 +6,5 @@
     },
     "display": "@solana/rpc-graphql",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/rpc-parsed-types/tsconfig.declarations.json
+++ b/packages/rpc-parsed-types/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc-parsed-types/tsconfig.json
+++ b/packages/rpc-parsed-types/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/rpc-types",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/rpc-spec-types/src/types/global.d.ts
+++ b/packages/rpc-spec-types/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/rpc-spec-types/tsconfig.declarations.json
+++ b/packages/rpc-spec-types/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc-spec-types/tsconfig.json
+++ b/packages/rpc-spec-types/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/rpc-spec-types",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/rpc-spec/src/types/global.d.ts
+++ b/packages/rpc-spec/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/rpc-spec/tsconfig.declarations.json
+++ b/packages/rpc-spec/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc-spec/tsconfig.json
+++ b/packages/rpc-spec/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/rpc-spec",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/rpc-subscriptions-api/tsconfig.declarations.json
+++ b/packages/rpc-subscriptions-api/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc-subscriptions-api/tsconfig.json
+++ b/packages/rpc-subscriptions-api/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/rpc-subscriptions-api",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/rpc-subscriptions-channel-websocket/src/types/global.d.ts
+++ b/packages/rpc-subscriptions-channel-websocket/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/rpc-subscriptions-channel-websocket/tsconfig.declarations.json
+++ b/packages/rpc-subscriptions-channel-websocket/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc-subscriptions-channel-websocket/tsconfig.json
+++ b/packages/rpc-subscriptions-channel-websocket/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/rpc-subscriptions-channel-websocket",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/rpc-subscriptions-spec/src/types/global.d.ts
+++ b/packages/rpc-subscriptions-spec/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/rpc-subscriptions-spec/tsconfig.declarations.json
+++ b/packages/rpc-subscriptions-spec/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc-subscriptions-spec/tsconfig.json
+++ b/packages/rpc-subscriptions-spec/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/rpc-subscriptions-spec",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/rpc-subscriptions/src/types/global.d.ts
+++ b/packages/rpc-subscriptions/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/rpc-subscriptions/tsconfig.declarations.json
+++ b/packages/rpc-subscriptions/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc-subscriptions/tsconfig.json
+++ b/packages/rpc-subscriptions/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/rpc-subscriptions",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/rpc-transformers/src/types/global.d.ts
+++ b/packages/rpc-transformers/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/rpc-transformers/tsconfig.declarations.json
+++ b/packages/rpc-transformers/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc-transformers/tsconfig.json
+++ b/packages/rpc-transformers/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/rpc-transformers",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/rpc-transport-http/src/types/global.d.ts
+++ b/packages/rpc-transport-http/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/rpc-transport-http/tsconfig.declarations.json
+++ b/packages/rpc-transport-http/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc-transport-http/tsconfig.json
+++ b/packages/rpc-transport-http/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/rpc-transport-http",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/rpc-types/tsconfig.declarations.json
+++ b/packages/rpc-types/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc-types/tsconfig.json
+++ b/packages/rpc-types/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/rpc-types",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/rpc/src/types/global.d.ts
+++ b/packages/rpc/src/types/global.d.ts
@@ -1,5 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;
-declare const __VERSION__: string;

--- a/packages/rpc/tsconfig.declarations.json
+++ b/packages/rpc/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/rpc/tsconfig.json
+++ b/packages/rpc/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/rpc",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/signers/src/types/global.d.ts
+++ b/packages/signers/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/signers/tsconfig.declarations.json
+++ b/packages/signers/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/signers/tsconfig.json
+++ b/packages/signers/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/signers",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/subscribable/src/types/global.d.ts
+++ b/packages/subscribable/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/subscribable/tsconfig.declarations.json
+++ b/packages/subscribable/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/subscribable/tsconfig.json
+++ b/packages/subscribable/tsconfig.json
@@ -2,7 +2,7 @@
     "$schema": "https://json.schemastore.org/tsconfig",
     "display": "@solana/subscribable",
     "extends": "../tsconfig/base.json",
-    "include": ["src"],
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"],
     "compilerOptions": {
         "lib": ["DOM", "ES2015"]
     }

--- a/packages/sysvars/tsconfig.declarations.json
+++ b/packages/sysvars/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/sysvars/tsconfig.json
+++ b/packages/sysvars/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/sysvars",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/text-encoding-impl/tsconfig.declarations.json
+++ b/packages/text-encoding-impl/tsconfig.declarations.json
@@ -7,5 +7,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.browser.ts"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.browser.ts"]
 }

--- a/packages/text-encoding-impl/tsconfig.json
+++ b/packages/text-encoding-impl/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "TextEncoder and TextDecoder Implementation",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/transaction-confirmation/src/types/global.d.ts
+++ b/packages/transaction-confirmation/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/transaction-confirmation/tsconfig.declarations.json
+++ b/packages/transaction-confirmation/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/transaction-confirmation/tsconfig.json
+++ b/packages/transaction-confirmation/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/transaction-confirmation",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/transaction-messages/src/types/global.d.ts
+++ b/packages/transaction-messages/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/transaction-messages/tsconfig.declarations.json
+++ b/packages/transaction-messages/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/transaction-messages/tsconfig.json
+++ b/packages/transaction-messages/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/transaction-messages",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/transactions/src/types/global.d.ts
+++ b/packages/transactions/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/transactions/tsconfig.declarations.json
+++ b/packages/transactions/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/transactions/tsconfig.json
+++ b/packages/transactions/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/transactions",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/webcrypto-ed25519-polyfill/src/types/global.d.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/types/global.d.ts
@@ -1,4 +1,0 @@
-declare const __BROWSER__: boolean;
-declare const __DEV__: boolean;
-declare const __NODEJS__: boolean;
-declare const __REACTNATIVE__: boolean;

--- a/packages/webcrypto-ed25519-polyfill/tsconfig.declarations.json
+++ b/packages/webcrypto-ed25519-polyfill/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.ts", "src/types"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
 }

--- a/packages/webcrypto-ed25519-polyfill/tsconfig.json
+++ b/packages/webcrypto-ed25519-polyfill/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "@solana/webcrypto-ed25519-polyfill",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }

--- a/packages/ws-impl/tsconfig.declarations.json
+++ b/packages/ws-impl/tsconfig.declarations.json
@@ -7,5 +7,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["src/index.browser.ts"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.browser.ts"]
 }

--- a/packages/ws-impl/tsconfig.json
+++ b/packages/ws-impl/tsconfig.json
@@ -5,5 +5,5 @@
     },
     "display": "WebSocket Implementation",
     "extends": "../tsconfig/base.json",
-    "include": ["src"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src"]
 }


### PR DESCRIPTION
#### Problem

Since these get erased at build time there's no harm in keeping them outside of the package directory.

#### Summary of Changes

Move the build-time constants' types into a commmon place and refer to them everywhere they're needed.
