### PR TITLE
Add `TransactionPlanner` type

### DIFF
--- a/.changeset/floppy-queens-tickle.md
+++ b/.changeset/floppy-queens-tickle.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Add a `TransactionPlanner` function type that defines how `InstructionPlans` gets planned and turned into `TransactionPlans`.

--- a/packages/instruction-plans/src/__typetests__/transaction-planner-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-planner-typetest.ts
@@ -1,0 +1,16 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
+import type { InstructionPlan } from '../instruction-plan';
+import type { TransactionPlan } from '../transaction-plan';
+import type { TransactionPlanner } from '../transaction-planner';
+
+// [DESCRIBE] TransactionPlanner
+{
+    // Its return type satisfies TransactionPlan.
+    {
+        const instructionPlan = null as unknown as InstructionPlan;
+        const planner = null as unknown as TransactionPlanner;
+        const transactionPlan = planner(instructionPlan);
+        transactionPlan satisfies Promise<TransactionPlan>;
+    }
+}

--- a/packages/instruction-plans/src/transaction-planner.ts
+++ b/packages/instruction-plans/src/transaction-planner.ts
@@ -1,0 +1,16 @@
+import type { InstructionPlan } from './instruction-plan';
+import type { TransactionPlan } from './transaction-plan';
+
+/**
+ * Plans one or more transactions according to the provided instruction plan.
+ *
+ * @param instructionPlan - The instruction plan to be planned and executed.
+ * @param config - Optional configuration object that can include an `AbortSignal` to cancel the planning process.
+ *
+ * @see {@link InstructionPlan}
+ * @see {@link TransactionPlan}
+ */
+export type TransactionPlanner = (
+    instructionPlan: InstructionPlan,
+    config?: { abortSignal?: AbortSignal },
+) => Promise<TransactionPlan>;


### PR DESCRIPTION
This PR adds the `TransactionPlanner` function type. It defines how `InstructionPlans` turn into `TransactionPlans`.