### PR TITLE
Allow messages with no lifetime in Signer API

### DIFF
--- a/.changeset/beige-moles-relate.md
+++ b/.changeset/beige-moles-relate.md
@@ -1,0 +1,5 @@
+---
+'@solana/signers': minor
+---
+
+Allow transaction messages with no lifetime constraints to be signed using the Signer API helpers such as `signTransactionMessageWithSigners` and `partiallySignTransactionMessageWithSigners`. This is because some `TransactionSigners` such as `TransactionModifyingSigners` have the ability to update the transaction before signing it, meaning that the lifetime constraint may not be known until the transaction is signed.

--- a/packages/signers/src/__typetests__/sign-transaction-typetest.ts
+++ b/packages/signers/src/__typetests__/sign-transaction-typetest.ts
@@ -59,6 +59,18 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 }
 
 {
+    // [partiallySignTransactionMessageWithSigners]: returns a transaction with no lifetime constraint
+    const transactionMessage = null as unknown as BaseTransactionMessage &
+        TransactionMessageWithFeePayer &
+        TransactionMessageWithSigners;
+    partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<Readonly<Transaction>>;
+    // @ts-expect-error Expects no lifetime constraint
+    partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
+        Readonly<Transaction & TransactionWithLifetime>
+    >;
+}
+
+{
     // [partiallySignTransactionMessageWithSigners]: returns a transaction with a `TransactionWithinSizeLimit` flag
     const transactionMessage = null as unknown as BaseTransactionMessage &
         TransactionMessageWithFeePayer &
@@ -100,6 +112,18 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
         TransactionMessageWithSigners;
     signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
         Readonly<FullySignedTransaction & TransactionWithLifetime>
+    >;
+}
+
+{
+    // [signTransactionMessageWithSigners]: returns a transaction with no lifetime constraint
+    const transactionMessage = null as unknown as BaseTransactionMessage &
+        TransactionMessageWithFeePayer &
+        TransactionMessageWithSigners;
+    signTransactionMessageWithSigners(transactionMessage) satisfies Promise<Readonly<Transaction>>;
+    // @ts-expect-error Expects no lifetime constraint
+    signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
+        Readonly<Transaction & TransactionWithLifetime>
     >;
 }
 

--- a/packages/signers/src/sign-transaction.ts
+++ b/packages/signers/src/sign-transaction.ts
@@ -1,10 +1,6 @@
 import { SOLANA_ERROR__SIGNER__TRANSACTION_SENDING_SIGNER_MISSING, SolanaError } from '@solana/errors';
 import { SignatureBytes } from '@solana/keys';
-import {
-    BaseTransactionMessage,
-    TransactionMessageWithFeePayer,
-    TransactionMessageWithLifetime,
-} from '@solana/transaction-messages';
+import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 import {
     assertIsFullySignedTransaction,
     compileTransaction,
@@ -69,10 +65,7 @@ import { assertIsTransactionMessageWithSingleSendingSigner } from './transaction
  * @see {@link signAndSendTransactionMessageWithSigners}
  */
 export async function partiallySignTransactionMessageWithSigners<
-    TTransactionMessage extends BaseTransactionMessage &
-        TransactionMessageWithFeePayer &
-        TransactionMessageWithLifetime &
-        TransactionMessageWithSigners,
+    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners,
 >(
     transactionMessage: TTransactionMessage,
     config?: TransactionPartialSignerConfig,
@@ -117,10 +110,7 @@ export async function partiallySignTransactionMessageWithSigners<
  * @see {@link signAndSendTransactionMessageWithSigners}
  */
 export async function signTransactionMessageWithSigners<
-    TTransactionMessage extends BaseTransactionMessage &
-        TransactionMessageWithFeePayer &
-        TransactionMessageWithLifetime &
-        TransactionMessageWithSigners,
+    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners,
 >(
     transactionMessage: TTransactionMessage,
     config?: TransactionPartialSignerConfig,
@@ -181,10 +171,7 @@ export async function signTransactionMessageWithSigners<
  *
  */
 export async function signAndSendTransactionMessageWithSigners<
-    TTransactionMessage extends BaseTransactionMessage &
-        TransactionMessageWithFeePayer &
-        TransactionMessageWithLifetime &
-        TransactionMessageWithSigners,
+    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners,
 >(transaction: TTransactionMessage, config?: TransactionSendingSignerConfig): Promise<SignatureBytes> {
     assertIsTransactionMessageWithSingleSendingSigner(transaction);
 
@@ -290,10 +277,7 @@ function identifyTransactionModifyingSigners(
  * sequentially followed by the TransactionPartialSigners in parallel.
  */
 async function signModifyingAndPartialTransactionSigners<
-    TTransactionMessage extends BaseTransactionMessage &
-        TransactionMessageWithFeePayer &
-        TransactionMessageWithLifetime &
-        TransactionMessageWithSigners,
+    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners,
 >(
     transactionMessage: TTransactionMessage,
     modifyingSigners: readonly TransactionModifyingSigner[] = [],

--- a/packages/signers/src/transaction-with-single-sending-signer.ts
+++ b/packages/signers/src/transaction-with-single-sending-signer.ts
@@ -4,7 +4,7 @@ import {
     SolanaError,
 } from '@solana/errors';
 import { Brand } from '@solana/nominal-types';
-import { CompilableTransactionMessage } from '@solana/transaction-messages';
+import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
 import { getSignersFromTransactionMessage, TransactionMessageWithSigners } from './account-signer-meta';
 import { isTransactionModifyingSigner } from './transaction-modifying-signer';
@@ -63,9 +63,9 @@ export type TransactionMessageWithSingleSendingSigner = Brand<
  * @see {@link signAndSendTransactionMessageWithSigners}
  * @see {@link assertIsTransactionMessageWithSingleSendingSigner}
  */
-export function isTransactionMessageWithSingleSendingSigner<TTransactionMessage extends CompilableTransactionMessage>(
-    transaction: TTransactionMessage,
-): transaction is TransactionMessageWithSingleSendingSigner & TTransactionMessage {
+export function isTransactionMessageWithSingleSendingSigner<
+    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+>(transaction: TTransactionMessage): transaction is TransactionMessageWithSingleSendingSigner & TTransactionMessage {
     try {
         assertIsTransactionMessageWithSingleSendingSigner(transaction);
         return true;
@@ -97,7 +97,7 @@ export function isTransactionMessageWithSingleSendingSigner<TTransactionMessage 
  * @see {@link isTransactionMessageWithSingleSendingSigner}
  */
 export function assertIsTransactionMessageWithSingleSendingSigner<
-    TTransactionMessage extends CompilableTransactionMessage,
+    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer,
 >(
     transaction: TTransactionMessage,
 ): asserts transaction is TransactionMessageWithSingleSendingSigner & TTransactionMessage {


### PR DESCRIPTION
This PR allows transaction messages with no lifetime constraints to be signed using the Signer API helpers such as `signTransactionMessageWithSigners` and `partiallySignTransactionMessageWithSigners`.

This is because some `TransactionSigners` such as `TransactionModifyingSigners` have the ability to update the transaction before signing it, meaning that the lifetime constraint may not be known until the transaction is signed.
