### PR TITLE
Deprecate `CompilableTransactionMessage`

### DIFF
--- a/.changeset/cuddly-showers-spend.md
+++ b/.changeset/cuddly-showers-spend.md
@@ -1,0 +1,7 @@
+---
+'@solana/transaction-messages': patch
+'@solana/signers': patch
+'@solana/kit': patch
+---
+
+Deprecate `CompilableTransactionMessage` in favour of `TransactionMessage & TransactionMessageWithFeePayer`

--- a/examples/signers/src/example.ts
+++ b/examples/signers/src/example.ts
@@ -12,7 +12,6 @@ import {
     address,
     appendTransactionMessageInstruction,
     Blockhash,
-    CompilableTransactionMessage,
     compileTransaction,
     createKeyPairSignerFromBytes,
     createKeyPairSignerFromPrivateKeyBytes,
@@ -26,6 +25,9 @@ import {
     pipe,
     setTransactionMessageFeePayerSigner,
     setTransactionMessageLifetimeUsingBlockhash,
+    TransactionMessage,
+    TransactionMessageWithFeePayer,
+    TransactionMessageWithLifetime,
     TransactionPartialSigner,
     TransactionSigner,
 } from '@solana/kit';
@@ -85,7 +87,10 @@ async function signMessage(signer: MessagePartialSigner, message: string) {
  * SETUP: SIGN A TRANSACTION
  * This helper function signs a transaction message using the given signer.
  */
-async function signTransaction(signer: TransactionPartialSigner, transactionMessage: CompilableTransactionMessage) {
+async function signTransaction(
+    signer: TransactionPartialSigner,
+    transactionMessage: TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime,
+) {
     const transaction = compileTransaction(transactionMessage);
     const [signatureDictionary] = await signer.signTransactions([transaction]);
     const signature = signatureDictionary[signer.address];
@@ -102,7 +107,9 @@ async function signTransaction(signer: TransactionPartialSigner, transactionMess
  * For instance, in our transfer SOL transaction message, we can
  * extract the fee payer and the transfer source as signers.
  */
-async function signTransactionWithSigners(transactionMessage: CompilableTransactionMessage) {
+async function signTransactionWithSigners(
+    transactionMessage: TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime,
+) {
     const signedTransaction = await partiallySignTransactionMessageWithSigners(transactionMessage);
     const signature = signedTransaction.signatures[transactionMessage.feePayer.address];
     log.info(

--- a/packages/kit/src/compute-limit.ts
+++ b/packages/kit/src/compute-limit.ts
@@ -1,9 +1,5 @@
 import { Rpc, SimulateTransactionApi } from '@solana/rpc';
-import {
-    CompilableTransactionMessage,
-    TransactionMessage,
-    TransactionMessageWithFeePayer,
-} from '@solana/transaction-messages';
+import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
 import { getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPORT } from './compute-limit-internal';
 
@@ -12,7 +8,7 @@ type ComputeUnitEstimateForTransactionMessageFactoryConfig = Readonly<{
     rpc: Rpc<SimulateTransactionApi>;
 }>;
 type ComputeUnitEstimateForTransactionMessageFunction = (
-    transactionMessage: CompilableTransactionMessage | (TransactionMessage & TransactionMessageWithFeePayer),
+    transactionMessage: TransactionMessage & TransactionMessageWithFeePayer,
     config?: Omit<
         Parameters<typeof getComputeUnitEstimateForTransactionMessage_INTERNAL_ONLY_DO_NOT_EXPORT>[0],
         'rpc' | 'transactionMessage'

--- a/packages/transaction-messages/src/__typetests__/durable-nonce-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/durable-nonce-typetest.ts
@@ -3,7 +3,6 @@ import { pipe } from '@solana/functional';
 import { Instruction } from '@solana/instructions';
 
 import { TransactionMessageWithBlockhashLifetime } from '../blockhash';
-import { CompilableTransactionMessage } from '../compilable-transaction-message';
 import { createTransactionMessage } from '../create-transaction-message';
 import {
     assertIsTransactionMessageWithDurableNonceLifetime,
@@ -13,7 +12,7 @@ import {
     TransactionMessageWithDurableNonceLifetime,
 } from '../durable-nonce';
 import { AdvanceNonceAccountInstruction } from '../durable-nonce-instruction';
-import { setTransactionMessageFeePayer } from '../fee-payer';
+import { setTransactionMessageFeePayer, TransactionMessageWithFeePayer } from '../fee-payer';
 import { appendTransactionMessageInstruction } from '../instructions';
 import { BaseTransactionMessage, TransactionMessage } from '../transaction-message';
 import { TransactionMessageWithinSizeLimit } from '../transaction-message-size';
@@ -98,9 +97,8 @@ type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
             m => setTransactionMessageLifetimeUsingDurableNonce(mockNonceConfig, m),
         );
 
-        message satisfies CompilableTransactionMessage;
-        message satisfies BaseTransactionMessage &
-            TransactionMessageWithDurableNonceLifetime<'nonce', 'nonceAuthority', 'nonce'>;
+        message satisfies BaseTransactionMessage & TransactionMessageWithFeePayer;
+        message satisfies TransactionMessageWithDurableNonceLifetime<'nonce', 'nonceAuthority', 'nonce'>;
         message.instructions satisfies readonly [
             AdvanceNonceAccountInstruction<'nonce', 'nonceAuthority'>,
             InstructionA,
@@ -118,9 +116,8 @@ type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
             m => setTransactionMessageLifetimeUsingDurableNonce(newMockNonceConfig, m),
         );
 
-        message satisfies CompilableTransactionMessage;
-        message satisfies BaseTransactionMessage &
-            TransactionMessageWithDurableNonceLifetime<'newNonce', 'newNonceAuthority', 'newNonce'>;
+        message satisfies BaseTransactionMessage & TransactionMessageWithFeePayer;
+        message satisfies TransactionMessageWithDurableNonceLifetime<'newNonce', 'newNonceAuthority', 'newNonce'>;
         message.instructions satisfies readonly [
             AdvanceNonceAccountInstruction<'newNonce', 'newNonceAuthority'>,
             InstructionA,

--- a/packages/transaction-messages/src/__typetests__/instructions-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/instructions-typetest.ts
@@ -2,14 +2,13 @@ import { Address } from '@solana/addresses';
 import { pipe } from '@solana/functional';
 
 import { setTransactionMessageLifetimeUsingBlockhash, TransactionMessageWithBlockhashLifetime } from '../blockhash';
-import { CompilableTransactionMessage } from '../compilable-transaction-message';
 import { createTransactionMessage } from '../create-transaction-message';
 import {
     setTransactionMessageLifetimeUsingDurableNonce,
     TransactionMessageWithDurableNonceLifetime,
 } from '../durable-nonce';
 import { AdvanceNonceAccountInstruction } from '../durable-nonce-instruction';
-import { setTransactionMessageFeePayer } from '../fee-payer';
+import { setTransactionMessageFeePayer, TransactionMessageWithFeePayer } from '../fee-payer';
 import {
     appendTransactionMessageInstruction,
     appendTransactionMessageInstructions,
@@ -62,8 +61,9 @@ type InstructionC = Instruction & { identifier: 'C' };
             m => appendTransactionMessageInstruction(null as unknown as InstructionA, m),
         );
 
-        message satisfies CompilableTransactionMessage;
-        message satisfies BaseTransactionMessage & TransactionMessageWithBlockhashLifetime;
+        message satisfies BaseTransactionMessage &
+            TransactionMessageWithBlockhashLifetime &
+            TransactionMessageWithFeePayer;
         message.instructions satisfies readonly [InstructionA];
     }
 
@@ -78,8 +78,9 @@ type InstructionC = Instruction & { identifier: 'C' };
             m => appendTransactionMessageInstruction(null as unknown as InstructionA, m),
         );
 
-        message satisfies CompilableTransactionMessage;
-        message satisfies BaseTransactionMessage & TransactionMessageWithDurableNonceLifetime;
+        message satisfies BaseTransactionMessage &
+            TransactionMessageWithDurableNonceLifetime &
+            TransactionMessageWithFeePayer;
         message.instructions satisfies readonly [AdvanceNonceAccountInstruction, InstructionA];
     }
 
@@ -190,8 +191,9 @@ type InstructionC = Instruction & { identifier: 'C' };
             m => prependTransactionMessageInstruction(null as unknown as InstructionA, m),
         );
 
-        message satisfies CompilableTransactionMessage;
-        message satisfies BaseTransactionMessage & TransactionMessageWithBlockhashLifetime;
+        message satisfies BaseTransactionMessage &
+            TransactionMessageWithBlockhashLifetime &
+            TransactionMessageWithFeePayer;
         message.instructions satisfies readonly [InstructionA];
     }
 
@@ -207,10 +209,9 @@ type InstructionC = Instruction & { identifier: 'C' };
         );
 
         message.instructions satisfies readonly [InstructionA, AdvanceNonceAccountInstruction];
+        message satisfies BaseTransactionMessage & TransactionMessageWithFeePayer;
         // @ts-expect-error No longer a durable nonce lifetime.
-        message satisfies CompilableTransactionMessage;
-        // @ts-expect-error No longer a durable nonce lifetime.
-        message satisfies BaseTransactionMessage & TransactionMessageWithDurableNonceLifetime;
+        message satisfies TransactionMessageWithDurableNonceLifetime;
     }
 
     // It removes the size limit type safety.

--- a/packages/transaction-messages/src/compilable-transaction-message.ts
+++ b/packages/transaction-messages/src/compilable-transaction-message.ts
@@ -8,6 +8,14 @@ import { BaseTransactionMessage, TransactionVersion } from './transaction-messag
  * A transaction message having sufficient detail to be compiled for execution on the network.
  *
  * In essence, this means that it has at minimum a version, a fee payer, and a lifetime constraint.
+ *
+ * @deprecated Use `BaseTransactionMessage & TransactionMessageWithFeePayer` instead. Alternatively,
+ * use `BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime`
+ * if you need a lifetime constraint.
+ *
+ * @see {@link BaseTransactionMessage}
+ * @see {@link TransactionMessageWithFeePayer}
+ * @see {@link TransactionMessageWithLifetime}
  */
 export type CompilableTransactionMessage<
     TVersion extends TransactionVersion = TransactionVersion,


### PR DESCRIPTION
This PR deprecated the `CompilableTransactionMessage` type and removes internal usages of that type.