### PR TITLE
Use Ed25519 algorithm identifier in examples that's compatible everywhere

### DIFF
--- a/packages/webcrypto-ed25519-polyfill/README.md
+++ b/packages/webcrypto-ed25519-polyfill/README.md
@@ -32,11 +32,11 @@ import { install } from '@solana/webcrypto-ed25519-polyfill';
 install();
 
 // Now you can do this, in environments that do not otherwise support Ed25519.
-const keyPair = await crypto.subtle.generateKey('Ed25519', false, ['sign']);
+const keyPair = await crypto.subtle.generateKey({ name: 'Ed25519' }, false, ['sign']);
 const publicKeyBytes = await crypto.subtle.exportKey('raw', keyPair.publicKey);
 const data = new Uint8Array([1, 2, 3]);
-const signature = await crypto.subtle.sign('Ed25519', keyPair.privateKey, data);
-if (await crypto.subtle.verify('Ed25519', keyPair.publicKey, signature, data)) {
+const signature = await crypto.subtle.sign({ name: 'Ed25519' }, keyPair.privateKey, data);
+if (await crypto.subtle.verify({ name: 'Ed25519' }, keyPair.publicKey, signature, data)) {
     console.log('Data was signed using the private key associated with this public key');
 } else {
     throw new Error('Signature verification error');

--- a/packages/webcrypto-ed25519-polyfill/src/index.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/index.ts
@@ -27,11 +27,11 @@
  * install();
  *
  * // Now you can do this, in environments that do not otherwise support Ed25519.
- * const keyPair = await crypto.subtle.generateKey('Ed25519', false, ['sign']);
+ * const keyPair = await crypto.subtle.generateKey({ name: 'Ed25519' }, false, ['sign']);
  * const publicKeyBytes = await crypto.subtle.exportKey('raw', keyPair.publicKey);
  * const data = new Uint8Array([1, 2, 3]);
- * const signature = await crypto.subtle.sign('Ed25519', keyPair.privateKey, data);
- * if (await crypto.subtle.verify('Ed25519', keyPair.publicKey, signature, data)) {
+ * const signature = await crypto.subtle.sign({ name: 'Ed25519' }, keyPair.privateKey, data);
+ * if (await crypto.subtle.verify({ name: 'Ed25519' }, keyPair.publicKey, signature, data)) {
  *     console.log('Data was signed using the private key associated with this public key');
  * } else {
  *     throw new Error('Signature verification error');

--- a/packages/webcrypto-ed25519-polyfill/src/install.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/install.ts
@@ -26,11 +26,11 @@ function isAlgorithmEd25519(putativeEd25519Algorithm: AlgorithmIdentifier): bool
  * install();
  *
  * // Now you can do this, in environments that do not otherwise support Ed25519.
- * const keyPair = await crypto.subtle.generateKey('Ed25519', false, ['sign']);
+ * const keyPair = await crypto.subtle.generateKey({ name: 'Ed25519' }, false, ['sign']);
  * const publicKeyBytes = await crypto.subtle.exportKey('raw', keyPair.publicKey);
  * const data = new Uint8Array([1, 2, 3]);
- * const signature = await crypto.subtle.sign('Ed25519', keyPair.privateKey, data);
- * if (await crypto.subtle.verify('Ed25519', keyPair.publicKey, signature, data)) {
+ * const signature = await crypto.subtle.sign({ name: 'Ed25519' }, keyPair.privateKey, data);
+ * if (await crypto.subtle.verify({ name: 'Ed25519' }, keyPair.publicKey, signature, data)) {
  *     console.log('Data was signed using the private key associated with this public key');
  * } else {
  *     throw new Error('Signature verification error');


### PR DESCRIPTION
#### Problem

Firefox does not accept the identifier `'Ed25519'`, requiring instead `{ name: 'Ed25519' }`, as we learned in #60.

#### Summary of Changes

Change this in examples, in case readers are using Firefox.
