### PR TITLE
Trick Changesets into pushing tags and publishing Github releases after our custom publish script completes

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -51,7 +51,11 @@ jobs:
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
           # Some tasks slow down considerably on GitHub Actions runners when concurrency is high
-          publish: pnpm turbo publish-packages --concurrency=1
+          publish: |
+            pnpm turbo publish-packages --concurrency=1 && \
+            # Changesets will only create the tags/release if it sees "New tag:" in the publish command's output
+            # See https://github.com/changesets/action/blob/06245a4e0a36c064a573d4150030f5ec548e4fcc/src/run.ts#L176
+            echo 'New tag:'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Fixes #499
