### PR TITLE
Extract lifetime from `CompiledTransactionMessage`

### DIFF
--- a/.changeset/major-guests-shine.md
+++ b/.changeset/major-guests-shine.md
@@ -1,0 +1,6 @@
+---
+'@solana/transaction-messages': minor
+'@solana/kit': minor
+---
+
+Extract lifetime token from `CompiledTransactionMessage`. `CompiledTransactionMessage & CompiledTransactionMessageWithLifetime` may now be used to refer to a compiled transaction message with a lifetime token. This enables `CompiledTransactionMessages` to be encoded without the need to specify a mock lifetime token.

--- a/packages/kit/src/__tests__/decompile-transaction-message-fetching-lookup-tables-test.ts
+++ b/packages/kit/src/__tests__/decompile-transaction-message-fetching-lookup-tables-test.ts
@@ -4,6 +4,7 @@ import type { GetMultipleAccountsApi, Rpc } from '@solana/rpc';
 import type { Blockhash, Lamports } from '@solana/rpc-types';
 import {
     CompiledTransactionMessage,
+    CompiledTransactionMessageWithLifetime,
     decompileTransactionMessage,
     TransactionMessage,
 } from '@solana/transaction-messages';
@@ -20,7 +21,7 @@ describe('decompileTransactionMessageFetchingLookupTables', () => {
     };
 
     describe('for a legacy transaction', () => {
-        const compiledTransactionMessage: CompiledTransactionMessage = {
+        const compiledTransactionMessage: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
             // no `addressTableLookups` field
             header: {
                 numReadonlyNonSignerAccounts: 0,
@@ -89,7 +90,7 @@ describe('decompileTransactionMessageFetchingLookupTables', () => {
     });
 
     describe('for a versioned transaction with no `addressTableLookups` field', () => {
-        const compiledTransactionMessage: CompiledTransactionMessage = {
+        const compiledTransactionMessage: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
             // no `addressTableLookups` field
             header: {
                 numReadonlyNonSignerAccounts: 0,
@@ -158,7 +159,7 @@ describe('decompileTransactionMessageFetchingLookupTables', () => {
     });
 
     describe('for a versioned transaction with empty `addressTableLookups`', () => {
-        const compiledTransactionMessage: CompiledTransactionMessage = {
+        const compiledTransactionMessage: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
             addressTableLookups: [],
             header: {
                 numReadonlyNonSignerAccounts: 0,
@@ -230,7 +231,7 @@ describe('decompileTransactionMessageFetchingLookupTables', () => {
         const lookupTableAddress1 = '1111' as Address;
         const lookupTableAddress2 = '2222' as Address;
 
-        const compiledTransactionMessage: CompiledTransactionMessage = {
+        const compiledTransactionMessage: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
             addressTableLookups: [
                 // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                 {

--- a/packages/kit/src/decompile-transaction-message-fetching-lookup-tables.ts
+++ b/packages/kit/src/decompile-transaction-message-fetching-lookup-tables.ts
@@ -3,6 +3,7 @@ import type { GetMultipleAccountsApi, Rpc } from '@solana/rpc';
 import {
     BaseTransactionMessage,
     CompiledTransactionMessage,
+    CompiledTransactionMessageWithLifetime,
     decompileTransactionMessage,
     TransactionMessageWithFeePayer,
     TransactionMessageWithLifetime,
@@ -24,7 +25,7 @@ type DecompileTransactionMessageFetchingLookupTablesConfig = FetchAccountsConfig
  * @param config
  */
 export async function decompileTransactionMessageFetchingLookupTables(
-    compiledTransactionMessage: CompiledTransactionMessage,
+    compiledTransactionMessage: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime,
     rpc: Rpc<GetMultipleAccountsApi>,
     config?: DecompileTransactionMessageFetchingLookupTablesConfig,
 ): Promise<BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime> {

--- a/packages/transaction-messages/src/__tests__/decompile-message-test.ts
+++ b/packages/transaction-messages/src/__tests__/decompile-message-test.ts
@@ -8,7 +8,7 @@ import {
 } from '@solana/errors';
 import { AccountLookupMeta, AccountMeta, AccountRole, Instruction } from '@solana/instructions';
 
-import { CompiledTransactionMessage } from '../compile';
+import { CompiledTransactionMessage, CompiledTransactionMessageWithLifetime } from '../compile';
 import { decompileTransactionMessage } from '../decompile-message';
 import { Nonce } from '../durable-nonce';
 
@@ -20,7 +20,7 @@ describe('decompileTransactionMessage', () => {
         const blockhash = 'J4yED2jcMAHyQUg61DBmm4njmEydUr2WqrV9cdEcDDgL';
 
         it('converts a transaction with no instructions', () => {
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 0,
                     numReadonlySignerAccounts: 0,
@@ -43,7 +43,7 @@ describe('decompileTransactionMessage', () => {
         });
 
         it('freezes the blockhash lifetime constraint', () => {
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 0,
                     numReadonlySignerAccounts: 0,
@@ -60,7 +60,7 @@ describe('decompileTransactionMessage', () => {
         });
 
         it('converts a transaction with version legacy', () => {
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 0,
                     numReadonlySignerAccounts: 0,
@@ -79,7 +79,7 @@ describe('decompileTransactionMessage', () => {
         it('converts a transaction with one instruction with no accounts or data', () => {
             const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
 
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 1,
                     // fee payer
@@ -102,7 +102,7 @@ describe('decompileTransactionMessage', () => {
         it('converts a transaction with one instruction with accounts and data', () => {
             const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
 
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 2, // 1 passed into instruction + 1 program
                     numReadonlySignerAccounts: 1,
@@ -162,7 +162,7 @@ describe('decompileTransactionMessage', () => {
         it('freezes the instruction accounts', () => {
             const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
 
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 2, // 1 passed into instruction + 1 program
                     numReadonlySignerAccounts: 1,
@@ -196,7 +196,7 @@ describe('decompileTransactionMessage', () => {
         });
 
         it('converts a transaction with multiple instructions', () => {
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 3, // 3 programs
                     numReadonlySignerAccounts: 0,
@@ -231,7 +231,7 @@ describe('decompileTransactionMessage', () => {
         });
 
         it('converts a transaction with a given lastValidBlockHeight', () => {
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 0,
                     numReadonlySignerAccounts: 0,
@@ -253,7 +253,7 @@ describe('decompileTransactionMessage', () => {
         it('freezes the instructions within the transaction', () => {
             const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
 
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 1,
                     // fee payer
@@ -273,7 +273,7 @@ describe('decompileTransactionMessage', () => {
         it('freezes the instructions array', () => {
             const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
 
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 1,
                     // fee payer
@@ -304,7 +304,7 @@ describe('decompileTransactionMessage', () => {
         const recentBlockhashesSysvarAddress = 'SysvarRecentB1ockHashes11111111111111111111' as Address;
 
         it('converts a transaction with one instruction which is advance nonce (fee payer is nonce authority)', () => {
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 2, // recent blockhashes sysvar, system program
                     numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
@@ -362,7 +362,7 @@ describe('decompileTransactionMessage', () => {
         });
 
         it('freezes the nonce lifetime constraint', () => {
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 2, // recent blockhashes sysvar, system program
                     numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
@@ -398,7 +398,7 @@ describe('decompileTransactionMessage', () => {
         });
 
         it('converts a transaction with one instruction which is advance nonce (fee payer is not nonce authority)', () => {
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 2, // recent blockhashes sysvar, system program
                     numReadonlySignerAccounts: 1, // nonce authority
@@ -454,7 +454,7 @@ describe('decompileTransactionMessage', () => {
         });
 
         it('converts a durable nonce transaction with multiple instruction', () => {
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 4, // recent blockhashes sysvar, system program, 2 other program addresses
                     numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
@@ -538,7 +538,7 @@ describe('decompileTransactionMessage', () => {
         });
 
         it('freezes the instructions within the transaction', () => {
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 4, // recent blockhashes sysvar, system program, 2 other program addresses
                     numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
@@ -584,7 +584,7 @@ describe('decompileTransactionMessage', () => {
         });
 
         it('freezes the instructions array', () => {
-            const compiledTransaction: CompiledTransactionMessage = {
+            const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                 header: {
                     numReadonlyNonSignerAccounts: 4, // recent blockhashes sysvar, system program, 2 other program addresses
                     numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
@@ -641,7 +641,7 @@ describe('decompileTransactionMessage', () => {
                     [lookupTableAddress]: [addressInLookup],
                 };
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -696,7 +696,7 @@ describe('decompileTransactionMessage', () => {
                     ],
                 };
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -754,7 +754,7 @@ describe('decompileTransactionMessage', () => {
                     [lookupTableAddress]: [addressInLookup],
                 };
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -809,7 +809,7 @@ describe('decompileTransactionMessage', () => {
                     ],
                 };
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -872,7 +872,7 @@ describe('decompileTransactionMessage', () => {
                     ],
                 };
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -933,7 +933,7 @@ describe('decompileTransactionMessage', () => {
 
                 const staticAddress = 'GbRuWcHyNaVuE9rJE4sKpkHYa9k76VJBCCwGtf87ikH3' as Address;
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -993,7 +993,7 @@ describe('decompileTransactionMessage', () => {
                     ],
                 };
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -1055,7 +1055,7 @@ describe('decompileTransactionMessage', () => {
             });
 
             it('throws if the lookup table is not passed in', () => {
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -1097,7 +1097,7 @@ describe('decompileTransactionMessage', () => {
                     [lookupTableAddress]: [addressInLookup],
                 };
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -1142,7 +1142,7 @@ describe('decompileTransactionMessage', () => {
                     [lookupTableAddress]: [addressInLookup],
                 };
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -1195,7 +1195,7 @@ describe('decompileTransactionMessage', () => {
                     [lookupTableAddress2]: [addressInLookup2],
                 };
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -1261,7 +1261,7 @@ describe('decompileTransactionMessage', () => {
                     [lookupTableAddress2]: [addressInLookup2],
                 };
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -1330,7 +1330,7 @@ describe('decompileTransactionMessage', () => {
                     [lookupTableAddress2]: [readonlyAddressInLookup2, writableAddressInLookup2],
                 };
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -1420,7 +1420,7 @@ describe('decompileTransactionMessage', () => {
                     [lookupTableAddress2]: [readonlyAddressInLookup2, writableAddressInLookup2],
                 };
 
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {
@@ -1515,7 +1515,7 @@ describe('decompileTransactionMessage', () => {
             });
 
             it('throws if multiple lookup tables are not passed in', () => {
-                const compiledTransaction: CompiledTransactionMessage = {
+                const compiledTransaction: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime = {
                     addressTableLookups: [
                         // @ts-expect-error Remove when `readableIndices` and `writableIndices` are removed.
                         {

--- a/packages/transaction-messages/src/codecs/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/codecs/__tests__/message-test.ts
@@ -1,7 +1,7 @@
 import { Address } from '@solana/addresses';
 import { Decoder, Encoder } from '@solana/codecs-core';
 
-import { CompiledTransactionMessage } from '../../compile/message';
+import { CompiledTransactionMessage, CompiledTransactionMessageWithLifetime } from '../../compile/message';
 import {
     getCompiledTransactionMessageCodec,
     getCompiledTransactionMessageDecoder,
@@ -11,7 +11,9 @@ import {
 describe.each([getCompiledTransactionMessageCodec, getCompiledTransactionMessageEncoder])(
     'Transaction message serializer %p',
     serializerFactory => {
-        let compiledMessage: Encoder<CompiledTransactionMessage>;
+        let compiledMessage: Encoder<
+            CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime)
+        >;
         beforeEach(() => {
             compiledMessage = serializerFactory();
         });

--- a/packages/transaction-messages/src/codecs/message.ts
+++ b/packages/transaction-messages/src/codecs/message.ts
@@ -11,45 +11,70 @@ import {
     VariableSizeDecoder,
     VariableSizeEncoder,
 } from '@solana/codecs-core';
-import { getArrayDecoder, getArrayEncoder, getStructDecoder, getStructEncoder } from '@solana/codecs-data-structures';
+import {
+    getArrayDecoder,
+    getArrayEncoder,
+    getConstantEncoder,
+    getStructDecoder,
+    getStructEncoder,
+    getUnionEncoder,
+} from '@solana/codecs-data-structures';
 import { getShortU16Decoder, getShortU16Encoder } from '@solana/codecs-numbers';
 import { getBase58Decoder, getBase58Encoder } from '@solana/codecs-strings';
 
 import { getCompiledAddressTableLookups } from '../compile/address-table-lookups';
-import { CompiledTransactionMessage } from '../compile/message';
+import { CompiledTransactionMessage, CompiledTransactionMessageWithLifetime } from '../compile/message';
 import { getAddressTableLookupDecoder, getAddressTableLookupEncoder } from './address-table-lookup';
 import { getMessageHeaderDecoder, getMessageHeaderEncoder } from './header';
 import { getInstructionDecoder, getInstructionEncoder } from './instruction';
 import { getTransactionVersionDecoder, getTransactionVersionEncoder } from './transaction-version';
 
-function getCompiledMessageLegacyEncoder(): VariableSizeEncoder<CompiledTransactionMessage> {
-    return getStructEncoder(getPreludeStructEncoderTuple()) as VariableSizeEncoder<CompiledTransactionMessage>;
+function getCompiledMessageLegacyEncoder(): VariableSizeEncoder<
+    CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime)
+> {
+    return getStructEncoder(getPreludeStructEncoderTuple()) as VariableSizeEncoder<
+        CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime)
+    >;
 }
 
-function getCompiledMessageVersionedEncoder(): VariableSizeEncoder<CompiledTransactionMessage> {
+function getCompiledMessageVersionedEncoder(): VariableSizeEncoder<
+    CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime)
+> {
     return transformEncoder(
         getStructEncoder([
             ...getPreludeStructEncoderTuple(),
             ['addressTableLookups', getAddressTableLookupArrayEncoder()],
-        ]) as VariableSizeEncoder<CompiledTransactionMessage>,
-        (value: CompiledTransactionMessage) => {
+        ]) as VariableSizeEncoder<
+            CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime)
+        >,
+        value => {
             if (value.version === 'legacy') {
                 return value;
             }
             return {
                 ...value,
                 addressTableLookups: value.addressTableLookups ?? [],
-            } as Exclude<CompiledTransactionMessage, { readonly version: 'legacy' }>;
+            };
         },
     );
 }
 
 function getPreludeStructEncoderTuple() {
+    const lifetimeTokenEncoder = getUnionEncoder(
+        [
+            // Use a 32-byte constant encoder for a missing lifetime token (index 0).
+            getConstantEncoder(new Uint8Array(32)),
+            // Use a 32-byte base58 encoder for a valid lifetime token (index 1).
+            fixEncoderSize(getBase58Encoder(), 32),
+        ],
+        value => (value === undefined ? 0 : 1),
+    );
+
     return [
         ['version', getTransactionVersionEncoder()],
         ['header', getMessageHeaderEncoder()],
         ['staticAccounts', getArrayEncoder(getAddressEncoder(), { size: getShortU16Encoder() })],
-        ['lifetimeToken', fixEncoderSize(getBase58Encoder(), 32)],
+        ['lifetimeToken', lifetimeTokenEncoder],
         ['instructions', getArrayEncoder(getInstructionEncoder(), { size: getShortU16Encoder() })],
     ] as const;
 }
@@ -80,9 +105,11 @@ function getAddressTableLookupArrayDecoder() {
  * The wire format of a Solana transaction consists of signatures followed by a compiled transaction
  * message. The byte array produced by this encoder is the message part.
  */
-export function getCompiledTransactionMessageEncoder(): VariableSizeEncoder<CompiledTransactionMessage> {
+export function getCompiledTransactionMessageEncoder(): VariableSizeEncoder<
+    CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime)
+> {
     return createEncoder({
-        getSizeFromValue: (compiledMessage: CompiledTransactionMessage) => {
+        getSizeFromValue: compiledMessage => {
             if (compiledMessage.version === 'legacy') {
                 return getCompiledMessageLegacyEncoder().getSizeFromValue(compiledMessage);
             } else {
@@ -106,19 +133,21 @@ export function getCompiledTransactionMessageEncoder(): VariableSizeEncoder<Comp
  * The wire format of a Solana transaction consists of signatures followed by a compiled transaction
  * message. You can use this decoder to decode the message part.
  */
-export function getCompiledTransactionMessageDecoder(): VariableSizeDecoder<CompiledTransactionMessage> {
+export function getCompiledTransactionMessageDecoder(): VariableSizeDecoder<
+    CompiledTransactionMessage & CompiledTransactionMessageWithLifetime
+> {
     return transformDecoder(
         getStructDecoder(getPreludeStructDecoderTuple()) as VariableSizeDecoder<
-            CompiledTransactionMessage & { addressTableLookups?: ReturnType<typeof getCompiledAddressTableLookups> }
+            CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & {
+                    addressTableLookups?: ReturnType<typeof getCompiledAddressTableLookups>;
+                }
         >,
         ({ addressTableLookups, ...restOfMessage }) => {
             if (restOfMessage.version === 'legacy' || !addressTableLookups?.length) {
                 return restOfMessage;
             }
-            return { ...restOfMessage, addressTableLookups } as Exclude<
-                CompiledTransactionMessage,
-                { readonly version: 'legacy' }
-            >;
+            return { ...restOfMessage, addressTableLookups };
         },
     );
 }
@@ -129,6 +158,9 @@ export function getCompiledTransactionMessageDecoder(): VariableSizeDecoder<Comp
  * @see {@link getCompiledTransactionMessageDecoder}
  * @see {@link getCompiledTransactionMessageEncoder}
  */
-export function getCompiledTransactionMessageCodec(): VariableSizeCodec<CompiledTransactionMessage> {
+export function getCompiledTransactionMessageCodec(): VariableSizeCodec<
+    CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime),
+    CompiledTransactionMessage & CompiledTransactionMessageWithLifetime
+> {
     return combineCodec(getCompiledTransactionMessageEncoder(), getCompiledTransactionMessageDecoder());
 }

--- a/packages/transaction-messages/src/decompile-message.ts
+++ b/packages/transaction-messages/src/decompile-message.ts
@@ -12,7 +12,7 @@ import type { Blockhash } from '@solana/rpc-types';
 
 import { AddressesByLookupTableAddress } from './addresses-by-lookup-table-address';
 import { setTransactionMessageLifetimeUsingBlockhash } from './blockhash';
-import { CompiledTransactionMessage } from './compile';
+import { CompiledTransactionMessage, CompiledTransactionMessageWithLifetime } from './compile';
 import type { getCompiledAddressTableLookups } from './compile/address-table-lookups';
 import { createTransactionMessage } from './create-transaction-message';
 import { Nonce, setTransactionMessageLifetimeUsingDurableNonce } from './durable-nonce';
@@ -214,7 +214,7 @@ export type DecompileTransactionMessageConfig = {
  * @see {@link compileTransactionMessage}
  */
 export function decompileTransactionMessage(
-    compiledTransactionMessage: CompiledTransactionMessage,
+    compiledTransactionMessage: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime,
     config?: DecompileTransactionMessageConfig,
 ): BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime {
     const feePayer = compiledTransactionMessage.staticAccounts[0];

--- a/packages/transactions/src/__tests__/compile-transaction-test.ts
+++ b/packages/transactions/src/__tests__/compile-transaction-test.ts
@@ -4,6 +4,7 @@ import { Address } from '@solana/addresses';
 import { Blockhash } from '@solana/rpc-types';
 import {
     CompiledTransactionMessage,
+    CompiledTransactionMessageWithLifetime,
     compileTransactionMessage,
     getCompiledTransactionMessageEncoder,
     Nonce,
@@ -34,7 +35,7 @@ describe('compileTransactionMessage', () => {
         lifetimeToken: 'a',
         staticAccounts: [mockAddressA, mockAddressB],
         version: 0,
-    } as CompiledTransactionMessage;
+    } as CompiledTransactionMessage & CompiledTransactionMessageWithLifetime;
     const mockCompiledMessageBytes = new Uint8Array(Array(100)).fill(1);
     beforeEach(() => {
         (compileTransactionMessage as jest.Mock).mockReturnValue(mockCompiledMessage);


### PR DESCRIPTION
This PR removes the `lifetimeToken` attribute from `CompiledTransactionMessage` and adds it to a new type `CompiledTransactionMessageWithLifetime` that can be composed with the former.

This enables `CompiledTransactionMessages` to be encoded without the need to specify a mock lifetime token and for decoded compiled messages to be typed as having a lifetime.