### PR TITLE
Add `TransactionPlanExecutor` type

### DIFF
--- a/.changeset/purple-yaks-follow.md
+++ b/.changeset/purple-yaks-follow.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Add a `TransactionPlanExecutor` function type that defines how `TransactionPlans` get executed and turned into `TransactionPlanResults`.

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+
+import type { TransactionPlan } from '../transaction-plan';
+import type { TransactionPlanExecutor } from '../transaction-plan-executor';
+import type { TransactionPlanResult } from '../transaction-plan-result';
+
+// [DESCRIBE] TransactionPlanExecutor
+{
+    // Its return type satisfies TransactionPlanResult.
+    {
+        const transactionPlan = null as unknown as TransactionPlan;
+        const executor = null as unknown as TransactionPlanExecutor;
+        const result = executor(transactionPlan);
+        result satisfies Promise<TransactionPlanResult>;
+    }
+
+    // Its return type keeps track of the executor context.
+    {
+        type CustomContext = { customData: string };
+        const transactionPlan = null as unknown as TransactionPlan;
+        const executor = null as unknown as TransactionPlanExecutor<CustomContext>;
+        const result = executor(transactionPlan);
+        result satisfies Promise<TransactionPlanResult<CustomContext>>;
+    }
+}

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -1,0 +1,7 @@
+import type { TransactionPlan } from './transaction-plan';
+import type { TransactionPlanResult, TransactionPlanResultContext } from './transaction-plan-result';
+
+export type TransactionPlanExecutor<TContext extends TransactionPlanResultContext = TransactionPlanResultContext> = (
+    transactionPlan: TransactionPlan,
+    config?: { abortSignal?: AbortSignal },
+) => Promise<TransactionPlanResult<TContext>>;


### PR DESCRIPTION
This PR adds the `TransactionPlanExecutor` function type. It defines how `TransactionPlans` turn into `TransactionPlanResults`.