### PR TITLE
Add `TransactionPlanResult` type and helpers

### DIFF
--- a/.changeset/afraid-tables-occur.md
+++ b/.changeset/afraid-tables-occur.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Add new `TransactionPlanResult` type with helpers. This type describes the execution results of transaction plans with the same structural hierarchy — capturing the execution status of each transaction message whether executed in parallel, sequentially, or as a single transaction.

--- a/packages/instruction-plans/src/__tests__/transaction-plan-result-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-result-test.ts
@@ -1,0 +1,205 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import { Address } from '@solana/addresses';
+import { SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE, SolanaError } from '@solana/errors';
+import { pipe } from '@solana/functional';
+import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { createTransactionMessage, setTransactionMessageFeePayer } from '@solana/transaction-messages';
+import { Transaction } from '@solana/transactions';
+
+import {
+    canceledSingleTransactionPlanResult,
+    failedSingleTransactionPlanResult,
+    nonDivisibleSequentialTransactionPlanResult,
+    parallelTransactionPlanResult,
+    sequentialTransactionPlanResult,
+    successfulSingleTransactionPlanResult,
+} from '../transaction-plan-result';
+
+function createMessage<TId extends string>(
+    id: TId,
+): BaseTransactionMessage & TransactionMessageWithFeePayer & { id: TId } {
+    return pipe(
+        createTransactionMessage({ version: 0 }),
+        m => setTransactionMessageFeePayer('E9Nykp3rSdza2moQutaJ3K3RSC8E5iFERX2SqLTsQfjJ' as Address, m),
+        m => Object.freeze({ ...m, id }),
+    );
+}
+
+function createTransaction<TId extends string>(id: TId): Transaction & { id: TId } {
+    return Object.freeze({ id }) as unknown as Transaction & { id: TId };
+}
+
+describe('successfulSingleTransactionPlanResult', () => {
+    it('creates SingleTransactionPlanResult objects with successful status', () => {
+        const messageA = createMessage('A');
+        const transactionA = createTransaction('A');
+        const result = successfulSingleTransactionPlanResult(messageA, transactionA);
+        expect(result).toEqual({
+            kind: 'single',
+            message: messageA,
+            status: { context: {}, kind: 'successful', transaction: transactionA },
+        });
+    });
+    it('accepts an optional context object', () => {
+        const messageA = createMessage('A');
+        const transactionA = createTransaction('A');
+        const context = { foo: 'bar' };
+        const result = successfulSingleTransactionPlanResult(messageA, transactionA, context);
+        expect(result).toEqual({
+            kind: 'single',
+            message: messageA,
+            status: { context, kind: 'successful', transaction: transactionA },
+        });
+    });
+    it('freezes created SingleTransactionPlanResult objects', () => {
+        const messageA = createMessage('A');
+        const transactionA = createTransaction('A');
+        const result = successfulSingleTransactionPlanResult(messageA, transactionA);
+        expect(result).toBeFrozenObject();
+    });
+    it('freezes the status object of created SingleTransactionPlanResult objects', () => {
+        const messageA = createMessage('A');
+        const transactionA = createTransaction('A');
+        const result = successfulSingleTransactionPlanResult(messageA, transactionA);
+        expect(result.status).toBeFrozenObject();
+    });
+});
+
+describe('failedSingleTransactionPlanResult', () => {
+    it('creates SingleTransactionPlanResult objects with failed status', () => {
+        const messageA = createMessage('A');
+        const error = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+        const result = failedSingleTransactionPlanResult(messageA, error);
+        expect(result).toEqual({
+            kind: 'single',
+            message: messageA,
+            status: { error, kind: 'failed' },
+        });
+    });
+    it('freezes created SingleTransactionPlanResult objects', () => {
+        const messageA = createMessage('A');
+        const error = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+        const result = failedSingleTransactionPlanResult(messageA, error);
+        expect(result).toBeFrozenObject();
+    });
+    it('freezes the status object of created SingleTransactionPlanResult objects', () => {
+        const messageA = createMessage('A');
+        const error = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+        const result = failedSingleTransactionPlanResult(messageA, error);
+        expect(result.status).toBeFrozenObject();
+    });
+});
+
+describe('canceledSingleTransactionPlanResult', () => {
+    it('creates SingleTransactionPlanResult objects with canceled status', () => {
+        const messageA = createMessage('A');
+        const result = canceledSingleTransactionPlanResult(messageA);
+        expect(result).toEqual({
+            kind: 'single',
+            message: messageA,
+            status: { kind: 'canceled' },
+        });
+    });
+    it('freezes created SingleTransactionPlanResult objects', () => {
+        const messageA = createMessage('A');
+        const result = canceledSingleTransactionPlanResult(messageA);
+        expect(result).toBeFrozenObject();
+    });
+    it('freezes the status object of created SingleTransactionPlanResult objects', () => {
+        const messageA = createMessage('A');
+        const result = canceledSingleTransactionPlanResult(messageA);
+        expect(result.status).toBeFrozenObject();
+    });
+});
+
+describe('parallelTransactionPlanResult', () => {
+    it('creates ParallelTransactionPlanResult objects from other results', () => {
+        const planA = canceledSingleTransactionPlanResult(createMessage('A'));
+        const planB = canceledSingleTransactionPlanResult(createMessage('B'));
+        const result = parallelTransactionPlanResult([planA, planB]);
+        expect(result).toEqual({
+            kind: 'parallel',
+            plans: [planA, planB],
+        });
+    });
+    it('can nest other result types', () => {
+        const planA = canceledSingleTransactionPlanResult(createMessage('A'));
+        const planB = canceledSingleTransactionPlanResult(createMessage('B'));
+        const planC = canceledSingleTransactionPlanResult(createMessage('C'));
+        const result = parallelTransactionPlanResult([planA, parallelTransactionPlanResult([planB, planC])]);
+        expect(result).toEqual({
+            kind: 'parallel',
+            plans: [planA, { kind: 'parallel', plans: [planB, planC] }],
+        });
+    });
+    it('freezes created ParallelTransactionPlanResult objects', () => {
+        const planA = canceledSingleTransactionPlanResult(createMessage('A'));
+        const planB = canceledSingleTransactionPlanResult(createMessage('B'));
+        const result = parallelTransactionPlanResult([planA, planB]);
+        expect(result).toBeFrozenObject();
+    });
+});
+
+describe('sequentialTransactionPlanResult', () => {
+    it('creates divisible SequentialTransactionPlanResult objects from other results', () => {
+        const planA = canceledSingleTransactionPlanResult(createMessage('A'));
+        const planB = canceledSingleTransactionPlanResult(createMessage('B'));
+        const result = sequentialTransactionPlanResult([planA, planB]);
+        expect(result).toEqual({
+            divisible: true,
+            kind: 'sequential',
+            plans: [planA, planB],
+        });
+    });
+    it('can nest other result types', () => {
+        const planA = canceledSingleTransactionPlanResult(createMessage('A'));
+        const planB = canceledSingleTransactionPlanResult(createMessage('B'));
+        const planC = canceledSingleTransactionPlanResult(createMessage('C'));
+        const result = sequentialTransactionPlanResult([planA, sequentialTransactionPlanResult([planB, planC])]);
+        expect(result).toEqual({
+            divisible: true,
+            kind: 'sequential',
+            plans: [planA, { divisible: true, kind: 'sequential', plans: [planB, planC] }],
+        });
+    });
+    it('freezes created SequentialTransactionPlanResult objects', () => {
+        const planA = canceledSingleTransactionPlanResult(createMessage('A'));
+        const planB = canceledSingleTransactionPlanResult(createMessage('B'));
+        const result = sequentialTransactionPlanResult([planA, planB]);
+        expect(result).toBeFrozenObject();
+    });
+});
+
+describe('nonDivisibleSequentialTransactionPlanResult', () => {
+    it('creates non-divisible SequentialTransactionPlanResult objects from other results', () => {
+        const planA = canceledSingleTransactionPlanResult(createMessage('A'));
+        const planB = canceledSingleTransactionPlanResult(createMessage('B'));
+        const result = nonDivisibleSequentialTransactionPlanResult([planA, planB]);
+        expect(result).toEqual({
+            divisible: false,
+            kind: 'sequential',
+            plans: [planA, planB],
+        });
+    });
+    it('can nest other result types', () => {
+        const planA = canceledSingleTransactionPlanResult(createMessage('A'));
+        const planB = canceledSingleTransactionPlanResult(createMessage('B'));
+        const planC = canceledSingleTransactionPlanResult(createMessage('C'));
+        const result = nonDivisibleSequentialTransactionPlanResult([
+            planA,
+            nonDivisibleSequentialTransactionPlanResult([planB, planC]),
+        ]);
+        expect(result).toEqual({
+            divisible: false,
+            kind: 'sequential',
+            plans: [planA, { divisible: false, kind: 'sequential', plans: [planB, planC] }],
+        });
+    });
+    it('freezes created SequentialTransactionPlanResult objects', () => {
+        const planA = canceledSingleTransactionPlanResult(createMessage('A'));
+        const planB = canceledSingleTransactionPlanResult(createMessage('B'));
+        const result = nonDivisibleSequentialTransactionPlanResult([planA, planB]);
+        expect(result).toBeFrozenObject();
+    });
+});

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
@@ -1,0 +1,171 @@
+import type { SolanaError } from '@solana/errors';
+import type { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import type { Transaction } from '@solana/transactions';
+
+import {
+    canceledSingleTransactionPlanResult,
+    failedSingleTransactionPlanResult,
+    nonDivisibleSequentialTransactionPlanResult,
+    ParallelTransactionPlanResult,
+    parallelTransactionPlanResult,
+    SequentialTransactionPlanResult,
+    sequentialTransactionPlanResult,
+    SingleTransactionPlanResult,
+    successfulSingleTransactionPlanResult,
+    TransactionPlanResult,
+    TransactionPlanResultContext,
+} from '../transaction-plan-result';
+
+const messageA = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer & { id: 'A' };
+const messageB = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer & { id: 'B' };
+const messageC = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer & { id: 'C' };
+const transactionA = null as unknown as Transaction;
+const transactionB = null as unknown as Transaction;
+const error = null as unknown as SolanaError;
+
+type CustomContext = { customData: string };
+
+// [DESCRIBE] parallelTransactionPlanResult
+{
+    // It satisfies ParallelTransactionPlanResult.
+    {
+        const result = parallelTransactionPlanResult([
+            successfulSingleTransactionPlanResult(messageA, transactionA),
+            successfulSingleTransactionPlanResult(messageB, transactionB),
+        ]);
+        result satisfies ParallelTransactionPlanResult;
+        result satisfies TransactionPlanResult;
+    }
+
+    // It can work with custom context.
+    {
+        const result = parallelTransactionPlanResult([
+            successfulSingleTransactionPlanResult(messageA, transactionA, { customData: 'A' }),
+            successfulSingleTransactionPlanResult(messageB, transactionB, { customData: 'B' }),
+        ]);
+        result satisfies ParallelTransactionPlanResult<CustomContext>;
+        result satisfies TransactionPlanResult;
+    }
+
+    // It can nest other result plans.
+    {
+        const result = parallelTransactionPlanResult([
+            successfulSingleTransactionPlanResult(messageA, transactionA),
+            parallelTransactionPlanResult([
+                successfulSingleTransactionPlanResult(messageB, transactionB),
+                canceledSingleTransactionPlanResult(messageC),
+            ]),
+        ]);
+        result satisfies ParallelTransactionPlanResult;
+        result satisfies TransactionPlanResult;
+    }
+}
+
+// [DESCRIBE] sequentialTransactionPlanResult
+{
+    // It satisfies a divisible SequentialTransactionPlanResult.
+    {
+        const result = sequentialTransactionPlanResult([
+            successfulSingleTransactionPlanResult(messageA, transactionA),
+            successfulSingleTransactionPlanResult(messageB, transactionB),
+        ]);
+        result satisfies SequentialTransactionPlanResult & { divisible: true };
+        result satisfies TransactionPlanResult;
+    }
+
+    // It can work with custom context.
+    {
+        const result = sequentialTransactionPlanResult([
+            successfulSingleTransactionPlanResult(messageA, transactionA, { customData: 'A' }),
+            successfulSingleTransactionPlanResult(messageB, transactionB, { customData: 'B' }),
+        ]);
+        result satisfies SequentialTransactionPlanResult<CustomContext> & { divisible: true };
+        result satisfies TransactionPlanResult;
+    }
+
+    // It can nest other result plans.
+    {
+        const result = sequentialTransactionPlanResult([
+            successfulSingleTransactionPlanResult(messageA, transactionA),
+            sequentialTransactionPlanResult([
+                successfulSingleTransactionPlanResult(messageB, transactionB),
+                canceledSingleTransactionPlanResult(messageC),
+            ]),
+        ]);
+        result satisfies SequentialTransactionPlanResult & { divisible: true };
+        result satisfies TransactionPlanResult;
+    }
+}
+
+// [DESCRIBE] nonDivisibleSequentialTransactionPlanResult
+{
+    // It satisfies a non-divisible SequentialTransactionPlanResult.
+    {
+        const result = nonDivisibleSequentialTransactionPlanResult([
+            successfulSingleTransactionPlanResult(messageA, transactionA),
+            successfulSingleTransactionPlanResult(messageB, transactionB),
+        ]);
+        result satisfies SequentialTransactionPlanResult & { divisible: false };
+        result satisfies TransactionPlanResult;
+    }
+
+    // It can work with custom context.
+    {
+        const result = nonDivisibleSequentialTransactionPlanResult([
+            successfulSingleTransactionPlanResult(messageA, transactionA, { customData: 'A' }),
+            successfulSingleTransactionPlanResult(messageB, transactionB, { customData: 'B' }),
+        ]);
+        result satisfies SequentialTransactionPlanResult<CustomContext> & { divisible: false };
+        result satisfies TransactionPlanResult;
+    }
+
+    // It can nest other result plans.
+    {
+        const result = nonDivisibleSequentialTransactionPlanResult([
+            successfulSingleTransactionPlanResult(messageA, transactionA),
+            nonDivisibleSequentialTransactionPlanResult([
+                successfulSingleTransactionPlanResult(messageB, transactionB),
+                canceledSingleTransactionPlanResult(messageC),
+            ]),
+        ]);
+        result satisfies SequentialTransactionPlanResult & { divisible: false };
+        result satisfies TransactionPlanResult;
+    }
+}
+
+// [DESCRIBE] successfulSingleTransactionPlanResult
+{
+    // It satisfies SingleTransactionPlanResult with a successful status.
+    {
+        const result = successfulSingleTransactionPlanResult(messageA, transactionA);
+        result satisfies SingleTransactionPlanResult<TransactionPlanResultContext, typeof messageA>;
+        result satisfies TransactionPlanResult;
+    }
+
+    // It can include a custom context.
+    {
+        const result = successfulSingleTransactionPlanResult(messageA, transactionA, { customData: 'test' });
+        result satisfies SingleTransactionPlanResult<CustomContext, typeof messageA>;
+        result satisfies TransactionPlanResult;
+    }
+}
+
+// [DESCRIBE] failedSingleTransactionPlanResult
+{
+    // It satisfies SingleTransactionPlanResult with a failed status.
+    {
+        const result = failedSingleTransactionPlanResult(messageA, error);
+        result satisfies SingleTransactionPlanResult<TransactionPlanResultContext, typeof messageA>;
+        result satisfies TransactionPlanResult;
+    }
+}
+
+// [DESCRIBE] canceledSingleTransactionPlanResult
+{
+    // It satisfies SingleTransactionPlanResult with a canceled status.
+    {
+        const result = canceledSingleTransactionPlanResult(messageA);
+        result satisfies SingleTransactionPlanResult<TransactionPlanResultContext, typeof messageA>;
+        result satisfies TransactionPlanResult;
+    }
+}

--- a/packages/instruction-plans/src/transaction-plan-result.ts
+++ b/packages/instruction-plans/src/transaction-plan-result.ts
@@ -1,0 +1,364 @@
+import { SolanaError } from '@solana/errors';
+import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { Transaction } from '@solana/transactions';
+
+/**
+ * The result of executing a transaction plan.
+ *
+ * This is structured as a recursive tree of results that mirrors the structure
+ * of the original transaction plan, capturing the execution status at each level.
+ *
+ * Namely, the following result types are supported:
+ * - {@link SingleTransactionPlanResult} - A result for a single transaction message
+ *   containing its execution status.
+ * - {@link ParallelTransactionPlanResult} - A result containing other results that
+ *   were executed in parallel.
+ * - {@link SequentialTransactionPlanResult} - A result containing other results that
+ *   were executed sequentially. It also retains the divisibility property from the
+ *   original plan.
+ *
+ * @template TContext - The type of the context object that may be passed along with successful results
+ *
+ * @see {@link SingleTransactionPlanResult}
+ * @see {@link ParallelTransactionPlanResult}
+ * @see {@link SequentialTransactionPlanResult}
+ * @see {@link TransactionPlanResultStatus}
+ */
+export type TransactionPlanResult<TContext extends TransactionPlanResultContext = TransactionPlanResultContext> =
+    | ParallelTransactionPlanResult<TContext>
+    | SequentialTransactionPlanResult<TContext>
+    | SingleTransactionPlanResult<TContext>;
+
+/** A context object that may be passed along with successful results. */
+export type TransactionPlanResultContext = Record<number | string | symbol, unknown>;
+
+/**
+ * A result for a sequential transaction plan.
+ *
+ * This represents the execution result of a {@link SequentialTransactionPlan} and
+ * contains child results that were executed sequentially. It also retains the
+ * divisibility property from the original plan.
+ *
+ * You may use the {@link sequentialTransactionPlanResult} and
+ * {@link nonDivisibleSequentialTransactionPlanResult} helpers to create objects of this type.
+ *
+ * @template TContext - The type of the context object that may be passed along with successful results
+ *
+ * @example
+ * ```ts
+ * const result = sequentialTransactionPlanResult([
+ *   singleResultA,
+ *   singleResultB,
+ * ]);
+ * result satisfies SequentialTransactionPlanResult;
+ * ```
+ *
+ * @example
+ * Non-divisible sequential result.
+ * ```ts
+ * const result = nonDivisibleSequentialTransactionPlanResult([
+ *   singleResultA,
+ *   singleResultB,
+ * ]);
+ * result satisfies SequentialTransactionPlanResult & { divisible: false };
+ * ```
+ *
+ * @see {@link sequentialTransactionPlanResult}
+ * @see {@link nonDivisibleSequentialTransactionPlanResult}
+ */
+export type SequentialTransactionPlanResult<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+> = Readonly<{
+    divisible: boolean;
+    kind: 'sequential';
+    plans: TransactionPlanResult<TContext>[];
+}>;
+
+/**
+ * A result for a parallel transaction plan.
+ *
+ * This represents the execution result of a {@link ParallelTransactionPlan} and
+ * contains child results that were executed in parallel.
+ *
+ * You may use the {@link parallelTransactionPlanResult} helper to create objects of this type.
+ *
+ * @template TContext - The type of the context object that may be passed along with successful results
+ *
+ * @example
+ * ```ts
+ * const result = parallelTransactionPlanResult([
+ *   singleResultA,
+ *   singleResultB,
+ * ]);
+ * result satisfies ParallelTransactionPlanResult;
+ * ```
+ *
+ * @see {@link parallelTransactionPlanResult}
+ */
+export type ParallelTransactionPlanResult<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+> = Readonly<{
+    kind: 'parallel';
+    plans: TransactionPlanResult<TContext>[];
+}>;
+
+/**
+ * A result for a single transaction plan.
+ *
+ * This represents the execution result of a {@link SingleTransactionPlan} and
+ * contains the original transaction message along with its execution status.
+ *
+ * You may use the {@link successfulSingleTransactionPlanResult},
+ * {@link failedSingleTransactionPlanResult}, or {@link canceledSingleTransactionPlanResult}
+ * helpers to create objects of this type.
+ *
+ * @template TContext - The type of the context object that may be passed along with successful results
+ * @template TTransactionMessage - The type of the transaction message
+ *
+ * @example
+ * Successful result with a transaction and context.
+ * ```ts
+ * const result = successfulSingleTransactionPlanResult(
+ *   transactionMessage,
+ *   transaction
+ * );
+ * result satisfies SingleTransactionPlanResult;
+ * ```
+ *
+ * @example
+ * Failed result with an error.
+ * ```ts
+ * const result = failedSingleTransactionPlanResult(
+ *   transactionMessage,
+ *   new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE),
+ * );
+ * result satisfies SingleTransactionPlanResult;
+ * ```
+ *
+ * @example
+ * Canceled result.
+ * ```ts
+ * const result = canceledSingleTransactionPlanResult(transactionMessage);
+ * result satisfies SingleTransactionPlanResult;
+ * ```
+ *
+ * @see {@link successfulSingleTransactionPlanResult}
+ * @see {@link failedSingleTransactionPlanResult}
+ * @see {@link canceledSingleTransactionPlanResult}
+ */
+export type SingleTransactionPlanResult<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
+        TransactionMessageWithFeePayer,
+> = Readonly<{
+    kind: 'single';
+    message: TTransactionMessage;
+    status: TransactionPlanResultStatus<TContext>;
+}>;
+
+/**
+ * The status of a single transaction plan execution.
+ *
+ * This represents the outcome of executing a single transaction message and can be one of:
+ * - `successful` - The transaction was successfully executed. Contains the transaction
+ *   and an optional context object.
+ * - `failed` - The transaction execution failed. Contains the error that caused the failure.
+ * - `canceled` - The transaction execution was canceled.
+ *
+ * @template TContext - The type of the context object that may be passed along with successful results
+ */
+export type TransactionPlanResultStatus<TContext extends TransactionPlanResultContext = TransactionPlanResultContext> =
+    | Readonly<{ context: TContext; kind: 'successful'; transaction: Transaction }>
+    | Readonly<{ error: SolanaError; kind: 'failed' }>
+    | Readonly<{ kind: 'canceled' }>;
+
+/**
+ * Creates a divisible {@link SequentialTransactionPlanResult} from an array of nested results.
+ *
+ * This function creates a sequential result with the `divisible` property set to `true`,
+ * indicating that the nested plans were executed sequentially but could have been
+ * split into separate transactions or batches.
+ *
+ * @template TContext - The type of the context object that may be passed along with successful results
+ * @param plans - The child results that were executed sequentially
+ *
+ * @example
+ * ```ts
+ * const result = sequentialTransactionPlanResult([
+ *   singleResultA,
+ *   singleResultB,
+ * ]);
+ * result satisfies SequentialTransactionPlanResult & { divisible: true };
+ * ```
+ *
+ * @see {@link SequentialTransactionPlanResult}
+ */
+export function sequentialTransactionPlanResult<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+>(plans: TransactionPlanResult<TContext>[]): SequentialTransactionPlanResult<TContext> & { divisible: true } {
+    return Object.freeze({ divisible: true, kind: 'sequential', plans });
+}
+
+/**
+ * Creates a non-divisible {@link SequentialTransactionPlanResult} from an array of nested results.
+ *
+ * This function creates a sequential result with the `divisible` property set to `false`,
+ * indicating that the nested plans were executed sequentially and could not have been
+ * split into separate transactions or batches (e.g., they were executed as a transaction bundle).
+ *
+ * @template TContext - The type of the context object that may be passed along with successful results
+ * @param plans - The child results that were executed sequentially
+ *
+ * @example
+ * ```ts
+ * const result = nonDivisibleSequentialTransactionPlanResult([
+ *   singleResultA,
+ *   singleResultB,
+ * ]);
+ * result satisfies SequentialTransactionPlanResult & { divisible: false };
+ * ```
+ *
+ * @see {@link SequentialTransactionPlanResult}
+ */
+export function nonDivisibleSequentialTransactionPlanResult<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+>(plans: TransactionPlanResult<TContext>[]): SequentialTransactionPlanResult<TContext> & { divisible: false } {
+    return Object.freeze({ divisible: false, kind: 'sequential', plans });
+}
+
+/**
+ * Creates a {@link ParallelTransactionPlanResult} from an array of nested results.
+ *
+ * This function creates a parallel result indicating that the nested plans
+ * were executed in parallel.
+ *
+ * @template TContext - The type of the context object that may be passed along with successful results
+ * @param plans - The child results that were executed in parallel
+ *
+ * @example
+ * ```ts
+ * const result = parallelTransactionPlanResult([
+ *   singleResultA,
+ *   singleResultB,
+ * ]);
+ * result satisfies ParallelTransactionPlanResult;
+ * ```
+ *
+ * @see {@link ParallelTransactionPlanResult}
+ */
+export function parallelTransactionPlanResult<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+>(plans: TransactionPlanResult<TContext>[]): ParallelTransactionPlanResult<TContext> {
+    return Object.freeze({ kind: 'parallel', plans });
+}
+
+/**
+ * Creates a successful {@link SingleTransactionPlanResult} from a transaction message and transaction.
+ *
+ * This function creates a single result with a 'successful' status, indicating that
+ * the transaction was successfully executed. It also includes the original transaction
+ * message, the executed transaction, and an optional context object.
+ *
+ * @template TContext - The type of the context object
+ * @template TTransactionMessage - The type of the transaction message
+ * @param transactionMessage - The original transaction message
+ * @param transaction - The successfully executed transaction
+ * @param context - Optional context object to be included with the result
+ *
+ * @example
+ * ```ts
+ * const result = successfulSingleTransactionPlanResult(
+ *   transactionMessage,
+ *   transaction
+ * );
+ * result satisfies SingleTransactionPlanResult;
+ * ```
+ *
+ * @see {@link SingleTransactionPlanResult}
+ */
+export function successfulSingleTransactionPlanResult<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
+        TransactionMessageWithFeePayer,
+>(
+    transactionMessage: TTransactionMessage,
+    transaction: Transaction,
+    context?: TContext,
+): SingleTransactionPlanResult<TContext, TTransactionMessage> {
+    return Object.freeze({
+        kind: 'single',
+        message: transactionMessage,
+        status: Object.freeze({ context: context ?? ({} as TContext), kind: 'successful', transaction }),
+    });
+}
+
+/**
+ * Creates a failed {@link SingleTransactionPlanResult} from a transaction message and error.
+ *
+ * This function creates a single result with a 'failed' status, indicating that
+ * the transaction execution failed. It includes the original transaction message
+ * and the error that caused the failure.
+ *
+ * @template TContext - The type of the context object (not used in failed results)
+ * @template TTransactionMessage - The type of the transaction message
+ * @param transactionMessage - The original transaction message
+ * @param error - The error that caused the transaction to fail
+ *
+ * @example
+ * ```ts
+ * const result = failedSingleTransactionPlanResult(
+ *   transactionMessage,
+ *   new SolanaError({
+ *     code: 123,
+ *     message: 'Transaction simulation failed',
+ *   }),
+ * );
+ * result satisfies SingleTransactionPlanResult;
+ * ```
+ *
+ * @see {@link SingleTransactionPlanResult}
+ */
+export function failedSingleTransactionPlanResult<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
+        TransactionMessageWithFeePayer,
+>(
+    transactionMessage: TTransactionMessage,
+    error: SolanaError,
+): SingleTransactionPlanResult<TContext, TTransactionMessage> {
+    return Object.freeze({
+        kind: 'single',
+        message: transactionMessage,
+        status: Object.freeze({ error, kind: 'failed' }),
+    });
+}
+
+/**
+ * Creates a canceled {@link SingleTransactionPlanResult} from a transaction message.
+ *
+ * This function creates a single result with a 'canceled' status, indicating that
+ * the transaction execution was canceled. It includes the original transaction message.
+ *
+ * @template TContext - The type of the context object (not used in canceled results)
+ * @template TTransactionMessage - The type of the transaction message
+ * @param transactionMessage - The original transaction message
+ *
+ * @example
+ * ```ts
+ * const result = canceledSingleTransactionPlanResult(transactionMessage);
+ * result satisfies SingleTransactionPlanResult;
+ * ```
+ *
+ * @see {@link SingleTransactionPlanResult}
+ */
+export function canceledSingleTransactionPlanResult<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
+        TransactionMessageWithFeePayer,
+>(transactionMessage: TTransactionMessage): SingleTransactionPlanResult<TContext, TTransactionMessage> {
+    return Object.freeze({
+        kind: 'single',
+        message: transactionMessage,
+        status: Object.freeze({ kind: 'canceled' }),
+    });
+}


### PR DESCRIPTION
This PR adds the `TransactionPlanResult` type and a variety of helpers to create `TransactionPlanResults` of different kinds.