### PR TITLE
Add provisory blockhash lifetime helpers

### DIFF
--- a/.changeset/every-boxes-tell.md
+++ b/.changeset/every-boxes-tell.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-messages': patch
+---
+
+Add provisory blockhash lifetime helpers to use as placeholders when constructing transaction messages. Namely, it adds the `PROVISORY_BLOCKHASH_LIFETIME_CONSTRAINT` constant and the `fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash` and `setTransactionMessageLifetimeUsingProvisoryBlockhash` functions.

--- a/packages/transaction-messages/src/__tests__/blockhash-test.ts
+++ b/packages/transaction-messages/src/__tests__/blockhash-test.ts
@@ -5,7 +5,10 @@ import type { Blockhash } from '@solana/rpc-types';
 
 import {
     assertIsTransactionMessageWithBlockhashLifetime,
+    fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash,
+    PROVISORY_BLOCKHASH_LIFETIME_CONSTRAINT,
     setTransactionMessageLifetimeUsingBlockhash,
+    setTransactionMessageLifetimeUsingProvisoryBlockhash,
     TransactionMessageWithBlockhashLifetime,
 } from '../blockhash';
 import { BaseTransactionMessage } from '../transaction-message';
@@ -142,6 +145,78 @@ describe('setTransactionMessageLifetimeUsingBlockhash', () => {
             BLOCKHASH_CONSTRAINT_A,
             baseTx,
         );
+        expect(txWithBlockhashLifetimeConstraint.lifetimeConstraint).toBeFrozenObject();
+    });
+});
+
+describe('setTransactionMessageLifetimeUsingProvisoryBlockhash', () => {
+    let baseTx: BaseTransactionMessage;
+    beforeEach(() => {
+        baseTx = { instructions: [], version: 0 };
+    });
+    it('sets the provisory lifetime constraint on the transaction message', () => {
+        const txWithBlockhashLifetimeConstraint = setTransactionMessageLifetimeUsingProvisoryBlockhash(baseTx);
+        expect(txWithBlockhashLifetimeConstraint).toHaveProperty(
+            'lifetimeConstraint',
+            PROVISORY_BLOCKHASH_LIFETIME_CONSTRAINT,
+        );
+    });
+    it('overrides the existing blockhash lifetime constraint with the provisory one', () => {
+        const EXISTING_BLOCKHASH_CONSTRAINT = {
+            blockhash: 'F7vmkY3DTaxfagttWjQweib42b6ZHADSx94Tw8gHx3W7' as Blockhash,
+            lastValidBlockHeight: 123n,
+        };
+        const txWithBlockhashLifetimeConstraint = { ...baseTx, lifetimeConstraint: EXISTING_BLOCKHASH_CONSTRAINT };
+        const updatedTxWithBlockhashLifetimeConstraint = setTransactionMessageLifetimeUsingProvisoryBlockhash(
+            txWithBlockhashLifetimeConstraint,
+        );
+        expect(updatedTxWithBlockhashLifetimeConstraint).toHaveProperty(
+            'lifetimeConstraint',
+            PROVISORY_BLOCKHASH_LIFETIME_CONSTRAINT,
+        );
+    });
+    it('freezes the object', () => {
+        const txWithBlockhashLifetimeConstraint = setTransactionMessageLifetimeUsingProvisoryBlockhash(baseTx);
+        expect(txWithBlockhashLifetimeConstraint).toBeFrozenObject();
+    });
+    it('freezes the blockhash constraint', () => {
+        const txWithBlockhashLifetimeConstraint = setTransactionMessageLifetimeUsingProvisoryBlockhash(baseTx);
+        expect(txWithBlockhashLifetimeConstraint.lifetimeConstraint).toBeFrozenObject();
+    });
+});
+
+describe('fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash', () => {
+    let baseTx: BaseTransactionMessage;
+    beforeEach(() => {
+        baseTx = { instructions: [], version: 0 };
+    });
+    it('sets the provisory lifetime constraint on the transaction message', () => {
+        const txWithBlockhashLifetimeConstraint = fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash(baseTx);
+        expect(txWithBlockhashLifetimeConstraint).toHaveProperty(
+            'lifetimeConstraint',
+            PROVISORY_BLOCKHASH_LIFETIME_CONSTRAINT,
+        );
+    });
+    it('does not override the existing blockhash lifetime constraint with the provisory one', () => {
+        const EXISTING_BLOCKHASH_CONSTRAINT = {
+            blockhash: 'F7vmkY3DTaxfagttWjQweib42b6ZHADSx94Tw8gHx3W7' as Blockhash,
+            lastValidBlockHeight: 123n,
+        };
+        const txWithBlockhashLifetimeConstraint = { ...baseTx, lifetimeConstraint: EXISTING_BLOCKHASH_CONSTRAINT };
+        const updatedTxWithBlockhashLifetimeConstraint = fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash(
+            txWithBlockhashLifetimeConstraint,
+        );
+        expect(updatedTxWithBlockhashLifetimeConstraint).toHaveProperty(
+            'lifetimeConstraint',
+            EXISTING_BLOCKHASH_CONSTRAINT,
+        );
+    });
+    it('freezes the object', () => {
+        const txWithBlockhashLifetimeConstraint = fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash(baseTx);
+        expect(txWithBlockhashLifetimeConstraint).toBeFrozenObject();
+    });
+    it('freezes the blockhash constraint', () => {
+        const txWithBlockhashLifetimeConstraint = fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash(baseTx);
         expect(txWithBlockhashLifetimeConstraint.lifetimeConstraint).toBeFrozenObject();
     });
 });

--- a/packages/transaction-messages/src/__typetests__/blockhash-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/blockhash-typetest.ts
@@ -2,10 +2,13 @@ import { Blockhash } from '@solana/rpc-types';
 
 import {
     assertIsTransactionMessageWithBlockhashLifetime,
+    fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash,
     isTransactionMessageWithBlockhashLifetime,
     setTransactionMessageLifetimeUsingBlockhash,
+    setTransactionMessageLifetimeUsingProvisoryBlockhash,
     TransactionMessageWithBlockhashLifetime,
 } from '../blockhash';
+import { TransactionMessageWithDurableNonceLifetime } from '../durable-nonce';
 import { BaseTransactionMessage, TransactionMessage } from '../transaction-message';
 
 const mockBlockhash = null as unknown as Blockhash;
@@ -66,5 +69,61 @@ type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
         newMessage satisfies LegacyTransactionMessage & TransactionMessageWithBlockhashLifetime & { some: 1 };
         // @ts-expect-error Should not be a v0 message.
         newMessage satisfies TransactionMessageWithBlockhashLifetime & V0TransactionMessage & { some: 1 };
+    }
+}
+
+// [DESCRIBE] setTransactionMessageLifetimeUsingProvisoryBlockhash
+{
+    // It sets the blockhash lifetime on the transaction message.
+    {
+        const message = null as unknown as TransactionMessage;
+        const newMessage = setTransactionMessageLifetimeUsingProvisoryBlockhash(message);
+        newMessage satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
+        // @ts-expect-error Should not be a durable nonce lifetime.
+        newMessage satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+    }
+
+    // It overrides existing lifetime constraints on the transaction message.
+    {
+        const message = null as unknown as TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+        const newMessage = setTransactionMessageLifetimeUsingProvisoryBlockhash(message);
+        newMessage satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
+        // @ts-expect-error Should not be a durable nonce lifetime.
+        newMessage satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+    }
+
+    // It keeps any extra properties on the transaction message.
+    {
+        const message = null as unknown as TransactionMessage & { some: 1 };
+        const newMessage = setTransactionMessageLifetimeUsingProvisoryBlockhash(message);
+        newMessage satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime & { some: 1 };
+    }
+}
+
+// [DESCRIBE] fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash
+{
+    // It sets the blockhash lifetime on the transaction message.
+    {
+        const message = null as unknown as TransactionMessage;
+        const newMessage = fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash(message);
+        newMessage satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
+        // @ts-expect-error Should not be a durable nonce lifetime.
+        newMessage satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+    }
+
+    // It does not override existing lifetime constraints on the transaction message.
+    {
+        const message = null as unknown as TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+        const newMessage = fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash(message);
+        newMessage satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+        // @ts-expect-error Should not be a blockhash lifetime.
+        newMessage satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
+    }
+
+    // It keeps any extra properties on the transaction message.
+    {
+        const message = null as unknown as TransactionMessage & { some: 1 };
+        const newMessage = fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash(message);
+        newMessage satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime & { some: 1 };
     }
 }

--- a/packages/transactions/src/__tests__/transaction-message-size-test.ts
+++ b/packages/transactions/src/__tests__/transaction-message-size-test.ts
@@ -1,12 +1,11 @@
 import { address } from '@solana/addresses';
 import { SOLANA_ERROR__TRANSACTION__EXCEEDS_SIZE_LIMIT, SolanaError } from '@solana/errors';
 import { pipe } from '@solana/functional';
-import type { Blockhash } from '@solana/rpc-types';
 import {
     appendTransactionMessageInstruction,
     createTransactionMessage,
     setTransactionMessageFeePayer,
-    setTransactionMessageLifetimeUsingBlockhash,
+    setTransactionMessageLifetimeUsingProvisoryBlockhash,
 } from '@solana/transaction-messages';
 
 import {
@@ -16,14 +15,9 @@ import {
 } from '../transaction-message-size';
 import { TRANSACTION_SIZE_LIMIT } from '../transaction-size';
 
-const MOCK_BLOCKHASH = {
-    blockhash: '11111111111111111111111111111111' as Blockhash,
-    lastValidBlockHeight: 0n,
-};
-
 const SMALL_TRANSACTION_MESSAGE = pipe(
     createTransactionMessage({ version: 0 }),
-    m => setTransactionMessageLifetimeUsingBlockhash(MOCK_BLOCKHASH, m),
+    setTransactionMessageLifetimeUsingProvisoryBlockhash,
     m => setTransactionMessageFeePayer(address('22222222222222222222222222222222222222222222'), m),
 );
 

--- a/packages/transactions/src/__tests__/transaction-size-test.ts
+++ b/packages/transactions/src/__tests__/transaction-size-test.ts
@@ -1,12 +1,11 @@
 import { address } from '@solana/addresses';
 import { SOLANA_ERROR__TRANSACTION__EXCEEDS_SIZE_LIMIT, SolanaError } from '@solana/errors';
 import { pipe } from '@solana/functional';
-import type { Blockhash } from '@solana/rpc-types';
 import {
     appendTransactionMessageInstruction,
     createTransactionMessage,
     setTransactionMessageFeePayer,
-    setTransactionMessageLifetimeUsingBlockhash,
+    setTransactionMessageLifetimeUsingProvisoryBlockhash,
 } from '@solana/transaction-messages';
 
 import { compileTransaction } from '../compile-transaction';
@@ -17,14 +16,9 @@ import {
     TRANSACTION_SIZE_LIMIT,
 } from '../transaction-size';
 
-const MOCK_BLOCKHASH = {
-    blockhash: '11111111111111111111111111111111' as Blockhash,
-    lastValidBlockHeight: 0n,
-};
-
 const SMALL_TRANSACTION_MESSAGE = pipe(
     createTransactionMessage({ version: 0 }),
-    m => setTransactionMessageLifetimeUsingBlockhash(MOCK_BLOCKHASH, m),
+    setTransactionMessageLifetimeUsingProvisoryBlockhash,
     m => setTransactionMessageFeePayer(address('22222222222222222222222222222222222222222222'), m),
 );
 


### PR DESCRIPTION
This PR adds the following items to the `transaction-messages` package:
- The `PROVISORY_BLOCKHASH_LIFETIME_CONSTRAINT` constant. It defines an invalid but temporary blockhash lifetime constraint that can be used for a variety of applications such as: simulating a transaction before setting its actual blockhash, calculating the size of the transaction message, etc.
- The `setTransactionMessageLifetimeUsingProvisoryBlockhash` function that simply sets the blockhash lifetime constraint using the `PROVISORY_BLOCKHASH_LIFETIME_CONSTRAINT`.
- The `fillMissingTransactionMessageLifetimeUsingProvisoryBlockhash` function that only sets the provisory blockhash if and only if the provided transaction message does not already have a set lifetime constraint.

Note that this is currently [used by the Compute Budget client](https://github.com/solana-program/compute-budget/blob/238034bbe03e7be358a6a6b7427de23c9e358104/clients/js/src/internalMoveToKit.ts) and will be required for Instruction Plans.