### PR TITLE
Allow messages with no lifetime in size helpers

### DIFF
--- a/.changeset/grumpy-candles-read.md
+++ b/.changeset/grumpy-candles-read.md
@@ -1,0 +1,5 @@
+---
+'@solana/transactions': minor
+---
+
+Allow transaction messages with no lifetime constraints in transaction size helpers — i.e. `getTransactionMessageSize`, `isTransactionMessageWithinSizeLimit` and `assertIsTransactionMessageWithinSizeLimit`.

--- a/packages/transactions/src/__typetests__/transaction-message-size-typetest.ts
+++ b/packages/transactions/src/__typetests__/transaction-message-size-typetest.ts
@@ -1,4 +1,8 @@
-import { CompilableTransactionMessage, TransactionMessageWithinSizeLimit } from '@solana/transaction-messages';
+import {
+    BaseTransactionMessage,
+    TransactionMessageWithFeePayer,
+    TransactionMessageWithinSizeLimit,
+} from '@solana/transaction-messages';
 
 import {
     assertIsTransactionMessageWithinSizeLimit,
@@ -9,17 +13,20 @@ import {
 {
     // It narrows the type of the transaction message to include the `TransactionMessageWithinSizeLimit` flag.
     {
-        const transactionMessage = null as unknown as CompilableTransactionMessage;
+        const transactionMessage = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer;
         if (isTransactionMessageWithinSizeLimit(transactionMessage)) {
-            transactionMessage satisfies CompilableTransactionMessage & TransactionMessageWithinSizeLimit;
+            transactionMessage satisfies BaseTransactionMessage &
+                TransactionMessageWithFeePayer &
+                TransactionMessageWithinSizeLimit;
         }
     }
 
     // It keeps any extra properties from the transaction message.
     {
-        const transactionMessage = null as unknown as CompilableTransactionMessage & { some: 1 };
+        const transactionMessage = null as unknown as BaseTransactionMessage &
+            TransactionMessageWithFeePayer & { some: 1 };
         if (isTransactionMessageWithinSizeLimit(transactionMessage)) {
-            transactionMessage satisfies CompilableTransactionMessage & { some: 1 };
+            transactionMessage satisfies BaseTransactionMessage & TransactionMessageWithFeePayer & { some: 1 };
         }
     }
 }
@@ -28,15 +35,18 @@ import {
 {
     // It narrows the type of the transaction message to include the `TransactionMessageWithinSizeLimit` flag.
     {
-        const transactionMessage = null as unknown as CompilableTransactionMessage;
+        const transactionMessage = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer;
         assertIsTransactionMessageWithinSizeLimit(transactionMessage);
-        transactionMessage satisfies CompilableTransactionMessage & TransactionMessageWithinSizeLimit;
+        transactionMessage satisfies BaseTransactionMessage &
+            TransactionMessageWithFeePayer &
+            TransactionMessageWithinSizeLimit;
     }
 
     // It keeps any extra properties from the transaction message.
     {
-        const transactionMessage = null as unknown as CompilableTransactionMessage & { some: 1 };
+        const transactionMessage = null as unknown as BaseTransactionMessage &
+            TransactionMessageWithFeePayer & { some: 1 };
         assertIsTransactionMessageWithinSizeLimit(transactionMessage);
-        transactionMessage satisfies CompilableTransactionMessage & { some: 1 };
+        transactionMessage satisfies BaseTransactionMessage & TransactionMessageWithFeePayer & { some: 1 };
     }
 }

--- a/packages/transactions/src/transaction-message-size.ts
+++ b/packages/transactions/src/transaction-message-size.ts
@@ -1,5 +1,9 @@
 import { SOLANA_ERROR__TRANSACTION__EXCEEDS_SIZE_LIMIT, SolanaError } from '@solana/errors';
-import type { CompilableTransactionMessage, TransactionMessageWithinSizeLimit } from '@solana/transaction-messages';
+import type {
+    BaseTransactionMessage,
+    TransactionMessageWithFeePayer,
+    TransactionMessageWithinSizeLimit,
+} from '@solana/transaction-messages';
 
 import { compileTransaction } from './compile-transaction';
 import { getTransactionSize, TRANSACTION_SIZE_LIMIT } from './transaction-size';
@@ -12,7 +16,9 @@ import { getTransactionSize, TRANSACTION_SIZE_LIMIT } from './transaction-size';
  * const transactionSize = getTransactionMessageSize(transactionMessage);
  * ```
  */
-export function getTransactionMessageSize(transactionMessage: CompilableTransactionMessage): number {
+export function getTransactionMessageSize(
+    transactionMessage: BaseTransactionMessage & TransactionMessageWithFeePayer,
+): number {
     return getTransactionSize(compileTransaction(transactionMessage));
 }
 
@@ -29,7 +35,9 @@ export function getTransactionMessageSize(transactionMessage: CompilableTransact
  * }
  * ```
  */
-export function isTransactionMessageWithinSizeLimit<TTransactionMessage extends CompilableTransactionMessage>(
+export function isTransactionMessageWithinSizeLimit<
+    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+>(
     transactionMessage: TTransactionMessage,
 ): transactionMessage is TransactionMessageWithinSizeLimit & TTransactionMessage {
     return getTransactionMessageSize(transactionMessage) <= TRANSACTION_SIZE_LIMIT;
@@ -50,7 +58,9 @@ export function isTransactionMessageWithinSizeLimit<TTransactionMessage extends 
  * transactionMessage satisfies TransactionMessageWithinSizeLimit;
  * ```
  */
-export function assertIsTransactionMessageWithinSizeLimit<TTransactionMessage extends CompilableTransactionMessage>(
+export function assertIsTransactionMessageWithinSizeLimit<
+    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+>(
     transactionMessage: TTransactionMessage,
 ): asserts transactionMessage is TransactionMessageWithinSizeLimit & TTransactionMessage {
     const transactionSize = getTransactionMessageSize(transactionMessage);


### PR DESCRIPTION
Now that we've allowed transaction messages to be compiled without a lifetime constraint, we can do the same with helpers that return the transaction size for a given message. This PR does just that.