### PR TITLE
Refactor `FullySignedTransaction` helpers

### DIFF
--- a/.changeset/fresh-ghosts-sniff.md
+++ b/.changeset/fresh-ghosts-sniff.md
@@ -1,0 +1,5 @@
+---
+'@solana/transactions': minor
+---
+
+Adds `isFullySignedTransaction` helper and renames `assertTransactionIsFullySigned` to `assertIsFullySignedTransaction`. The old name was kept as an alias but marked as deprecated.

--- a/README.md
+++ b/README.md
@@ -1138,7 +1138,7 @@ const signedTransaction = await signTransaction([], transactionMessage);
 
 // Asserts the transaction is a `FullySignedTransaction`
 // Throws an error if any signatures are missing!
-assertTransactionIsFullySigned(signedTransaction);
+assertIsFullySignedTransaction(signedTransaction);
 
 await sendAndConfirmTransaction(signedTransaction);
 ```

--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -60,11 +60,11 @@ import {
     SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING,
     isSolanaError,
 } from '@solana/errors';
-import { assertTransactionIsFullySigned, getSignatureFromTransaction } from '@solana/transactions';
+import { assertIsFullySignedTransaction, getSignatureFromTransaction } from '@solana/transactions';
 
 try {
     const transactionSignature = getSignatureFromTransaction(tx);
-    assertTransactionIsFullySigned(tx);
+    assertIsFullySignedTransaction(tx);
     /* ... */
 } catch (e) {
     if (isSolanaError(e, SOLANA_ERROR__TRANSACTION__SIGNATURES_MISSING)) {

--- a/packages/errors/src/error.ts
+++ b/packages/errors/src/error.ts
@@ -18,11 +18,11 @@ import { getErrorMessage } from './message-formatter';
  *     SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING,
  *     isSolanaError,
  * } from '@solana/errors';
- * import { assertTransactionIsFullySigned, getSignatureFromTransaction } from '@solana/transactions';
+ * import { assertIsFullySignedTransaction, getSignatureFromTransaction } from '@solana/transactions';
  *
  * try {
  *     const transactionSignature = getSignatureFromTransaction(tx);
- *     assertTransactionIsFullySigned(tx);
+ *     assertIsFullySignedTransaction(tx);
  *     /* ... *\/
  * } catch (e) {
  *     if (isSolanaError(e, SOLANA_ERROR__TRANSACTION__SIGNATURES_MISSING)) {

--- a/packages/signers/src/sign-transaction.ts
+++ b/packages/signers/src/sign-transaction.ts
@@ -2,7 +2,7 @@ import { SOLANA_ERROR__SIGNER__TRANSACTION_SENDING_SIGNER_MISSING, SolanaError }
 import { SignatureBytes } from '@solana/keys';
 import { CompilableTransactionMessage } from '@solana/transaction-messages';
 import {
-    assertTransactionIsFullySigned,
+    assertIsFullySignedTransaction,
     compileTransaction,
     FullySignedTransaction,
     Transaction,
@@ -118,7 +118,7 @@ export async function signTransactionMessageWithSigners<
     config?: TransactionPartialSignerConfig,
 ): Promise<FullySignedTransaction & TransactionFromCompilableTransactionMessage<TTransactionMessage>> {
     const signedTransaction = await partiallySignTransactionMessageWithSigners(transactionMessage, config);
-    assertTransactionIsFullySigned(signedTransaction);
+    assertIsFullySignedTransaction(signedTransaction);
     return signedTransaction;
 }
 

--- a/packages/transactions/src/__tests__/signatures-test.ts
+++ b/packages/transactions/src/__tests__/signatures-test.ts
@@ -11,8 +11,9 @@ import {
 import { SignatureBytes, signBytes } from '@solana/keys';
 
 import {
-    assertTransactionIsFullySigned,
+    assertIsFullySignedTransaction,
     getSignatureFromTransaction,
+    isFullySignedTransaction,
     partiallySignTransaction,
     signTransaction,
 } from '../signatures';
@@ -398,7 +399,47 @@ describe('signTransaction', () => {
     });
 });
 
-describe('assertTransactionIsFullySigned', () => {
+describe('isFullySignedTransaction', () => {
+    const mockPublicKeyAddressA = 'A' as Address;
+    const mockSignatureA = new Uint8Array(0) as SignatureBytes;
+    const mockPublicKeyAddressB = 'B' as Address;
+    const mockSignatureB = new Uint8Array(1) as SignatureBytes;
+
+    it('returns false if the transaction has missing signatures', () => {
+        const signatures: SignaturesMap = {};
+        signatures[mockPublicKeyAddressA] = null;
+        const transaction: Transaction = {
+            messageBytes: new Uint8Array() as ReadonlyUint8Array as TransactionMessageBytes,
+            signatures,
+        };
+
+        expect(isFullySignedTransaction(transaction)).toBe(false);
+    });
+
+    it('returns true if the transaction is signed by all its signers', () => {
+        const signatures: SignaturesMap = {};
+        signatures[mockPublicKeyAddressA] = mockSignatureA;
+        signatures[mockPublicKeyAddressB] = mockSignatureB;
+        const transaction: Transaction = {
+            messageBytes: new Uint8Array() as ReadonlyUint8Array as TransactionMessageBytes,
+            signatures,
+        };
+
+        expect(isFullySignedTransaction(transaction)).toBe(true);
+    });
+
+    it('return true if the transaction has no signatures', () => {
+        const signatures: SignaturesMap = {};
+        const transaction: Transaction = {
+            messageBytes: new Uint8Array() as ReadonlyUint8Array as TransactionMessageBytes,
+            signatures,
+        };
+
+        expect(isFullySignedTransaction(transaction)).toBe(true);
+    });
+});
+
+describe('assertIsFullySignedTransaction', () => {
     const mockPublicKeyAddressA = 'A' as Address;
     const mockSignatureA = new Uint8Array(0) as SignatureBytes;
     const mockPublicKeyAddressB = 'B' as Address;
@@ -412,7 +453,7 @@ describe('assertTransactionIsFullySigned', () => {
             signatures,
         };
 
-        expect(() => assertTransactionIsFullySigned(transaction)).toThrow(
+        expect(() => assertIsFullySignedTransaction(transaction)).toThrow(
             new SolanaError(SOLANA_ERROR__TRANSACTION__SIGNATURES_MISSING, {
                 addresses: [mockPublicKeyAddressA],
             }),
@@ -428,7 +469,7 @@ describe('assertTransactionIsFullySigned', () => {
             signatures,
         };
 
-        expect(() => assertTransactionIsFullySigned(transaction)).toThrow(
+        expect(() => assertIsFullySignedTransaction(transaction)).toThrow(
             new SolanaError(SOLANA_ERROR__TRANSACTION__SIGNATURES_MISSING, {
                 addresses: [mockPublicKeyAddressA, mockPublicKeyAddressB],
             }),
@@ -443,7 +484,7 @@ describe('assertTransactionIsFullySigned', () => {
             signatures,
         };
 
-        expect(() => assertTransactionIsFullySigned(transaction)).not.toThrow();
+        expect(() => assertIsFullySignedTransaction(transaction)).not.toThrow();
     });
 
     it('does not throw if the transaction is signed by all its signers', () => {
@@ -455,7 +496,7 @@ describe('assertTransactionIsFullySigned', () => {
             signatures,
         };
 
-        expect(() => assertTransactionIsFullySigned(transaction)).not.toThrow();
+        expect(() => assertIsFullySignedTransaction(transaction)).not.toThrow();
     });
 
     it('does not throw if the transaction has no signatures', () => {
@@ -464,6 +505,6 @@ describe('assertTransactionIsFullySigned', () => {
             messageBytes: new Uint8Array() as ReadonlyUint8Array as TransactionMessageBytes,
             signatures,
         };
-        expect(() => assertTransactionIsFullySigned(transaction)).not.toThrow();
+        expect(() => assertIsFullySignedTransaction(transaction)).not.toThrow();
     });
 });

--- a/packages/transactions/src/__typetests__/signatures-typetest.ts
+++ b/packages/transactions/src/__typetests__/signatures-typetest.ts
@@ -2,9 +2,10 @@
 import { Signature } from '@solana/keys';
 
 import {
-    assertTransactionIsFullySigned,
+    assertIsFullySignedTransaction,
     FullySignedTransaction,
     getSignatureFromTransaction,
+    isFullySignedTransaction,
     partiallySignTransaction,
     signTransaction,
 } from '..';
@@ -28,9 +29,17 @@ import { Transaction } from '../transaction';
     signTransaction([], transaction) satisfies Promise<FullySignedTransaction & { some: 1 }>;
 }
 
-// assertTransactionIsFullySigned
+// isFullySignedTransaction
 {
     const transaction = null as unknown as Transaction & { some: 1 };
-    assertTransactionIsFullySigned(transaction);
-    transaction satisfies FullySignedTransaction & { some: 1 };
+    if (isFullySignedTransaction(transaction)) {
+        transaction satisfies FullySignedTransaction & Transaction & { some: 1 };
+    }
+}
+
+// assertIsFullySignedTransaction
+{
+    const transaction = null as unknown as Transaction & { some: 1 };
+    assertIsFullySignedTransaction(transaction);
+    transaction satisfies FullySignedTransaction & Transaction & { some: 1 };
 }

--- a/packages/transactions/src/deprecated.ts
+++ b/packages/transactions/src/deprecated.ts
@@ -1,0 +1,29 @@
+import { assertIsFullySignedTransaction } from './signatures';
+
+/**
+ * From time to time you might acquire a {@link Transaction}, that you expect to be fully signed,
+ * from an untrusted network API or user input. Use this function to assert that such a transaction
+ * is fully signed.
+ *
+ * @deprecated Use {@link assertIsFullySignedTransaction} instead. It was only renamed.
+ *
+ * @example
+ * ```ts
+ * import { assertTransactionIsFullySigned } from '@solana/transactions';
+ *
+ * const transaction = getTransactionDecoder().decode(transactionBytes);
+ * try {
+ *     // If this type assertion function doesn't throw, then Typescript will upcast `transaction`
+ *     // to `FullySignedTransaction`.
+ *     assertTransactionIsFullySigned(transaction);
+ *     // At this point we know that the transaction is signed and can be sent to the network.
+ *     await sendAndConfirmTransaction(transaction, { commitment: 'confirmed' });
+ * } catch(e) {
+ *     if (isSolanaError(e, SOLANA_ERROR__TRANSACTION__SIGNATURES_MISSING)) {
+ *         setError(`Missing signatures for ${e.context.addresses.join(', ')}`);
+ *     }
+ *     throw;
+ * }
+ * ```
+ */
+export const assertTransactionIsFullySigned = assertIsFullySignedTransaction;

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -16,3 +16,6 @@ export * from './wire-transaction';
 export * from './transaction-message-size';
 export * from './transaction-size';
 export * from './transaction';
+
+// Remove in the next major version.
+export * from './deprecated';


### PR DESCRIPTION
This PR renames `assertTransactionIsFullySigned` to `assertIsFullySignedTransaction` and adds a new `isFullySignedTransaction` helper. This helps keep our naming consistent across the library.