### PR TITLE
Allow compiled messages with no lifetime

### DIFF
--- a/.changeset/fancy-cameras-rescue.md
+++ b/.changeset/fancy-cameras-rescue.md
@@ -1,0 +1,6 @@
+---
+'@solana/transaction-messages': minor
+'@solana/kit': minor
+---
+
+Allow `CompiledTransactionMessages` to have no lifetime constraints

--- a/examples/deserialize-transaction/src/example.ts
+++ b/examples/deserialize-transaction/src/example.ts
@@ -315,6 +315,9 @@ const decompiledTransactionMessage = await decompileTransactionMessageFetchingLo
 log.info(`[step 3] The transaction fee payer is ${decompiledTransactionMessage.feePayer.address}`);
 
 // And the lifetime constraint:
+if (!('lifetimeConstraint' in decompiledTransactionMessage)) {
+    throw new Error('We expect a lifetime');
+}
 log.info(decompiledTransactionMessage.lifetimeConstraint, '[step 3] The transaction lifetime constraint');
 
 /**

--- a/packages/kit/src/decompile-transaction-message-fetching-lookup-tables.ts
+++ b/packages/kit/src/decompile-transaction-message-fetching-lookup-tables.ts
@@ -27,7 +27,10 @@ export async function decompileTransactionMessageFetchingLookupTables(
     compiledTransactionMessage: CompiledTransactionMessage,
     rpc: Rpc<GetMultipleAccountsApi>,
     config?: DecompileTransactionMessageFetchingLookupTablesConfig,
-): Promise<BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime> {
+): Promise<
+    | (BaseTransactionMessage & TransactionMessageWithFeePayer)
+    | (BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime)
+> {
     const lookupTables =
         'addressTableLookups' in compiledTransactionMessage &&
         compiledTransactionMessage.addressTableLookups !== undefined &&

--- a/packages/transaction-messages/src/__tests__/decompile-message-test.ts
+++ b/packages/transaction-messages/src/__tests__/decompile-message-test.ts
@@ -11,6 +11,7 @@ import { AccountLookupMeta, AccountMeta, AccountRole, Instruction } from '@solan
 import { CompiledTransactionMessage } from '../compile';
 import { decompileTransactionMessage } from '../decompile-message';
 import { Nonce } from '../durable-nonce';
+import { TransactionMessageWithLifetime } from '../lifetime';
 
 describe('decompileTransactionMessage', () => {
     const U64_MAX = 2n ** 64n - 1n;
@@ -36,7 +37,7 @@ describe('decompileTransactionMessage', () => {
 
             expect(transaction.version).toBe(0);
             expect(transaction.feePayer.address).toEqual(feePayer);
-            expect(transaction.lifetimeConstraint).toEqual({
+            expect((transaction as TransactionMessageWithLifetime).lifetimeConstraint).toEqual({
                 blockhash,
                 lastValidBlockHeight: U64_MAX,
             });
@@ -56,7 +57,7 @@ describe('decompileTransactionMessage', () => {
             };
 
             const transaction = decompileTransactionMessage(compiledTransaction);
-            expect(transaction.lifetimeConstraint).toBeFrozenObject();
+            expect((transaction as TransactionMessageWithLifetime).lifetimeConstraint).toBeFrozenObject();
         });
 
         it('converts a transaction with version legacy', () => {
@@ -244,7 +245,7 @@ describe('decompileTransactionMessage', () => {
             };
 
             const transaction = decompileTransactionMessage(compiledTransaction, { lastValidBlockHeight: 100n });
-            expect(transaction.lifetimeConstraint).toEqual({
+            expect((transaction as TransactionMessageWithLifetime).lifetimeConstraint).toEqual({
                 blockhash,
                 lastValidBlockHeight: 100n,
             });
@@ -358,7 +359,7 @@ describe('decompileTransactionMessage', () => {
 
             expect(transaction.instructions).toStrictEqual([expectedInstruction]);
             expect(transaction.feePayer.address).toStrictEqual(nonceAuthorityAddress);
-            expect(transaction.lifetimeConstraint).toStrictEqual({ nonce });
+            expect((transaction as TransactionMessageWithLifetime).lifetimeConstraint).toStrictEqual({ nonce });
         });
 
         it('freezes the nonce lifetime constraint', () => {
@@ -394,7 +395,7 @@ describe('decompileTransactionMessage', () => {
             };
 
             const transaction = decompileTransactionMessage(compiledTransaction);
-            expect(transaction.lifetimeConstraint).toBeFrozenObject();
+            expect((transaction as TransactionMessageWithLifetime).lifetimeConstraint).toBeFrozenObject();
         });
 
         it('converts a transaction with one instruction which is advance nonce (fee payer is not nonce authority)', () => {
@@ -534,7 +535,7 @@ describe('decompileTransactionMessage', () => {
             ];
 
             expect(transaction.instructions).toStrictEqual(expectedInstructions);
-            expect(transaction.lifetimeConstraint).toStrictEqual({ nonce });
+            expect((transaction as TransactionMessageWithLifetime).lifetimeConstraint).toStrictEqual({ nonce });
         });
 
         it('freezes the instructions within the transaction', () => {

--- a/packages/transaction-messages/src/codecs/message.ts
+++ b/packages/transaction-messages/src/codecs/message.ts
@@ -49,7 +49,13 @@ function getPreludeStructEncoderTuple() {
         ['version', getTransactionVersionEncoder()],
         ['header', getMessageHeaderEncoder()],
         ['staticAccounts', getArrayEncoder(getAddressEncoder(), { size: getShortU16Encoder() })],
-        ['lifetimeToken', fixEncoderSize(getBase58Encoder(), 32)],
+        [
+            'lifetimeToken',
+            transformEncoder(
+                fixEncoderSize(getBase58Encoder(), 32),
+                (lifetimeToken: string | undefined): string => lifetimeToken ?? '11111111111111111111111111111111',
+            ),
+        ],
         ['instructions', getArrayEncoder(getInstructionEncoder(), { size: getShortU16Encoder() })],
     ] as const;
 }
@@ -59,7 +65,12 @@ function getPreludeStructDecoderTuple() {
         ['version', getTransactionVersionDecoder() as Decoder<number>],
         ['header', getMessageHeaderDecoder()],
         ['staticAccounts', getArrayDecoder(getAddressDecoder(), { size: getShortU16Decoder() })],
-        ['lifetimeToken', fixDecoderSize(getBase58Decoder(), 32)],
+        [
+            'lifetimeToken',
+            transformDecoder(fixDecoderSize(getBase58Decoder(), 32), (lifetimeToken: string): string | undefined =>
+                lifetimeToken === '11111111111111111111111111111111' ? undefined : lifetimeToken,
+            ),
+        ],
         ['instructions', getArrayDecoder(getInstructionDecoder(), { size: getShortU16Decoder() })],
         ['addressTableLookups', getAddressTableLookupArrayDecoder()],
     ] as const;


### PR DESCRIPTION
This PR allows `CompiledTransactionMessages` to have no lifetime constraint.

It does it by filling the lifetime token with zeroes when encoding the message — that is, at the very last possible moment.

In order to have reciprocity when decoding `CompiledTransactionMessages`, the decoder also recognises a lifetime token filled with zeroes and translate this as an `undefined` lifetime token.