### PR TITLE
Correct the type of `unitsConsumed`

### DIFF
--- a/.changeset/dirty-lights-watch.md
+++ b/.changeset/dirty-lights-watch.md
@@ -1,0 +1,5 @@
+---
+'@solana/errors': patch
+---
+
+The `unitsConsumed` property in simulation result errors was incorrectly marked as a `number` when it is in fact a `bigint`

--- a/packages/errors/src/json-rpc-error.ts
+++ b/packages/errors/src/json-rpc-error.ts
@@ -89,7 +89,7 @@ export interface RpcSimulateTransactionResult {
         data: [string, 'base64'];
         programId: string;
     } | null;
-    unitsConsumed: number | null;
+    unitsConsumed: bigint | null;
 }
 
 export function getSolanaErrorFromJsonRpcError(putativeErrorResponse: unknown): SolanaError {

--- a/packages/rpc-api/src/__tests__/send-transaction-test.ts
+++ b/packages/rpc-api/src/__tests__/send-transaction-test.ts
@@ -249,7 +249,7 @@ describe('sendTransaction', () => {
                 innerInstructions: null,
                 logs: [],
                 returnData: null,
-                unitsConsumed: 0,
+                unitsConsumed: 0n,
             }),
         );
     });
@@ -284,7 +284,7 @@ describe('sendTransaction', () => {
                 innerInstructions: null,
                 logs: [],
                 returnData: null,
-                unitsConsumed: 0,
+                unitsConsumed: 0n,
             }),
         );
     });
@@ -316,7 +316,7 @@ describe('sendTransaction', () => {
                 innerInstructions: null,
                 logs: [],
                 returnData: null,
-                unitsConsumed: 0,
+                unitsConsumed: 0n,
             }),
         );
     });


### PR DESCRIPTION
#### Problem

This is correct to leave as a `number` in the error message `SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT` because of the downcast that we do before throwing that error, but the _actual_ value vended by the RPC is, in fact, a `bigint`

#### Summary of Changes

Change the response type to `bigint | null`.
