### PR TITLE
Modify all branded types such that they will match with any structurally similar type from any package version, going forward

### DIFF
--- a/.changeset/legal-cases-lose.md
+++ b/.changeset/legal-cases-lose.md
@@ -1,0 +1,58 @@
+---
+'@solana/rpc-subscriptions-channel-websocket': patch
+'@solana/webcrypto-ed25519-polyfill': patch
+'@solana/transaction-confirmation': patch
+'@solana/codecs-data-structures': patch
+'@solana/rpc-subscriptions-spec': patch
+'@solana/fast-stable-stringify': patch
+'@solana/rpc-subscriptions-api': patch
+'@solana/transaction-messages': patch
+'@solana/rpc-transport-http': patch
+'@solana/rpc-subscriptions': patch
+'@solana/rpc-parsed-types': patch
+'@solana/rpc-transformers': patch
+'@solana/codecs-numbers': patch
+'@solana/codecs-strings': patch
+'@solana/rpc-spec-types': patch
+'@solana/nominal-types': patch
+'@solana/instructions': patch
+'@solana/subscribable': patch
+'@solana/transactions': patch
+'@solana/codecs-core': patch
+'@solana/rpc-graphql': patch
+'@solana/assertions': patch
+'@solana/functional': patch
+'@solana/addresses': patch
+'@solana/rpc-types': patch
+'@solana/accounts': patch
+'@solana/programs': patch
+'@solana/promises': patch
+'@solana/rpc-spec': patch
+'@solana/options': patch
+'@solana/rpc-api': patch
+'@solana/signers': patch
+'@solana/sysvars': patch
+'@solana/codecs': patch
+'@solana/compat': patch
+'@solana/errors': patch
+'@solana/react': patch
+'@solana/keys': patch
+'@solana/kit': patch
+'@solana/rpc': patch
+---
+
+The identity of all branded types has changed in such a way that the types from v2.1.1 will be compatible with any other version going forward, which is not the case for versions v2.1.0 and before.
+
+If you end up with a mix of versions in your project prior to v2.1.1 (eg. `@solana/addresses@2.0.0` and `@solana/addresses@2.1.0`) you may discover that branded types like `Address` raise a type error, even though they are runtime compatible. Your options are:
+
+1. Always make sure that you have exactly one instance of each `@solana/*` dependency in your project at any given time
+2. Upgrade all of your `@solana/*` dependencies to v2.1.1 at minimum, even if their minor or patch versions differ.
+3. Suppress the type errors using a comment like the following:
+    ```ts
+    const myAddress = address('1234..5678');     // from @solana/addresses@2.0.0
+    const myAccount = await fetchEncodedAccount( // imports @solana/addresses@2.1.0
+        rpc,
+        // @ts-expect-error Address types mismatch between installed versions of @solana/addresses
+        myAddress,
+    );
+    ```

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -75,7 +75,8 @@
         "@solana/assertions": "workspace:*",
         "@solana/codecs-core": "workspace:*",
         "@solana/codecs-strings": "workspace:*",
-        "@solana/errors": "workspace:*"
+        "@solana/errors": "workspace:*",
+        "@solana/nominal-types": "workspace:*"
     },
     "peerDependencies": {
         "typescript": ">=5.3.3"

--- a/packages/addresses/src/__typetests__/coercions-typetests.ts
+++ b/packages/addresses/src/__typetests__/coercions-typetests.ts
@@ -1,3 +1,7 @@
+import { Brand, EncodedString } from '@solana/nominal-types';
+
 import { Address, address } from '../address';
 
 address('555555555555555555555555') satisfies Address<'555555555555555555555555'>;
+address('555555555555555555555555') satisfies Brand<'555555555555555555555555', 'Address'>;
+address('555555555555555555555555') satisfies EncodedString<'555555555555555555555555', 'base58'>;

--- a/packages/addresses/src/address.ts
+++ b/packages/addresses/src/address.ts
@@ -15,6 +15,7 @@ import {
     SOLANA_ERROR__ADDRESSES__STRING_LENGTH_OUT_OF_RANGE,
     SolanaError,
 } from '@solana/errors';
+import { Brand, EncodedString } from '@solana/nominal-types';
 
 /**
  * Represents a string that validates as a Solana address. Functions that require well-formed
@@ -23,9 +24,7 @@ import {
  * Whenever you need to validate an arbitrary string as a base58-encoded address, use the
  * {@link address}, {@link assertIsAddress}, or {@link isAddress} functions in this package.
  */
-export type Address<TAddress extends string = string> = TAddress & {
-    readonly __brand: unique symbol;
-};
+export type Address<TAddress extends string = string> = Brand<EncodedString<TAddress, 'base58'>, 'Address'>;
 
 let memoizedBase58Encoder: Encoder<string> | undefined;
 let memoizedBase58Decoder: Decoder<string> | undefined;

--- a/packages/addresses/src/program-derived-address.ts
+++ b/packages/addresses/src/program-derived-address.ts
@@ -11,6 +11,7 @@ import {
     SOLANA_ERROR__ADDRESSES__PDA_ENDS_WITH_PDA_MARKER,
     SolanaError,
 } from '@solana/errors';
+import { Brand } from '@solana/nominal-types';
 
 import { Address, assertIsAddress, getAddressCodec, isAddress } from './address';
 import { compressedPointBytesAreOnCurve } from './curve';
@@ -32,9 +33,7 @@ export type ProgramDerivedAddress<TAddress extends string = string> = Readonly<
  * Represents an integer in the range [0,255] used in the derivation of a program derived address to
  * ensure that it does not fall on the Ed25519 curve.
  */
-export type ProgramDerivedAddressBump = number & {
-    readonly __brand: unique symbol;
-};
+export type ProgramDerivedAddressBump = Brand<number, 'ProgramDerivedAddressBump'>;
 
 /**
  * A type guard that returns `true` if the input tuple conforms to the {@link ProgramDerivedAddress}

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -76,7 +76,8 @@
         "@solana/assertions": "workspace:*",
         "@solana/codecs-core": "workspace:*",
         "@solana/codecs-strings": "workspace:*",
-        "@solana/errors": "workspace:*"
+        "@solana/errors": "workspace:*",
+        "@solana/nominal-types": "workspace:*"
     },
     "peerDependencies": {
         "typescript": ">=5.3.3"

--- a/packages/keys/src/__typetests__/signatures-typetests.ts
+++ b/packages/keys/src/__typetests__/signatures-typetests.ts
@@ -1,3 +1,20 @@
+import { EncodedString } from '@solana/nominal-types';
+
 import { Signature, signature } from '../signatures';
 
-signature('x') satisfies Signature;
+// [DESCRIBE] signature()
+{
+    // It returns a `Signature`
+    {
+        signature('x') satisfies Signature;
+    }
+}
+
+// [DESCRIBE] Signature
+{
+    // It satisfies the base58 encoded string brand
+    {
+        const signature = null as unknown as Signature;
+        signature satisfies EncodedString<string, 'base58'>;
+    }
+}

--- a/packages/keys/src/signatures.ts
+++ b/packages/keys/src/signatures.ts
@@ -6,13 +6,14 @@ import {
     SOLANA_ERROR__KEYS__SIGNATURE_STRING_LENGTH_OUT_OF_RANGE,
     SolanaError,
 } from '@solana/errors';
+import { Brand, EncodedString } from '@solana/nominal-types';
 
 import { ED25519_ALGORITHM_IDENTIFIER } from './algorithm';
 
 /**
  * A 64-byte Ed25519 signature as a base58-encoded string.
  */
-export type Signature = string & { readonly __brand: unique symbol };
+export type Signature = Brand<EncodedString<string, 'base58'>, 'Signature'>;
 /**
  * A 64-byte Ed25519 signature.
  *
@@ -20,7 +21,7 @@ export type Signature = string & { readonly __brand: unique symbol };
  * produced by signing some known bytes using the private key associated with some known public key,
  * use the {@link verifySignature} function in this package.
  */
-export type SignatureBytes = Uint8Array & { readonly __brand: unique symbol };
+export type SignatureBytes = Brand<Uint8Array, 'SignatureBytes'>;
 
 let base58Encoder: Encoder<string> | undefined;
 

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -74,6 +74,7 @@
     "dependencies": {
         "@solana/errors": "workspace:*",
         "@solana/functional": "workspace:*",
+        "@solana/nominal-types": "workspace:*",
         "@solana/rpc-spec-types": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },

--- a/packages/rpc-transformers/src/tree-traversal.ts
+++ b/packages/rpc-transformers/src/tree-traversal.ts
@@ -1,6 +1,6 @@
 import { RpcRequest, RpcRequestTransformer, RpcResponseTransformer } from '@solana/rpc-spec-types';
 
-export type KeyPathWildcard = { readonly __brand: unique symbol };
+export type KeyPathWildcard = { readonly ['__keyPathWildcard:@solana/kit']: unique symbol };
 export type KeyPath = ReadonlyArray<KeyPath | KeyPathWildcard | number | string>;
 
 export const KEYPATH_WILDCARD = {} as KeyPathWildcard;

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -76,7 +76,8 @@
         "@solana/codecs-core": "workspace:*",
         "@solana/codecs-numbers": "workspace:*",
         "@solana/codecs-strings": "workspace:*",
-        "@solana/errors": "workspace:*"
+        "@solana/errors": "workspace:*",
+        "@solana/nominal-types": "workspace:*"
     },
     "peerDependencies": {
         "typescript": ">=5.3.3"

--- a/packages/rpc-types/src/__typetests__/blockhash-typetests.ts
+++ b/packages/rpc-types/src/__typetests__/blockhash-typetests.ts
@@ -1,0 +1,12 @@
+import { EncodedString } from '@solana/nominal-types';
+
+import { Blockhash } from '../blockhash';
+
+// [DESCRIBE] Blockhash
+{
+    // It satisfies the base58 encoded string brand
+    {
+        const blockhash = null as unknown as Blockhash;
+        blockhash satisfies EncodedString<string, 'base58'>;
+    }
+}

--- a/packages/rpc-types/src/__typetests__/encoded-bytes-typetests.ts
+++ b/packages/rpc-types/src/__typetests__/encoded-bytes-typetests.ts
@@ -1,0 +1,35 @@
+import { CompressedData, EncodedString } from '@solana/nominal-types';
+
+import { Base58EncodedBytes, Base64EncodedBytes, Base64EncodedZStdCompressedBytes } from '../encoded-bytes';
+
+// [DESCRIBE] Base58EncodedBytes
+{
+    // It satisfies the base58 encoded string brand
+    {
+        const encodedBytes = null as unknown as Base58EncodedBytes;
+        encodedBytes satisfies EncodedString<string, 'base58'>;
+    }
+}
+
+// [DESCRIBE] Base64EncodedBytes
+{
+    // It satisfies the base64 encoded string brand
+    {
+        const encodedBytes = null as unknown as Base64EncodedBytes;
+        encodedBytes satisfies EncodedString<string, 'base64'>;
+    }
+}
+
+// [DESCRIBE] Base64EncodedZStdCompressedBytes
+{
+    // It satisfies the base64 encoded string brand
+    {
+        const encodedBytes = null as unknown as Base64EncodedZStdCompressedBytes;
+        encodedBytes satisfies EncodedString<string, 'base64'>;
+    }
+    // It satisfies the ztd compressed data type
+    {
+        const encodedBytes = null as unknown as Base64EncodedZStdCompressedBytes;
+        encodedBytes satisfies CompressedData<string, 'zstd'>;
+    }
+}

--- a/packages/rpc-types/src/blockhash.ts
+++ b/packages/rpc-types/src/blockhash.ts
@@ -15,8 +15,9 @@ import {
     SOLANA_ERROR__INVALID_BLOCKHASH_BYTE_LENGTH,
     SolanaError,
 } from '@solana/errors';
+import { Brand, EncodedString } from '@solana/nominal-types';
 
-export type Blockhash = string & { readonly __brand: unique symbol };
+export type Blockhash = Brand<EncodedString<string, 'base58'>, 'Blockhash'>;
 
 let memoizedBase58Encoder: Encoder<string> | undefined;
 let memoizedBase58Decoder: Decoder<string> | undefined;

--- a/packages/rpc-types/src/encoded-bytes.ts
+++ b/packages/rpc-types/src/encoded-bytes.ts
@@ -1,6 +1,11 @@
-export type Base58EncodedBytes = string & { readonly __brand: unique symbol };
-export type Base64EncodedBytes = string & { readonly __brand: unique symbol };
-export type Base64EncodedZStdCompressedBytes = string & { readonly __brand: unique symbol };
+import { Brand, CompressedData, EncodedString } from '@solana/nominal-types';
+
+export type Base58EncodedBytes = Brand<EncodedString<string, 'base58'>, 'Base58EncodedBytes'>;
+export type Base64EncodedBytes = Brand<EncodedString<string, 'base64'>, 'Base64EncodedBytes'>;
+export type Base64EncodedZStdCompressedBytes = Brand<
+    EncodedString<CompressedData<string, 'zstd'>, 'base64'>,
+    'Base64EncodedZStdCompressedBytes'
+>;
 
 export type Base58EncodedDataResponse = [Base58EncodedBytes, 'base58'];
 export type Base64EncodedDataResponse = [Base64EncodedBytes, 'base64'];

--- a/packages/rpc-types/src/lamports.ts
+++ b/packages/rpc-types/src/lamports.ts
@@ -10,13 +10,14 @@ import {
 } from '@solana/codecs-core';
 import { getU64Decoder, getU64Encoder, NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-numbers';
 import { SOLANA_ERROR__LAMPORTS_OUT_OF_RANGE, SolanaError } from '@solana/errors';
+import { Brand } from '@solana/nominal-types';
 
 /**
  * Represents an integer value denominated in Lamports (ie. $1 \times 10^{-9}$ ◎).
  *
  * It is represented as a `bigint` in client code and an `u64` in server code.
  */
-export type Lamports = bigint & { readonly __brand: unique symbol };
+export type Lamports = Brand<bigint, 'Lamports'>;
 
 // Largest possible value to be represented by a u64
 const maxU64Value = 18446744073709551615n; // 2n ** 64n - 1n

--- a/packages/rpc-types/src/stringified-bigint.ts
+++ b/packages/rpc-types/src/stringified-bigint.ts
@@ -1,10 +1,11 @@
 import { SOLANA_ERROR__MALFORMED_BIGINT_STRING, SolanaError } from '@solana/errors';
+import { Brand } from '@solana/nominal-types';
 
 /**
  * This type represents a `bigint` which has been encoded as a string for transit over a transport
  * that does not support `bigint` values natively. The JSON-RPC is such a transport.
  */
-export type StringifiedBigInt = string & { readonly __brand: unique symbol };
+export type StringifiedBigInt = Brand<string, 'StringifiedBigInt'>;
 
 /**
  * A type guard that returns `true` if the input string parses as a `BigInt`, and refines its type

--- a/packages/rpc-types/src/stringified-number.ts
+++ b/packages/rpc-types/src/stringified-number.ts
@@ -1,11 +1,12 @@
 import { SOLANA_ERROR__MALFORMED_NUMBER_STRING, SolanaError } from '@solana/errors';
+import { Brand } from '@solana/nominal-types';
 
 /**
  * This type represents a number which has been encoded as a string for transit over a transport
  * where loss of precision when using the native number type is a concern. The JSON-RPC is such a
  * transport.
  */
-export type StringifiedNumber = string & { readonly __brand: unique symbol };
+export type StringifiedNumber = Brand<string, 'StringifiedNumber'>;
 
 /**
  * A type guard that returns `true` if the input string parses as a `Number`, and refines its type

--- a/packages/rpc-types/src/typed-numbers.ts
+++ b/packages/rpc-types/src/typed-numbers.ts
@@ -1,8 +1,10 @@
+import { Brand } from '@solana/nominal-types';
+
 export type Slot = bigint;
 export type Epoch = bigint;
 
 // Specifically being used to denote micro-lamports, which are 0.000001 lamports.
-export type MicroLamports = bigint & { readonly __brand: unique symbol };
+export type MicroLamports = Brand<bigint, 'MicroLamports'>;
 export type SignedLamports = bigint;
 
 // FIXME(solana-labs/solana/issues/30341)

--- a/packages/rpc-types/src/unix-timestamp.ts
+++ b/packages/rpc-types/src/unix-timestamp.ts
@@ -1,11 +1,12 @@
 import { SOLANA_ERROR__TIMESTAMP_OUT_OF_RANGE, SolanaError } from '@solana/errors';
+import { Brand } from '@solana/nominal-types';
 
 /**
  * This type represents a Unix timestamp in _seconds_.
  *
  * It is represented as a `bigint` in client code and an `i64` in server code.
  */
-export type UnixTimestamp = bigint & { readonly __brand: unique symbol };
+export type UnixTimestamp = Brand<bigint, 'UnixTimestamp'>;
 
 // Largest possible value to be represented by an i64
 const maxI64Value = 9223372036854775807n; // 2n ** 63n - 1n

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -77,6 +77,7 @@
         "@solana/errors": "workspace:*",
         "@solana/instructions": "workspace:*",
         "@solana/keys": "workspace:*",
+        "@solana/nominal-types": "workspace:*",
         "@solana/transaction-messages": "workspace:*",
         "@solana/transactions": "workspace:*"
     },

--- a/packages/signers/src/transaction-with-single-sending-signer.ts
+++ b/packages/signers/src/transaction-with-single-sending-signer.ts
@@ -3,6 +3,7 @@ import {
     SOLANA_ERROR__SIGNER__TRANSACTION_SENDING_SIGNER_MISSING,
     SolanaError,
 } from '@solana/errors';
+import { Brand } from '@solana/nominal-types';
 import { CompilableTransactionMessage } from '@solana/transaction-messages';
 
 import { getSignersFromTransactionMessage, ITransactionMessageWithSigners } from './account-signer-meta';
@@ -27,9 +28,10 @@ import { isTransactionSendingSigner } from './transaction-sending-signer';
  * @see {@link isTransactionMessageWithSingleSendingSigner}
  * @see {@link assertIsTransactionMessageWithSingleSendingSigner}
  */
-export type ITransactionMessageWithSingleSendingSigner = ITransactionMessageWithSigners & {
-    readonly __transactionWithSingleSendingSigner: unique symbol;
-};
+export type ITransactionMessageWithSingleSendingSigner = Brand<
+    ITransactionMessageWithSigners,
+    'TransactionMessageWithSingleSendingSigner'
+>;
 
 /**
  * Checks whether the provided transaction has exactly one {@link TransactionSendingSigner}.

--- a/packages/transaction-messages/package.json
+++ b/packages/transaction-messages/package.json
@@ -79,6 +79,7 @@
         "@solana/errors": "workspace:*",
         "@solana/functional": "workspace:*",
         "@solana/instructions": "workspace:*",
+        "@solana/nominal-types": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },
     "devDependencies": {

--- a/packages/transaction-messages/src/compile/accounts.ts
+++ b/packages/transaction-messages/src/compile/accounts.ts
@@ -19,6 +19,7 @@ import {
     WritableAccountLookup,
     WritableSignerAccount,
 } from '@solana/instructions';
+import { Brand } from '@solana/nominal-types';
 
 export const enum AddressMapEntryType {
     FEE_PAYER,
@@ -35,7 +36,7 @@ type FeePayerAccountEntry = Omit<WritableSignerAccount, 'address'> & {
 type LookupTableAccountEntry = Omit<ReadonlyAccountLookup | WritableAccountLookup, 'address'> & {
     [TYPE]: AddressMapEntryType.LOOKUP_TABLE;
 };
-export type OrderedAccounts = (IAccountLookupMeta | IAccountMeta)[] & { readonly __brand: unique symbol };
+export type OrderedAccounts = Brand<(IAccountLookupMeta | IAccountMeta)[], 'OrderedAccounts'>;
 type StaticAccountEntry = Omit<
     ReadonlyAccount | ReadonlySignerAccount | WritableAccount | WritableSignerAccount,
     'address'

--- a/packages/transaction-messages/src/durable-nonce.ts
+++ b/packages/transaction-messages/src/durable-nonce.ts
@@ -12,6 +12,7 @@ import {
     WritableAccount,
     WritableSignerAccount,
 } from '@solana/instructions';
+import { Brand } from '@solana/nominal-types';
 
 import { BaseTransactionMessage } from './transaction-message';
 
@@ -27,9 +28,7 @@ type AdvanceNonceAccountInstruction<
         ]
     > &
     IInstructionWithData<AdvanceNonceAccountInstructionData>;
-type AdvanceNonceAccountInstructionData = Uint8Array & {
-    readonly __brand: unique symbol;
-};
+type AdvanceNonceAccountInstructionData = Brand<Uint8Array, 'AdvanceNonceAccountInstructionData'>;
 type DurableNonceConfig<
     TNonceAccountAddress extends string = string,
     TNonceAuthorityAddress extends string = string,
@@ -40,7 +39,7 @@ type DurableNonceConfig<
     readonly nonceAuthorityAddress: Address<TNonceAuthorityAddress>;
 }>;
 /** Represents a string that is particularly known to be the base58-encoded value of a nonce. */
-export type Nonce<TNonceValue extends string = string> = TNonceValue & { readonly __brand: unique symbol };
+export type Nonce<TNonceValue extends string = string> = Brand<TNonceValue, 'Nonce'>;
 /**
  * A constraint which, when applied to a transaction message, makes that transaction message
  * eligible to land on the network.

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -81,6 +81,7 @@
         "@solana/functional": "workspace:*",
         "@solana/instructions": "workspace:*",
         "@solana/keys": "workspace:*",
+        "@solana/nominal-types": "workspace:*",
         "@solana/rpc-types": "workspace:*",
         "@solana/transaction-messages": "workspace:*"
     },

--- a/packages/transactions/src/__typetests__/transaction-typetests.ts
+++ b/packages/transactions/src/__typetests__/transaction-typetests.ts
@@ -1,0 +1,12 @@
+import { EncodedString } from '@solana/nominal-types';
+
+import { TransactionMessageBytesBase64 } from '../transaction';
+
+// [DESCRIBE] TransactionMessageBytesBase64
+{
+    // It satisfies the base64 encoded string brand
+    {
+        const encodedBytes = null as unknown as TransactionMessageBytesBase64;
+        encodedBytes satisfies EncodedString<string, 'base64'>;
+    }
+}

--- a/packages/transactions/src/__typetests__/wire-transaction-typetests.ts
+++ b/packages/transactions/src/__typetests__/wire-transaction-typetests.ts
@@ -1,0 +1,14 @@
+import { EncodedString } from '@solana/nominal-types';
+
+import { Transaction } from '../transaction';
+import { getBase64EncodedWireTransaction } from '../wire-transaction';
+
+const transaction = null as unknown as Transaction;
+
+// [DESCRIBE] getBase64EncodedWireTransaction
+{
+    // The return value satisfies the base64 encoded string brand
+    {
+        getBase64EncodedWireTransaction(transaction) satisfies EncodedString<string, 'base64'>;
+    }
+}

--- a/packages/transactions/src/signatures.ts
+++ b/packages/transactions/src/signatures.ts
@@ -8,6 +8,7 @@ import {
     SolanaError,
 } from '@solana/errors';
 import { Signature, SignatureBytes, signBytes } from '@solana/keys';
+import { NominalType } from '@solana/nominal-types';
 
 import { Transaction } from './transaction';
 
@@ -15,9 +16,7 @@ import { Transaction } from './transaction';
  * Represents a transaction that is signed by all of its required signers. Being fully signed is a
  * prerequisite of functions designed to land transactions on the network.
  */
-export interface FullySignedTransaction extends Transaction {
-    readonly __brand: unique symbol;
-}
+export type FullySignedTransaction = NominalType<'transactionSignedness', 'fullySigned'> & Transaction;
 
 let base58Decoder: Decoder<string> | undefined;
 

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -1,9 +1,10 @@
 import { Address } from '@solana/addresses';
 import { ReadonlyUint8Array } from '@solana/codecs-core';
 import { SignatureBytes } from '@solana/keys';
+import { Brand, EncodedString } from '@solana/nominal-types';
 
-export type TransactionMessageBytes = ReadonlyUint8Array & { readonly __brand: unique symbol };
-export type TransactionMessageBytesBase64 = string & { readonly __serializedMessageBytesBase64: unique symbol };
+export type TransactionMessageBytes = Brand<ReadonlyUint8Array, 'TransactionMessageBytes'>;
+export type TransactionMessageBytesBase64 = Brand<EncodedString<string, 'base64'>, 'TransactionMessageBytesBase64'>;
 
 type OrderedMap<K extends string, V> = Record<K, V>;
 export type SignaturesMap = OrderedMap<Address, SignatureBytes | null>;

--- a/packages/transactions/src/wire-transaction.ts
+++ b/packages/transactions/src/wire-transaction.ts
@@ -1,12 +1,11 @@
 import { getBase64Decoder } from '@solana/codecs-strings';
+import { Brand, EncodedString } from '@solana/nominal-types';
 
 import { getTransactionEncoder } from './codecs';
 import { Transaction } from './transaction';
 
 /** Represents the wire format of a transaction as a base64-encoded string. */
-export type Base64EncodedWireTransaction = string & {
-    readonly __brand: unique symbol;
-};
+export type Base64EncodedWireTransaction = Brand<EncodedString<string, 'base64'>, 'Base64EncodedWireTransaction'>;
 
 /**
  * Given a signed transaction, this method returns the transaction as a string that conforms to the

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      '@solana/nominal-types':
+        specifier: workspace:*
+        version: link:../nominal-types
       typescript:
         specifier: '>=5.3.3'
         version: 5.8.2
@@ -561,6 +564,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      '@solana/nominal-types':
+        specifier: workspace:*
+        version: link:../nominal-types
       typescript:
         specifier: '>=5.3.3'
         version: 5.8.2
@@ -1025,6 +1031,9 @@ importers:
       '@solana/functional':
         specifier: workspace:*
         version: link:../functional
+      '@solana/nominal-types':
+        specifier: workspace:*
+        version: link:../nominal-types
       '@solana/rpc-spec-types':
         specifier: workspace:*
         version: link:../rpc-spec-types
@@ -1080,6 +1089,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      '@solana/nominal-types':
+        specifier: workspace:*
+        version: link:../nominal-types
       typescript:
         specifier: '>=5.3.3'
         version: 5.8.2
@@ -1101,6 +1113,9 @@ importers:
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys
+      '@solana/nominal-types':
+        specifier: workspace:*
+        version: link:../nominal-types
       '@solana/transaction-messages':
         specifier: workspace:*
         version: link:../transaction-messages
@@ -1262,6 +1277,9 @@ importers:
       '@solana/instructions':
         specifier: workspace:*
         version: link:../instructions
+      '@solana/nominal-types':
+        specifier: workspace:*
+        version: link:../nominal-types
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
@@ -1302,6 +1320,9 @@ importers:
       '@solana/keys':
         specifier: workspace:*
         version: link:../keys
+      '@solana/nominal-types':
+        specifier: workspace:*
+        version: link:../nominal-types
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types


### PR DESCRIPTION
#### Problem

Two versions of any given package may introduce two distinct instances of our branded types into a project. That is to say you might get the `Address` type from v2.0.0 and v2.1.0 in the same project.

#### Summary of Changes

Here we use the type utilities in the previous stacked PR to reimagine these types as structurally identical, rather than having an identity that's tied to one particular instance of a module.

This will make it so that `Address` and other branded types like it are compatible from version v2.1.1 and onward.

Fixes #459
