### PR TITLE
Make rpc non-thenable

### DIFF
--- a/.changeset/hip-dragons-yell.md
+++ b/.changeset/hip-dragons-yell.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-subscriptions-spec': patch
+---
+
+Fix RPC objects incorrectly appearing as thenable Promises which caused silent program termination when awaited.

--- a/.changeset/nine-hands-cross.md
+++ b/.changeset/nine-hands-cross.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-spec': patch
+---
+
+Fix RPC objects incorrectly appearing as thenable Promises which caused silent program termination when awaited.

--- a/packages/rpc-spec/src/__tests__/rpc-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-test.ts
@@ -75,6 +75,10 @@ describe('JSON-RPC 2.0', () => {
             const sendPromise = rpc.someMethod().send();
             await expect(sendPromise).rejects.toThrow(transportError);
         });
+        it('should not be thenable', () => {
+            expect.assertions(1);
+            expect((rpc as { then?: unknown }).then).toBeUndefined();
+        });
     });
     describe('when calling a method having a concrete implementation', () => {
         let rpc: Rpc<TestRpcMethods>;

--- a/packages/rpc-spec/src/__tests__/rpc-test.ts
+++ b/packages/rpc-spec/src/__tests__/rpc-test.ts
@@ -77,7 +77,7 @@ describe('JSON-RPC 2.0', () => {
         });
         it('should not be thenable', () => {
             expect.assertions(1);
-            expect((rpc as { then?: unknown }).then).toBeUndefined();
+            expect(rpc).not.toHaveProperty('then');
         });
     });
     describe('when calling a method having a concrete implementation', () => {

--- a/packages/rpc-spec/src/rpc.ts
+++ b/packages/rpc-spec/src/rpc.ts
@@ -72,6 +72,9 @@ function makeProxy<TRpcMethods, TRpcTransport extends RpcTransport>(
             return false;
         },
         get(target, p, receiver) {
+            if (p === 'then') {
+                return undefined;
+            }
             return function (...rawParams: unknown[]) {
                 const methodName = p.toString();
                 const getApiPlan = Reflect.get(target, methodName, receiver);

--- a/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-test.ts
+++ b/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-test.ts
@@ -1,18 +1,23 @@
 import { SOLANA_ERROR__RPC_SUBSCRIPTIONS__CANNOT_CREATE_SUBSCRIPTION_PLAN, SolanaError } from '@solana/errors';
 
-import { createSubscriptionRpc } from '../rpc-subscriptions';
+import { createSubscriptionRpc, type RpcSubscriptions } from '../rpc-subscriptions';
 
 interface TestRpcSubscriptionNotifications {
     thingNotifications(...args: unknown[]): unknown;
 }
 
 describe('createSubscriptionRpc', () => {
-    it('throws when the API produces no subscription plan', () => {
-        const rpcSubscriptions = createSubscriptionRpc<TestRpcSubscriptionNotifications>({
+    let rpcSubscriptions: RpcSubscriptions<TestRpcSubscriptionNotifications>;
+
+    beforeEach(() => {
+        rpcSubscriptions = createSubscriptionRpc<TestRpcSubscriptionNotifications>({
             // @ts-expect-error Does not implement API on purpose
             api: {},
             transport: jest.fn(),
         });
+    });
+
+    it('throws when the API produces no subscription plan', () => {
         expect(() => {
             rpcSubscriptions.thingNotifications();
         }).toThrow(
@@ -20,5 +25,9 @@ describe('createSubscriptionRpc', () => {
                 notificationName: 'thingNotifications',
             }),
         );
+    });
+
+    it('should not be thenable', () => {
+        expect((rpcSubscriptions as { then?: unknown }).then).toBeUndefined();
     });
 });

--- a/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-test.ts
+++ b/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-test.ts
@@ -28,6 +28,6 @@ describe('createSubscriptionRpc', () => {
     });
 
     it('should not be thenable', () => {
-        expect((rpcSubscriptions as { then?: unknown }).then).toBeUndefined();
+        expect(rpcSubscriptions).not.toHaveProperty('then');
     });
 });

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
@@ -60,7 +60,6 @@ export function createSubscriptionRpc<TRpcSubscriptionsApiMethods>(
                 return undefined;
             }
             return function (...rawParams: unknown[]) {
-                
                 const notificationName = p.toString();
                 const createRpcSubscriptionPlan = Reflect.get(target, notificationName, receiver);
                 if (!createRpcSubscriptionPlan) {

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
@@ -56,10 +56,11 @@ export function createSubscriptionRpc<TRpcSubscriptionsApiMethods>(
             return false;
         },
         get(target, p, receiver) {
+            if (p === 'then') {
+                return undefined;
+            }
             return function (...rawParams: unknown[]) {
-                if (p === 'then') {
-                    return undefined;
-                }
+                
                 const notificationName = p.toString();
                 const createRpcSubscriptionPlan = Reflect.get(target, notificationName, receiver);
                 if (!createRpcSubscriptionPlan) {

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
@@ -35,10 +35,10 @@ type PendingRpcSubscriptionsRequestBuilder<TSubscriptionMethodImplementations> =
 type PendingRpcSubscriptionsRequestReturnTypeMapper<TSubscriptionMethodImplementation> =
     // Check that this property of the TRpcSubscriptionMethods interface is, in fact, a function.
     TSubscriptionMethodImplementation extends Callable
-    ? (
-        ...args: Parameters<TSubscriptionMethodImplementation>
-    ) => PendingRpcSubscriptionsRequest<ReturnType<TSubscriptionMethodImplementation>>
-    : never;
+        ? (
+              ...args: Parameters<TSubscriptionMethodImplementation>
+          ) => PendingRpcSubscriptionsRequest<ReturnType<TSubscriptionMethodImplementation>>
+        : never;
 
 /**
  * Creates a {@link RpcSubscriptions} instance given a
@@ -56,9 +56,6 @@ export function createSubscriptionRpc<TRpcSubscriptionsApiMethods>(
             return false;
         },
         get(target, p, receiver) {
-            if (p === 'then') {
-                return undefined;
-            }
             return function (...rawParams: unknown[]) {
                 const notificationName = p.toString();
                 const createRpcSubscriptionPlan = Reflect.get(target, notificationName, receiver);

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
@@ -57,6 +57,9 @@ export function createSubscriptionRpc<TRpcSubscriptionsApiMethods>(
         },
         get(target, p, receiver) {
             return function (...rawParams: unknown[]) {
+                if (p === 'then') {
+                    return undefined;
+                }
                 const notificationName = p.toString();
                 const createRpcSubscriptionPlan = Reflect.get(target, notificationName, receiver);
                 if (!createRpcSubscriptionPlan) {

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
@@ -35,10 +35,10 @@ type PendingRpcSubscriptionsRequestBuilder<TSubscriptionMethodImplementations> =
 type PendingRpcSubscriptionsRequestReturnTypeMapper<TSubscriptionMethodImplementation> =
     // Check that this property of the TRpcSubscriptionMethods interface is, in fact, a function.
     TSubscriptionMethodImplementation extends Callable
-        ? (
-              ...args: Parameters<TSubscriptionMethodImplementation>
-          ) => PendingRpcSubscriptionsRequest<ReturnType<TSubscriptionMethodImplementation>>
-        : never;
+    ? (
+        ...args: Parameters<TSubscriptionMethodImplementation>
+    ) => PendingRpcSubscriptionsRequest<ReturnType<TSubscriptionMethodImplementation>>
+    : never;
 
 /**
  * Creates a {@link RpcSubscriptions} instance given a
@@ -56,6 +56,9 @@ export function createSubscriptionRpc<TRpcSubscriptionsApiMethods>(
             return false;
         },
         get(target, p, receiver) {
+            if (p === 'then') {
+                return undefined;
+            }
             return function (...rawParams: unknown[]) {
                 const notificationName = p.toString();
                 const createRpcSubscriptionPlan = Reflect.get(target, notificationName, receiver);


### PR DESCRIPTION
#### Problem
RPC objects created by Solana Kit use a proxy that converts all property access into methods. When JavaScript's Promise machinery checks for a `.then` property (which happens when you `async await` an RPC object), the proxy intercepts this and returns a method `{ send: [AsyncFunction: send] }` instead of `undefined` or the proper Promise interface, making the RPC object appear thenable when it isn't. This causes JavaScript/TypeScript to silently terminate the program when you try to `await` the RPC object as if it were a Promise.

#### Summary of Changes
- Modified `makeProxy` function to specifically intercept `then` property access and return `undefined`
- Prevents the proxy from treating `.then` like any other RPC method
- Added test case to verify RPC objects are not thenable