### PR TITLE
Deprecate `getComputeUnitEstimateForTransactionMessageFactory`

### DIFF
--- a/.changeset/angry-places-drop.md
+++ b/.changeset/angry-places-drop.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit': patch
+---
+
+Deprecate the `getComputeUnitEstimateForTransactionMessageFactory` function in favor of the `estimateComputeUnitLimitFactory` function from the `@solana-program/compute-budget` client.

--- a/packages/kit/src/compute-limit.ts
+++ b/packages/kit/src/compute-limit.ts
@@ -53,6 +53,8 @@ type ComputeUnitEstimateForTransactionMessageFunction = (
  *
  * @param config
  *
+ * @deprecated Use `estimateComputeUnitLimitFactory` from `@solana-program/compute-budget` instead.
+ *
  * @example
  * ```ts
  * import { getSetComputeUnitLimitInstruction } from '@solana-program/compute-budget';


### PR DESCRIPTION
This PR deprecates the `getComputeUnitEstimateForTransactionMessageFactory` function in favour of the `estimateComputeUnitLimitFactory` function from the `@solana-program/compute-budget` client.