### PR TITLE
Remove I prefixes before Instruction types

### DIFF
--- a/.changeset/weak-boxes-stay.md
+++ b/.changeset/weak-boxes-stay.md
@@ -1,0 +1,9 @@
+---
+'@solana/transaction-messages': minor
+'@solana/instructions': minor
+'@solana/signers': minor
+'@solana/compat': minor
+'@solana/kit': minor
+---
+
+Remove the `I` prefix on the following types: `IInstruction`, `IInstructionWithAccounts`, `IInstructionWithData`, `IInstructionWithSigners`, `IAccountMeta`, `IAccountLookupMeta` and `IAccountSignerMeta`. The old names are kept as aliases but marked as deprecated.

--- a/README.md
+++ b/README.md
@@ -1168,7 +1168,7 @@ const stillNotNonceTransactionMessage = {
 };
 
 stillNotNonceTransactionMessage satisfies TransactionMessageWithDurableNonceLifetime;
-// => 'readonly IInstruction<string>[]' is not assignable to type 'readonly [AdvanceNonceAccountInstruction<string, string>, ...IInstruction<string>[]]'
+// => 'readonly Instruction<string>[]' is not assignable to type 'readonly [AdvanceNonceAccountInstruction<string, string>, ...Instruction<string>[]]'
 
 const validNonceTransactionMessage = pipe(
     createTransactionMessage({ version: 0 }),

--- a/packages/compat/README.md
+++ b/packages/compat/README.md
@@ -47,7 +47,7 @@ const transaction = fromVersionedTransaction(legacyVersionedTransaction);
 
 ### `fromLegacyTransactionInstruction()`
 
-This can be used to convert a legacy `TransactionInstruction` object to a `IInstruction` object.
+This can be used to convert a legacy `TransactionInstruction` object to a `Instruction` object.
 
 ```ts
 import { fromLegacyTransactionInstruction } from '@solana/compat';

--- a/packages/compat/src/__tests__/instruction-test.ts
+++ b/packages/compat/src/__tests__/instruction-test.ts
@@ -3,7 +3,7 @@ import '@solana/test-matchers/toBeFrozenObject';
 import { ImplicitArrayBuffer } from 'node:buffer';
 
 import { address } from '@solana/addresses';
-import { AccountRole, IInstruction } from '@solana/instructions';
+import { AccountRole, Instruction } from '@solana/instructions';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 
 import { fromLegacyPublicKey } from '../address';
@@ -39,7 +39,7 @@ describe('fromLegacyTransactionInstruction', () => {
 
         const converted = fromLegacyTransactionInstruction(instruction);
 
-        expect(converted).toStrictEqual<IInstruction>({
+        expect(converted).toStrictEqual<Instruction>({
             accounts: [
                 {
                     address: address('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
@@ -129,7 +129,7 @@ describe('fromLegacyTransactionInstruction', () => {
 
         const converted = fromLegacyTransactionInstruction(instruction);
 
-        expect(converted).toStrictEqual<IInstruction>({
+        expect(converted).toStrictEqual<Instruction>({
             data,
             programAddress: fromLegacyPublicKey(new PublicKey(programId)),
         });
@@ -155,7 +155,7 @@ describe('fromLegacyTransactionInstruction', () => {
 
         const converted = fromLegacyTransactionInstruction(instruction);
 
-        expect(converted).toStrictEqual<IInstruction>({
+        expect(converted).toStrictEqual<Instruction>({
             accounts: [
                 {
                     address: address('7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK'),
@@ -189,7 +189,7 @@ describe('fromLegacyTransactionInstruction', () => {
 
         const converted = fromLegacyTransactionInstruction(instruction);
 
-        expect(converted).toStrictEqual<IInstruction>({
+        expect(converted).toStrictEqual<Instruction>({
             accounts: [
                 {
                     address: address('F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT'),
@@ -217,7 +217,7 @@ describe('fromLegacyTransactionInstruction', () => {
 
         const converted = fromLegacyTransactionInstruction(instruction);
 
-        expect(converted).toStrictEqual<IInstruction>({
+        expect(converted).toStrictEqual<Instruction>({
             accounts: [
                 {
                     address: address('F7Kzv7G6p1PvHXL1xXLPTm4myKWpLjnVphCV8ABZJfgT'),

--- a/packages/compat/src/__typetests__/instruction-typetest.ts
+++ b/packages/compat/src/__typetests__/instruction-typetest.ts
@@ -1,8 +1,8 @@
-import { IInstruction } from '@solana/instructions';
+import { Instruction } from '@solana/instructions';
 import { TransactionInstruction } from '@solana/web3.js';
 
 import { fromLegacyTransactionInstruction } from '../instruction';
 
 const legacyInstruction = null as unknown as TransactionInstruction;
 
-fromLegacyTransactionInstruction(legacyInstruction) satisfies IInstruction;
+fromLegacyTransactionInstruction(legacyInstruction) satisfies Instruction;

--- a/packages/compat/src/instruction.ts
+++ b/packages/compat/src/instruction.ts
@@ -1,11 +1,11 @@
-import { AccountRole, IInstruction } from '@solana/instructions';
+import { AccountRole, Instruction } from '@solana/instructions';
 import { TransactionInstruction } from '@solana/web3.js';
 
 import { fromLegacyPublicKey } from './address';
 
 /**
  * This can be used to convert a legacy [`TransactionInstruction`](https://solana-foundation.github.io/solana-web3.js/classes/TransactionInstruction.html)
- * object to an {@link IInstruction}.
+ * object to an {@link Instruction}.
  *
  * @example
  * ```ts
@@ -16,7 +16,7 @@ import { fromLegacyPublicKey } from './address';
  * const instruction = fromLegacyTransactionInstruction(legacyInstruction);
  * ```
  */
-export function fromLegacyTransactionInstruction(legacyInstruction: TransactionInstruction): IInstruction {
+export function fromLegacyTransactionInstruction(legacyInstruction: TransactionInstruction): Instruction {
     const data = legacyInstruction.data?.byteLength > 0 ? Uint8Array.from(legacyInstruction.data) : undefined;
     const accounts = legacyInstruction.keys.map(accountMeta =>
         Object.freeze({

--- a/packages/instructions/README.md
+++ b/packages/instructions/README.md
@@ -26,7 +26,7 @@ The purpose for which an account participates in a transaction is described by t
 | `AccountRole.READONLY_SIGNER` | &#x2705;   | &#x274c;     |
 | `AccountRole.WRITABLE_SIGNER` | &#x2705;   | &#x2705;     |
 
-### `IAccountMeta<TAddress>`
+### `AccountMeta<TAddress>`
 
 This type represents an account's address and metadata about its mutability and whether it must be a signer of the transaction.
 
@@ -45,7 +45,7 @@ For example, you could type the rent sysvar account like this:
 type RentSysvar = ReadonlyAccount<'SysvarRent111111111111111111111111111111111'>;
 ```
 
-### `IAccountLookupMeta<TAddress, TLookupTableAddress>`
+### `AccountLookupMeta<TAddress, TLookupTableAddress>`
 
 This type represents a lookup of the account's address in an address lookup table. It specifies which lookup table account in which to perform the lookup, the index of the desired account address in that table, and metadata about its mutability. Notably, account addresses obtained via lookups may not act as signers.
 
@@ -65,20 +65,20 @@ type RentSysvar = ReadonlyLookupAccount<
 >;
 ```
 
-### `IInstruction<TProgramAddress>`
+### `Instruction<TProgramAddress>`
 
 Use this to specify an instruction destined for a given program.
 
 ```ts
-type StakeProgramInstruction = IInstruction<'StakeConfig11111111111111111111111111111111'>;
+type StakeProgramInstruction = Instruction<'StakeConfig11111111111111111111111111111111'>;
 ```
 
-### `IInstructionWithAccounts<TAccounts>`
+### `InstructionWithAccounts<TAccounts>`
 
 Use this type to specify an instruction that loads certain accounts.
 
 ```ts
-type InstructionWithTwoAccounts = IInstructionWithAccounts<
+type InstructionWithTwoAccounts = InstructionWithAccounts<
     [
         WritableAccount, // First account
         RentSysvar, // Second account
@@ -86,7 +86,7 @@ type InstructionWithTwoAccounts = IInstructionWithAccounts<
 >;
 ```
 
-### `IInstructionWithData<TData>`
+### `InstructionWithData<TData>`
 
 Use this type to specify an instruction whose data conforms to a certain type. This is most useful when you have a branded `Uint8Array` that represents a particular instruction's data.
 
@@ -96,15 +96,15 @@ For example, here is how the `AdvanceNonce` instruction is typed.
 type AdvanceNonceAccountInstruction<
     TNonceAccountAddress extends string = string,
     TNonceAuthorityAddress extends string = string,
-> = IInstruction<'11111111111111111111111111111111'> &
-    IInstructionWithAccounts<
+> = Instruction<'11111111111111111111111111111111'> &
+    InstructionWithAccounts<
         [
             WritableAccount<TNonceAccountAddress>,
             ReadonlyAccount<'SysvarRecentB1ockHashes11111111111111111111'>,
             ReadonlySignerAccount<TNonceAuthorityAddress>,
         ]
     > &
-    IInstructionWithData<AdvanceNonceAccountInstructionData>;
+    InstructionWithData<AdvanceNonceAccountInstructionData>;
 ```
 
 ## Functions

--- a/packages/instructions/src/__tests__/instruction-test.ts
+++ b/packages/instructions/src/__tests__/instruction-test.ts
@@ -5,7 +5,7 @@ import {
     assertIsInstructionForProgram,
     assertIsInstructionWithAccounts,
     assertIsInstructionWithData,
-    IInstruction,
+    Instruction,
     isInstructionForProgram,
     isInstructionWithAccounts,
     isInstructionWithData,
@@ -16,14 +16,14 @@ const programAddress = 'address' as Address;
 
 describe('isInstructionForProgram', () => {
     it('returns true when the instruction has the given program address', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             programAddress,
         };
         expect(isInstructionForProgram(instruction, programAddress)).toBe(true);
     });
 
     it('returns false when the instruction does not have the given program address', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             programAddress,
         };
         const address = 'abc' as Address;
@@ -33,7 +33,7 @@ describe('isInstructionForProgram', () => {
 
 describe('assertIsInstructionForProgram', () => {
     it('does not throw when the instruction has the given program address', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             programAddress,
         };
         const assert = () => assertIsInstructionForProgram(instruction, programAddress);
@@ -41,7 +41,7 @@ describe('assertIsInstructionForProgram', () => {
     });
 
     it('throws when the instruction does not have the given program address', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             programAddress,
         };
         const address = 'abc' as Address;
@@ -52,7 +52,7 @@ describe('assertIsInstructionForProgram', () => {
 
 describe('isInstructionWithAccounts', () => {
     it('returns true when the instruction has an array of accounts', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             accounts: [
                 {
                     address: 'abc' as Address,
@@ -65,7 +65,7 @@ describe('isInstructionWithAccounts', () => {
     });
 
     it('returns true when the instruction has an empty array of accounts', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             accounts: [],
             programAddress,
         };
@@ -73,7 +73,7 @@ describe('isInstructionWithAccounts', () => {
     });
 
     it('returns false when the instruction does not have accounts defined', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             programAddress,
         };
         expect(isInstructionWithAccounts(instruction)).toBe(false);
@@ -82,7 +82,7 @@ describe('isInstructionWithAccounts', () => {
 
 describe('assertIsInstructionWithAccounts', () => {
     it('does not throw when the instruction has an array of accounts', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             accounts: [
                 {
                     address: 'abc' as Address,
@@ -96,7 +96,7 @@ describe('assertIsInstructionWithAccounts', () => {
     });
 
     it('does not throw when the instruction has an empty array of accounts', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             accounts: [],
             programAddress,
         };
@@ -105,7 +105,7 @@ describe('assertIsInstructionWithAccounts', () => {
     });
 
     it('throws when the instruction does not have accounts defined', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             programAddress,
         };
         const assert = () => assertIsInstructionWithAccounts(instruction);
@@ -115,7 +115,7 @@ describe('assertIsInstructionWithAccounts', () => {
 
 describe('isInstructionWithData', () => {
     it('returns true when the instruction has a non-empty data', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             data: new Uint8Array([1, 2, 3, 4]),
             programAddress,
         };
@@ -123,7 +123,7 @@ describe('isInstructionWithData', () => {
     });
 
     it('returns true when the instruction has an empty data', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             data: new Uint8Array([]),
             programAddress,
         };
@@ -131,7 +131,7 @@ describe('isInstructionWithData', () => {
     });
 
     it('returns false when the instruction does not have data defined', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             programAddress,
         };
         expect(isInstructionWithData(instruction)).toBe(false);
@@ -140,7 +140,7 @@ describe('isInstructionWithData', () => {
 
 describe('assertIsInstructionWithData', () => {
     it('does not throw when the instruction has a non-empty data', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             data: new Uint8Array([1, 2, 3, 4]),
             programAddress,
         };
@@ -149,7 +149,7 @@ describe('assertIsInstructionWithData', () => {
     });
 
     it('does not throw when the instruction has an empty data', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             data: new Uint8Array([]),
             programAddress,
         };
@@ -158,7 +158,7 @@ describe('assertIsInstructionWithData', () => {
     });
 
     it('throws when the instruction does not have data defined', () => {
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             programAddress,
         };
         const assert = () => assertIsInstructionWithData(instruction);

--- a/packages/instructions/src/__typetests__/instruction-typetest.ts
+++ b/packages/instructions/src/__typetests__/instruction-typetest.ts
@@ -1,14 +1,14 @@
 import { Address } from '@solana/addresses';
 import { ReadonlyUint8Array } from '@solana/codecs-core';
 
-import { IAccountLookupMeta, IAccountMeta } from '../accounts';
+import { AccountLookupMeta, AccountMeta } from '../accounts';
 import {
     assertIsInstructionForProgram,
     assertIsInstructionWithAccounts,
     assertIsInstructionWithData,
-    IInstruction,
-    IInstructionWithAccounts,
-    IInstructionWithData,
+    Instruction,
+    InstructionWithAccounts,
+    InstructionWithData,
     isInstructionForProgram,
     isInstructionWithAccounts,
     isInstructionWithData,
@@ -16,55 +16,55 @@ import {
 
 // narrowing using if checks
 {
-    const instruction = {} as unknown as IInstruction;
+    const instruction = {} as unknown as Instruction;
 
     // @ts-expect-error instruction might not have accounts
-    instruction satisfies IInstructionWithAccounts<readonly (IAccountLookupMeta | IAccountMeta)[]>;
+    instruction satisfies InstructionWithAccounts<readonly (AccountLookupMeta | AccountMeta)[]>;
 
     // @ts-expect-error instruction might not have data
-    instruction satisfies IInstructionWithData<ReadonlyUint8Array>;
+    instruction satisfies InstructionWithData<ReadonlyUint8Array>;
 
     if (isInstructionWithAccounts(instruction) && isInstructionWithData(instruction)) {
-        instruction satisfies IInstruction &
-            IInstructionWithAccounts<readonly (IAccountLookupMeta | IAccountMeta)[]> &
-            IInstructionWithData<ReadonlyUint8Array>;
+        instruction satisfies Instruction &
+            InstructionWithAccounts<readonly (AccountLookupMeta | AccountMeta)[]> &
+            InstructionWithData<ReadonlyUint8Array>;
     }
 }
 
 // narrowing using assertions
 {
-    const instruction = {} as unknown as IInstruction;
+    const instruction = {} as unknown as Instruction;
 
     // @ts-expect-error instruction might not have accounts
-    instruction satisfies IInstructionWithAccounts<readonly (IAccountLookupMeta | IAccountMeta)[]>;
+    instruction satisfies InstructionWithAccounts<readonly (AccountLookupMeta | AccountMeta)[]>;
 
     // @ts-expect-error instruction might not have data
-    instruction satisfies IInstructionWithData<ReadonlyUint8Array>;
+    instruction satisfies InstructionWithData<ReadonlyUint8Array>;
 
     assertIsInstructionWithAccounts(instruction);
-    instruction satisfies IInstruction & IInstructionWithAccounts<readonly (IAccountLookupMeta | IAccountMeta)[]>;
+    instruction satisfies Instruction & InstructionWithAccounts<readonly (AccountLookupMeta | AccountMeta)[]>;
 
     assertIsInstructionWithData(instruction);
-    instruction satisfies IInstruction &
-        IInstructionWithAccounts<readonly (IAccountLookupMeta | IAccountMeta)[]> &
-        IInstructionWithData<ReadonlyUint8Array>;
+    instruction satisfies Instruction &
+        InstructionWithAccounts<readonly (AccountLookupMeta | AccountMeta)[]> &
+        InstructionWithData<ReadonlyUint8Array>;
 }
 
 // narrowing by program address
 {
-    const instruction = {} as unknown as IInstruction;
+    const instruction = {} as unknown as Instruction;
     const myAddress = '1111' as Address<'1111'>;
     type MyAddress = typeof myAddress;
 
     // @ts-expect-error instruction might not have the right address
-    instruction satisfies IInstruction<MyAddress>;
+    instruction satisfies Instruction<MyAddress>;
 
     if (isInstructionForProgram(instruction, myAddress)) {
-        instruction satisfies IInstruction<MyAddress>;
-        instruction satisfies IInstruction<'1111'>;
+        instruction satisfies Instruction<MyAddress>;
+        instruction satisfies Instruction<'1111'>;
     }
 
     assertIsInstructionForProgram(instruction, myAddress);
-    instruction satisfies IInstruction<MyAddress>;
-    instruction satisfies IInstruction<'1111'>;
+    instruction satisfies Instruction<MyAddress>;
+    instruction satisfies Instruction<'1111'>;
 }

--- a/packages/instructions/src/accounts.ts
+++ b/packages/instructions/src/accounts.ts
@@ -20,31 +20,31 @@ import { AccountRole } from './roles';
  * type RentSysvar = ReadonlyAccount<'SysvarRent111111111111111111111111111111111'>;
  * ```
  */
-export interface IAccountMeta<TAddress extends string = string> {
+export interface AccountMeta<TAddress extends string = string> {
     readonly address: Address<TAddress>;
     readonly role: AccountRole;
 }
 
 /**
- * @see {@link IAccountMeta}
+ * @see {@link AccountMeta}
  */
-export type ReadonlyAccount<TAddress extends string = string> = IAccountMeta<TAddress> & {
+export type ReadonlyAccount<TAddress extends string = string> = AccountMeta<TAddress> & {
     readonly role: AccountRole.READONLY;
 };
 /**
- * @see {@link IAccountMeta}
+ * @see {@link AccountMeta}
  */
-export type WritableAccount<TAddress extends string = string> = IAccountMeta<TAddress> & { role: AccountRole.WRITABLE };
+export type WritableAccount<TAddress extends string = string> = AccountMeta<TAddress> & { role: AccountRole.WRITABLE };
 /**
- * @see {@link IAccountMeta}
+ * @see {@link AccountMeta}
  */
-export type ReadonlySignerAccount<TAddress extends string = string> = IAccountMeta<TAddress> & {
+export type ReadonlySignerAccount<TAddress extends string = string> = AccountMeta<TAddress> & {
     role: AccountRole.READONLY_SIGNER;
 };
 /**
- * @see {@link IAccountMeta}
+ * @see {@link AccountMeta}
  */
-export type WritableSignerAccount<TAddress extends string = string> = IAccountMeta<TAddress> & {
+export type WritableSignerAccount<TAddress extends string = string> = AccountMeta<TAddress> & {
     role: AccountRole.WRITABLE_SIGNER;
 };
 
@@ -69,7 +69,7 @@ export type WritableSignerAccount<TAddress extends string = string> = IAccountMe
  * >;
  * ```
  */
-export interface IAccountLookupMeta<TAddress extends string = string, TLookupTableAddress extends string = string> {
+export interface AccountLookupMeta<TAddress extends string = string, TLookupTableAddress extends string = string> {
     readonly address: Address<TAddress>;
     readonly addressIndex: number;
     readonly lookupTableAddress: Address<TLookupTableAddress>;
@@ -77,16 +77,16 @@ export interface IAccountLookupMeta<TAddress extends string = string, TLookupTab
 }
 
 /**
- * @see {@link IAccountLookupMeta}
+ * @see {@link AccountLookupMeta}
  */
 export type ReadonlyAccountLookup<
     TAddress extends string = string,
     TLookupTableAddress extends string = string,
-> = IAccountLookupMeta<TAddress, TLookupTableAddress> & { readonly role: AccountRole.READONLY };
+> = AccountLookupMeta<TAddress, TLookupTableAddress> & { readonly role: AccountRole.READONLY };
 /**
- * @see {@link IAccountLookupMeta}
+ * @see {@link AccountLookupMeta}
  */
 export type WritableAccountLookup<
     TAddress extends string = string,
     TLookupTableAddress extends string = string,
-> = IAccountLookupMeta<TAddress, TLookupTableAddress> & { readonly role: AccountRole.WRITABLE };
+> = AccountLookupMeta<TAddress, TLookupTableAddress> & { readonly role: AccountRole.WRITABLE };

--- a/packages/instructions/src/deprecated.ts
+++ b/packages/instructions/src/deprecated.ts
@@ -1,0 +1,113 @@
+import type { ReadonlyUint8Array } from '@solana/codecs-core';
+
+import type { AccountLookupMeta, AccountMeta } from './accounts';
+import type { Instruction, InstructionWithAccounts, InstructionWithData } from './instruction';
+
+/**
+ * Represents an account's address and metadata about its mutability and whether it must be a signer
+ * of the transaction.
+ *
+ * Typically, you will use one of its subtypes.
+ *
+ * |                                   | `role`                        | `isSigner` | `isWritable` |
+ * | --------------------------------- | ----------------------------- | ---------- | ------------ |
+ * | `ReadonlyAccount<TAddress>`       | `AccountRole.READONLY`        |  No        |  No          |
+ * | `WritableAccount<TAddress>`       | `AccountRole.WRITABLE`        |  No        |  Yes         |
+ * | `ReadonlySignerAccount<TAddress>` | `AccountRole.READONLY_SIGNER` |  Yes       |  No          |
+ * | `WritableSignerAccount<TAddress>` | `AccountRole.WRITABLE_SIGNER` |  Yes       |  Yes         |
+ *
+ * @deprecated Use {@link AccountMeta} instead. It was only renamed.
+ *
+ * @example A type for the Rent sysvar account
+ * ```ts
+ * type RentSysvar = ReadonlyAccount<'SysvarRent111111111111111111111111111111111'>;
+ * ```
+ */
+export type IAccountMeta<TAddress extends string = string> = AccountMeta<TAddress>;
+
+/**
+ * Represents a lookup of the account's address in an address lookup table. It specifies which
+ * lookup table account in which to perform the lookup, the index of the desired account address in
+ * that table, and metadata about its mutability. Notably, account addresses obtained via lookups
+ * may not act as signers.
+ *
+ * Typically, you will use one of its subtypes.
+ *
+ * |                                                        | `role`                 | `isSigner` | `isWritable` |
+ * | ------------------------------------------------------ | ---------------------- | ---------- | ------------ |
+ * | `ReadonlyLookupAccount<TAddress, TLookupTableAddress>` | `AccountRole.READONLY` |  No        |  No          |
+ * | `WritableLookupAccount<TAddress, TLookupTableAddress>` | `AccountRole.WRITABLE` |  No        |  Yes         |
+ *
+ * @deprecated Use {@link AccountLookupMeta} instead. It was only renamed.
+ *
+ * @example A type for the Rent sysvar account that you looked up in a lookup table
+ * ```ts
+ * type RentSysvar = ReadonlyLookupAccount<
+ *     'SysvarRent111111111111111111111111111111111',
+ *     'MyLookupTable111111111111111111111111111111'
+ * >;
+ * ```
+ */
+export type IAccountLookupMeta<
+    TAddress extends string = string,
+    TLookupTableAddress extends string = string,
+> = AccountLookupMeta<TAddress, TLookupTableAddress>;
+
+/**
+ * An instruction destined for a given program.
+ *
+ * @deprecated Use {@link Instruction} instead. It was only renamed.
+ *
+ * @example
+ * ```ts
+ * type StakeProgramInstruction = IInstruction<'StakeConfig11111111111111111111111111111111'>;
+ * ```
+ */
+export type IInstruction<
+    TProgramAddress extends string = string,
+    TAccounts extends readonly (AccountLookupMeta | AccountMeta)[] = readonly (AccountLookupMeta | AccountMeta)[],
+> = Instruction<TProgramAddress, TAccounts>;
+
+/**
+ * An instruction that loads certain accounts.
+ *
+ * @deprecated Use {@link InstructionWithAccounts} instead. It was only renamed.
+ *
+ * @example
+ * ```ts
+ * type InstructionWithTwoAccounts = IInstructionWithAccounts<
+ *     [
+ *         WritableAccount, // First account
+ *         RentSysvar, // Second account
+ *     ]
+ * >;
+ * ```
+ */
+export type IInstructionWithAccounts<TAccounts extends readonly (AccountLookupMeta | AccountMeta)[]> =
+    InstructionWithAccounts<TAccounts>;
+
+/**
+ * An instruction whose data conforms to a certain type.
+ *
+ * This is most useful when you have a branded `Uint8Array` that represents a particular
+ * instruction's data.
+ *
+ * @deprecated Use {@link InstructionWithData} instead. It was only renamed.
+ *
+ * @example A type for the \`AdvanceNonce\` instruction of the System program
+ * ```ts
+ * type AdvanceNonceAccountInstruction<
+ *     TNonceAccountAddress extends string = string,
+ *     TNonceAuthorityAddress extends string = string,
+ * > = Instruction<'11111111111111111111111111111111'> &
+ *     InstructionWithAccounts<
+ *         [
+ *             WritableAccount<TNonceAccountAddress>,
+ *             ReadonlyAccount<'SysvarRecentB1ockHashes11111111111111111111'>,
+ *             ReadonlySignerAccount<TNonceAuthorityAddress>,
+ *         ]
+ *     > &
+ *     IInstructionWithData<AdvanceNonceAccountInstructionData>;
+ * ```
+ */
+export type IInstructionWithData<TData extends ReadonlyUint8Array> = InstructionWithData<TData>;

--- a/packages/instructions/src/index.ts
+++ b/packages/instructions/src/index.ts
@@ -5,3 +5,6 @@
 export * from './accounts';
 export * from './instruction';
 export * from './roles';
+
+// Remove in the next major version.
+export * from './deprecated';

--- a/packages/instructions/src/instruction.ts
+++ b/packages/instructions/src/instruction.ts
@@ -7,19 +7,19 @@ import {
     SolanaError,
 } from '@solana/errors';
 
-import { IAccountLookupMeta, IAccountMeta } from './accounts';
+import { AccountLookupMeta, AccountMeta } from './accounts';
 
 /**
  * An instruction destined for a given program.
  *
  * @example
  * ```ts
- * type StakeProgramInstruction = IInstruction<'StakeConfig11111111111111111111111111111111'>;
+ * type StakeProgramInstruction = Instruction<'StakeConfig11111111111111111111111111111111'>;
  * ```
  */
-export interface IInstruction<
+export interface Instruction<
     TProgramAddress extends string = string,
-    TAccounts extends readonly (IAccountLookupMeta | IAccountMeta)[] = readonly (IAccountLookupMeta | IAccountMeta)[],
+    TAccounts extends readonly (AccountLookupMeta | AccountMeta)[] = readonly (AccountLookupMeta | AccountMeta)[],
 > {
     readonly accounts?: TAccounts;
     readonly data?: ReadonlyUint8Array;
@@ -31,7 +31,7 @@ export interface IInstruction<
  *
  * @example
  * ```ts
- * type InstructionWithTwoAccounts = IInstructionWithAccounts<
+ * type InstructionWithTwoAccounts = InstructionWithAccounts<
  *     [
  *         WritableAccount, // First account
  *         RentSysvar, // Second account
@@ -39,19 +39,19 @@ export interface IInstruction<
  * >;
  * ```
  */
-export interface IInstructionWithAccounts<TAccounts extends readonly (IAccountLookupMeta | IAccountMeta)[]>
-    extends IInstruction {
+export interface InstructionWithAccounts<TAccounts extends readonly (AccountLookupMeta | AccountMeta)[]>
+    extends Instruction {
     readonly accounts: TAccounts;
 }
 
-export function isInstructionForProgram<TProgramAddress extends string, TInstruction extends IInstruction>(
+export function isInstructionForProgram<TProgramAddress extends string, TInstruction extends Instruction>(
     instruction: TInstruction,
     programAddress: Address<TProgramAddress>,
 ): instruction is TInstruction & { programAddress: Address<TProgramAddress> } {
     return instruction.programAddress === programAddress;
 }
 
-export function assertIsInstructionForProgram<TProgramAddress extends string, TInstruction extends IInstruction>(
+export function assertIsInstructionForProgram<TProgramAddress extends string, TInstruction extends Instruction>(
     instruction: TInstruction,
     programAddress: Address<TProgramAddress>,
 ): asserts instruction is TInstruction & { programAddress: Address<TProgramAddress> } {
@@ -64,16 +64,16 @@ export function assertIsInstructionForProgram<TProgramAddress extends string, TI
 }
 
 export function isInstructionWithAccounts<
-    TAccounts extends readonly (IAccountLookupMeta | IAccountMeta)[] = readonly (IAccountLookupMeta | IAccountMeta)[],
-    TInstruction extends IInstruction = IInstruction,
->(instruction: TInstruction): instruction is IInstructionWithAccounts<TAccounts> & TInstruction {
+    TAccounts extends readonly (AccountLookupMeta | AccountMeta)[] = readonly (AccountLookupMeta | AccountMeta)[],
+    TInstruction extends Instruction = Instruction,
+>(instruction: TInstruction): instruction is InstructionWithAccounts<TAccounts> & TInstruction {
     return instruction.accounts !== undefined;
 }
 
 export function assertIsInstructionWithAccounts<
-    TAccounts extends readonly (IAccountLookupMeta | IAccountMeta)[] = readonly (IAccountLookupMeta | IAccountMeta)[],
-    TInstruction extends IInstruction = IInstruction,
->(instruction: TInstruction): asserts instruction is IInstructionWithAccounts<TAccounts> & TInstruction {
+    TAccounts extends readonly (AccountLookupMeta | AccountMeta)[] = readonly (AccountLookupMeta | AccountMeta)[],
+    TInstruction extends Instruction = Instruction,
+>(instruction: TInstruction): asserts instruction is InstructionWithAccounts<TAccounts> & TInstruction {
     if (instruction.accounts === undefined) {
         throw new SolanaError(SOLANA_ERROR__INSTRUCTION__EXPECTED_TO_HAVE_ACCOUNTS, {
             data: instruction.data,
@@ -93,32 +93,32 @@ export function assertIsInstructionWithAccounts<
  * type AdvanceNonceAccountInstruction<
  *     TNonceAccountAddress extends string = string,
  *     TNonceAuthorityAddress extends string = string,
- * > = IInstruction<'11111111111111111111111111111111'> &
- *     IInstructionWithAccounts<
+ * > = Instruction<'11111111111111111111111111111111'> &
+ *     InstructionWithAccounts<
  *         [
  *             WritableAccount<TNonceAccountAddress>,
  *             ReadonlyAccount<'SysvarRecentB1ockHashes11111111111111111111'>,
  *             ReadonlySignerAccount<TNonceAuthorityAddress>,
  *         ]
  *     > &
- *     IInstructionWithData<AdvanceNonceAccountInstructionData>;
+ *     InstructionWithData<AdvanceNonceAccountInstructionData>;
  * ```
  */
-export interface IInstructionWithData<TData extends ReadonlyUint8Array> extends IInstruction {
+export interface InstructionWithData<TData extends ReadonlyUint8Array> extends Instruction {
     readonly data: TData;
 }
 
 export function isInstructionWithData<
     TData extends ReadonlyUint8Array = ReadonlyUint8Array,
-    TInstruction extends IInstruction = IInstruction,
->(instruction: TInstruction): instruction is IInstructionWithData<TData> & TInstruction {
+    TInstruction extends Instruction = Instruction,
+>(instruction: TInstruction): instruction is InstructionWithData<TData> & TInstruction {
     return instruction.data !== undefined;
 }
 
 export function assertIsInstructionWithData<
     TData extends ReadonlyUint8Array = ReadonlyUint8Array,
-    TInstruction extends IInstruction = IInstruction,
->(instruction: TInstruction): asserts instruction is IInstructionWithData<TData> & TInstruction {
+    TInstruction extends Instruction = Instruction,
+>(instruction: TInstruction): asserts instruction is InstructionWithData<TData> & TInstruction {
     if (instruction.data === undefined) {
         throw new SolanaError(SOLANA_ERROR__INSTRUCTION__EXPECTED_TO_HAVE_DATA, {
             accountAddresses: instruction.accounts?.map(a => a.address),

--- a/packages/kit/src/compute-limit-internal.ts
+++ b/packages/kit/src/compute-limit-internal.ts
@@ -6,12 +6,7 @@ import {
     SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
     SolanaError,
 } from '@solana/errors';
-import {
-    IInstruction,
-    IInstructionWithData,
-    isInstructionForProgram,
-    isInstructionWithData,
-} from '@solana/instructions';
+import { Instruction, InstructionWithData, isInstructionForProgram, isInstructionWithData } from '@solana/instructions';
 import { Rpc, SimulateTransactionApi } from '@solana/rpc';
 import { Blockhash, Commitment, Slot } from '@solana/rpc-types';
 import {
@@ -55,7 +50,7 @@ const INVALID_BUT_SUFFICIENT_FOR_COMPILATION_BLOCKHASH = {
 } as const;
 const SET_COMPUTE_UNIT_LIMIT_INSTRUCTION_INDEX = 0x02;
 
-function createComputeUnitLimitInstruction(units: number): IInstruction<typeof COMPUTE_BUDGET_PROGRAM_ADDRESS> {
+function createComputeUnitLimitInstruction(units: number): Instruction<typeof COMPUTE_BUDGET_PROGRAM_ADDRESS> {
     const data = new Uint8Array(5);
     data[0] = SET_COMPUTE_UNIT_LIMIT_INSTRUCTION_INDEX;
     getU32Encoder().write(units, data, 1 /* offset */);
@@ -66,8 +61,8 @@ function createComputeUnitLimitInstruction(units: number): IInstruction<typeof C
 }
 
 function isSetComputeLimitInstruction(
-    instruction: IInstruction,
-): instruction is IInstruction<typeof COMPUTE_BUDGET_PROGRAM_ADDRESS> & IInstructionWithData<Uint8Array> {
+    instruction: Instruction,
+): instruction is Instruction<typeof COMPUTE_BUDGET_PROGRAM_ADDRESS> & InstructionWithData<Uint8Array> {
     return (
         isInstructionForProgram(instruction, COMPUTE_BUDGET_PROGRAM_ADDRESS) &&
         isInstructionWithData(instruction) &&

--- a/packages/rpc-spec-types/src/rpc-response.ts
+++ b/packages/rpc-spec-types/src/rpc-response.ts
@@ -18,7 +18,7 @@ export type RpcResponseTransformer<TResponse = unknown> = {
     (response: RpcResponse, request: RpcRequest): RpcResponse<TResponse>;
 };
 
-interface IHasIdentifier {
+interface HasIdentifier {
     readonly id: string;
 }
 
@@ -28,5 +28,5 @@ type RpcErrorResponsePayload = Readonly<{
     message: string;
 }>;
 
-export type RpcResponseData<TResponse> = IHasIdentifier &
+export type RpcResponseData<TResponse> = HasIdentifier &
     Readonly<{ error: RpcErrorResponsePayload } | { result: TResponse }>;

--- a/packages/signers/README.md
+++ b/packages/signers/README.md
@@ -406,24 +406,24 @@ It also provides helper functions that deduplicate and extract signers from inst
 
 ### Types
 
-#### `IAccountSignerMeta`
+#### `AccountSignerMeta`
 
-Alternative `IAccountMeta` definition for signer accounts that allows us to store `TransactionSigners` inside it.
+Alternative `AccountMeta` definition for signer accounts that allows us to store `TransactionSigners` inside it.
 
 ```ts
-const mySignerMeta: IAccountSignerMeta = {
+const mySignerMeta: AccountSignerMeta = {
     address: myTransactionSigner.address,
     role: AccountRole.READONLY_SIGNER,
     signer: myTransactionSigner,
 };
 ```
 
-#### `IInstructionWithSigners`
+#### `InstructionWithSigners`
 
-Composable type that allows `IAccountSignerMetas` to be used inside the instruction's `accounts` array.
+Composable type that allows `AccountSignerMetas` to be used inside the instruction's `accounts` array.
 
 ```ts
-const myInstructionWithSigners: IInstruction & IInstructionWithSigners = {
+const myInstructionWithSigners: Instruction & InstructionWithSigners = {
     programAddress: address('1234..5678'),
     accounts: [
         {
@@ -437,14 +437,14 @@ const myInstructionWithSigners: IInstruction & IInstructionWithSigners = {
 
 #### `TransactionMessageWithSigners`
 
-Composable type that allows `IAccountSignerMetas` to be used inside all of the transaction message's account metas.
+Composable type that allows `AccountSignerMetas` to be used inside all of the transaction message's account metas.
 
 ```ts
 const myTransactionMessageWithSigners: BaseTransactionMessage & TransactionMessageWithSigners = {
     instructions: [
-        myInstructionA as IInstruction & IInstructionWithSigners,
-        myInstructionB as IInstruction & IInstructionWithSigners,
-        myInstructionC as IInstruction,
+        myInstructionA as Instruction & InstructionWithSigners,
+        myInstructionB as Instruction & InstructionWithSigners,
+        myInstructionC as Instruction,
     ],
     version: 0,
 };
@@ -459,7 +459,7 @@ Extracts and deduplicates all signers stored inside the account metas of an inst
 ```ts
 const mySignerA = { address: address('1111..1111'), signTransactions: async () => {} };
 const mySignerB = { address: address('2222..2222'), signTransactions: async () => {} };
-const myInstructionWithSigners: IInstructionWithSigners = {
+const myInstructionWithSigners: InstructionWithSigners = {
     programAddress: address('1234..5678'),
     accounts: [
         { address: mySignerA.address, role: AccountRole.READONLY_SIGNER, signer: mySignerA },
@@ -489,7 +489,7 @@ Helper function that adds the provided signers to any of the applicable account 
 - Must not have an attached signer already.
 
 ```ts
-const myInstruction: IInstruction = {
+const myInstruction: Instruction = {
     accounts: [
         { address: '1111' as Address, role: AccountRole.READONLY_SIGNER },
         { address: '2222' as Address, role: AccountRole.WRITABLE_SIGNER },

--- a/packages/signers/src/__tests__/__setup__.ts
+++ b/packages/signers/src/__tests__/__setup__.ts
@@ -1,5 +1,5 @@
 import { Address } from '@solana/addresses';
-import { AccountRole, IInstruction } from '@solana/instructions';
+import { AccountRole, Instruction } from '@solana/instructions';
 import type { Blockhash } from '@solana/rpc-types';
 import { CompilableTransactionMessage } from '@solana/transaction-messages';
 import {
@@ -9,7 +9,7 @@ import {
     setTransactionMessageLifetimeUsingBlockhash,
 } from '@solana/transaction-messages';
 
-import { IAccountSignerMeta, IInstructionWithSigners, TransactionMessageWithSigners } from '../account-signer-meta';
+import { AccountSignerMeta, InstructionWithSigners, TransactionMessageWithSigners } from '../account-signer-meta';
 import { MessageModifyingSigner } from '../message-modifying-signer';
 import { MessagePartialSigner } from '../message-partial-signer';
 import { TransactionModifyingSigner } from '../transaction-modifying-signer';
@@ -17,10 +17,10 @@ import { TransactionPartialSigner } from '../transaction-partial-signer';
 import { TransactionSendingSigner } from '../transaction-sending-signer';
 import { TransactionSigner } from '../transaction-signer';
 
-export function createMockInstructionWithSigners(signers: TransactionSigner[]): IInstruction & IInstructionWithSigners {
+export function createMockInstructionWithSigners(signers: TransactionSigner[]): Instruction & InstructionWithSigners {
     return {
         accounts: signers.map(
-            (signer): IAccountSignerMeta => ({ address: signer.address, role: AccountRole.READONLY_SIGNER, signer }),
+            (signer): AccountSignerMeta => ({ address: signer.address, role: AccountRole.READONLY_SIGNER, signer }),
         ),
         data: new Uint8Array([]),
         programAddress: '11111111111111111111111111111111' as Address,

--- a/packages/signers/src/__tests__/add-signers-test.ts
+++ b/packages/signers/src/__tests__/add-signers-test.ts
@@ -2,10 +2,10 @@ import '@solana/test-matchers/toBeFrozenObject';
 
 import { Address } from '@solana/addresses';
 import { SOLANA_ERROR__SIGNER__ADDRESS_CANNOT_HAVE_MULTIPLE_SIGNERS, SolanaError } from '@solana/errors';
-import { AccountRole, IInstruction } from '@solana/instructions';
+import { AccountRole, Instruction } from '@solana/instructions';
 import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
-import { IAccountSignerMeta, IInstructionWithSigners } from '../account-signer-meta';
+import { AccountSignerMeta, InstructionWithSigners } from '../account-signer-meta';
 import { addSignersToInstruction, addSignersToTransactionMessage } from '../add-signers';
 import { TransactionMessageWithFeePayerSigner } from '../fee-payer-signer';
 import { createMockTransactionModifyingSigner, createMockTransactionPartialSigner } from './__setup__';
@@ -13,7 +13,7 @@ import { createMockTransactionModifyingSigner, createMockTransactionPartialSigne
 describe('addSignersToInstruction', () => {
     it('adds signers to the account metas of the instruction', () => {
         // Given an instruction with signer account metas.
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             accounts: [
                 { address: '1111' as Address, role: AccountRole.READONLY_SIGNER },
                 { address: '2222' as Address, role: AccountRole.WRITABLE_SIGNER },
@@ -39,13 +39,13 @@ describe('addSignersToInstruction', () => {
     it('ignores account metas that already have a signer', () => {
         // Given an instruction with a signer account metas that already has a signer A attached to it.
         const signerA = createMockTransactionPartialSigner('1111' as Address);
-        const instruction: IInstruction & IInstructionWithSigners = {
+        const instruction: Instruction & InstructionWithSigners = {
             accounts: [
                 {
                     address: '1111' as Address,
                     role: AccountRole.READONLY_SIGNER,
                     signer: signerA,
-                } as IAccountSignerMeta,
+                } as AccountSignerMeta,
             ],
             data: new Uint8Array([]),
             programAddress: '9999' as Address,
@@ -63,7 +63,7 @@ describe('addSignersToInstruction', () => {
 
     it('ignores account metas that do not have a signer role', () => {
         // Given an instruction with a non-signer account metas.
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             accounts: [{ address: '1111' as Address, role: AccountRole.WRITABLE }],
             data: new Uint8Array([]),
             programAddress: '9999' as Address,
@@ -81,7 +81,7 @@ describe('addSignersToInstruction', () => {
 
     it('can add the same signer to multiple account metas', () => {
         // Given an instruction with two signer account metas that share the same address.
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             accounts: [
                 { address: '1111' as Address, role: AccountRole.READONLY_SIGNER },
                 { address: '1111' as Address, role: AccountRole.WRITABLE_SIGNER },
@@ -103,7 +103,7 @@ describe('addSignersToInstruction', () => {
 
     it('fails if two distincts signers are provided for the same address', () => {
         // Given an instruction with a signer account meta.
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             accounts: [{ address: '1111' as Address, role: AccountRole.READONLY_SIGNER }],
             data: new Uint8Array([]),
             programAddress: '9999' as Address,
@@ -126,7 +126,7 @@ describe('addSignersToInstruction', () => {
 
     it('freezes the returned instruction', () => {
         // Given an instruction with a signer account metas.
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             accounts: [{ address: '1111' as Address, role: AccountRole.READONLY_SIGNER }],
             data: new Uint8Array([]),
             programAddress: '9999' as Address,
@@ -143,7 +143,7 @@ describe('addSignersToInstruction', () => {
 
     it('returns the instruction as-is if it has no account metas', () => {
         // Given an instruction with no account metas.
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             accounts: [],
             data: new Uint8Array([]),
             programAddress: '9999' as Address,
@@ -160,12 +160,12 @@ describe('addSignersToInstruction', () => {
 describe('addSignersToTransactionMessage', () => {
     it('adds signers to the account metas of the transaction', () => {
         // Given a transaction with two instructions with signer account metas.
-        const instructionA: IInstruction = {
+        const instructionA: Instruction = {
             accounts: [{ address: '1111' as Address, role: AccountRole.READONLY_SIGNER }],
             data: new Uint8Array([]),
             programAddress: '8888' as Address,
         };
-        const instructionB: IInstruction = {
+        const instructionB: Instruction = {
             accounts: [{ address: '2222' as Address, role: AccountRole.WRITABLE_SIGNER }],
             data: new Uint8Array([]),
             programAddress: '9999' as Address,

--- a/packages/signers/src/__typetests__/account-signer-meta-typetest.ts
+++ b/packages/signers/src/__typetests__/account-signer-meta-typetest.ts
@@ -1,34 +1,34 @@
 import { address } from '@solana/addresses';
 import { AccountRole } from '@solana/instructions';
 
-import { IAccountSignerMeta } from '../account-signer-meta';
+import { AccountSignerMeta } from '../account-signer-meta';
 import { TransactionSigner } from '../transaction-signer';
 
 {
-    // [IAccountSignerMeta]: It adds a transaction signer to a valid account meta.
+    // [AccountSignerMeta]: It adds a transaction signer to a valid account meta.
     ({
         address: address('1'),
         role: AccountRole.READONLY_SIGNER,
         signer: {} as TransactionSigner,
-    }) satisfies IAccountSignerMeta;
+    }) satisfies AccountSignerMeta;
 }
 
 {
-    // [IAccountSignerMeta]: It fails if the signer is not a transaction signer.
+    // [AccountSignerMeta]: It fails if the signer is not a transaction signer.
     ({
         address: address('1'),
         role: AccountRole.READONLY_SIGNER,
         // @ts-expect-error Signer is not a transaction signer.
         signer: {} as MessageSigner,
-    }) satisfies IAccountSignerMeta;
+    }) satisfies AccountSignerMeta;
 }
 
 {
-    // [IAccountSignerMeta]: It fails if the account meta is not a signer.
+    // [AccountSignerMeta]: It fails if the account meta is not a signer.
     ({
         address: address('1'),
         // @ts-expect-error Role is not a signer role.
         role: AccountRole.READONLY,
         signer: {} as TransactionSigner,
-    }) satisfies IAccountSignerMeta;
+    }) satisfies AccountSignerMeta;
 }

--- a/packages/signers/src/__typetests__/add-signers-typetest.ts
+++ b/packages/signers/src/__typetests__/add-signers-typetest.ts
@@ -1,14 +1,14 @@
-import { IInstruction } from '@solana/instructions';
+import { Instruction } from '@solana/instructions';
 import { TransactionMessage } from '@solana/transaction-messages';
 
-import { IInstructionWithSigners, TransactionMessageWithSigners } from '../account-signer-meta';
+import { InstructionWithSigners, TransactionMessageWithSigners } from '../account-signer-meta';
 import { addSignersToInstruction, addSignersToTransactionMessage } from '../add-signers';
 import { TransactionSigner } from '../transaction-signer';
 
 const aliceSigner = null as unknown as TransactionSigner<'alice'>;
 const bobSigner = null as unknown as TransactionSigner<'bob'>;
 
-const instruction = null as unknown as IInstruction;
+const instruction = null as unknown as Instruction;
 const message = null as unknown as TransactionMessage;
 
 // [DESCRIBE] addSignersToInstruction
@@ -16,7 +16,7 @@ const message = null as unknown as TransactionMessage;
     // It adds the `WithSigners` type expansion to the instruction
     {
         const instructionWithSigners = addSignersToInstruction([aliceSigner, bobSigner], instruction);
-        instructionWithSigners satisfies IInstructionWithSigners;
+        instructionWithSigners satisfies InstructionWithSigners;
     }
 }
 

--- a/packages/signers/src/add-signers.ts
+++ b/packages/signers/src/add-signers.ts
@@ -1,8 +1,8 @@
 import { Address } from '@solana/addresses';
-import { IInstruction, isSignerRole } from '@solana/instructions';
+import { Instruction, isSignerRole } from '@solana/instructions';
 import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
-import { IAccountSignerMeta, IInstructionWithSigners, TransactionMessageWithSigners } from './account-signer-meta';
+import { AccountSignerMeta, InstructionWithSigners, TransactionMessageWithSigners } from './account-signer-meta';
 import { deduplicateSigners } from './deduplicate-signers';
 import { isTransactionSigner, TransactionSigner } from './transaction-signer';
 
@@ -19,10 +19,10 @@ import { isTransactionSigner, TransactionSigner } from './transaction-signer';
  *
  * @example
  * ```ts
- * import { AccountRole, IInstruction } from '@solana/instructions';
+ * import { AccountRole, Instruction } from '@solana/instructions';
  * import { addSignersToInstruction, TransactionSigner } from '@solana/signers';
  *
- * const instruction: IInstruction = {
+ * const instruction: Instruction = {
  *     accounts: [
  *         { address: '1111' as Address, role: AccountRole.READONLY_SIGNER },
  *         { address: '2222' as Address, role: AccountRole.WRITABLE_SIGNER },
@@ -41,12 +41,12 @@ import { isTransactionSigner, TransactionSigner } from './transaction-signer';
  * // instructionWithSigners.accounts[1].signer === signerB
  * ```
  */
-export function addSignersToInstruction<TInstruction extends IInstruction>(
+export function addSignersToInstruction<TInstruction extends Instruction>(
     signers: TransactionSigner[],
-    instruction: TInstruction | (IInstructionWithSigners & TInstruction),
-): IInstructionWithSigners & TInstruction {
+    instruction: TInstruction | (InstructionWithSigners & TInstruction),
+): InstructionWithSigners & TInstruction {
     if (!instruction.accounts || instruction.accounts.length === 0) {
-        return instruction as IInstructionWithSigners & TInstruction;
+        return instruction as InstructionWithSigners & TInstruction;
     }
 
     const signerByAddress = new Map(deduplicateSigners(signers).map(signer => [signer.address, signer]));
@@ -57,7 +57,7 @@ export function addSignersToInstruction<TInstruction extends IInstruction>(
             if (!isSignerRole(account.role) || 'signer' in account || !signer) {
                 return account;
             }
-            return Object.freeze({ ...account, signer } as IAccountSignerMeta);
+            return Object.freeze({ ...account, signer } as AccountSignerMeta);
         }),
     });
 }
@@ -76,15 +76,15 @@ export function addSignersToInstruction<TInstruction extends IInstruction>(
  *
  * @example
  * ```ts
- * import { AccountRole, IInstruction } from '@solana/instructions';
+ * import { AccountRole, Instruction } from '@solana/instructions';
  * import { BaseTransactionMessage } from '@solana/transaction-messages';
  * import { addSignersToTransactionMessage, TransactionSigner } from '@solana/signers';
  *
- * const instructionA: IInstruction = {
+ * const instructionA: Instruction = {
  *     accounts: [{ address: '1111' as Address, role: AccountRole.READONLY_SIGNER }],
  *     // ...
  * };
- * const instructionB: IInstruction = {
+ * const instructionB: Instruction = {
  *     accounts: [{ address: '2222' as Address, role: AccountRole.WRITABLE_SIGNER }],
  *     // ...
  * };

--- a/packages/signers/src/deprecated.ts
+++ b/packages/signers/src/deprecated.ts
@@ -1,7 +1,7 @@
-import type { IAccountLookupMeta, IAccountMeta } from '@solana/instructions';
+import type { AccountLookupMeta, AccountMeta } from '@solana/instructions';
 import type { Brand } from '@solana/nominal-types';
 
-import type { IAccountSignerMeta, TransactionMessageWithSigners } from './account-signer-meta';
+import type { AccountSignerMeta, InstructionWithSigners, TransactionMessageWithSigners } from './account-signer-meta';
 import type { TransactionSigner } from './transaction-signer';
 
 /**
@@ -35,13 +35,13 @@ import type { TransactionSigner } from './transaction-signer';
 export type ITransactionMessageWithSigners<
     TAddress extends string = string,
     TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
-    TAccounts extends readonly IAccountMetaWithSigner<TSigner>[] = readonly IAccountMetaWithSigner<TSigner>[],
+    TAccounts extends readonly AccountMetaWithSigner<TSigner>[] = readonly AccountMetaWithSigner<TSigner>[],
 > = TransactionMessageWithSigners<TAddress, TSigner, TAccounts>;
 
-type IAccountMetaWithSigner<TSigner extends TransactionSigner = TransactionSigner> =
-    | IAccountLookupMeta
-    | IAccountMeta
-    | IAccountSignerMeta<string, TSigner>;
+type AccountMetaWithSigner<TSigner extends TransactionSigner = TransactionSigner> =
+    | AccountLookupMeta
+    | AccountMeta
+    | AccountSignerMeta<string, TSigner>;
 
 /**
  * Alternative to {@link TransactionMessageWithFeePayer} that uses a {@link TransactionSigner} for the fee payer.
@@ -93,3 +93,74 @@ export type ITransactionMessageWithSingleSendingSigner = Brand<
     TransactionMessageWithSigners,
     'TransactionMessageWithSingleSendingSigner'
 >;
+
+/**
+ * An extension of the {@link AccountMeta} type that allows us to store {@link TransactionSigner | TransactionSigners} inside it.
+ *
+ * Note that, because this type represents a signer, it must use one the following two roles:
+ * - {@link AccountRole.READONLY_SIGNER}
+ * - {@link AccountRole.WRITABLE_SIGNER}
+ *
+ * @deprecated Use {@link AccountSignerMeta} instead. It was only renamed.
+ *
+ * @typeParam TAddress - Supply a string literal to define an account having a particular address.
+ * @typeParam TSigner - Optionally provide a narrower type for the {@link TransactionSigner} to use within the account meta.
+ *
+ * @interface
+ *
+ * @example
+ * ```ts
+ * import { AccountRole } from '@solana/instructions';
+ * import { generateKeyPairSigner, IAccountSignerMeta } from '@solana/signers';
+ *
+ * const signer = await generateKeyPairSigner();
+ * const account: IAccountSignerMeta = {
+ *     address: signer.address,
+ *     role: AccountRole.READONLY_SIGNER,
+ *     signer,
+ * };
+ * ```
+ */
+export type IAccountSignerMeta<
+    TAddress extends string = string,
+    TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
+> = AccountSignerMeta<TAddress, TSigner>;
+
+/**
+ * Composable type that allows {@link AccountSignerMeta | AccountSignerMetas} to be used inside the instruction's `accounts` array
+ *
+ * @typeParam TSigner - Optionally provide a narrower type for {@link TransactionSigner | TransactionSigners}.
+ * @typeParam TAccounts - Optionally provide a narrower type for the account metas.
+ *
+ * @deprecated Use {@link InstructionWithSigners} instead. It was only renamed.
+ *
+ * @interface
+ *
+ * @example
+ * ```ts
+ * import { AccountRole, Instruction } from '@solana/instructions';
+ * import { generateKeyPairSigner, IInstructionWithSigners } from '@solana/signers';
+ *
+ * const [authority, buffer] = await Promise.all([
+ *     generateKeyPairSigner(),
+ *     generateKeyPairSigner(),
+ * ]);
+ * const instruction: Instruction & IInstructionWithSigners = {
+ *     programAddress: address('1234..5678'),
+ *     accounts: [
+ *         // The authority is a signer account.
+ *         {
+ *             address: authority.address,
+ *             role: AccountRole.READONLY_SIGNER,
+ *             signer: authority,
+ *         },
+ *         // The buffer is a writable account.
+ *         { address: buffer.address, role: AccountRole.WRITABLE },
+ *     ],
+ * };
+ * ```
+ */
+export type IInstructionWithSigners<
+    TSigner extends TransactionSigner = TransactionSigner,
+    TAccounts extends readonly AccountMetaWithSigner<TSigner>[] = readonly AccountMetaWithSigner<TSigner>[],
+> = InstructionWithSigners<TSigner, TAccounts>;

--- a/packages/transaction-messages/README.md
+++ b/packages/transaction-messages/README.md
@@ -181,15 +181,15 @@ See [`assertIsBlockhash()`](#assertisblockhash) for an example of how to use an 
 
 ### Types
 
-#### `IInstruction`
+#### `Instruction`
 
 This type represents an instruction to be issued to a program. Objects that conform to this type have a `programAddress` property that is the base58-encoded address of the program in question.
 
-#### `IInstructionWithAccounts`
+#### `InstructionWithAccounts`
 
-This type represents an instruction that specifies a list of accounts that a program may read from, write to, or require be signers of the transaction itself. Objects that conform to this type have an `accounts` property that is an array of `IAccountMeta | IAccountLookupMeta` in the order the instruction requires.
+This type represents an instruction that specifies a list of accounts that a program may read from, write to, or require be signers of the transaction itself. Objects that conform to this type have an `accounts` property that is an array of `AccountMeta | AccountLookupMeta` in the order the instruction requires.
 
-#### `IInstructionWithData`
+#### `InstructionWithData`
 
 This type represents an instruction that supplies some data as input to the program. Objects that conform to this type have a `data` property that can be any type of `Uint8Array`.
 
@@ -234,7 +234,7 @@ This type represents a mapping of lookup table addresses to the addresses of the
 
 #### `compressTransactionMessageUsingAddressLookupTables`
 
-Given a transaction message and a mapping of lookup tables to the addresses stored in them, this function will return a new transaction message with the same instructions but with all non-signer accounts that are found in the given lookup tables represented by an `IAccountLookupMeta` instead of an `IAccountMeta`.
+Given a transaction message and a mapping of lookup tables to the addresses stored in them, this function will return a new transaction message with the same instructions but with all non-signer accounts that are found in the given lookup tables represented by an `AccountLookupMeta` instead of an `AccountMeta`.
 
 This means that these accounts will take up less space in the compiled transaction message. This size reduction is most significant when the transaction includes many accounts from the same lookup table.
 

--- a/packages/transaction-messages/src/__tests__/compress-transaction-message-test.ts
+++ b/packages/transaction-messages/src/__tests__/compress-transaction-message-test.ts
@@ -2,7 +2,7 @@ import '@solana/test-matchers/toBeFrozenObject';
 
 import { Address } from '@solana/addresses';
 import { pipe } from '@solana/functional';
-import { AccountRole, IAccountLookupMeta, IAccountMeta, IInstruction } from '@solana/instructions';
+import { AccountLookupMeta, AccountMeta, AccountRole, Instruction } from '@solana/instructions';
 
 import { AddressesByLookupTableAddress } from '../addresses-by-lookup-table-address';
 import { compressTransactionMessageUsingAddressLookupTables } from '../compress-transaction-message';
@@ -37,7 +37,7 @@ describe('compressTransactionMessageUsingAddressLookupTables', () => {
 
         const result = compressTransactionMessageUsingAddressLookupTables(transactionMessage, lookupTables);
 
-        const expectedLookupMeta: IAccountLookupMeta = {
+        const expectedLookupMeta: AccountLookupMeta = {
             address,
             addressIndex: 0,
             lookupTableAddress,
@@ -72,7 +72,7 @@ describe('compressTransactionMessageUsingAddressLookupTables', () => {
 
         const result = compressTransactionMessageUsingAddressLookupTables(transactionMessage, lookupTables);
 
-        const expectedLookupMeta: IAccountLookupMeta = {
+        const expectedLookupMeta: AccountLookupMeta = {
             address,
             addressIndex: 0,
             lookupTableAddress,
@@ -86,7 +86,7 @@ describe('compressTransactionMessageUsingAddressLookupTables', () => {
         const address = 'address1' as Address;
         const lookupTableAddress = 'lookupTableAddress' as Address;
 
-        const accountMeta: IAccountMeta = {
+        const accountMeta: AccountMeta = {
             address,
             role: AccountRole.READONLY_SIGNER,
         };
@@ -114,7 +114,7 @@ describe('compressTransactionMessageUsingAddressLookupTables', () => {
         const address = 'address1' as Address;
         const lookupTableAddress = 'lookupTableAddress' as Address;
 
-        const accountMeta: IAccountMeta = {
+        const accountMeta: AccountMeta = {
             address,
             role: AccountRole.WRITABLE_SIGNER,
         };
@@ -142,7 +142,7 @@ describe('compressTransactionMessageUsingAddressLookupTables', () => {
         const address = 'address1' as Address;
         const lookupTableAddress = 'lookupTableAddress' as Address;
 
-        const lookupMeta: IAccountLookupMeta = {
+        const lookupMeta: AccountLookupMeta = {
             address,
             addressIndex: 0,
             lookupTableAddress,
@@ -198,14 +198,14 @@ describe('compressTransactionMessageUsingAddressLookupTables', () => {
 
         const result = compressTransactionMessageUsingAddressLookupTables(transactionMessage, lookupTables);
 
-        const expectedLookupMeta1: IAccountLookupMeta = {
+        const expectedLookupMeta1: AccountLookupMeta = {
             address: address1,
             addressIndex: 0,
             lookupTableAddress,
             role: AccountRole.READONLY,
         };
 
-        const expectedLookupMeta2: IAccountLookupMeta = {
+        const expectedLookupMeta2: AccountLookupMeta = {
             address: address2,
             addressIndex: 1,
             lookupTableAddress,
@@ -256,7 +256,7 @@ describe('compressTransactionMessageUsingAddressLookupTables', () => {
 
         const result = compressTransactionMessageUsingAddressLookupTables(transactionMessage, lookupTables);
 
-        const expectedLookupMeta: IAccountLookupMeta = {
+        const expectedLookupMeta: AccountLookupMeta = {
             address: address,
             addressIndex: 0,
             lookupTableAddress,
@@ -299,14 +299,14 @@ describe('compressTransactionMessageUsingAddressLookupTables', () => {
 
         const result = compressTransactionMessageUsingAddressLookupTables(transactionMessage, lookupTables);
 
-        const expectedLookupMeta1: IAccountLookupMeta = {
+        const expectedLookupMeta1: AccountLookupMeta = {
             address: address1,
             addressIndex: 0,
             lookupTableAddress: lookupTableAddress1,
             role: AccountRole.READONLY,
         };
 
-        const expectedLookupMeta2: IAccountLookupMeta = {
+        const expectedLookupMeta2: AccountLookupMeta = {
             address: address2,
             addressIndex: 0,
             lookupTableAddress: lookupTableAddress2,
@@ -433,7 +433,7 @@ describe('compressTransactionMessageUsingAddressLookupTables', () => {
         const address = 'address1' as Address;
         const lookupTableAddress = 'lookupTableAddress' as Address;
 
-        const instruction: IInstruction = {
+        const instruction: Instruction = {
             accounts: [
                 {
                     address,

--- a/packages/transaction-messages/src/__tests__/decompile-message-test.ts
+++ b/packages/transaction-messages/src/__tests__/decompile-message-test.ts
@@ -6,7 +6,7 @@ import {
     SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_INDEX_OUT_OF_RANGE,
     SolanaError,
 } from '@solana/errors';
-import { AccountRole, IAccountLookupMeta, IAccountMeta, IInstruction } from '@solana/instructions';
+import { AccountLookupMeta, AccountMeta, AccountRole, Instruction } from '@solana/instructions';
 
 import { CompiledTransactionMessage } from '../compile';
 import { decompileTransactionMessage } from '../decompile-message';
@@ -93,7 +93,7 @@ describe('decompileTransactionMessage', () => {
             };
 
             const transaction = decompileTransactionMessage(compiledTransaction);
-            const expectedInstruction: IInstruction = {
+            const expectedInstruction: Instruction = {
                 programAddress,
             };
             expect(transaction.instructions).toStrictEqual([expectedInstruction]);
@@ -133,7 +133,7 @@ describe('decompileTransactionMessage', () => {
 
             const transaction = decompileTransactionMessage(compiledTransaction);
 
-            const expectedInstruction: IInstruction = {
+            const expectedInstruction: Instruction = {
                 accounts: [
                     {
                         address: 'H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x' as Address,
@@ -215,7 +215,7 @@ describe('decompileTransactionMessage', () => {
 
             const transaction = decompileTransactionMessage(compiledTransaction);
 
-            const expectedInstructions: IInstruction[] = [
+            const expectedInstructions: Instruction[] = [
                 {
                     programAddress: '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
                 },
@@ -337,7 +337,7 @@ describe('decompileTransactionMessage', () => {
 
             const transaction = decompileTransactionMessage(compiledTransaction);
 
-            const expectedInstruction: IInstruction = {
+            const expectedInstruction: Instruction = {
                 accounts: [
                     {
                         address: nonceAccountAddress,
@@ -432,7 +432,7 @@ describe('decompileTransactionMessage', () => {
 
             const transaction = decompileTransactionMessage(compiledTransaction);
 
-            const expectedInstruction: IInstruction = {
+            const expectedInstruction: Instruction = {
                 accounts: [
                     {
                         address: nonceAccountAddress,
@@ -495,7 +495,7 @@ describe('decompileTransactionMessage', () => {
 
             const transaction = decompileTransactionMessage(compiledTransaction);
 
-            const expectedInstructions: IInstruction[] = [
+            const expectedInstructions: Instruction[] = [
                 {
                     accounts: [
                         {
@@ -670,7 +670,7 @@ describe('decompileTransactionMessage', () => {
                     addressesByLookupTableAddress: lookupTables,
                 });
 
-                const expectedAccountLookupMeta: IAccountLookupMeta = {
+                const expectedAccountLookupMeta: AccountLookupMeta = {
                     address: addressInLookup,
                     addressIndex: 0,
                     lookupTableAddress,
@@ -725,7 +725,7 @@ describe('decompileTransactionMessage', () => {
                     addressesByLookupTableAddress: lookupTables,
                 });
 
-                const expectedAccountLookupMetas: IAccountLookupMeta[] = [
+                const expectedAccountLookupMetas: AccountLookupMeta[] = [
                     {
                         address: addressInLookup1,
                         addressIndex: 0,
@@ -783,7 +783,7 @@ describe('decompileTransactionMessage', () => {
                     addressesByLookupTableAddress: lookupTables,
                 });
 
-                const expectedAccountLookupMeta: IAccountLookupMeta = {
+                const expectedAccountLookupMeta: AccountLookupMeta = {
                     address: addressInLookup,
                     addressIndex: 0,
                     lookupTableAddress,
@@ -838,7 +838,7 @@ describe('decompileTransactionMessage', () => {
                     addressesByLookupTableAddress: lookupTables,
                 });
 
-                const expectedAccountLookupMetas: IAccountLookupMeta[] = [
+                const expectedAccountLookupMetas: AccountLookupMeta[] = [
                     {
                         address: addressInLookup1,
                         addressIndex: 0,
@@ -901,7 +901,7 @@ describe('decompileTransactionMessage', () => {
                     addressesByLookupTableAddress: lookupTables,
                 });
 
-                const expectedAccountLookupMetas: IAccountLookupMeta[] = [
+                const expectedAccountLookupMetas: AccountLookupMeta[] = [
                     // writable is first since we used account indices [2,3]
                     {
                         address: addressInLookup2,
@@ -962,12 +962,12 @@ describe('decompileTransactionMessage', () => {
                     addressesByLookupTableAddress: lookupTables,
                 });
 
-                const expectedAccountMeta: IAccountMeta = {
+                const expectedAccountMeta: AccountMeta = {
                     address: staticAddress,
                     role: AccountRole.READONLY,
                 };
 
-                const expectedAccountLookupMeta: IAccountLookupMeta = {
+                const expectedAccountLookupMeta: AccountLookupMeta = {
                     address: addressInLookup,
                     addressIndex: 0,
                     lookupTableAddress,
@@ -1026,14 +1026,14 @@ describe('decompileTransactionMessage', () => {
                     addressesByLookupTableAddress: lookupTables,
                 });
 
-                const expectedAccountLookupMeta1: IAccountLookupMeta = {
+                const expectedAccountLookupMeta1: AccountLookupMeta = {
                     address: addressInLookup1,
                     addressIndex: 0,
                     lookupTableAddress,
                     role: AccountRole.READONLY,
                 };
 
-                const expectedAccountLookupMeta2: IAccountLookupMeta = {
+                const expectedAccountLookupMeta2: AccountLookupMeta = {
                     address: addressInLookup2,
                     addressIndex: 2,
                     lookupTableAddress,
@@ -1230,7 +1230,7 @@ describe('decompileTransactionMessage', () => {
                     addressesByLookupTableAddress: lookupTables,
                 });
 
-                const expectedAccountLookupMetas: IAccountLookupMeta[] = [
+                const expectedAccountLookupMetas: AccountLookupMeta[] = [
                     {
                         address: addressInLookup1,
                         addressIndex: 0,
@@ -1296,7 +1296,7 @@ describe('decompileTransactionMessage', () => {
                     addressesByLookupTableAddress: lookupTables,
                 });
 
-                const expectedAccountLookupMetas: IAccountLookupMeta[] = [
+                const expectedAccountLookupMetas: AccountLookupMeta[] = [
                     {
                         address: addressInLookup1,
                         addressIndex: 0,
@@ -1374,7 +1374,7 @@ describe('decompileTransactionMessage', () => {
                     addressesByLookupTableAddress: lookupTables,
                 });
 
-                const expectedAccountLookupMetas: IAccountLookupMeta[] = [
+                const expectedAccountLookupMetas: AccountLookupMeta[] = [
                     {
                         address: writableAddressInLookup1,
                         addressIndex: 1,
@@ -1468,7 +1468,7 @@ describe('decompileTransactionMessage', () => {
                     addressesByLookupTableAddress: lookupTables,
                 });
 
-                const expectedAccountLookupMetasInstruction1: IAccountLookupMeta[] = [
+                const expectedAccountLookupMetasInstruction1: AccountLookupMeta[] = [
                     // index 2 - writable from lookup1
                     {
                         address: writableAddressInLookup1,
@@ -1485,7 +1485,7 @@ describe('decompileTransactionMessage', () => {
                     },
                 ];
 
-                const expectedAccountLookupMetasInstruction2: IAccountLookupMeta[] = [
+                const expectedAccountLookupMetasInstruction2: AccountLookupMeta[] = [
                     // index 3 - writable from lookup2
                     {
                         address: writableAddressInLookup2,

--- a/packages/transaction-messages/src/__tests__/durable-nonce-test.ts
+++ b/packages/transaction-messages/src/__tests__/durable-nonce-test.ts
@@ -1,7 +1,7 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
 import { Address } from '@solana/addresses';
-import { AccountRole, IInstruction, ReadonlySignerAccount, WritableAccount } from '@solana/instructions';
+import { AccountRole, Instruction, ReadonlySignerAccount, WritableAccount } from '@solana/instructions';
 import type { Blockhash } from '@solana/rpc-types';
 
 import { TransactionMessageWithBlockhashLifetime } from '../blockhash';
@@ -140,7 +140,7 @@ describe('assertIsDurableNonceTransactionMessage()', () => {
     it('does not throw when the nonce authority is a writable signer', () => {
         const advanceDurableNonceInstruction = createMockAdvanceNonceAccountInstruction(NONCE_CONSTRAINT);
         const { accounts } = advanceDurableNonceInstruction;
-        const updatedInstruction: IInstruction = {
+        const updatedInstruction: Instruction = {
             ...advanceDurableNonceInstruction,
             accounts: [
                 accounts[0],

--- a/packages/transaction-messages/src/__tests__/instructions-test.ts
+++ b/packages/transaction-messages/src/__tests__/instructions-test.ts
@@ -1,7 +1,7 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
 import { Address } from '@solana/addresses';
-import { IInstruction } from '@solana/instructions';
+import { Instruction } from '@solana/instructions';
 
 import {
     appendTransactionMessageInstruction,
@@ -20,8 +20,8 @@ const PROGRAM_C =
 
 describe('Transaction instruction helpers', () => {
     let baseTx: BaseTransactionMessage;
-    let exampleInstruction: IInstruction<string>;
-    let secondExampleInstruction: IInstruction<string>;
+    let exampleInstruction: Instruction<string>;
+    let secondExampleInstruction: Instruction<string>;
     beforeEach(() => {
         baseTx = {
             instructions: [

--- a/packages/transaction-messages/src/__typetests__/durable-nonce-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/durable-nonce-typetest.ts
@@ -1,6 +1,6 @@
 import type { Address } from '@solana/addresses';
 import { pipe } from '@solana/functional';
-import { IInstruction } from '@solana/instructions';
+import { Instruction } from '@solana/instructions';
 
 import { TransactionMessageWithBlockhashLifetime } from '../blockhash';
 import { CompilableTransactionMessage } from '../compilable-transaction-message';
@@ -30,7 +30,7 @@ const newMockNonceConfig = {
     nonceAuthorityAddress: null as unknown as Address<'newNonceAuthority'>,
 };
 
-type InstructionA = IInstruction & { identifier: 'A' };
+type InstructionA = Instruction & { identifier: 'A' };
 type LegacyTransactionMessage = Extract<TransactionMessage, { version: 'legacy' }>;
 type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
 

--- a/packages/transaction-messages/src/__typetests__/instructions-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/instructions-typetest.ts
@@ -19,17 +19,17 @@ import {
 import { BaseTransactionMessage } from '../transaction-message';
 import { TransactionMessageWithinSizeLimit } from '../transaction-message-size';
 
-type IInstruction = BaseTransactionMessage['instructions'][number];
-type InstructionA = IInstruction & { identifier: 'A' };
-type InstructionB = IInstruction & { identifier: 'B' };
-type InstructionC = IInstruction & { identifier: 'C' };
+type Instruction = BaseTransactionMessage['instructions'][number];
+type InstructionA = Instruction & { identifier: 'A' };
+type InstructionB = Instruction & { identifier: 'B' };
+type InstructionC = Instruction & { identifier: 'C' };
 
 // [DESCRIBE] appendTransactionMessageInstruction
 {
     // It returns the same TransactionMessage type
     {
         const message = null as unknown as BaseTransactionMessage & { some: 1 };
-        const newMessage = appendTransactionMessageInstruction(null as unknown as IInstruction, message);
+        const newMessage = appendTransactionMessageInstruction(null as unknown as Instruction, message);
         newMessage satisfies BaseTransactionMessage & { some: 1 };
     }
 
@@ -48,7 +48,7 @@ type InstructionC = IInstruction & { identifier: 'C' };
     {
         const message = null as unknown as BaseTransactionMessage;
         const newMessage = appendTransactionMessageInstruction(null as unknown as InstructionA, message);
-        newMessage.instructions satisfies readonly [...IInstruction[], InstructionA];
+        newMessage.instructions satisfies readonly [...Instruction[], InstructionA];
     }
 
     // It keeps the blockhash lifetime type safety.
@@ -86,7 +86,7 @@ type InstructionC = IInstruction & { identifier: 'C' };
     // It removes the size limit type safety.
     {
         const message = null as unknown as BaseTransactionMessage & TransactionMessageWithinSizeLimit;
-        const newMessage = appendTransactionMessageInstruction(null as unknown as IInstruction, message);
+        const newMessage = appendTransactionMessageInstruction(null as unknown as Instruction, message);
         // @ts-expect-error Potentially no longer within size limit.
         newMessage satisfies TransactionMessageWithinSizeLimit;
     }
@@ -97,7 +97,7 @@ type InstructionC = IInstruction & { identifier: 'C' };
     // It returns the same TransactionMessage type
     {
         const message = null as unknown as BaseTransactionMessage & { some: 1 };
-        const newMessage = appendTransactionMessageInstructions(null as unknown as IInstruction[], message);
+        const newMessage = appendTransactionMessageInstructions(null as unknown as Instruction[], message);
         newMessage satisfies BaseTransactionMessage & { some: 1 };
     }
 
@@ -122,13 +122,13 @@ type InstructionC = IInstruction & { identifier: 'C' };
             [null as unknown as InstructionA, null as unknown as InstructionB],
             message,
         );
-        newMessage.instructions satisfies readonly [...IInstruction[], InstructionA, InstructionB];
+        newMessage.instructions satisfies readonly [...Instruction[], InstructionA, InstructionB];
     }
 
     // It removes the size limit type safety.
     {
         const message = null as unknown as BaseTransactionMessage & TransactionMessageWithinSizeLimit;
-        const newMessage = appendTransactionMessageInstructions([null as unknown as IInstruction], message);
+        const newMessage = appendTransactionMessageInstructions([null as unknown as Instruction], message);
         // @ts-expect-error Potentially no longer within size limit.
         newMessage satisfies TransactionMessageWithinSizeLimit;
     }
@@ -139,7 +139,7 @@ type InstructionC = IInstruction & { identifier: 'C' };
     // It returns the same TransactionMessage type
     {
         const message = null as unknown as BaseTransactionMessage & { some: 1 };
-        const newMessage = prependTransactionMessageInstruction(null as unknown as IInstruction, message);
+        const newMessage = prependTransactionMessageInstruction(null as unknown as Instruction, message);
         newMessage satisfies BaseTransactionMessage & { some: 1 };
     }
 
@@ -147,7 +147,7 @@ type InstructionC = IInstruction & { identifier: 'C' };
     {
         const message = null as unknown as BaseTransactionMessage &
             TransactionMessageWithDurableNonceLifetime & { some: 1 };
-        const newMessage = prependTransactionMessageInstruction(null as unknown as IInstruction, message);
+        const newMessage = prependTransactionMessageInstruction(null as unknown as Instruction, message);
         newMessage satisfies BaseTransactionMessage & { some: 1 };
         // @ts-expect-error The durable nonce transaction message type should be stripped.
         newMessage satisfies TransactionMessageWithDurableNonceLifetime;
@@ -157,7 +157,7 @@ type InstructionC = IInstruction & { identifier: 'C' };
     {
         const message = null as unknown as BaseTransactionMessage &
             TransactionMessageWithBlockhashLifetime & { some: 1 };
-        const newMessage = prependTransactionMessageInstruction(null as unknown as IInstruction, message);
+        const newMessage = prependTransactionMessageInstruction(null as unknown as Instruction, message);
         newMessage satisfies BaseTransactionMessage & TransactionMessageWithBlockhashLifetime & { some: 1 };
     }
 
@@ -176,7 +176,7 @@ type InstructionC = IInstruction & { identifier: 'C' };
     {
         const message = null as unknown as BaseTransactionMessage;
         const newMessage = prependTransactionMessageInstruction(null as unknown as InstructionA, message);
-        newMessage.instructions satisfies readonly [InstructionA, ...IInstruction[]];
+        newMessage.instructions satisfies readonly [InstructionA, ...Instruction[]];
     }
 
     // It keeps the blockhash lifetime type safety.
@@ -216,7 +216,7 @@ type InstructionC = IInstruction & { identifier: 'C' };
     // It removes the size limit type safety.
     {
         const message = null as unknown as BaseTransactionMessage & TransactionMessageWithinSizeLimit;
-        const newMessage = prependTransactionMessageInstruction(null as unknown as IInstruction, message);
+        const newMessage = prependTransactionMessageInstruction(null as unknown as Instruction, message);
         // @ts-expect-error Potentially no longer within size limit.
         newMessage satisfies TransactionMessageWithinSizeLimit;
     }
@@ -227,7 +227,7 @@ type InstructionC = IInstruction & { identifier: 'C' };
     // It returns the same TransactionMessage type
     {
         const message = null as unknown as BaseTransactionMessage & { some: 1 };
-        const newMessage = prependTransactionMessageInstructions(null as unknown as IInstruction[], message);
+        const newMessage = prependTransactionMessageInstructions(null as unknown as Instruction[], message);
         newMessage satisfies BaseTransactionMessage & { some: 1 };
     }
 
@@ -235,7 +235,7 @@ type InstructionC = IInstruction & { identifier: 'C' };
     {
         const message = null as unknown as BaseTransactionMessage &
             TransactionMessageWithDurableNonceLifetime & { some: 1 };
-        const newMessage = prependTransactionMessageInstructions(null as unknown as IInstruction[], message);
+        const newMessage = prependTransactionMessageInstructions(null as unknown as Instruction[], message);
         newMessage satisfies BaseTransactionMessage & { some: 1 };
         // @ts-expect-error The durable nonce transaction message type should be stripped.
         newMessage satisfies TransactionMessageWithDurableNonceLifetime;
@@ -262,13 +262,13 @@ type InstructionC = IInstruction & { identifier: 'C' };
             [null as unknown as InstructionA, null as unknown as InstructionB],
             message,
         );
-        newMessage.instructions satisfies readonly [InstructionA, InstructionB, ...IInstruction[]];
+        newMessage.instructions satisfies readonly [InstructionA, InstructionB, ...Instruction[]];
     }
 
     // It removes the size limit type safety.
     {
         const message = null as unknown as BaseTransactionMessage & TransactionMessageWithinSizeLimit;
-        const newMessage = prependTransactionMessageInstructions([null as unknown as IInstruction], message);
+        const newMessage = prependTransactionMessageInstructions([null as unknown as Instruction], message);
         // @ts-expect-error Potentially no longer within size limit.
         newMessage satisfies TransactionMessageWithinSizeLimit;
     }

--- a/packages/transaction-messages/src/compilable-transaction-message.ts
+++ b/packages/transaction-messages/src/compilable-transaction-message.ts
@@ -1,4 +1,4 @@
-import { IInstruction } from '@solana/instructions';
+import { Instruction } from '@solana/instructions';
 
 import { TransactionMessageWithFeePayer } from './fee-payer';
 import { TransactionMessageWithLifetime } from './lifetime';
@@ -11,5 +11,5 @@ import { BaseTransactionMessage, TransactionVersion } from './transaction-messag
  */
 export type CompilableTransactionMessage<
     TVersion extends TransactionVersion = TransactionVersion,
-    TInstruction extends IInstruction = IInstruction,
+    TInstruction extends Instruction = Instruction,
 > = BaseTransactionMessage<TVersion, TInstruction> & TransactionMessageWithFeePayer & TransactionMessageWithLifetime;

--- a/packages/transaction-messages/src/compile/__tests__/accounts-test.ts
+++ b/packages/transaction-messages/src/compile/__tests__/accounts-test.ts
@@ -1,5 +1,5 @@
 import { Address, getAddressComparator } from '@solana/addresses';
-import { AccountRole, IAccountLookupMeta, IInstruction } from '@solana/instructions';
+import { AccountLookupMeta, AccountRole, Instruction } from '@solana/instructions';
 
 import {
     ADDRESS_MAP_TYPE_PROPERTY as TYPE,
@@ -20,7 +20,7 @@ type TestCase = {
         | typeof STATIC_ENTRY_READONLY_SIGNER
         | typeof STATIC_ENTRY_WRITABLE
         | typeof STATIC_ENTRY_WRITABLE_SIGNER;
-    instructionOrder: [string, (i: IInstruction[]) => IInstruction[]];
+    instructionOrder: [string, (i: Instruction[]) => Instruction[]];
     lutRole: AccountRoleEnumName;
     role: AccountRoleEnumName;
     staticRole: AccountRoleEnumName;
@@ -39,10 +39,10 @@ let _nextMockAddress = 0;
 function getMockAddress() {
     return `${_nextMockAddress++}` as Address;
 }
-function forwardOrder(i: IInstruction[]) {
+function forwardOrder(i: Instruction[]) {
     return i;
 }
-function reverseOrder(i: IInstruction[]) {
+function reverseOrder(i: Instruction[]) {
     return i.reverse();
 }
 
@@ -141,7 +141,7 @@ describe('getAddressMapFromInstructions', () => {
                             addressIndex: 0,
                             lookupTableAddress: getMockAddress(),
                             role: AccountRole[role],
-                        } as IAccountLookupMeta<typeof commonAddress>,
+                        } as AccountLookupMeta<typeof commonAddress>,
                     ],
                     programAddress: getMockAddress(),
                 },

--- a/packages/transaction-messages/src/compile/__tests__/instructions-test.ts
+++ b/packages/transaction-messages/src/compile/__tests__/instructions-test.ts
@@ -1,5 +1,5 @@
 import { Address } from '@solana/addresses';
-import { AccountRole, IInstruction } from '@solana/instructions';
+import { AccountRole, Instruction } from '@solana/instructions';
 
 import { OrderedAccounts } from '../../compile/accounts';
 import { getCompiledInstructions } from '../../compile/instructions';
@@ -50,7 +50,7 @@ describe('getCompiledInstructions', () => {
                 ],
                 programAddress: programAddressAtIndex1,
             },
-        ] as IInstruction[];
+        ] as Instruction[];
         const compiledInstructions = getCompiledInstructions(instructions, [
             { address: getMockAddress(), role: AccountRole.WRITABLE_SIGNER },
             { address: programAddressAtIndex1, role: AccountRole.READONLY },

--- a/packages/transaction-messages/src/compile/accounts.ts
+++ b/packages/transaction-messages/src/compile/accounts.ts
@@ -5,10 +5,10 @@ import {
     SolanaError,
 } from '@solana/errors';
 import {
+    AccountLookupMeta,
+    AccountMeta,
     AccountRole,
-    IAccountLookupMeta,
-    IAccountMeta,
-    IInstruction,
+    Instruction,
     isSignerRole,
     isWritableRole,
     mergeRoles,
@@ -36,7 +36,7 @@ type FeePayerAccountEntry = Omit<WritableSignerAccount, 'address'> & {
 type LookupTableAccountEntry = Omit<ReadonlyAccountLookup | WritableAccountLookup, 'address'> & {
     [TYPE]: AddressMapEntryType.LOOKUP_TABLE;
 };
-export type OrderedAccounts = Brand<(IAccountLookupMeta | IAccountMeta)[], 'OrderedAccounts'>;
+export type OrderedAccounts = Brand<(AccountLookupMeta | AccountMeta)[], 'OrderedAccounts'>;
 type StaticAccountEntry = Omit<
     ReadonlyAccount | ReadonlySignerAccount | WritableAccount | WritableSignerAccount,
     'address'
@@ -55,7 +55,7 @@ function upsert(
 const TYPE = Symbol('AddressMapTypeProperty');
 export const ADDRESS_MAP_TYPE_PROPERTY: typeof TYPE = TYPE;
 
-export function getAddressMapFromInstructions(feePayer: Address, instructions: readonly IInstruction[]): AddressMap {
+export function getAddressMapFromInstructions(feePayer: Address, instructions: readonly Instruction[]): AddressMap {
     const addressMap: AddressMap = {
         [feePayer]: { [TYPE]: AddressMapEntryType.FEE_PAYER, role: AccountRole.WRITABLE_SIGNER },
     };
@@ -200,7 +200,7 @@ export function getAddressMapFromInstructions(feePayer: Address, instructions: r
 
 export function getOrderedAccountsFromAddressMap(addressMap: AddressMap): OrderedAccounts {
     let addressComparator: ReturnType<typeof getAddressComparator>;
-    const orderedAccounts: (IAccountLookupMeta | IAccountMeta)[] = Object.entries(addressMap)
+    const orderedAccounts: (AccountLookupMeta | AccountMeta)[] = Object.entries(addressMap)
         .sort(([leftAddress, leftEntry], [rightAddress, rightEntry]) => {
             // STEP 1: Rapid precedence check. Fee payer, then static addresses, then lookups.
             if (leftEntry[TYPE] !== rightEntry[TYPE]) {

--- a/packages/transaction-messages/src/compile/instructions.ts
+++ b/packages/transaction-messages/src/compile/instructions.ts
@@ -1,6 +1,6 @@
 import { Address } from '@solana/addresses';
 import { ReadonlyUint8Array } from '@solana/codecs-core';
-import { IInstruction } from '@solana/instructions';
+import { Instruction } from '@solana/instructions';
 
 import { OrderedAccounts } from './accounts';
 
@@ -28,7 +28,7 @@ function getAccountIndex(orderedAccounts: OrderedAccounts) {
 }
 
 export function getCompiledInstructions(
-    instructions: readonly IInstruction[],
+    instructions: readonly Instruction[],
     orderedAccounts: OrderedAccounts,
 ): CompiledInstruction[] {
     const accountIndex = getAccountIndex(orderedAccounts);

--- a/packages/transaction-messages/src/durable-nonce-instruction.ts
+++ b/packages/transaction-messages/src/durable-nonce-instruction.ts
@@ -2,9 +2,9 @@ import { Address } from '@solana/addresses';
 import { ReadonlyUint8Array } from '@solana/codecs-core';
 import {
     AccountRole,
-    IInstruction,
-    IInstructionWithAccounts,
-    IInstructionWithData,
+    Instruction,
+    InstructionWithAccounts,
+    InstructionWithData,
     isSignerRole,
     ReadonlyAccount,
     ReadonlySignerAccount,
@@ -16,15 +16,15 @@ import { Brand } from '@solana/nominal-types';
 export type AdvanceNonceAccountInstruction<
     TNonceAccountAddress extends string = string,
     TNonceAuthorityAddress extends string = string,
-> = IInstruction<'11111111111111111111111111111111'> &
-    IInstructionWithAccounts<
+> = Instruction<'11111111111111111111111111111111'> &
+    InstructionWithAccounts<
         readonly [
             WritableAccount<TNonceAccountAddress>,
             ReadonlyAccount<'SysvarRecentB1ockHashes11111111111111111111'>,
             ReadonlySignerAccount<TNonceAuthorityAddress> | WritableSignerAccount<TNonceAuthorityAddress>,
         ]
     > &
-    IInstructionWithData<AdvanceNonceAccountInstructionData>;
+    InstructionWithData<AdvanceNonceAccountInstructionData>;
 
 type AdvanceNonceAccountInstructionData = Brand<Uint8Array, 'AdvanceNonceAccountInstructionData'>;
 
@@ -84,7 +84,7 @@ export function createAdvanceNonceAccountInstruction<
  * ```
  */
 export function isAdvanceNonceAccountInstruction(
-    instruction: IInstruction,
+    instruction: Instruction,
 ): instruction is AdvanceNonceAccountInstruction {
     return (
         instruction.programAddress === SYSTEM_PROGRAM_ADDRESS &&

--- a/packages/transaction-messages/src/durable-nonce.ts
+++ b/packages/transaction-messages/src/durable-nonce.ts
@@ -1,6 +1,6 @@
 import { Address } from '@solana/addresses';
 import { SOLANA_ERROR__TRANSACTION__EXPECTED_NONCE_LIFETIME, SolanaError } from '@solana/errors';
-import { IInstruction } from '@solana/instructions';
+import { Instruction } from '@solana/instructions';
 import { Brand } from '@solana/nominal-types';
 
 import {
@@ -57,7 +57,7 @@ export interface TransactionMessageWithDurableNonceLifetime<
     readonly instructions: readonly [
         // The first instruction *must* be the system program's `AdvanceNonceAccount` instruction.
         AdvanceNonceAccountInstruction<TNonceAccountAddress, TNonceAuthorityAddress>,
-        ...IInstruction[],
+        ...Instruction[],
     ];
     readonly lifetimeConstraint: NonceLifetimeConstraint<TNonceValue>;
 }
@@ -214,7 +214,7 @@ export function setTransactionMessageLifetimeUsingDurableNonce<
 
     let newInstructions: [
         AdvanceNonceAccountInstruction<TNonceAccountAddress, TNonceAuthorityAddress>,
-        ...IInstruction[],
+        ...Instruction[],
     ];
 
     const firstInstruction = transactionMessage.instructions[0];
@@ -272,7 +272,7 @@ type SetTransactionMessageWithDurableNonceLifetime<
     // 3. Replace or prepend the first instruction with the advance nonce account instruction.
     readonly instructions: TTransactionMessage['instructions'] extends readonly [
         AdvanceNonceAccountInstruction,
-        ...infer TTail extends readonly IInstruction[],
+        ...infer TTail extends readonly Instruction[],
     ]
         ? readonly [AdvanceNonceAccountInstruction<TNonceAccountAddress, TNonceAuthorityAddress>, ...TTail]
         : readonly [

--- a/packages/transaction-messages/src/instructions.ts
+++ b/packages/transaction-messages/src/instructions.ts
@@ -1,4 +1,4 @@
-import { IInstruction } from '@solana/instructions';
+import { Instruction } from '@solana/instructions';
 
 import { ExcludeTransactionMessageDurableNonceLifetime } from './durable-nonce';
 import { BaseTransactionMessage } from './transaction-message';
@@ -10,7 +10,7 @@ import { ExcludeTransactionMessageWithinSizeLimit } from './transaction-message-
  */
 type AppendTransactionMessageInstructions<
     TTransactionMessage extends BaseTransactionMessage,
-    TInstructions extends readonly IInstruction[],
+    TInstructions extends readonly Instruction[],
 > = Omit<ExcludeTransactionMessageWithinSizeLimit<TTransactionMessage>, 'instructions'> & {
     readonly instructions: readonly [...TTransactionMessage['instructions'], ...TInstructions];
 };
@@ -21,7 +21,7 @@ type AppendTransactionMessageInstructions<
  */
 type PrependTransactionMessageInstructions<
     TTransactionMessage extends BaseTransactionMessage,
-    TInstructions extends readonly IInstruction[],
+    TInstructions extends readonly Instruction[],
 > = Omit<
     ExcludeTransactionMessageWithinSizeLimit<ExcludeTransactionMessageDurableNonceLifetime<TTransactionMessage>>,
     'instructions'
@@ -52,7 +52,7 @@ type PrependTransactionMessageInstructions<
  */
 export function appendTransactionMessageInstruction<
     TTransactionMessage extends BaseTransactionMessage,
-    TInstruction extends IInstruction,
+    TInstruction extends Instruction,
 >(
     instruction: TInstruction,
     transactionMessage: TTransactionMessage,
@@ -89,7 +89,7 @@ export function appendTransactionMessageInstruction<
  */
 export function appendTransactionMessageInstructions<
     TTransactionMessage extends BaseTransactionMessage,
-    const TInstructions extends readonly IInstruction[],
+    const TInstructions extends readonly Instruction[],
 >(
     instructions: TInstructions,
     transactionMessage: TTransactionMessage,
@@ -126,7 +126,7 @@ export function appendTransactionMessageInstructions<
  */
 export function prependTransactionMessageInstruction<
     TTransactionMessage extends BaseTransactionMessage,
-    TInstruction extends IInstruction,
+    TInstruction extends Instruction,
 >(
     instruction: TInstruction,
     transactionMessage: TTransactionMessage,
@@ -163,7 +163,7 @@ export function prependTransactionMessageInstruction<
  */
 export function prependTransactionMessageInstructions<
     TTransactionMessage extends BaseTransactionMessage,
-    const TInstructions extends readonly IInstruction[],
+    const TInstructions extends readonly Instruction[],
 >(
     instructions: TInstructions,
     transactionMessage: TTransactionMessage,

--- a/packages/transaction-messages/src/transaction-message.ts
+++ b/packages/transaction-messages/src/transaction-message.ts
@@ -1,19 +1,16 @@
-import { IAccountMeta, IInstruction } from '@solana/instructions';
+import { AccountMeta, Instruction } from '@solana/instructions';
 
 export type BaseTransactionMessage<
     TVersion extends TransactionVersion = TransactionVersion,
-    TInstruction extends IInstruction = IInstruction,
+    TInstruction extends Instruction = Instruction,
 > = Readonly<{
     instructions: readonly TInstruction[];
     version: TVersion;
 }>;
 
-type ILegacyInstruction<TProgramAddress extends string = string> = IInstruction<
-    TProgramAddress,
-    readonly IAccountMeta[]
->;
-type LegacyTransactionMessage = BaseTransactionMessage<'legacy', ILegacyInstruction>;
-type V0TransactionMessage = BaseTransactionMessage<0, IInstruction>;
+type LegacyInstruction<TProgramAddress extends string = string> = Instruction<TProgramAddress, readonly AccountMeta[]>;
+type LegacyTransactionMessage = BaseTransactionMessage<'legacy', LegacyInstruction>;
+type V0TransactionMessage = BaseTransactionMessage<0, Instruction>;
 
 export type TransactionMessage = LegacyTransactionMessage | V0TransactionMessage;
 export type TransactionVersion = 'legacy' | 0;


### PR DESCRIPTION
This PR removes the `I` prefix on the following types: 

- `IInstruction`
- `IInstructionWithAccounts`
- `IInstructionWithData`, `IInstructionWithSigners`
- `IAccountMeta`
- `IAccountLookupMeta`
- `IAccountSignerMeta`

This helps keep a consistent naming convention across all types in the library. Note that these are/were the last I-prefixed types.