### PR TITLE
Update docs Prettier config

### DIFF
--- a/docs/.prettierignore
+++ b/docs/.prettierignore
@@ -1,0 +1,2 @@
+pnpm-lock.yaml
+content/api/

--- a/docs/content/.prettierrc
+++ b/docs/content/.prettierrc
@@ -1,5 +1,6 @@
 {
-  "tabWidth": 2,
-  "singleQuote": false,
-  "printWidth": 120
+    "$schema": "https://json.schemastore.org/prettierrc",
+    "tabWidth": 4,
+    "singleQuote": true,
+    "printWidth": 100
 }

--- a/docs/content/docs/concepts/codecs.mdx
+++ b/docs/content/docs/concepts/codecs.mdx
@@ -38,19 +38,26 @@ No matter which serialization strategy we use, Codecs abstract away its implemen
 Here's a quick example that encodes and decodes a simple `Person` type.
 
 ```ts twoslash
-import { Codec, addCodecSizePrefix, getUtf8Codec, getU32Codec, getStructCodec, ReadonlyUint8Array } from "@solana/kit";
+import {
+    Codec,
+    addCodecSizePrefix,
+    getUtf8Codec,
+    getU32Codec,
+    getStructCodec,
+    ReadonlyUint8Array,
+} from '@solana/kit';
 // ---cut-before---
 // Use composable codecs to build complex data structures.
 type Person = { name: string; age: number };
 const getPersonCodec = (): Codec<Person> =>
-  getStructCodec([
-    ["name", addCodecSizePrefix(getUtf8Codec(), getU32Codec())],
-    ["age", getU32Codec()],
-  ]);
+    getStructCodec([
+        ['name', addCodecSizePrefix(getUtf8Codec(), getU32Codec())],
+        ['age', getU32Codec()],
+    ]);
 
 // Use your own codecs to encode and decode data.
 const personCodec = getPersonCodec();
-const encodedPerson = personCodec.encode({ name: "John", age: 42 });
+const encodedPerson = personCodec.encode({ name: 'John', age: 42 });
 const decodedPerson = personCodec.decode(encodedPerson);
 ```
 
@@ -69,36 +76,50 @@ For instance, consider the following codecs available:
 By combining them together we can create a custom codec for the following `Person` type.
 
 ```ts twoslash
-import { Codec, addCodecSizePrefix, getUtf8Codec, getU32Codec, getStructCodec, getBooleanCodec } from "@solana/kit";
+import {
+    Codec,
+    addCodecSizePrefix,
+    getUtf8Codec,
+    getU32Codec,
+    getStructCodec,
+    getBooleanCodec,
+} from '@solana/kit';
 // ---cut-before---
 type Person = {
-  name: string;
-  age: number;
-  verified: boolean;
+    name: string;
+    age: number;
+    verified: boolean;
 };
 
 const getPersonCodec = (): Codec<Person> =>
-  getStructCodec([
-    ["name", addCodecSizePrefix(getUtf8Codec(), getU32Codec())],
-    ["age", getU32Codec()],
-    ["verified", getBooleanCodec()],
-  ]);
+    getStructCodec([
+        ['name', addCodecSizePrefix(getUtf8Codec(), getU32Codec())],
+        ['age', getU32Codec()],
+        ['verified', getBooleanCodec()],
+    ]);
 ```
 
 This function returns a `Codec` object which contains both an `encode` and `decode` function that can be used to convert a `Person` type to and from a `Uint8Array`.
 
 ```ts twoslash
-import { Codec, addCodecSizePrefix, getUtf8Codec, getU32Codec, getStructCodec, getBooleanCodec } from "@solana/kit";
+import {
+    Codec,
+    addCodecSizePrefix,
+    getUtf8Codec,
+    getU32Codec,
+    getStructCodec,
+    getBooleanCodec,
+} from '@solana/kit';
 type Person = { name: string; age: number; verified: boolean };
 const getPersonCodec = (): Codec<Person> =>
-  getStructCodec([
-    ["name", addCodecSizePrefix(getUtf8Codec(), getU32Codec())],
-    ["age", getU32Codec()],
-    ["verified", getBooleanCodec()],
-  ]);
+    getStructCodec([
+        ['name', addCodecSizePrefix(getUtf8Codec(), getU32Codec())],
+        ['age', getU32Codec()],
+        ['verified', getBooleanCodec()],
+    ]);
 // ---cut-before---
 const personCodec = getPersonCodec();
-const bytes = personCodec.encode({ name: "John", age: 42, verified: true });
+const bytes = personCodec.encode({ name: 'John', age: 42, verified: true });
 const person = personCodec.decode(bytes);
 ```
 
@@ -110,45 +131,45 @@ Whilst Codecs can both encode and decode, it is possible to only focus on encodi
 
 ```ts twoslash
 import {
-  Encoder,
-  addEncoderSizePrefix,
-  getUtf8Encoder,
-  getU32Encoder,
-  getStructEncoder,
-  getBooleanEncoder,
-} from "@solana/kit";
+    Encoder,
+    addEncoderSizePrefix,
+    getUtf8Encoder,
+    getU32Encoder,
+    getStructEncoder,
+    getBooleanEncoder,
+} from '@solana/kit';
 type Person = { name: string; age: number; verified: boolean };
 // ---cut-before---
 const getPersonEncoder = (): Encoder<Person> =>
-  getStructEncoder([
-    ["name", addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
-    ["age", getU32Encoder()],
-    ["verified", getBooleanEncoder()],
-  ]);
+    getStructEncoder([
+        ['name', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+        ['age', getU32Encoder()],
+        ['verified', getBooleanEncoder()],
+    ]);
 
-const bytes = getPersonEncoder().encode({ name: "John", age: 42, verified: true });
+const bytes = getPersonEncoder().encode({ name: 'John', age: 42, verified: true });
 ```
 
 The same can be done for decoding the `Person` type by using Decoders like so.
 
 ```ts twoslash
 import {
-  Decoder,
-  addDecoderSizePrefix,
-  getUtf8Decoder,
-  getU32Decoder,
-  getStructDecoder,
-  getBooleanDecoder,
-} from "@solana/kit";
+    Decoder,
+    addDecoderSizePrefix,
+    getUtf8Decoder,
+    getU32Decoder,
+    getStructDecoder,
+    getBooleanDecoder,
+} from '@solana/kit';
 type Person = { name: string; age: number; verified: boolean };
 const bytes = null as unknown as Uint8Array;
 // ---cut-before---
 const getPersonDecoder = (): Decoder<Person> =>
-  getStructDecoder([
-    ["name", addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
-    ["age", getU32Decoder()],
-    ["verified", getBooleanDecoder()],
-  ]);
+    getStructDecoder([
+        ['name', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+        ['age', getU32Decoder()],
+        ['verified', getBooleanDecoder()],
+    ]);
 
 const person = getPersonDecoder().decode(bytes);
 ```
@@ -160,7 +181,7 @@ Separating Codecs into Encoders and Decoders is particularly good practice for l
 That's why this library offers a `combineCodec` helper that creates a `Codec` instance from a matching `Encoder` and `Decoder`.
 
 ```ts twoslash
-import { Codec, Encoder, Decoder, combineCodec } from "@solana/kit";
+import { Codec, Encoder, Decoder, combineCodec } from '@solana/kit';
 type Person = { name: string; age: number; verified: boolean };
 const getPersonEncoder = null as unknown as () => Encoder<Person>;
 const getPersonDecoder = null as unknown as () => Decoder<Person>;
@@ -175,8 +196,8 @@ type MyType = /* ... */;
 const getMyTypeEncoder = (): Encoder<MyType> => { /* ... */ };
 const getMyTypeDecoder = (): Decoder<MyType> => { /* ... */ };
 const getMyTypeCodec = (): Codec<MyType> => combineCodec(
-  getMyTypeEncoder(),
-  getMyTypeDecoder()
+    getMyTypeEncoder(),
+    getMyTypeDecoder(),
 );
 ```
 
@@ -185,7 +206,7 @@ const getMyTypeCodec = (): Codec<MyType> => combineCodec(
 When creating codecs, the encoded type is allowed to be looser than the decoded type. A good example of that is the u64 number codec:
 
 ```ts twoslash
-import { Codec, getU64Codec } from "@solana/kit";
+import { Codec, getU64Codec } from '@solana/kit';
 // ---cut-before---
 const u64Codec: Codec<number | bigint, bigint> = getU64Codec();
 ```
@@ -193,7 +214,7 @@ const u64Codec: Codec<number | bigint, bigint> = getU64Codec();
 As you can see, the first type parameter is looser since it accepts numbers or big integers, whereas the second type parameter only accepts big integers. That's because when _encoding_ a u64 number, you may provide either a `bigint` or a `number` for convenience. However, when you decode a u64 number, you will always get a `bigint` because not all u64 values can fit in a JavaScript `number` type.
 
 ```ts twoslash
-import { getU64Codec } from "@solana/kit";
+import { getU64Codec } from '@solana/kit';
 const u64Codec = getU64Codec();
 // ---cut-before---
 const bytes = u64Codec.encode(42);
@@ -206,40 +227,41 @@ Here's another example using an object with default values. You can read more ab
 
 ```ts twoslash
 import {
-  Codec,
-  Encoder,
-  Decoder,
-  transformEncoder,
-  getStructEncoder,
-  getStructDecoder,
-  addEncoderSizePrefix,
-  addDecoderSizePrefix,
-  getUtf8Encoder,
-  getUtf8Decoder,
-  getU32Encoder,
-  getU32Decoder,
-  combineCodec,
-} from "@solana/kit";
+    Codec,
+    Encoder,
+    Decoder,
+    transformEncoder,
+    getStructEncoder,
+    getStructDecoder,
+    addEncoderSizePrefix,
+    addDecoderSizePrefix,
+    getUtf8Encoder,
+    getUtf8Decoder,
+    getU32Encoder,
+    getU32Decoder,
+    combineCodec,
+} from '@solana/kit';
 // ---cut-before---
 type Person = { name: string; age: number };
 type PersonInput = { name: string; age?: number };
 
 const getPersonEncoder = (): Encoder<PersonInput> =>
-  transformEncoder(
-    getStructEncoder([
-      ["name", addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
-      ["age", getU32Encoder()],
-    ]),
-    (input) => ({ ...input, age: input.age ?? 42 }),
-  );
+    transformEncoder(
+        getStructEncoder([
+            ['name', addEncoderSizePrefix(getUtf8Encoder(), getU32Encoder())],
+            ['age', getU32Encoder()],
+        ]),
+        (input) => ({ ...input, age: input.age ?? 42 }),
+    );
 
 const getPersonDecoder = (): Decoder<Person> =>
-  getStructDecoder([
-    ["name", addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
-    ["age", getU32Decoder()],
-  ]);
+    getStructDecoder([
+        ['name', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+        ['age', getU32Decoder()],
+    ]);
 
-const getPersonCodec = (): Codec<PersonInput, Person> => combineCodec(getPersonEncoder(), getPersonDecoder());
+const getPersonCodec = (): Codec<PersonInput, Person> =>
+    combineCodec(getPersonEncoder(), getPersonDecoder());
 ```
 
 ## Fixed-size and variable-size codecs
@@ -249,7 +271,7 @@ It is also worth noting that Codecs can either be of fixed size or variable size
 `FixedSizeCodecs` have a `fixedSize` number attribute that tells us exactly how big their encoded data is in bytes.
 
 ```ts twoslash
-import { FixedSizeCodec, getU32Codec } from "@solana/kit";
+import { FixedSizeCodec, getU32Codec } from '@solana/kit';
 // ---cut-before---
 const myCodec = getU32Codec();
 myCodec satisfies FixedSizeCodec<number>;
@@ -259,11 +281,11 @@ myCodec.fixedSize; // 4 bytes.
 On the other hand, `VariableSizeCodecs` do not know the size of their encoded data in advance. Instead, they will grab that information either from the provided encoded data or from the value to encode. For the former, we can simply access the length of the `Uint8Array`. For the latter, it provides a `getSizeFromValue` that tells us the encoded byte size of the provided value.
 
 ```ts twoslash
-import { VariableSizeCodec, getUtf8Codec, getU32Codec, addCodecSizePrefix } from "@solana/kit";
+import { VariableSizeCodec, getUtf8Codec, getU32Codec, addCodecSizePrefix } from '@solana/kit';
 // ---cut-before---
 const myCodec = addCodecSizePrefix(getUtf8Codec(), getU32Codec());
 myCodec satisfies VariableSizeCodec<string>;
-myCodec.getSizeFromValue("hello world"); // 4 + 11 bytes.
+myCodec.getSizeFromValue('hello world'); // 4 + 11 bytes.
 ```
 
 Also note that, if the `VariableSizeCodec` is bounded by a maximum size, it can be provided as a `maxSize` number attribute.
@@ -287,77 +309,77 @@ The `read` function accepts the `bytes` to decode from and the `offset` at each 
 - The second item should be the next offset to read from.
 
 ```ts twoslash
-import { createCodec, Offset } from "@solana/kit";
-const write = null as unknown as Parameters<typeof createCodec<number>>[0]["write"];
+import { createCodec, Offset } from '@solana/kit';
+const write = null as unknown as Parameters<typeof createCodec<number>>[0]['write'];
 const fixedSize = null as unknown as 1;
 // ---cut-before---
 createCodec({
-  read(bytes, offset) {
-    const value = bytes[offset];
-    return [value, offset + 1];
-  },
-  write,
-  fixedSize,
+    read(bytes, offset) {
+        const value = bytes[offset];
+        return [value, offset + 1];
+    },
+    write,
+    fixedSize,
 });
 ```
 
 Reciprocally, the `write` function accepts the `value` to encode, the array of `bytes` to write the encoded value to and the `offset` at which it should be written. It should encode the given value, insert it in the byte array, and provide the next offset to write to as the return value.
 
 ```ts twoslash
-import { createCodec } from "@solana/kit";
-const read = null as unknown as Parameters<typeof createCodec<number>>[0]["read"];
+import { createCodec } from '@solana/kit';
+const read = null as unknown as Parameters<typeof createCodec<number>>[0]['read'];
 const fixedSize = null as unknown as 1;
 // ---cut-before---
 createCodec({
-  write(value: number, bytes, offset) {
-    bytes.set([value], offset);
-    return offset + 1;
-  },
-  read,
-  fixedSize,
+    write(value: number, bytes, offset) {
+        bytes.set([value], offset);
+        return offset + 1;
+    },
+    read,
+    fixedSize,
 });
 ```
 
 Additionally, we must specify the size of the codec. If we are defining a `FixedSizeCodec`, we must simply provide the `fixedSize` number attribute. For `VariableSizeCodecs`, we must provide the `getSizeFromValue` function as described in the previous section.
 
 ```ts twoslash
-import { createCodec } from "@solana/kit";
+import { createCodec } from '@solana/kit';
 type Config = Parameters<typeof createCodec<string>>[0];
-const read = null as unknown as Config["read"];
-const write = null as unknown as Config["write"];
+const read = null as unknown as Config['read'];
+const write = null as unknown as Config['write'];
 // ---cut-before---
 // FixedSizeCodec.
 createCodec({
-  fixedSize: 1,
-  read,
-  write,
+    fixedSize: 1,
+    read,
+    write,
 });
 
 // VariableSizeCodec.
 createCodec({
-  getSizeFromValue: (value: string) => value.length,
-  read,
-  write,
+    getSizeFromValue: (value: string) => value.length,
+    read,
+    write,
 });
 ```
 
 Here's a concrete example of a custom codec that encodes any unsigned integer in a single byte. Since a single byte can only store integers from 0 to 255, if any other integer is provided it will take its modulo 256 to ensure it fits in a single byte. Because it always requires a single byte, that codec is a `FixedSizeCodec` of size `1`.
 
 ```ts twoslash
-import { createCodec } from "@solana/kit";
+import { createCodec } from '@solana/kit';
 
 const getModuloU8Codec = () =>
-  createCodec<number>({
-    fixedSize: 1,
-    read(bytes, offset) {
-      const value = bytes[offset];
-      return [value, offset + 1];
-    },
-    write(value, bytes, offset) {
-      bytes.set([value % 256], offset);
-      return offset + 1;
-    },
-  });
+    createCodec<number>({
+        fixedSize: 1,
+        read(bytes, offset) {
+            const value = bytes[offset];
+            return [value, offset + 1];
+        },
+        write(value, bytes, offset) {
+            bytes.set([value % 256], offset);
+            return offset + 1;
+        },
+    });
 ```
 
 Note that, it is also possible to create custom encoders and decoders separately by using the `createEncoder` and `createDecoder` functions respectively and then use the `combineCodec` function on them just like we were doing with composed codecs.
@@ -367,25 +389,25 @@ This approach is recommended to library maintainers as it allows their users to 
 Here's our previous modulo u8 example but split into separate `Encoder`, `Decoder` and `Codec` instances.
 
 ```ts twoslash
-import { createEncoder, createDecoder, combineCodec } from "@solana/kit";
+import { createEncoder, createDecoder, combineCodec } from '@solana/kit';
 
 const getModuloU8Encoder = () =>
-  createEncoder<number>({
-    fixedSize: 1,
-    write(value, bytes, offset) {
-      bytes.set([value % 256], offset);
-      return offset + 1;
-    },
-  });
+    createEncoder<number>({
+        fixedSize: 1,
+        write(value, bytes, offset) {
+            bytes.set([value % 256], offset);
+            return offset + 1;
+        },
+    });
 
 const getModuloU8Decoder = () =>
-  createDecoder<number>({
-    fixedSize: 1,
-    read(bytes, offset) {
-      const value = bytes[offset];
-      return [value, offset + 1];
-    },
-  });
+    createDecoder<number>({
+        fixedSize: 1,
+        read(bytes, offset) {
+            const value = bytes[offset];
+            return [value, offset + 1];
+        },
+    });
 
 const getModuloU8Codec = () => combineCodec(getModuloU8Encoder(), getModuloU8Decoder());
 ```
@@ -393,27 +415,27 @@ const getModuloU8Codec = () => combineCodec(getModuloU8Encoder(), getModuloU8Dec
 Here's another example returning a `VariableSizeCodec`. This one transforms a simple string composed of characters from `a` to `z` to a buffer of numbers from `1` to `26` where `0` bytes are spaces.
 
 ```ts twoslash
-import { createEncoder, createDecoder, combineCodec } from "@solana/kit";
+import { createEncoder, createDecoder, combineCodec } from '@solana/kit';
 
-const alphabet = " abcdefghijklmnopqrstuvwxyz";
+const alphabet = ' abcdefghijklmnopqrstuvwxyz';
 
 const getCipherEncoder = () =>
-  createEncoder<string>({
-    getSizeFromValue: (value) => value.length,
-    write(value, bytes, offset) {
-      const bytesToAdd = [...value].map((char) => alphabet.indexOf(char));
-      bytes.set(bytesToAdd, offset);
-      return offset + bytesToAdd.length;
-    },
-  });
+    createEncoder<string>({
+        getSizeFromValue: (value) => value.length,
+        write(value, bytes, offset) {
+            const bytesToAdd = [...value].map((char) => alphabet.indexOf(char));
+            bytes.set(bytesToAdd, offset);
+            return offset + bytesToAdd.length;
+        },
+    });
 
 const getCipherDecoder = () =>
-  createDecoder<string>({
-    read(bytes, offset) {
-      const value = [...bytes.slice(offset)].map((byte) => alphabet.charAt(byte)).join("");
-      return [value, bytes.length];
-    },
-  });
+    createDecoder<string>({
+        read(bytes, offset) {
+            const value = [...bytes.slice(offset)].map((byte) => alphabet.charAt(byte)).join('');
+            return [value, bytes.length];
+        },
+    });
 
 const getCipherCodec = () => combineCodec(getCipherEncoder(), getCipherDecoder());
 ```
@@ -506,10 +528,10 @@ const getCipherCodec = () => combineCodec(getCipherEncoder(), getCipherDecoder()
 One way of delimiting the size of a codec is to use sentinels. The `addCodecSentinel` function allows us to add a sentinel to the end of the encoded data and to read until that sentinel is found when decoding. It accepts any codec and a `Uint8Array` sentinel responsible for delimiting the encoded data.
 
 ```ts twoslash
-import { addCodecSentinel, getUtf8Codec } from "@solana/kit";
+import { addCodecSentinel, getUtf8Codec } from '@solana/kit';
 // ---cut-before---
 const codec = addCodecSentinel(getUtf8Codec(), new Uint8Array([255, 255]));
-codec.encode("hello");
+codec.encode('hello');
 // 0x68656c6c6fffff
 //   |        └-- Our sentinel.
 //   └-- Our encoded string.
@@ -518,22 +540,27 @@ codec.encode("hello");
 Note that the sentinel _must not_ be present in the encoded data and _must_ be present in the decoded data for this to work. If this is not the case, dedicated errors will be thrown.
 
 ```ts twoslash
-import { addCodecSentinel, getUtf8Codec } from "@solana/kit";
+import { addCodecSentinel, getUtf8Codec } from '@solana/kit';
 // ---cut-before---
 const sentinel = new Uint8Array([108, 108]); // 'll'
 const codec = addCodecSentinel(getUtf8Codec(), sentinel);
 
-codec.encode("hello"); // Throws: sentinel is in encoded data.
+codec.encode('hello'); // Throws: sentinel is in encoded data.
 codec.decode(new Uint8Array([1, 2, 3])); // Throws: sentinel missing in decoded data.
 ```
 
 Separate `addEncoderSentinel` and `addDecoderSentinel` functions are also available.
 
 ```ts twoslash
-import { addEncoderSentinel, addDecoderSentinel, getUtf8Encoder, getUtf8Decoder } from "@solana/kit";
+import {
+    addEncoderSentinel,
+    addDecoderSentinel,
+    getUtf8Encoder,
+    getUtf8Decoder,
+} from '@solana/kit';
 const sentinel = null as unknown as Uint8Array;
 // ---cut-before---
-const bytes = addEncoderSentinel(getUtf8Encoder(), sentinel).encode("hello");
+const bytes = addEncoderSentinel(getUtf8Encoder(), sentinel).encode('hello');
 const value = addDecoderSentinel(getUtf8Decoder(), sentinel).decode(bytes);
 ```
 
@@ -546,11 +573,11 @@ When encoding, the size of the encoded data is stored before the encoded data it
 For example, say we want to represent a variable-size base-58 string using a `u32` size prefix. Here's how we can use the `addCodecSizePrefix` function to achieve that.
 
 ```ts twoslash
-import { addCodecSizePrefix, getBase58Codec, getU32Codec } from "@solana/kit";
+import { addCodecSizePrefix, getBase58Codec, getU32Codec } from '@solana/kit';
 // ---cut-before---
 const getU32Base58Codec = () => addCodecSizePrefix(getBase58Codec(), getU32Codec());
 
-getU32Base58Codec().encode("hello world");
+getU32Base58Codec().encode('hello world');
 // 0x0b00000068656c6c6f20776f726c64
 //   |       └-- Our encoded base-58 string.
 //   └-- Our encoded u32 size prefix.
@@ -560,14 +587,14 @@ You may also use the `addEncoderSizePrefix` and `addDecoderSizePrefix` functions
 
 ```ts twoslash
 import {
-  addEncoderSizePrefix,
-  addDecoderSizePrefix,
-  getBase58Encoder,
-  getBase58Decoder,
-  getU32Encoder,
-  getU32Decoder,
-  combineCodec,
-} from "@solana/kit";
+    addEncoderSizePrefix,
+    addDecoderSizePrefix,
+    getBase58Encoder,
+    getBase58Decoder,
+    getU32Encoder,
+    getU32Decoder,
+    combineCodec,
+} from '@solana/kit';
 // ---cut-before---
 const getU32Base58Encoder = () => addEncoderSizePrefix(getBase58Encoder(), getU32Encoder());
 const getU32Base58Decoder = () => addDecoderSizePrefix(getBase58Decoder(), getU32Decoder());
@@ -579,7 +606,7 @@ const getU32Base58Codec = () => combineCodec(getU32Base58Encoder(), getU32Base58
 Checks if a `Uint8Array` contains another `Uint8Array` at a given offset.
 
 ```ts twoslash
-import { containsBytes } from "@solana/kit";
+import { containsBytes } from '@solana/kit';
 // ---cut-before---
 containsBytes(new Uint8Array([1, 2, 3, 4]), new Uint8Array([2, 3]), 1); // true
 containsBytes(new Uint8Array([1, 2, 3, 4]), new Uint8Array([2, 3]), 2); // false
@@ -590,7 +617,7 @@ containsBytes(new Uint8Array([1, 2, 3, 4]), new Uint8Array([2, 3]), 2); // false
 Pads or truncates a `Uint8Array` so it has the specified length.
 
 ```ts twoslash
-import { fixBytes } from "@solana/kit";
+import { fixBytes } from '@solana/kit';
 // ---cut-before---
 fixBytes(new Uint8Array([1, 2]), 4); // Uint8Array([1, 2, 0, 0])
 fixBytes(new Uint8Array([1, 2, 3, 4]), 2); // Uint8Array([1, 2])
@@ -603,7 +630,7 @@ The `fixCodecSize` function allows us to bind the size of a given codec to the g
 For instance, say we wanted to represent a base-58 string that uses exactly 32 bytes when decoded. Here's how we can use the `fixCodecSize` helper to achieve that.
 
 ```ts twoslash
-import { fixCodecSize, getBase58Codec } from "@solana/kit";
+import { fixCodecSize, getBase58Codec } from '@solana/kit';
 // ---cut-before---
 const get32BytesBase58Codec = () => fixCodecSize(getBase58Codec(), 32);
 ```
@@ -611,11 +638,18 @@ const get32BytesBase58Codec = () => fixCodecSize(getBase58Codec(), 32);
 You may also use the `fixEncoderSize` and `fixDecoderSize` functions to separate your codec logic like so:
 
 ```ts twoslash
-import { fixEncoderSize, fixDecoderSize, getBase58Encoder, getBase58Decoder, combineCodec } from "@solana/kit";
+import {
+    fixEncoderSize,
+    fixDecoderSize,
+    getBase58Encoder,
+    getBase58Decoder,
+    combineCodec,
+} from '@solana/kit';
 // ---cut-before---
 const get32BytesBase58Encoder = () => fixEncoderSize(getBase58Encoder(), 32);
 const get32BytesBase58Decoder = () => fixDecoderSize(getBase58Decoder(), 32);
-const get32BytesBase58Codec = () => combineCodec(get32BytesBase58Encoder(), get32BytesBase58Decoder());
+const get32BytesBase58Codec = () =>
+    combineCodec(get32BytesBase58Encoder(), get32BytesBase58Decoder());
 ```
 
 ### mergeBytes [!toc] [#merge-bytes]
@@ -623,7 +657,7 @@ const get32BytesBase58Codec = () => combineCodec(get32BytesBase58Encoder(), get3
 Concatenates an array of `Uint8Arrays` into a single `Uint8Array`.
 
 ```ts twoslash
-import { mergeBytes } from "@solana/kit";
+import { mergeBytes } from '@solana/kit';
 // ---cut-before---
 const bytes1 = new Uint8Array([0x01, 0x02]);
 const bytes2 = new Uint8Array([]);
@@ -639,7 +673,7 @@ The `offsetCodec` function is a powerful codec primitive that allows us to move 
 To understand how this works, let's take the following `biggerU32Codec` example which encodes a `u32` number inside an 8-byte buffer by using the [resizeCodec](#resize-codec) helper.
 
 ```ts twoslash
-import { resizeCodec, getU32Codec } from "@solana/kit";
+import { resizeCodec, getU32Codec } from '@solana/kit';
 // ---cut-before---
 const biggerU32Codec = resizeCodec(getU32Codec(), (size) => size + 4);
 biggerU32Codec.encode(0xffffffff);
@@ -651,11 +685,11 @@ biggerU32Codec.encode(0xffffffff);
 Now, let's say we want to move the offset of that codec 2 bytes forward so that the encoded number sits in the middle of the buffer. To achieve, this we can use the `offsetCodec` helper and provide a `preOffset` function that moves the "pre-offset" of the codec 2 bytes forward.
 
 ```ts twoslash
-import { offsetCodec, resizeCodec, getU32Codec } from "@solana/kit";
+import { offsetCodec, resizeCodec, getU32Codec } from '@solana/kit';
 const biggerU32Codec = resizeCodec(getU32Codec(), (size) => size + 4);
 // ---cut-before---
 const u32InTheMiddleCodec = offsetCodec(biggerU32Codec, {
-  preOffset: ({ preOffset }) => preOffset + 2,
+    preOffset: ({ preOffset }) => preOffset + 2,
 });
 u32InTheMiddleCodec.encode(0xffffffff);
 // 0x0000ffffffff0000
@@ -667,11 +701,11 @@ We refer to this offset as the "pre-offset" because, once the inner codec is enc
 By default, that "post-offset" is simply the addition of the "pre-offset" and the size of the encoded or decoded inner data.
 
 ```ts twoslash
-import { offsetCodec, resizeCodec, getU32Codec } from "@solana/kit";
+import { offsetCodec, resizeCodec, getU32Codec } from '@solana/kit';
 const biggerU32Codec = resizeCodec(getU32Codec(), (size) => size + 4);
 // ---cut-before---
 const u32InTheMiddleCodec = offsetCodec(biggerU32Codec, {
-  preOffset: ({ preOffset }) => preOffset + 2,
+    preOffset: ({ preOffset }) => preOffset + 2,
 });
 u32InTheMiddleCodec.encode(0xffffffff);
 // 0x0000ffffffff0000
@@ -683,12 +717,12 @@ u32InTheMiddleCodec.encode(0xffffffff);
 However, you may also provide a `postOffset` function to adjust the "post-offset". For instance, let's push the "post-offset" 2 bytes forward as well such that any further codecs will start doing their job at the end of our 8-byte `u32` number.
 
 ```ts twoslash
-import { offsetCodec, resizeCodec, getU32Codec } from "@solana/kit";
+import { offsetCodec, resizeCodec, getU32Codec } from '@solana/kit';
 const biggerU32Codec = resizeCodec(getU32Codec(), (size) => size + 4);
 // ---cut-before---
 const u32InTheMiddleCodec = offsetCodec(biggerU32Codec, {
-  preOffset: ({ preOffset }) => preOffset + 2,
-  postOffset: ({ postOffset }) => postOffset + 2,
+    preOffset: ({ preOffset }) => preOffset + 2,
+    postOffset: ({ postOffset }) => postOffset + 2,
 });
 u32InTheMiddleCodec.encode(0xffffffff);
 // 0x0000ffffffff0000
@@ -712,12 +746,12 @@ Additionally, the post-offset function also provides the following attributes:
 Note that you may also decide to ignore these attributes to achieve absolute offsets. However, relative offsets are usually recommended as they won't break your codecs when composed with other codecs.
 
 ```ts twoslash
-import { offsetCodec, resizeCodec, getU32Codec } from "@solana/kit";
+import { offsetCodec, resizeCodec, getU32Codec } from '@solana/kit';
 const biggerU32Codec = resizeCodec(getU32Codec(), (size) => size + 4);
 // ---cut-before---
 const u32InTheMiddleCodec = offsetCodec(biggerU32Codec, {
-  preOffset: () => 2,
-  postOffset: () => 8,
+    preOffset: () => 2,
+    postOffset: () => 8,
 });
 u32InTheMiddleCodec.encode(0xffffffff);
 // 0x0000ffffffff0000
@@ -726,7 +760,7 @@ u32InTheMiddleCodec.encode(0xffffffff);
 Also note that any negative offset or offset that exceeds the size of the byte array will throw a `SolanaError` of code `SOLANA_ERROR__CODECS__OFFSET_OUT_OF_RANGE`.
 
 ```ts twoslash
-import { offsetCodec, resizeCodec, getU32Codec } from "@solana/kit";
+import { offsetCodec, resizeCodec, getU32Codec } from '@solana/kit';
 const biggerU32Codec = resizeCodec(getU32Codec(), (size) => size + 4);
 // ---cut-before---
 const u32InTheEndCodec = offsetCodec(biggerU32Codec, { preOffset: () => -4 });
@@ -737,11 +771,11 @@ u32InTheEndCodec.encode(0xffffffff);
 To avoid this, you may use the `wrapBytes` function to wrap the offset around the byte array length. For instance, here's how we can use the `wrapBytes` function to move the pre-offset 4 bytes from the end of the byte array.
 
 ```ts twoslash
-import { offsetCodec, resizeCodec, getU32Codec } from "@solana/kit";
+import { offsetCodec, resizeCodec, getU32Codec } from '@solana/kit';
 const biggerU32Codec = resizeCodec(getU32Codec(), (size) => size + 4);
 // ---cut-before---
 const u32InTheEndCodec = offsetCodec(biggerU32Codec, {
-  preOffset: ({ wrapBytes }) => wrapBytes(-4),
+    preOffset: ({ wrapBytes }) => wrapBytes(-4),
 });
 u32InTheEndCodec.encode(0xffffffff);
 // 0x00000000ffffffff
@@ -753,20 +787,23 @@ The `offsetEncoder` and `offsetDecoder` functions can also be used to split your
 
 ```ts twoslash
 import {
-  offsetEncoder,
-  resizeEncoder,
-  getU32Encoder,
-  offsetDecoder,
-  resizeDecoder,
-  getU32Decoder,
-  combineCodec,
-} from "@solana/kit";
+    offsetEncoder,
+    resizeEncoder,
+    getU32Encoder,
+    offsetDecoder,
+    resizeDecoder,
+    getU32Decoder,
+    combineCodec,
+} from '@solana/kit';
 const biggerU32Encoder = resizeEncoder(getU32Encoder(), (size) => size + 4);
 const biggerU32Decoder = resizeDecoder(getU32Decoder(), (size) => size + 4);
 // ---cut-before---
-const getU32InTheMiddleEncoder = () => offsetEncoder(biggerU32Encoder, { preOffset: ({ preOffset }) => preOffset + 2 });
-const getU32InTheMiddleDecoder = () => offsetDecoder(biggerU32Decoder, { preOffset: ({ preOffset }) => preOffset + 2 });
-const getU32InTheMiddleCodec = () => combineCodec(getU32InTheMiddleEncoder(), getU32InTheMiddleDecoder());
+const getU32InTheMiddleEncoder = () =>
+    offsetEncoder(biggerU32Encoder, { preOffset: ({ preOffset }) => preOffset + 2 });
+const getU32InTheMiddleDecoder = () =>
+    offsetDecoder(biggerU32Decoder, { preOffset: ({ preOffset }) => preOffset + 2 });
+const getU32InTheMiddleCodec = () =>
+    combineCodec(getU32InTheMiddleEncoder(), getU32InTheMiddleDecoder());
 ```
 
 ### padBytes [!toc] [#pad-bytes]
@@ -774,7 +811,7 @@ const getU32InTheMiddleCodec = () => combineCodec(getU32InTheMiddleEncoder(), ge
 Pads a `Uint8Array` with zeroes (to the right) to the specified length.
 
 ```ts twoslash
-import { padBytes } from "@solana/kit";
+import { padBytes } from '@solana/kit';
 // ---cut-before---
 padBytes(new Uint8Array([1, 2]), 4); // Uint8Array([1, 2, 0, 0])
 padBytes(new Uint8Array([1, 2, 3, 4]), 2); // Uint8Array([1, 2, 3, 4])
@@ -785,7 +822,7 @@ padBytes(new Uint8Array([1, 2, 3, 4]), 2); // Uint8Array([1, 2, 3, 4])
 The `padLeftCodec` helper can be used to add padding to the left of a given codec. It accepts an `offset` number that tells us how big the padding should be.
 
 ```ts twoslash
-import { padLeftCodec, getU16Codec } from "@solana/kit";
+import { padLeftCodec, getU16Codec } from '@solana/kit';
 // ---cut-before---
 const leftPaddedCodec = padLeftCodec(getU16Codec(), 4);
 leftPaddedCodec.encode(0xffff);
@@ -799,7 +836,13 @@ Note that the `padLeftCodec` function is a simple wrapper around the `offsetCode
 Encoder-only and decoder-only helpers are available for these padding functions.
 
 ```ts twoslash
-import { padLeftEncoder, padLeftDecoder, getU16Encoder, getU16Decoder, combineCodec } from "@solana/kit";
+import {
+    padLeftEncoder,
+    padLeftDecoder,
+    getU16Encoder,
+    getU16Decoder,
+    combineCodec,
+} from '@solana/kit';
 // ---cut-before---
 const getMyPaddedEncoder = () => padLeftEncoder(getU16Encoder(), 6);
 const getMyPaddedDecoder = () => padLeftDecoder(getU16Decoder(), 6);
@@ -811,7 +854,7 @@ const getMyPaddedCodec = () => combineCodec(getMyPaddedEncoder(), getMyPaddedDec
 The `padRightCodec` helper can be used to add padding to the right of a given codec. It accepts an `offset` number that tells us how big the padding should be.
 
 ```ts twoslash
-import { padRightCodec, getU16Codec } from "@solana/kit";
+import { padRightCodec, getU16Codec } from '@solana/kit';
 // ---cut-before---
 const rightPaddedCodec = padRightCodec(getU16Codec(), 4);
 rightPaddedCodec.encode(0xffff);
@@ -825,7 +868,13 @@ Note that the `padRightCodec` function is a simple wrapper around the `offsetCod
 Encoder-only and decoder-only helpers are available for these padding functions.
 
 ```ts twoslash
-import { padRightEncoder, padRightDecoder, getU16Encoder, getU16Decoder, combineCodec } from "@solana/kit";
+import {
+    padRightEncoder,
+    padRightDecoder,
+    getU16Encoder,
+    getU16Decoder,
+    combineCodec,
+} from '@solana/kit';
 // ---cut-before---
 const getMyPaddedEncoder = () => padRightEncoder(getU16Encoder(), 6);
 const getMyPaddedDecoder = () => padRightDecoder(getU16Decoder(), 6);
@@ -837,7 +886,7 @@ const getMyPaddedCodec = () => combineCodec(getMyPaddedEncoder(), getMyPaddedDec
 The `resizeCodec` helper re-defines the size of a given codec by accepting a function that takes the current size of the codec and returns a new size. This works for both fixed-size and variable-size codecs.
 
 ```ts twoslash
-import { resizeCodec, getU32Codec, getUtf8Codec } from "@solana/kit";
+import { resizeCodec, getU32Codec, getUtf8Codec } from '@solana/kit';
 // ---cut-before---
 // Fixed-size codec.
 const getBiggerU32Codec = () => resizeCodec(getU32Codec(), (size) => size + 4);
@@ -848,7 +897,7 @@ getBiggerU32Codec().encode(42);
 
 // Variable-size codec.
 const getBiggerUtf8Codec = () => resizeCodec(getUtf8Codec(), (size) => size + 4);
-getBiggerUtf8Codec().encode("ABC");
+getBiggerUtf8Codec().encode('ABC');
 // 0x41424300000000
 //   |     └-- Empty buffer space caused by the resizeCodec function.
 //   └-- Our encoded string.
@@ -857,7 +906,7 @@ getBiggerUtf8Codec().encode("ABC");
 Note that the `resizeCodec` function doesn't change any encoded or decoded bytes, it merely tells the `encode` and `decode` functions how big the `Uint8Array` should be before delegating to their respective `write` and `read` functions. In fact, this is completely bypassed when using the `write` and `read` functions directly. For instance:
 
 ```ts twoslash
-import { resizeCodec, getU32Codec } from "@solana/kit";
+import { resizeCodec, getU32Codec } from '@solana/kit';
 // ---cut-before---
 const getBiggerU32Codec = () => resizeCodec(getU32Codec(), (size) => size + 4);
 
@@ -874,21 +923,28 @@ getBiggerU32Codec().write(42, myCustomBytes, 0);
 So when would it make sense to use the `resizeCodec` function? This function is particularly useful when combined with the [offsetCodec](#offset-codec) function. Whilst `offsetCodec` may help us push the offset forward — e.g. to skip some padding — it won't change the size of the encoded data which means the last bytes will be truncated by how much we pushed the offset forward. The `resizeCodec` function can be used to fix that. For instance, here's how we can use the `resizeCodec` and the `offsetCodec` functions together to create a struct codec that includes some padding.
 
 ```ts twoslash
-import { getStructCodec, getUtf8Codec, getU32Codec, offsetCodec, resizeCodec, fixCodecSize } from "@solana/kit";
+import {
+    getStructCodec,
+    getUtf8Codec,
+    getU32Codec,
+    offsetCodec,
+    resizeCodec,
+    fixCodecSize,
+} from '@solana/kit';
 // ---cut-before---
 const personCodec = getStructCodec([
-  ["name", fixCodecSize(getUtf8Codec(), 8)],
-  // There is a 4-byte padding between name and age.
-  [
-    "age",
-    offsetCodec(
-      resizeCodec(getU32Codec(), (size) => size + 4),
-      { preOffset: ({ preOffset }) => preOffset + 4 },
-    ),
-  ],
+    ['name', fixCodecSize(getUtf8Codec(), 8)],
+    // There is a 4-byte padding between name and age.
+    [
+        'age',
+        offsetCodec(
+            resizeCodec(getU32Codec(), (size) => size + 4),
+            { preOffset: ({ preOffset }) => preOffset + 4 },
+        ),
+    ],
 ]);
 
-personCodec.encode({ name: "Alice", age: 42 });
+personCodec.encode({ name: 'Alice', age: 42 });
 // 0x416c696365000000000000002a000000
 //   |               |       └-- Our encoded u32 (42).
 //   |               └-- The 4-bytes of padding we are skipping.
@@ -900,7 +956,13 @@ Note that this can be achieved using the [padLeftCodec](#pad-left-codec) helper 
 The `resizeEncoder` and `resizeDecoder` functions can also be used to split your codec logic into tree-shakeable functions.
 
 ```ts twoslash
-import { resizeEncoder, resizeDecoder, getU32Encoder, getU32Decoder, combineCodec } from "@solana/kit";
+import {
+    resizeEncoder,
+    resizeDecoder,
+    getU32Encoder,
+    getU32Decoder,
+    combineCodec,
+} from '@solana/kit';
 // ---cut-before---
 const getBiggerU32Encoder = () => resizeEncoder(getU32Encoder(), (size) => size + 4);
 const getBiggerU32Decoder = () => resizeDecoder(getU32Decoder(), (size) => size + 4);
@@ -912,7 +974,7 @@ const getBiggerU32Codec = () => combineCodec(getBiggerU32Encoder(), getBiggerU32
 The `reverseCodec` helper reverses the bytes of the provided `FixedSizeCodec`.
 
 ```ts twoslash
-import { reverseCodec, getU64Codec } from "@solana/kit";
+import { reverseCodec, getU64Codec } from '@solana/kit';
 // ---cut-before---
 const getBigEndianU64Codec = () => reverseCodec(getU64Codec());
 ```
@@ -920,7 +982,7 @@ const getBigEndianU64Codec = () => reverseCodec(getU64Codec());
 Note that number codecs can already do that for you via their `endian` option.
 
 ```ts twoslash
-import { getU64Codec, Endian } from "@solana/kit";
+import { getU64Codec, Endian } from '@solana/kit';
 // ---cut-before---
 const getBigEndianU64Codec = () => getU64Codec({ endian: Endian.Big });
 ```
@@ -928,7 +990,13 @@ const getBigEndianU64Codec = () => getU64Codec({ endian: Endian.Big });
 The `reverseEncoder` and `reverseDecoder` functions can also be used to achieve that.
 
 ```ts twoslash
-import { reverseEncoder, reverseDecoder, getU64Encoder, getU64Decoder, combineCodec } from "@solana/kit";
+import {
+    reverseEncoder,
+    reverseDecoder,
+    getU64Encoder,
+    getU64Decoder,
+    combineCodec,
+} from '@solana/kit';
 // ---cut-before---
 const getBigEndianU64Encoder = () => reverseEncoder(getU64Encoder());
 const getBigEndianU64Decoder = () => reverseDecoder(getU64Decoder());
@@ -942,16 +1010,16 @@ It is possible to transform a `Codec<T>` to a `Codec<U>` by providing two mappin
 For instance, here's how you would map a `u32` integer into a `string` representation of that number.
 
 ```ts twoslash
-import { transformCodec, getU32Codec } from "@solana/kit";
+import { transformCodec, getU32Codec } from '@solana/kit';
 // ---cut-before---
 const getStringU32Codec = () =>
-  transformCodec(
-    getU32Codec(),
-    (integerAsString: string): number => parseInt(integerAsString),
-    (integer: number): string => integer.toString(),
-  );
+    transformCodec(
+        getU32Codec(),
+        (integerAsString: string): number => parseInt(integerAsString),
+        (integer: number): string => integer.toString(),
+    );
 
-getStringU32Codec().encode("42"); // new Uint8Array([42])
+getStringU32Codec().encode('42'); // new Uint8Array([42])
 getStringU32Codec().decode(new Uint8Array([42])); // "42"
 ```
 
@@ -960,15 +1028,15 @@ If a `Codec` has [different From and To types](#different-from-and-to-types), sa
 To illustrate that, let's take our previous `getStringU32Codec` example but make it use a `getU64Codec` codec instead as it returns a `Codec<number | bigint, bigint>`. Additionally, let's make it so our `getStringU64Codec` function returns a `Codec<number | string, string>` so that it also accepts numbers when encoding values. Here's what our mapping functions look like:
 
 ```ts twoslash
-import { transformCodec, getU64Codec } from "@solana/kit";
+import { transformCodec, getU64Codec } from '@solana/kit';
 // ---cut-before---
 const getStringU64Codec = () =>
-  transformCodec(
-    getU64Codec(),
-    (integerInput: number | string): number | bigint =>
-      typeof integerInput === "string" ? BigInt(integerInput) : integerInput,
-    (integer: bigint): string => integer.toString(),
-  );
+    transformCodec(
+        getU64Codec(),
+        (integerInput: number | string): number | bigint =>
+            typeof integerInput === 'string' ? BigInt(integerInput) : integerInput,
+        (integer: bigint): string => integer.toString(),
+    );
 ```
 
 Note that the second function that maps the decoded type is optional. That means, you can omit it to simply update or loosen the type to encode whilst keeping the decoded type the same.
@@ -976,7 +1044,7 @@ Note that the second function that maps the decoded type is optional. That means
 This is particularly useful to provide default values to object structures. For instance, here's how we can map a `Person` codec to give a default value to its `age` attribute.
 
 ```ts twoslash
-import { transformCodec, getStructCodec, Codec } from "@solana/kit";
+import { transformCodec, getStructCodec, Codec } from '@solana/kit';
 // ---cut-before---
 type Person = { name: string; age: number };
 type PersonInput = { name: string; age?: number };
@@ -984,17 +1052,29 @@ type PersonInput = { name: string; age?: number };
 const getPersonCodec = null as unknown as () => Codec<Person>;
 // ---cut-end---
 const getPersonWithDefaultValueCodec = (): Codec<PersonInput, Person> =>
-  transformCodec(getPersonCodec(), (person: PersonInput): Person => ({ ...person, age: person.age ?? 42 }));
+    transformCodec(
+        getPersonCodec(),
+        (person: PersonInput): Person => ({ ...person, age: person.age ?? 42 }),
+    );
 ```
 
 Similar helpers exist to map `Encoder` and `Decoder` instances allowing you to separate your codec logic into tree-shakeable functions. Here's our `getStringU32Codec` written that way.
 
 ```ts twoslash
-import { transformEncoder, transformDecoder, getU32Encoder, getU32Decoder, combineCodec } from "@solana/kit";
+import {
+    transformEncoder,
+    transformDecoder,
+    getU32Encoder,
+    getU32Decoder,
+    combineCodec,
+} from '@solana/kit';
 // ---cut-before---
 const getStringU32Encoder = () =>
-  transformEncoder(getU32Encoder(), (integerAsString: string): number => parseInt(integerAsString));
-const getStringU32Decoder = () => transformDecoder(getU32Decoder(), (integer: number): string => integer.toString());
+    transformEncoder(getU32Encoder(), (integerAsString: string): number =>
+        parseInt(integerAsString),
+    );
+const getStringU32Decoder = () =>
+    transformDecoder(getU32Decoder(), (integer: number): string => integer.toString());
 const getStringU32Codec = () => combineCodec(getStringU32Encoder(), getStringU32Decoder());
 ```
 
@@ -1007,7 +1087,7 @@ Encodes and decodes **signed 8-bit integers**. It supports values from -127 (`-2
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`.
 
 ```ts twoslash
-import { getI8Codec } from "@solana/kit";
+import { getI8Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getI8Codec();
 const bytes = codec.encode(-42); // 0xd6
@@ -1023,7 +1103,7 @@ Encodes and decodes **signed 16-bit integers**. It supports values from -32,768 
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`. Endianness can be specified using the `endian` option. The default is `Endian.Little`.
 
 ```ts twoslash
-import { getI16Codec, Endian } from "@solana/kit";
+import { getI16Codec, Endian } from '@solana/kit';
 // ---cut-before---
 // Little-endian.
 const codec = getI16Codec();
@@ -1045,7 +1125,7 @@ Encodes and decodes **signed 32-bit integers**. It supports values from -2,147,4
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`. Endianness can be specified using the `endian` option. The default is `Endian.Little`.
 
 ```ts twoslash
-import { getI32Codec, Endian } from "@solana/kit";
+import { getI32Codec, Endian } from '@solana/kit';
 // ---cut-before---
 // Little-endian.
 const codec = getI32Codec();
@@ -1067,7 +1147,7 @@ Encodes and decodes **signed 64-bit integers**. It supports values from `-2^63` 
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `bigint`. Endianness can be specified using the `endian` option. The default is `Endian.Little`.
 
 ```ts twoslash
-import { getI64Codec, Endian } from "@solana/kit";
+import { getI64Codec, Endian } from '@solana/kit';
 // ---cut-before---
 // Little-endian.
 const codec = getI64Codec();
@@ -1089,7 +1169,7 @@ Encodes and decodes **signed 128-bit integers**. It supports values from `-2^127
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `bigint`. Endianness can be specified using the `endian` option. The default is `Endian.Little`.
 
 ```ts twoslash
-import { getI128Codec, Endian } from "@solana/kit";
+import { getI128Codec, Endian } from '@solana/kit';
 // ---cut-before---
 // Little-endian.
 const codec = getI128Codec();
@@ -1111,7 +1191,7 @@ Encodes and decodes **32-bit floating-point numbers**. Due to the [IEEE 754](htt
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`. Endianness can be specified using the `endian` option. The default is `Endian.Little`.
 
 ```ts twoslash
-import { getF32Codec, Endian } from "@solana/kit";
+import { getF32Codec, Endian } from '@solana/kit';
 // ---cut-before---
 // Little-endian.
 const codec = getF32Codec();
@@ -1133,7 +1213,7 @@ Encodes and decodes **64-bit floating-point numbers**. Due to the [IEEE 754](htt
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`. Endianness can be specified using the `endian` option. The default is `Endian.Little`.
 
 ```ts twoslash
-import { getF64Codec, Endian } from "@solana/kit";
+import { getF64Codec, Endian } from '@solana/kit';
 // ---cut-before---
 // Little-endian.
 const codec = getF64Codec();
@@ -1169,7 +1249,7 @@ In other words, the encoding scheme follows this structure:
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`.
 
 ```ts twoslash
-import { getShortU16Codec } from "@solana/kit";
+import { getShortU16Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getShortU16Codec();
 const bytes1 = codec.encode(42); // 0x2a
@@ -1190,7 +1270,7 @@ Encodes and decodes **unsigned 8-bit integers**. It supports values from 0 to 25
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`.
 
 ```ts twoslash
-import { getU8Codec } from "@solana/kit";
+import { getU8Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getU8Codec();
 const bytes = codec.encode(42); // 0x2a
@@ -1206,7 +1286,7 @@ Encodes and decodes **unsigned 16-bit integers**. It supports values from 0 to 6
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`. Endianness can be specified using the `endian` option. The default is `Endian.Little`.
 
 ```ts twoslash
-import { getU16Codec, Endian } from "@solana/kit";
+import { getU16Codec, Endian } from '@solana/kit';
 // ---cut-before---
 // Little-endian.
 const codec = getU16Codec();
@@ -1228,7 +1308,7 @@ Encodes and decodes **unsigned 32-bit integers**. It supports values from 0 to 4
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `number`. Endianness can be specified using the `endian` option. The default is `Endian.Little`.
 
 ```ts twoslash
-import { getU32Codec, Endian } from "@solana/kit";
+import { getU32Codec, Endian } from '@solana/kit';
 // ---cut-before---
 // Little-endian.
 const codec = getU32Codec();
@@ -1250,7 +1330,7 @@ Encodes and decodes **unsigned 64-bit integers**. It supports values from 0 to `
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `bigint`. Endianness can be specified using the `endian` option. The default is `Endian.Little`.
 
 ```ts twoslash
-import { getU64Codec, Endian } from "@solana/kit";
+import { getU64Codec, Endian } from '@solana/kit';
 // ---cut-before---
 // Little-endian.
 const codec = getU64Codec();
@@ -1272,7 +1352,7 @@ Encodes and decodes **unsigned 128-bit integers**. It supports values from 0 to 
 Values can be provided as either `number` or `bigint`, but the decoded value is always a `bigint`. Endianness can be specified using the `endian` option. The default is `Endian.Little`.
 
 ```ts twoslash
-import { getU128Codec, Endian } from "@solana/kit";
+import { getU128Codec, Endian } from '@solana/kit';
 // ---cut-before---
 // Little-endian.
 const codec = getU128Codec();
@@ -1294,27 +1374,33 @@ const beValue = beCodec.decode(bytes); // 42
 Encodes and decodes **Base 10 strings**.
 
 ```ts twoslash
-import { getBase10Codec } from "@solana/kit";
+import { getBase10Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getBase10Codec();
-const bytes = codec.encode("1024"); // 0x0400
+const bytes = codec.encode('1024'); // 0x0400
 const value = codec.decode(bytes); // "1024"
 ```
 
 This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string. To add size constraints to your codec, you may use utility functions such as [`fixCodecSize`](#fix-codec-size), [`addCodecSizePrefix`](#add-codec-size-prefix) or [`addCodecSentinel`](#add-codec-sentinel).
 
 ```ts twoslash
-import { getBase10Codec, fixCodecSize, addCodecSizePrefix, getU32Codec, addCodecSentinel } from "@solana/kit";
+import {
+    getBase10Codec,
+    fixCodecSize,
+    addCodecSizePrefix,
+    getU32Codec,
+    addCodecSentinel,
+} from '@solana/kit';
 // ---cut-before---
-fixCodecSize(getBase10Codec(), 4).encode("1024");
+fixCodecSize(getBase10Codec(), 4).encode('1024');
 // 0x04000000 (padded to 4 bytes)
 
-addCodecSizePrefix(getBase10Codec(), getU32Codec()).encode("1024");
+addCodecSizePrefix(getBase10Codec(), getU32Codec()).encode('1024');
 // 0x020000000400
 //   |       └-- The 2 bytes of content.
 //   └-- 4-byte prefix telling us to read 2 bytes.
 
-addCodecSentinel(getBase10Codec(), new Uint8Array([0xff, 0xff])).encode("1024");
+addCodecSentinel(getBase10Codec(), new Uint8Array([0xff, 0xff])).encode('1024');
 // 0x0400ffff
 //   |   └-- The sentinel signaling the end of the content.
 //   └-- The 2 bytes of content.
@@ -1327,27 +1413,33 @@ addCodecSentinel(getBase10Codec(), new Uint8Array([0xff, 0xff])).encode("1024");
 Encodes and decodes **Base 16 strings**.
 
 ```ts twoslash
-import { getBase16Codec } from "@solana/kit";
+import { getBase16Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getBase16Codec();
-const bytes = codec.encode("deadface"); // 0xdeadface
+const bytes = codec.encode('deadface'); // 0xdeadface
 const value = codec.decode(bytes); // "deadface"
 ```
 
 This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string. To add size constraints to your codec, you may use utility functions such as [`fixCodecSize`](#fix-codec-size), [`addCodecSizePrefix`](#add-codec-size-prefix) or [`addCodecSentinel`](#add-codec-sentinel).
 
 ```ts twoslash
-import { getBase16Codec, fixCodecSize, addCodecSizePrefix, getU32Codec, addCodecSentinel } from "@solana/kit";
+import {
+    getBase16Codec,
+    fixCodecSize,
+    addCodecSizePrefix,
+    getU32Codec,
+    addCodecSentinel,
+} from '@solana/kit';
 // ---cut-before---
-fixCodecSize(getBase16Codec(), 2).encode("deadface");
+fixCodecSize(getBase16Codec(), 2).encode('deadface');
 // 0xdead (truncated to 2 bytes)
 
-addCodecSizePrefix(getBase16Codec(), getU32Codec()).encode("deadface");
+addCodecSizePrefix(getBase16Codec(), getU32Codec()).encode('deadface');
 // 0x04000000deadface
 //   |       └-- The 4 bytes of content.
 //   └-- 4-byte prefix telling us to read 4 bytes.
 
-addCodecSentinel(getBase16Codec(), new Uint8Array([0xff, 0xff])).encode("deadface");
+addCodecSentinel(getBase16Codec(), new Uint8Array([0xff, 0xff])).encode('deadface');
 // 0xdeadfaceffff
 //   |       └-- The sentinel signaling the end of the content.
 //   └-- The 4 bytes of content.
@@ -1360,27 +1452,33 @@ addCodecSentinel(getBase16Codec(), new Uint8Array([0xff, 0xff])).encode("deadfac
 Encodes and decodes **Base 58 strings**.
 
 ```ts twoslash
-import { getBase58Codec } from "@solana/kit";
+import { getBase58Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getBase58Codec();
-const bytes = codec.encode("heLLo"); // 0x1b6a3070
+const bytes = codec.encode('heLLo'); // 0x1b6a3070
 const value = codec.decode(bytes); // "heLLo"
 ```
 
 This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string. To add size constraints to your codec, you may use utility functions such as [`fixCodecSize`](#fix-codec-size), [`addCodecSizePrefix`](#add-codec-size-prefix) or [`addCodecSentinel`](#add-codec-sentinel).
 
 ```ts twoslash
-import { getBase58Codec, fixCodecSize, addCodecSizePrefix, getU32Codec, addCodecSentinel } from "@solana/kit";
+import {
+    getBase58Codec,
+    fixCodecSize,
+    addCodecSizePrefix,
+    getU32Codec,
+    addCodecSentinel,
+} from '@solana/kit';
 // ---cut-before---
-fixCodecSize(getBase58Codec(), 2).encode("heLLo");
+fixCodecSize(getBase58Codec(), 2).encode('heLLo');
 // 0x1b6a (truncated to 2 bytes)
 
-addCodecSizePrefix(getBase58Codec(), getU32Codec()).encode("heLLo");
+addCodecSizePrefix(getBase58Codec(), getU32Codec()).encode('heLLo');
 // 0x040000001b6a3070
 //   |       └-- The 4 bytes of content.
 //   └-- 4-byte prefix telling us to read 4 bytes.
 
-addCodecSentinel(getBase58Codec(), new Uint8Array([0xff, 0xff])).encode("heLLo");
+addCodecSentinel(getBase58Codec(), new Uint8Array([0xff, 0xff])).encode('heLLo');
 // 0x1b6a3070ffff
 //   |       └-- The sentinel signaling the end of the content.
 //   └-- The 4 bytes of content.
@@ -1393,27 +1491,33 @@ addCodecSentinel(getBase58Codec(), new Uint8Array([0xff, 0xff])).encode("heLLo")
 Encodes and decodes **Base 64 strings**.
 
 ```ts twoslash
-import { getBase64Codec } from "@solana/kit";
+import { getBase64Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getBase64Codec();
-const bytes = codec.encode("hello+world"); // 0x85e965a3ec28ae57
+const bytes = codec.encode('hello+world'); // 0x85e965a3ec28ae57
 const value = codec.decode(bytes); // "hello+world"
 ```
 
 This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string. To add size constraints to your codec, you may use utility functions such as [`fixCodecSize`](#fix-codec-size), [`addCodecSizePrefix`](#add-codec-size-prefix) or [`addCodecSentinel`](#add-codec-sentinel).
 
 ```ts twoslash
-import { getBase64Codec, fixCodecSize, addCodecSizePrefix, getU32Codec, addCodecSentinel } from "@solana/kit";
+import {
+    getBase64Codec,
+    fixCodecSize,
+    addCodecSizePrefix,
+    getU32Codec,
+    addCodecSentinel,
+} from '@solana/kit';
 // ---cut-before---
-fixCodecSize(getBase64Codec(), 4).encode("hello+world");
+fixCodecSize(getBase64Codec(), 4).encode('hello+world');
 // 0x85e965a3 (truncated to 4 bytes)
 
-addCodecSizePrefix(getBase64Codec(), getU32Codec()).encode("hello+world");
+addCodecSizePrefix(getBase64Codec(), getU32Codec()).encode('hello+world');
 // 0x0400000085e965a3ec28ae57
 //   |       └-- The 8 bytes of content.
 //   └-- 4-byte prefix telling us to read 8 bytes.
 
-addCodecSentinel(getBase64Codec(), new Uint8Array([0xff, 0xff])).encode("hello+world");
+addCodecSentinel(getBase64Codec(), new Uint8Array([0xff, 0xff])).encode('hello+world');
 // 0x85e965a3ec28ae57ffff
 //   |               └-- The sentinel signaling the end of the content.
 //   └-- The 8 bytes of content.
@@ -1426,29 +1530,35 @@ addCodecSentinel(getBase64Codec(), new Uint8Array([0xff, 0xff])).encode("hello+w
 The `getBaseXCodec` accepts a custom `alphabet` of `X` characters and **creates a base-X codec using that alphabet**. It does so by iteratively dividing by `X` and handling leading zeros.
 
 ```ts twoslash
-import { getBaseXCodec } from "@solana/kit";
+import { getBaseXCodec } from '@solana/kit';
 // ---cut-before---
-const codec = getBaseXCodec("0ehlo");
-const bytes = codec.encode("hello"); // 0x05bd
+const codec = getBaseXCodec('0ehlo');
+const bytes = codec.encode('hello'); // 0x05bd
 const value = codec.decode(bytes); // "hello"
 ```
 
 This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string. To add size constraints to your codec, you may use utility functions such as [`fixCodecSize`](#fix-codec-size), [`addCodecSizePrefix`](#add-codec-size-prefix) or [`addCodecSentinel`](#add-codec-sentinel).
 
 ```ts twoslash
-import { getBaseXCodec, fixCodecSize, addCodecSizePrefix, getU32Codec, addCodecSentinel } from "@solana/kit";
+import {
+    getBaseXCodec,
+    fixCodecSize,
+    addCodecSizePrefix,
+    getU32Codec,
+    addCodecSentinel,
+} from '@solana/kit';
 // ---cut-before---
-const codec = getBaseXCodec("0ehlo");
+const codec = getBaseXCodec('0ehlo');
 
-fixCodecSize(codec, 4).encode("hello");
+fixCodecSize(codec, 4).encode('hello');
 // 0x05bd0000 (padded to 4 bytes)
 
-addCodecSizePrefix(codec, getU32Codec()).encode("hello");
+addCodecSizePrefix(codec, getU32Codec()).encode('hello');
 // 0x0200000005bd
 //   |       └-- The 2 bytes of content.
 //   └-- 4-byte prefix telling us to read 2 bytes.
 
-addCodecSentinel(codec, new Uint8Array([0xff, 0xff])).encode("hello");
+addCodecSentinel(codec, new Uint8Array([0xff, 0xff])).encode('hello');
 // 0x05bdffff
 //   |   └-- The sentinel signaling the end of the content.
 //   └-- The 2 bytes of content.
@@ -1465,29 +1575,35 @@ It does so by re-slicing bytes into custom chunks of bits that are then mapped t
 This is typically used to create codecs whose alphabet's length is a power of 2 such as base-16 or base-64.
 
 ```ts twoslash
-import { getBaseXResliceCodec } from "@solana/kit";
+import { getBaseXResliceCodec } from '@solana/kit';
 // ---cut-before---
-const codec = getBaseXResliceCodec("elho", 2);
-const bytes = codec.encode("hellolol"); // 0x4aee
+const codec = getBaseXResliceCodec('elho', 2);
+const bytes = codec.encode('hellolol'); // 0x4aee
 const value = codec.decode(bytes); // "hellolol"
 ```
 
 This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string. To add size constraints to your codec, you may use utility functions such as [`fixCodecSize`](#fix-codec-size), [`addCodecSizePrefix`](#add-codec-size-prefix) or [`addCodecSentinel`](#add-codec-sentinel).
 
 ```ts twoslash
-import { getBaseXResliceCodec, fixCodecSize, addCodecSizePrefix, getU32Codec, addCodecSentinel } from "@solana/kit";
+import {
+    getBaseXResliceCodec,
+    fixCodecSize,
+    addCodecSizePrefix,
+    getU32Codec,
+    addCodecSentinel,
+} from '@solana/kit';
 // ---cut-before---
-const codec = getBaseXResliceCodec("elho", 2);
+const codec = getBaseXResliceCodec('elho', 2);
 
-fixCodecSize(codec, 4).encode("hellolol");
+fixCodecSize(codec, 4).encode('hellolol');
 // 0x4aee0000 (padded to 4 bytes)
 
-addCodecSizePrefix(codec, getU32Codec()).encode("hellolol");
+addCodecSizePrefix(codec, getU32Codec()).encode('hellolol');
 // 0x020000004aee
 //   |       └-- The 2 bytes of content.
 //   └-- 4-byte prefix telling us to read 2 bytes.
 
-addCodecSentinel(codec, new Uint8Array([0xff, 0xff])).encode("hellolol");
+addCodecSentinel(codec, new Uint8Array([0xff, 0xff])).encode('hellolol');
 // 0x4aeeffff
 //   |   └-- The sentinel signaling the end of the content.
 //   └-- The 2 bytes of content.
@@ -1500,27 +1616,33 @@ addCodecSentinel(codec, new Uint8Array([0xff, 0xff])).encode("hellolol");
 Encodes and decodes **UTF-8 strings**.
 
 ```ts twoslash
-import { getUtf8Codec } from "@solana/kit";
+import { getUtf8Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getUtf8Codec();
-const bytes = codec.encode("hello"); // 0x68656c6c6f
+const bytes = codec.encode('hello'); // 0x68656c6c6f
 const value = codec.decode(bytes); // "hello"
 ```
 
 This codec does not enforce a size boundary. It will encode and decode all bytes necessary to represent the string. To add size constraints to your codec, you may use utility functions such as [`fixCodecSize`](#fix-codec-size), [`addCodecSizePrefix`](#add-codec-size-prefix) or [`addCodecSentinel`](#add-codec-sentinel).
 
 ```ts twoslash
-import { getUtf8Codec, fixCodecSize, addCodecSizePrefix, getU32Codec, addCodecSentinel } from "@solana/kit";
+import {
+    getUtf8Codec,
+    fixCodecSize,
+    addCodecSizePrefix,
+    getU32Codec,
+    addCodecSentinel,
+} from '@solana/kit';
 // ---cut-before---
-fixCodecSize(getUtf8Codec(), 4).encode("hello");
+fixCodecSize(getUtf8Codec(), 4).encode('hello');
 // 0x68656c6c (truncated to 4 bytes)
 
-addCodecSizePrefix(getUtf8Codec(), getU32Codec()).encode("hello");
+addCodecSizePrefix(getUtf8Codec(), getU32Codec()).encode('hello');
 // 0x0500000068656c6c6f
 //   |       └-- The 5 bytes of content.
 //   └-- 4-byte prefix telling us to read 5 bytes.
 
-addCodecSentinel(getUtf8Codec(), new Uint8Array([0xff, 0xff])).encode("hello");
+addCodecSentinel(getUtf8Codec(), new Uint8Array([0xff, 0xff])).encode('hello');
 // 0x68656c6c6fffff
 //   |         └-- The sentinel signaling the end of the content.
 //   └-- The 5 bytes of content.
@@ -1535,7 +1657,7 @@ addCodecSentinel(getUtf8Codec(), new Uint8Array([0xff, 0xff])).encode("hello");
 The `getArrayCodec` function accepts any codec of type `T` and returns a codec of type `Array<T>`.
 
 ```ts twoslash
-import { getArrayCodec, getU8Codec } from "@solana/kit";
+import { getArrayCodec, getU8Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getArrayCodec(getU8Codec());
 const bytes = codec.encode([1, 2, 3]); // 0x03000000010203
@@ -1545,7 +1667,7 @@ const array = codec.decode(bytes); // [1, 2, 3]
 By default, the size of the array is stored as a `u32` prefix before encoding the items.
 
 ```ts twoslash
-import { getArrayCodec, getU8Codec } from "@solana/kit";
+import { getArrayCodec, getU8Codec } from '@solana/kit';
 // ---cut-before---
 getArrayCodec(getU8Codec()).encode([1, 2, 3]);
 // 0x03000000010203
@@ -1560,7 +1682,7 @@ However, you may use the `size` option to configure this behaviour. It can be on
 - `"remainder"`: When the string `"remainder"` is passed as a size, the codec will use the remainder of the bytes to encode/decode its items. This means the size is not stored or known in advance but simply inferred from the rest of the buffer. For instance, if we have an array of `u16` numbers and 10 bytes remaining, we know there are 5 items in this array.
 
 ```ts twoslash
-import { getArrayCodec, getU8Codec, getU16Codec } from "@solana/kit";
+import { getArrayCodec, getU8Codec, getU16Codec } from '@solana/kit';
 // ---cut-before---
 getArrayCodec(getU8Codec(), { size: getU16Codec() }).encode([1, 2, 3]);
 // 0x0300010203
@@ -1571,7 +1693,7 @@ getArrayCodec(getU8Codec(), { size: 3 }).encode([1, 2, 3]);
 // 0x010203
 //   └-- 3 items of 1 byte each. There must always be 3 items in the array.
 
-getArrayCodec(getU8Codec(), { size: "remainder" }).encode([1, 2, 3]);
+getArrayCodec(getU8Codec(), { size: 'remainder' }).encode([1, 2, 3]);
 // 0x010203
 //   └-- 3 items of 1 byte each. The size is inferred from the remainder of the bytes.
 ```
@@ -1583,7 +1705,7 @@ getArrayCodec(getU8Codec(), { size: "remainder" }).encode([1, 2, 3]);
 The `getBitArrayCodec` function returns a codec that encodes and decodes an array of booleans such that each boolean is represented by a single bit. It requires the size of the codec in bytes and an optional `backward` flag that can be used to reverse the order of the bits.
 
 ```ts twoslash
-import { getBitArrayCodec } from "@solana/kit";
+import { getBitArrayCodec } from '@solana/kit';
 // ---cut-before---
 const booleans = [true, false, true, false, true, false, true, false];
 
@@ -1601,7 +1723,7 @@ getBitArrayCodec(1, { backward: true }).encode(booleans);
 The `getBooleanCodec` function returns a `Codec<boolean>` that stores the boolean as `0` or `1` using a `u8` number by default.
 
 ```ts twoslash
-import { getBooleanCodec } from "@solana/kit";
+import { getBooleanCodec } from '@solana/kit';
 // ---cut-before---
 const codec = getBooleanCodec();
 const bytes = codec.encode(true); // 0x01
@@ -1611,7 +1733,7 @@ const value = codec.decode(bytes); // true
 You may configure that behaviour by providing an explicit number codec as the `size` option of the `getBooleanCodec` function. That number codec will then be used to encode and decode the values `0` and `1` accordingly.
 
 ```ts twoslash
-import { getBooleanCodec, getU16Codec, getU32Codec } from "@solana/kit";
+import { getBooleanCodec, getU16Codec, getU32Codec } from '@solana/kit';
 // ---cut-before---
 getBooleanCodec({ size: getU16Codec() }).encode(false); // 0x0000
 getBooleanCodec({ size: getU16Codec() }).encode(true); // 0x0100
@@ -1627,7 +1749,7 @@ getBooleanCodec({ size: getU32Codec() }).encode(true); // 0x01000000
 The `getBytesCodec` function returns a `Codec<Uint8Array>` meaning it converts `Uint8Arrays` to and from… `Uint8Arrays`! Whilst this might seem a bit useless, it can be useful when composed into other codecs. For example, you could use it in a struct codec to say that a particular field should be left unserialised.
 
 ```ts twoslash
-import { getBytesCodec } from "@solana/kit";
+import { getBytesCodec } from '@solana/kit';
 // ---cut-before---
 const codec = getBytesCodec();
 const bytes = codec.encode(new Uint8Array([42])); // 0x2a
@@ -1637,7 +1759,13 @@ const value = codec.decode(bytes); // 0x2a
 The `getBytesCodec` function will encode and decode `Uint8Arrays` using as many bytes as necessary. If you'd like to restrict the number of bytes used by this codec, you may combine it with utilities such as [`fixCodecSize`](#fix-codec-size), [`addCodecSizePrefix`](#add-codec-size-prefix) or [`addCodecSentinel`](#add-codec-sentinel).
 
 ```ts twoslash
-import { getBytesCodec, fixCodecSize, addCodecSizePrefix, getU32Codec, addCodecSentinel } from "@solana/kit";
+import {
+    getBytesCodec,
+    fixCodecSize,
+    addCodecSizePrefix,
+    getU32Codec,
+    addCodecSentinel,
+} from '@solana/kit';
 // ---cut-before---
 const value = new Uint8Array([42, 43]); // 0x2a2b
 
@@ -1662,7 +1790,7 @@ addCodecSentinel(getBytesCodec(), new Uint8Array([0xff, 0xff])).encode(value);
 The `getConstantCodec` function accepts any `Uint8Array` and returns a `Codec<void>`. When encoding, it will set the provided `Uint8Array` as-is. When decoding, it will assert that the next bytes contain the provided `Uint8Array` and move the offset forward.
 
 ```ts twoslash
-import { getConstantCodec } from "@solana/kit";
+import { getConstantCodec } from '@solana/kit';
 // ---cut-before---
 const codec = getConstantCodec(new Uint8Array([1, 2, 3]));
 
@@ -1687,9 +1815,9 @@ We use a special field named `__kind` to distinguish between the different varia
 
 ```ts twoslash
 type Message =
-  | { __kind: "quit" } // Empty variant.
-  | { __kind: "write"; fields: [string] } // Tuple variant.
-  | { __kind: "move"; x: number; y: number }; // Struct variant.
+    | { __kind: 'quit' } // Empty variant.
+    | { __kind: 'write'; fields: [string] } // Tuple variant.
+    | { __kind: 'move'; x: number; y: number }; // Struct variant.
 ```
 
 The `getDiscriminatedUnionCodec` function helps us encode and decode these discriminated unions.
@@ -1700,31 +1828,36 @@ Here is how we can create a discriminated union codec for our previous example.
 
 ```ts twoslash
 import {
-  getDiscriminatedUnionCodec,
-  getUnitCodec,
-  getStructCodec,
-  getTupleCodec,
-  getUtf8Codec,
-  getU32Codec,
-  addCodecSizePrefix,
-  getI32Codec,
-} from "@solana/kit";
+    getDiscriminatedUnionCodec,
+    getUnitCodec,
+    getStructCodec,
+    getTupleCodec,
+    getUtf8Codec,
+    getU32Codec,
+    addCodecSizePrefix,
+    getI32Codec,
+} from '@solana/kit';
 // ---cut-before---
 const messageCodec = getDiscriminatedUnionCodec([
-  // Empty variant.
-  ["quit", getUnitCodec()],
+    // Empty variant.
+    ['quit', getUnitCodec()],
 
-  // Tuple variant.
-  ["write", getStructCodec([["fields", getTupleCodec([addCodecSizePrefix(getUtf8Codec(), getU32Codec())])]])],
+    // Tuple variant.
+    [
+        'write',
+        getStructCodec([
+            ['fields', getTupleCodec([addCodecSizePrefix(getUtf8Codec(), getU32Codec())])],
+        ]),
+    ],
 
-  // Struct variant.
-  [
-    "move",
-    getStructCodec([
-      ["x", getI32Codec()],
-      ["y", getI32Codec()],
-    ]),
-  ],
+    // Struct variant.
+    [
+        'move',
+        getStructCodec([
+            ['x', getI32Codec()],
+            ['y', getI32Codec()],
+        ]),
+    ],
 ]);
 ```
 
@@ -1732,43 +1865,48 @@ And here's how we can use such a codec to encode discriminated unions. Notice th
 
 ```ts twoslash
 import {
-  getDiscriminatedUnionCodec,
-  getUnitCodec,
-  getStructCodec,
-  getTupleCodec,
-  getUtf8Codec,
-  getU32Codec,
-  addCodecSizePrefix,
-  getI32Codec,
-} from "@solana/kit";
+    getDiscriminatedUnionCodec,
+    getUnitCodec,
+    getStructCodec,
+    getTupleCodec,
+    getUtf8Codec,
+    getU32Codec,
+    addCodecSizePrefix,
+    getI32Codec,
+} from '@solana/kit';
 const messageCodec = getDiscriminatedUnionCodec([
-  // Empty variant.
-  ["quit", getUnitCodec()],
+    // Empty variant.
+    ['quit', getUnitCodec()],
 
-  // Tuple variant.
-  ["write", getStructCodec([["fields", getTupleCodec([addCodecSizePrefix(getUtf8Codec(), getU32Codec())])]])],
+    // Tuple variant.
+    [
+        'write',
+        getStructCodec([
+            ['fields', getTupleCodec([addCodecSizePrefix(getUtf8Codec(), getU32Codec())])],
+        ]),
+    ],
 
-  // Struct variant.
-  [
-    "move",
-    getStructCodec([
-      ["x", getI32Codec()],
-      ["y", getI32Codec()],
-    ]),
-  ],
+    // Struct variant.
+    [
+        'move',
+        getStructCodec([
+            ['x', getI32Codec()],
+            ['y', getI32Codec()],
+        ]),
+    ],
 ]);
 // ---cut-before---
-messageCodec.encode({ __kind: "quit" });
+messageCodec.encode({ __kind: 'quit' });
 // 0x00
 //   └-- 1-byte discriminator (Index 0 — the "quit" variant).
 
-messageCodec.encode({ __kind: "write", fields: ["Hi"] });
+messageCodec.encode({ __kind: 'write', fields: ['Hi'] });
 // 0x01020000004869
 //   | |       └-- utf8 string content ("Hi").
 //   | └-- u32 string prefix (2 characters).
 //   └-- 1-byte discriminator (Index 1 — the "write" variant).
 
-messageCodec.encode({ __kind: "move", x: 5, y: 6 });
+messageCodec.encode({ __kind: 'move', x: 5, y: 6 });
 // 0x020500000006000000
 //   | |       └-- Field y (6).
 //   | └-- Field x (5).
@@ -1779,40 +1917,42 @@ However, you may provide a number codec as the `size` option of the `getDiscrimi
 
 ```ts twoslash
 import {
-  getDiscriminatedUnionCodec,
-  getUnitCodec,
-  getStructCodec,
-  getTupleCodec,
-  getUtf8Codec,
-  getU32Codec,
-  addCodecSizePrefix,
-  getI32Codec,
-} from "@solana/kit";
+    getDiscriminatedUnionCodec,
+    getUnitCodec,
+    getStructCodec,
+    getTupleCodec,
+    getUtf8Codec,
+    getU32Codec,
+    addCodecSizePrefix,
+    getI32Codec,
+} from '@solana/kit';
 const quitCodec = getUnitCodec();
-const writeCodec = getStructCodec([["fields", getTupleCodec([addCodecSizePrefix(getUtf8Codec(), getU32Codec())])]]);
+const writeCodec = getStructCodec([
+    ['fields', getTupleCodec([addCodecSizePrefix(getUtf8Codec(), getU32Codec())])],
+]);
 const moveCodec = getStructCodec([
-  ["x", getI32Codec()],
-  ["y", getI32Codec()],
+    ['x', getI32Codec()],
+    ['y', getI32Codec()],
 ]);
 // ---cut-before---
 const u32MessageCodec = getDiscriminatedUnionCodec(
-  [
-    ["quit", quitCodec],
-    ["write", writeCodec],
-    ["move", moveCodec],
-  ],
-  { size: getU32Codec() },
+    [
+        ['quit', quitCodec],
+        ['write', writeCodec],
+        ['move', moveCodec],
+    ],
+    { size: getU32Codec() },
 );
 
-u32MessageCodec.encode({ __kind: "quit" });
+u32MessageCodec.encode({ __kind: 'quit' });
 // 0x00000000
 //   └------┘ 4-byte discriminator (Index 0).
 
-u32MessageCodec.encode({ __kind: "write", fields: ["Hi"] });
+u32MessageCodec.encode({ __kind: 'write', fields: ['Hi'] });
 // 0x01000000020000004869
 //   └------┘ 4-byte discriminator (Index 1).
 
-u32MessageCodec.encode({ __kind: "move", x: 5, y: 6 });
+u32MessageCodec.encode({ __kind: 'move', x: 5, y: 6 });
 // 0x020000000500000006000000
 //   └------┘ 4-byte discriminator (Index 2).
 ```
@@ -1821,69 +1961,73 @@ You may also customize the discriminator property — which defaults to `__kind`
 
 ```ts twoslash
 import {
-  getDiscriminatedUnionCodec,
-  getUnitCodec,
-  getStructCodec,
-  getTupleCodec,
-  getUtf8Codec,
-  getU32Codec,
-  addCodecSizePrefix,
-  getI32Codec,
-} from "@solana/kit";
+    getDiscriminatedUnionCodec,
+    getUnitCodec,
+    getStructCodec,
+    getTupleCodec,
+    getUtf8Codec,
+    getU32Codec,
+    addCodecSizePrefix,
+    getI32Codec,
+} from '@solana/kit';
 const quitCodec = getUnitCodec();
-const writeCodec = getStructCodec([["fields", getTupleCodec([addCodecSizePrefix(getUtf8Codec(), getU32Codec())])]]);
+const writeCodec = getStructCodec([
+    ['fields', getTupleCodec([addCodecSizePrefix(getUtf8Codec(), getU32Codec())])],
+]);
 const moveCodec = getStructCodec([
-  ["x", getI32Codec()],
-  ["y", getI32Codec()],
+    ['x', getI32Codec()],
+    ['y', getI32Codec()],
 ]);
 // ---cut-before---
 const messageCodec = getDiscriminatedUnionCodec(
-  [
-    ["quit", quitCodec],
-    ["write", writeCodec],
-    ["move", moveCodec],
-  ],
-  { discriminator: "message" },
+    [
+        ['quit', quitCodec],
+        ['write', writeCodec],
+        ['move', moveCodec],
+    ],
+    { discriminator: 'message' },
 );
 
-messageCodec.encode({ message: "quit" });
-messageCodec.encode({ message: "write", fields: ["Hi"] });
-messageCodec.encode({ message: "move", x: 5, y: 6 });
+messageCodec.encode({ message: 'quit' });
+messageCodec.encode({ message: 'write', fields: ['Hi'] });
+messageCodec.encode({ message: 'move', x: 5, y: 6 });
 ```
 
 Note that, the discriminator value of a variant may be any scalar value — such as `number`, `bigint`, `boolean`, a JavaScript `enum`, etc. For instance, the following is also valid:
 
 ```ts twoslash
 import {
-  getDiscriminatedUnionCodec,
-  getUnitCodec,
-  getStructCodec,
-  getTupleCodec,
-  getUtf8Codec,
-  getU32Codec,
-  addCodecSizePrefix,
-  getI32Codec,
-} from "@solana/kit";
+    getDiscriminatedUnionCodec,
+    getUnitCodec,
+    getStructCodec,
+    getTupleCodec,
+    getUtf8Codec,
+    getU32Codec,
+    addCodecSizePrefix,
+    getI32Codec,
+} from '@solana/kit';
 const quitCodec = getUnitCodec();
-const writeCodec = getStructCodec([["fields", getTupleCodec([addCodecSizePrefix(getUtf8Codec(), getU32Codec())])]]);
+const writeCodec = getStructCodec([
+    ['fields', getTupleCodec([addCodecSizePrefix(getUtf8Codec(), getU32Codec())])],
+]);
 const moveCodec = getStructCodec([
-  ["x", getI32Codec()],
-  ["y", getI32Codec()],
+    ['x', getI32Codec()],
+    ['y', getI32Codec()],
 ]);
 // ---cut-before---
 enum Message {
-  Quit,
-  Write,
-  Move,
+    Quit,
+    Write,
+    Move,
 }
 const messageCodec = getDiscriminatedUnionCodec([
-  [Message.Quit, quitCodec],
-  [Message.Write, writeCodec],
-  [Message.Move, moveCodec],
+    [Message.Quit, quitCodec],
+    [Message.Write, writeCodec],
+    [Message.Move, moveCodec],
 ]);
 
 messageCodec.encode({ __kind: Message.Quit });
-messageCodec.encode({ __kind: Message.Write, fields: ["Hi"] });
+messageCodec.encode({ __kind: Message.Write, fields: ['Hi'] });
 messageCodec.encode({ __kind: Message.Move, x: 5, y: 6 });
 ```
 
@@ -1894,11 +2038,11 @@ messageCodec.encode({ __kind: Message.Move, x: 5, y: 6 });
 The `getEnumCodec` function accepts a JavaScript enum constructor and returns a codec for encoding and decoding values of that enum.
 
 ```ts twoslash
-import { getEnumCodec } from "@solana/kit";
+import { getEnumCodec } from '@solana/kit';
 // ---cut-before---
 enum Direction {
-  Left,
-  Right,
+    Left,
+    Right,
 }
 
 const codec = getEnumCodec(Direction);
@@ -1909,25 +2053,25 @@ const direction = codec.decode(bytes); // Direction.Left
 When encoding an enum, you may either provide the value of the enum variant — e.g. `Direction.Left` — or its key — e.g. `'Left'`.
 
 ```ts twoslash
-import { getEnumCodec } from "@solana/kit";
+import { getEnumCodec } from '@solana/kit';
 enum Direction {
-  Left,
-  Right,
+    Left,
+    Right,
 }
 // ---cut-before---
 getEnumCodec(Direction).encode(Direction.Left); // 0x00
 getEnumCodec(Direction).encode(Direction.Right); // 0x01
-getEnumCodec(Direction).encode("Left"); // 0x00
-getEnumCodec(Direction).encode("Right"); // 0x01
+getEnumCodec(Direction).encode('Left'); // 0x00
+getEnumCodec(Direction).encode('Right'); // 0x01
 ```
 
 By default, a `u8` number is being used to store the enum value. However, a number codec may be passed as the `size` option to configure that behaviour.
 
 ```ts twoslash
-import { getEnumCodec, getU32Codec } from "@solana/kit";
+import { getEnumCodec, getU32Codec } from '@solana/kit';
 enum Direction {
-  Left,
-  Right,
+    Left,
+    Right,
 }
 // ---cut-before---
 const u32DirectionCodec = getEnumCodec(Direction, { size: getU32Codec() });
@@ -1938,23 +2082,23 @@ u32DirectionCodec.encode(Direction.Right); // 0x01000000
 This function also works with lexical enums — e.g. `enum Direction { Left = '←' }` — explicit numerical enums — e.g. `enum Speed { Left = 50 }` — and hybrid enums with a mix of both.
 
 ```ts twoslash
-import { getEnumCodec } from "@solana/kit";
+import { getEnumCodec } from '@solana/kit';
 // ---cut-before---
 enum Numbers {
-  One,
-  Five = 5,
-  Six,
-  Nine = "nine",
+    One,
+    Five = 5,
+    Six,
+    Nine = 'nine',
 }
 
 getEnumCodec(Numbers).encode(Numbers.One); // 0x00
 getEnumCodec(Numbers).encode(Numbers.Five); // 0x01
 getEnumCodec(Numbers).encode(Numbers.Six); // 0x02
 getEnumCodec(Numbers).encode(Numbers.Nine); // 0x03
-getEnumCodec(Numbers).encode("One"); // 0x00
-getEnumCodec(Numbers).encode("Five"); // 0x01
-getEnumCodec(Numbers).encode("Six"); // 0x02
-getEnumCodec(Numbers).encode("Nine"); // 0x03
+getEnumCodec(Numbers).encode('One'); // 0x00
+getEnumCodec(Numbers).encode('Five'); // 0x01
+getEnumCodec(Numbers).encode('Six'); // 0x02
+getEnumCodec(Numbers).encode('Nine'); // 0x03
 ```
 
 Notice how, by default, the index of the enum variant is used to encode the value of the enum. For instance, in the example above, `Numbers.Five` is encoded as `0x01` even though its value is `5`. This is also true for lexical enums.
@@ -1962,13 +2106,13 @@ Notice how, by default, the index of the enum variant is used to encode the valu
 However, when dealing with numerical enums that have explicit values, you may use the `useValuesAsDiscriminators` option to encode the value of the enum variant instead of its index.
 
 ```ts twoslash
-import { getEnumCodec } from "@solana/kit";
+import { getEnumCodec } from '@solana/kit';
 // ---cut-before---
 enum Numbers {
-  One,
-  Five = 5,
-  Six,
-  Nine = 9,
+    One,
+    Five = 5,
+    Six,
+    Nine = 9,
 }
 
 const codec = getEnumCodec(Numbers, { useValuesAsDiscriminators: true });
@@ -1976,20 +2120,20 @@ codec.encode(Numbers.One); // 0x00
 codec.encode(Numbers.Five); // 0x05
 codec.encode(Numbers.Six); // 0x06
 codec.encode(Numbers.Nine); // 0x09
-codec.encode("One"); // 0x00
-codec.encode("Five"); // 0x05
-codec.encode("Six"); // 0x06
-codec.encode("Nine"); // 0x09
+codec.encode('One'); // 0x00
+codec.encode('Five'); // 0x05
+codec.encode('Six'); // 0x06
+codec.encode('Nine'); // 0x09
 ```
 
 Note that when using the `useValuesAsDiscriminators` option on an enum that contains a lexical value, an error will be thrown.
 
 ```ts twoslash
-import { getEnumCodec } from "@solana/kit";
+import { getEnumCodec } from '@solana/kit';
 // ---cut-before---
 enum Lexical {
-  One,
-  Two = "two",
+    One,
+    Two = 'two',
 }
 getEnumCodec(Lexical, { useValuesAsDiscriminators: true }); // Throws an error.
 ```
@@ -2003,11 +2147,11 @@ The `getHiddenPrefixCodec` function allow us to prepend a list of hidden `Codec<
 When encoding, the hidden codecs will be encoded before the main codec and the offset will be moved accordingly. When decoding, the hidden codecs will be decoded but only the result of the main codec will be returned. This is particularly helpful when creating data structures that include constant values that should not be included in the final type.
 
 ```ts twoslash
-import { getHiddenPrefixCodec, getConstantCodec, getU16Codec } from "@solana/kit";
+import { getHiddenPrefixCodec, getConstantCodec, getU16Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getHiddenPrefixCodec(getU16Codec(), [
-  getConstantCodec(new Uint8Array([1, 2, 3])),
-  getConstantCodec(new Uint8Array([4, 5, 6])),
+    getConstantCodec(new Uint8Array([1, 2, 3])),
+    getConstantCodec(new Uint8Array([4, 5, 6])),
 ]);
 
 codec.encode(42);
@@ -2028,11 +2172,11 @@ The `getHiddenSuffixCodec` function allow us to append a list of hidden `Codec<v
 When encoding, the hidden codecs will be encoded after the main codec and the offset will be moved accordingly. When decoding, the hidden codecs will be decoded but only the result of the main codec will be returned. This is particularly helpful when creating data structures that include constant values that should not be included in the final type.
 
 ```ts twoslash
-import { getHiddenSuffixCodec, getConstantCodec, getU16Codec } from "@solana/kit";
+import { getHiddenSuffixCodec, getConstantCodec, getU16Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getHiddenSuffixCodec(getU16Codec(), [
-  getConstantCodec(new Uint8Array([1, 2, 3])),
-  getConstantCodec(new Uint8Array([4, 5, 6])),
+    getConstantCodec(new Uint8Array([1, 2, 3])),
+    getConstantCodec(new Uint8Array([4, 5, 6])),
 ]);
 
 codec.encode(42);
@@ -2051,28 +2195,28 @@ codec.decode(new Uint8Array([42, 0, 1, 2, 3, 4, 5, 6])); // 42
 The `getLiteralUnionCodec` function accepts an array of literal values — such as `string`, `number`, `boolean`, etc. — and returns a codec that encodes and decodes such values by using their index in the array. It uses TypeScript unions to represent all the possible values.
 
 ```ts twoslash
-import { getLiteralUnionCodec, FixedSizeCodec } from "@solana/kit";
+import { getLiteralUnionCodec, FixedSizeCodec } from '@solana/kit';
 // ---cut-before---
-const codec = getLiteralUnionCodec(["left", "right", "up", "down"]);
-codec satisfies FixedSizeCodec<"left" | "right" | "up" | "down">;
+const codec = getLiteralUnionCodec(['left', 'right', 'up', 'down']);
+codec satisfies FixedSizeCodec<'left' | 'right' | 'up' | 'down'>;
 
-const bytes = codec.encode("left"); // 0x00
+const bytes = codec.encode('left'); // 0x00
 const value = codec.decode(bytes); // 'left'
 ```
 
 It uses a `u8` number by default to store the index of the value. However, you may provide a number codec as the `size` option of the `getLiteralUnionCodec` function to customise that behaviour.
 
 ```ts twoslash
-import { getLiteralUnionCodec, getU32Codec } from "@solana/kit";
+import { getLiteralUnionCodec, getU32Codec } from '@solana/kit';
 // ---cut-before---
-const codec = getLiteralUnionCodec(["left", "right", "up", "down"], {
-  size: getU32Codec(),
+const codec = getLiteralUnionCodec(['left', 'right', 'up', 'down'], {
+    size: getU32Codec(),
 });
 
-codec.encode("left"); // 0x00000000
-codec.encode("right"); // 0x01000000
-codec.encode("up"); // 0x02000000
-codec.encode("down"); // 0x03000000
+codec.encode('left'); // 0x00000000
+codec.encode('right'); // 0x01000000
+codec.encode('up'); // 0x02000000
+codec.encode('down'); // 0x03000000
 ```
 
 `getLiteralUnionEncoder` and `getLiteralUnionDecoder` functions are also available.
@@ -2082,25 +2226,25 @@ codec.encode("down"); // 0x03000000
 The `getMapCodec` function accepts two codecs of type `K` and `V` and returns a codec of type `Map<K, V>`.
 
 ```ts twoslash
-import { getMapCodec, getU8Codec, getUtf8Codec, fixCodecSize } from "@solana/kit";
+import { getMapCodec, getU8Codec, getUtf8Codec, fixCodecSize } from '@solana/kit';
 // ---cut-before---
 const keyCodec = fixCodecSize(getUtf8Codec(), 8);
 const valueCodec = getU8Codec();
 const codec = getMapCodec(keyCodec, valueCodec);
 
-const bytes = codec.encode(new Map([["alice", 42]])); // 0x01000000616c6963650000002a
+const bytes = codec.encode(new Map([['alice', 42]])); // 0x01000000616c6963650000002a
 const map = codec.decode(bytes); // new Map([["alice", 42]])
 ```
 
 Each entry (key/value pair) is encoded one after the other with the key first and the value next. By default, the size of the map is stored as a `u32` prefix before encoding the entries.
 
 ```ts twoslash
-import { getMapCodec, getU8Codec, getUtf8Codec, fixCodecSize } from "@solana/kit";
+import { getMapCodec, getU8Codec, getUtf8Codec, fixCodecSize } from '@solana/kit';
 // ---cut-before---
 const codec = getMapCodec(fixCodecSize(getUtf8Codec(), 8), getU8Codec());
 const myMap = new Map<string, number>();
-myMap.set("alice", 42);
-myMap.set("bob", 5);
+myMap.set('alice', 42);
+myMap.set('bob', 5);
 
 codec.encode(myMap);
 // 0x02000000616c6963650000002a626f62000000000005
@@ -2118,14 +2262,14 @@ However, you may use the `size` option to configure this behaviour. It can be on
 - `"remainder"`: When the string `"remainder"` is passed as a size, the codec will use the remainder of the bytes to encode/decode its entries. This means the size is not stored or known in advance but simply inferred from the rest of the buffer. For instance, if we have a map of `u16` numbers and 10 bytes remaining, we know there are 5 entries in this map.
 
 ```ts twoslash
-import { getMapCodec, getU8Codec, getU16Codec, fixCodecSize, getUtf8Codec } from "@solana/kit";
+import { getMapCodec, getU8Codec, getU16Codec, fixCodecSize, getUtf8Codec } from '@solana/kit';
 // ---cut-before---
 const keyCodec = fixCodecSize(getUtf8Codec(), 8);
 const valueCodec = getU8Codec();
 
 const myMap = new Map<string, number>();
-myMap.set("alice", 42);
-myMap.set("bob", 5);
+myMap.set('alice', 42);
+myMap.set('bob', 5);
 
 getMapCodec(keyCodec, valueCodec, { size: getU16Codec() }).encode(myMap);
 // 0x0200616c6963650000002a626f62000000000005
@@ -2139,7 +2283,7 @@ getMapCodec(keyCodec, valueCodec, { size: 3 }).encode(myMap);
 //   └-- First entry.
 // There must always be 2 entries in the map.
 
-getMapCodec(keyCodec, valueCodec, { size: "remainder" }).encode(myMap);
+getMapCodec(keyCodec, valueCodec, { size: 'remainder' }).encode(myMap);
 // 0x616c6963650000002a626f62000000000005
 //   |                 └-- Second entry.
 //   └-- First entry.
@@ -2153,11 +2297,11 @@ getMapCodec(keyCodec, valueCodec, { size: "remainder" }).encode(myMap);
 The `getNullableCodec` function accepts a codec of type `T` and returns a codec of type `T | null`. It stores whether or not the item exists as a boolean prefix using a `u8` by default.
 
 ```ts twoslash
-import { getNullableCodec, getU32Codec, addCodecSizePrefix, getUtf8Codec } from "@solana/kit";
+import { getNullableCodec, getU32Codec, addCodecSizePrefix, getUtf8Codec } from '@solana/kit';
 // ---cut-before---
 const stringCodec = addCodecSizePrefix(getUtf8Codec(), getU32Codec());
 
-getNullableCodec(stringCodec).encode("Hi");
+getNullableCodec(stringCodec).encode('Hi');
 // 0x01020000004869
 //   | |       └-- utf8 string content ("Hi").
 //   | └-- u32 string prefix (2 characters).
@@ -2171,14 +2315,14 @@ getNullableCodec(stringCodec).encode(null);
 You may provide a number codec as the `prefix` option of the `getNullableCodec` function to configure how to store the boolean prefix.
 
 ```ts twoslash
-import { getNullableCodec, getU32Codec, addCodecSizePrefix, getUtf8Codec } from "@solana/kit";
+import { getNullableCodec, getU32Codec, addCodecSizePrefix, getUtf8Codec } from '@solana/kit';
 const stringCodec = addCodecSizePrefix(getUtf8Codec(), getU32Codec());
 // ---cut-before---
 const u32NullableStringCodec = getNullableCodec(stringCodec, {
-  prefix: getU32Codec(),
+    prefix: getU32Codec(),
 });
 
-u32NullableStringCodec.encode("Hi");
+u32NullableStringCodec.encode('Hi');
 // 0x01000000020000004869
 //   └------┘ 4-byte prefix (true).
 
@@ -2190,14 +2334,14 @@ u32NullableStringCodec.encode(null);
 Additionally, if the item is a `FixedSizeCodec`, you may set the `noneValue` option to `"zeroes"` to also make the returned nullable codec a `FixedSizeCodec`. To do so, it will pad `null` values with zeroes to match the length of existing values.
 
 ```ts twoslash
-import { getNullableCodec, fixCodecSize, getUtf8Codec } from "@solana/kit";
+import { getNullableCodec, fixCodecSize, getUtf8Codec } from '@solana/kit';
 // ---cut-before---
 const fixedNullableStringCodec = getNullableCodec(
-  fixCodecSize(getUtf8Codec(), 8), // Only works with fixed-size items.
-  { noneValue: "zeroes" },
+    fixCodecSize(getUtf8Codec(), 8), // Only works with fixed-size items.
+    { noneValue: 'zeroes' },
 );
 
-fixedNullableStringCodec.encode("Hi");
+fixedNullableStringCodec.encode('Hi');
 // 0x014869000000000000
 //   | └-- 8-byte utf8 string content ("Hi").
 //   └-- 1-byte prefix (true — The item exists).
@@ -2211,13 +2355,13 @@ fixedNullableStringCodec.encode(null);
 The `noneValue` option can also be set to an explicit byte array to use as the padding for `null` values. Note that, in this case, the returned codec will not be a `FixedSizeCodec` as the byte array representing `null` values may be of any length.
 
 ```ts twoslash
-import { getNullableCodec, getUtf8Codec } from "@solana/kit";
+import { getNullableCodec, getUtf8Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getNullableCodec(getUtf8Codec(), {
-  noneValue: new Uint8Array([255]), // 0xff means null.
+    noneValue: new Uint8Array([255]), // 0xff means null.
 });
 
-codec.encode("Hi");
+codec.encode('Hi');
 // 0x014869
 //   | └-- 2-byte utf8 string content ("Hi").
 //   └-- 1-byte prefix (true — The item exists).
@@ -2231,18 +2375,18 @@ codec.encode(null);
 The `prefix` option of the `getNullableCodec` function can also be set to `null`, meaning no prefix will be used to determine whether the item exists. In this case, the codec will rely on the `noneValue` option to determine whether the item is `null`.
 
 ```ts twoslash
-import { getNullableCodec, getU16Codec } from "@solana/kit";
+import { getNullableCodec, getU16Codec } from '@solana/kit';
 // ---cut-before---
 const codecWithZeroNoneValue = getNullableCodec(getU16Codec(), {
-  noneValue: "zeroes", // 0x0000 means null.
-  prefix: null,
+    noneValue: 'zeroes', // 0x0000 means null.
+    prefix: null,
 });
 codecWithZeroNoneValue.encode(42); // 0x2a00
 codecWithZeroNoneValue.encode(null); // 0x0000
 
 const codecWithCustomNoneValue = getNullableCodec(getU16Codec(), {
-  noneValue: new Uint8Array([255]), // 0xff means null.
-  prefix: null,
+    noneValue: new Uint8Array([255]), // 0xff means null.
+    prefix: null,
 });
 codecWithCustomNoneValue.encode(42); // 0x2a00
 codecWithCustomNoneValue.encode(null); // 0xff
@@ -2277,12 +2421,19 @@ The `getOptionCodec` function accepts a codec of type `T` and returns a codec of
 It stores whether or not the item exists as a boolean prefix using a `u8` by default.
 
 ```ts twoslash
-import { getOptionCodec, getU32Codec, addCodecSizePrefix, getUtf8Codec, some, none } from "@solana/kit";
+import {
+    getOptionCodec,
+    getU32Codec,
+    addCodecSizePrefix,
+    getUtf8Codec,
+    some,
+    none,
+} from '@solana/kit';
 // ---cut-before---
 const stringCodec = addCodecSizePrefix(getUtf8Codec(), getU32Codec());
 
-getOptionCodec(stringCodec).encode("Hi");
-getOptionCodec(stringCodec).encode(some("Hi"));
+getOptionCodec(stringCodec).encode('Hi');
+getOptionCodec(stringCodec).encode(some('Hi'));
 // 0x01020000004869
 //   | |       └-- utf8 string content ("Hi").
 //   | └-- u32 string prefix (2 characters).
@@ -2297,14 +2448,21 @@ getOptionCodec(stringCodec).encode(none());
 You may provide a number codec as the `prefix` option of the `getOptionCodec` function to configure how to store the boolean prefix.
 
 ```ts twoslash
-import { getOptionCodec, getU32Codec, addCodecSizePrefix, getUtf8Codec, some, none } from "@solana/kit";
+import {
+    getOptionCodec,
+    getU32Codec,
+    addCodecSizePrefix,
+    getUtf8Codec,
+    some,
+    none,
+} from '@solana/kit';
 const stringCodec = addCodecSizePrefix(getUtf8Codec(), getU32Codec());
 // ---cut-before---
 const u32OptionStringCodec = getOptionCodec(stringCodec, {
-  prefix: getU32Codec(),
+    prefix: getU32Codec(),
 });
 
-u32OptionStringCodec.encode(some("Hi"));
+u32OptionStringCodec.encode(some('Hi'));
 // 0x01000000020000004869
 //   └------┘ 4-byte prefix (Some).
 
@@ -2316,14 +2474,14 @@ u32OptionStringCodec.encode(none());
 Additionally, if the item is a `FixedSizeCodec`, you may set the `noneValue` option to `"zeroes"` to also make the returned Option codec a `FixedSizeCodec`. To do so, it will pad `None` values with zeroes to match the length of existing values.
 
 ```ts twoslash
-import { getOptionCodec, fixCodecSize, getUtf8Codec, some, none } from "@solana/kit";
+import { getOptionCodec, fixCodecSize, getUtf8Codec, some, none } from '@solana/kit';
 // ---cut-before---
 const codec = getOptionCodec(
-  fixCodecSize(getUtf8Codec(), 8), // Only works with fixed-size items.
-  { noneValue: "zeroes" },
+    fixCodecSize(getUtf8Codec(), 8), // Only works with fixed-size items.
+    { noneValue: 'zeroes' },
 );
 
-codec.encode(some("Hi"));
+codec.encode(some('Hi'));
 // 0x014869000000000000
 //   | └-- 8-byte utf8 string content ("Hi").
 //   └-- 1-byte prefix (Some).
@@ -2337,13 +2495,13 @@ codec.encode(none());
 The `noneValue` option can also be set to an explicit byte array to use as the padding for `None` values. Note that, in this case, the returned codec will not be a `FixedSizeCodec` as the byte array representing `None` values may be of any length.
 
 ```ts twoslash
-import { getOptionCodec, getUtf8Codec, some, none } from "@solana/kit";
+import { getOptionCodec, getUtf8Codec, some, none } from '@solana/kit';
 // ---cut-before---
 const codec = getOptionCodec(getUtf8Codec(), {
-  noneValue: new Uint8Array([255]), // 0xff means None.
+    noneValue: new Uint8Array([255]), // 0xff means None.
 });
 
-codec.encode(some("Hi"));
+codec.encode(some('Hi'));
 // 0x014869
 //   | └-- 2-byte utf8 string content ("Hi").
 //   └-- 1-byte prefix (Some).
@@ -2357,18 +2515,18 @@ codec.encode(none());
 The `prefix` option of the `getOptionCodec` function can also be set to `null`, meaning no prefix will be used to determine whether the item exists. In this case, the codec will rely on the `noneValue` option to determine whether the item is `None`.
 
 ```ts twoslash
-import { getOptionCodec, getU16Codec, some, none } from "@solana/kit";
+import { getOptionCodec, getU16Codec, some, none } from '@solana/kit';
 // ---cut-before---
 const codecWithZeroNoneValue = getOptionCodec(getU16Codec(), {
-  noneValue: "zeroes", // 0x0000 means None.
-  prefix: null,
+    noneValue: 'zeroes', // 0x0000 means None.
+    prefix: null,
 });
 codecWithZeroNoneValue.encode(some(42)); // 0x2a00
 codecWithZeroNoneValue.encode(none()); // 0x0000
 
 const codecWithCustomNoneValue = getOptionCodec(getU16Codec(), {
-  noneValue: new Uint8Array([255]), // 0xff means None.
-  prefix: null,
+    noneValue: new Uint8Array([255]), // 0xff means None.
+    prefix: null,
 });
 codecWithCustomNoneValue.encode(some(42)); // 0x2a00
 codecWithCustomNoneValue.encode(none()); // 0xff
@@ -2377,7 +2535,7 @@ codecWithCustomNoneValue.encode(none()); // 0xff
 Note that if `prefix` is set to `null` and no `noneValue` is provided, the codec assume that the item exists if and only if some remaining bytes are available to decode. This could be useful to describe data structures that may or may not have additional data to the end of the buffer.
 
 ```ts twoslash
-import { getOptionCodec, getU16Codec, some, none } from "@solana/kit";
+import { getOptionCodec, getU16Codec, some, none } from '@solana/kit';
 // ---cut-before---
 const codec = getOptionCodec(getU16Codec(), { prefix: null });
 codec.encode(some(42)); // 0x2a00
@@ -2401,7 +2559,7 @@ To recap, here are all the possible configurations of the `getOptionCodec` funct
 The `getSetCodec` function accepts any codec of type `T` and returns a codec of type `Set<T>`.
 
 ```ts twoslash
-import { getSetCodec, getU8Codec } from "@solana/kit";
+import { getSetCodec, getU8Codec } from '@solana/kit';
 // ---cut-before---
 const codec = getSetCodec(getU8Codec());
 const bytes = codec.encode(new Set([1, 2, 3])); // 0x03000000010203
@@ -2411,7 +2569,7 @@ const value = codec.decode(bytes); // new Set([1, 2, 3])
 By default, the size of the set is stored as a `u32` prefix before encoding the items.
 
 ```ts twoslash
-import { getSetCodec, getU8Codec } from "@solana/kit";
+import { getSetCodec, getU8Codec } from '@solana/kit';
 // ---cut-before---
 getSetCodec(getU8Codec()).encode(new Set([1, 2, 3]));
 // 0x03000000010203
@@ -2426,7 +2584,7 @@ However, you may use the `size` option to configure this behaviour. It can be on
 - `"remainder"`: When the string `"remainder"` is passed as a size, the codec will use the remainder of the bytes to encode/decode its items. This means the size is not stored or known in advance but simply inferred from the rest of the buffer. For instance, if we have a set of `u16` numbers and 10 bytes remaining, we know there are 5 items in this set.
 
 ```ts twoslash
-import { getSetCodec, getU8Codec, getU16Codec } from "@solana/kit";
+import { getSetCodec, getU8Codec, getU16Codec } from '@solana/kit';
 // ---cut-before---
 getSetCodec(getU8Codec(), { size: getU16Codec() }).encode(new Set([1, 2, 3]));
 // 0x0300010203
@@ -2437,7 +2595,7 @@ getSetCodec(getU8Codec(), { size: 3 }).encode(new Set([1, 2, 3]));
 // 0x010203
 //   └-- 3 items of 1 byte each. There must always be 3 items in the set.
 
-getSetCodec(getU8Codec(), { size: "remainder" }).encode(new Set([1, 2, 3]));
+getSetCodec(getU8Codec(), { size: 'remainder' }).encode(new Set([1, 2, 3]));
 // 0x010203
 //   └-- 3 items of 1 byte each. The size is inferred from the remainder of the bytes.
 ```
@@ -2449,15 +2607,22 @@ getSetCodec(getU8Codec(), { size: "remainder" }).encode(new Set([1, 2, 3]));
 The `getStructCodec` function accepts any number of field codecs and returns a codec for an object containing all these fields. Each provided field is an array such that the first item is the name of the field and the second item is the codec used to encode and decode that field type.
 
 ```ts twoslash
-import { getStructCodec, getU8Codec, getUtf8Codec, addCodecSizePrefix, Codec, getU32Codec } from "@solana/kit";
+import {
+    getStructCodec,
+    getU8Codec,
+    getUtf8Codec,
+    addCodecSizePrefix,
+    Codec,
+    getU32Codec,
+} from '@solana/kit';
 // ---cut-before---
 type Person = { name: string; age: number };
 const personCodec: Codec<Person> = getStructCodec([
-  ["name", addCodecSizePrefix(getUtf8Codec(), getU32Codec())],
-  ["age", getU8Codec()],
+    ['name', addCodecSizePrefix(getUtf8Codec(), getU32Codec())],
+    ['age', getU8Codec()],
 ]);
 
-const bytes = personCodec.encode({ name: "alice", age: 42 });
+const bytes = personCodec.encode({ name: 'alice', age: 42 });
 // 0x05000000616c6963652a
 //   |                 └-- Age field.
 //   └-- Name field.
@@ -2473,11 +2638,22 @@ const person = personCodec.decode(bytes);
 The `getTupleCodec` function accepts any number of codecs — `T`, `U`, `V`, etc. — and returns a tuple codec of type `[T, U, V, …]` such that each item is in the order of the provided codecs.
 
 ```ts twoslash
-import { getTupleCodec, getU8Codec, getU64Codec, addCodecSizePrefix, getUtf8Codec, getU32Codec } from "@solana/kit";
+import {
+    getTupleCodec,
+    getU8Codec,
+    getU64Codec,
+    addCodecSizePrefix,
+    getUtf8Codec,
+    getU32Codec,
+} from '@solana/kit';
 // ---cut-before---
-const tupleCodec = getTupleCodec([addCodecSizePrefix(getUtf8Codec(), getU32Codec()), getU8Codec(), getU64Codec()]);
+const tupleCodec = getTupleCodec([
+    addCodecSizePrefix(getUtf8Codec(), getU32Codec()),
+    getU8Codec(),
+    getU64Codec(),
+]);
 
-const bytes = tupleCodec.encode(["alice", 42, 123]);
+const bytes = tupleCodec.encode(['alice', 42, 123]);
 // 0x05000000616c6963652a7b00000000000000
 //   |                 | └-- 3rd item (123).
 //   |                 └-- 2nd item (42).
@@ -2500,12 +2676,12 @@ It accepts the following arguments:
 - A `getIndexFromBytes` function which, given the byte array to decode at a given offset, returns the index of the codec that should be used to decode the next bytes.
 
 ```ts twoslash
-import { getUnionCodec, getU16Codec, getBooleanCodec, Codec } from "@solana/kit";
+import { getUnionCodec, getU16Codec, getBooleanCodec, Codec } from '@solana/kit';
 // ---cut-before---
 const codec: Codec<number | boolean> = getUnionCodec(
-  [getU16Codec(), getBooleanCodec()],
-  (value) => (typeof value === "number" ? 0 : 1),
-  (bytes, offset) => (bytes.slice(offset).length > 1 ? 0 : 1),
+    [getU16Codec(), getBooleanCodec()],
+    (value) => (typeof value === 'number' ? 0 : 1),
+    (bytes, offset) => (bytes.slice(offset).length > 1 ? 0 : 1),
 );
 
 codec.encode(42); // 0x2a00
@@ -2519,7 +2695,7 @@ codec.encode(true); // 0x01
 The `getUnitCodec` function returns a `Codec<void>` that encodes `undefined` into an empty `Uint8Array` and returns `undefined` without consuming any bytes when decoding. This is more of a low-level codec that can be used internally by other codecs. For instance, this is how [getDiscriminatedUnionCodec](#get-discriminated-union-codec) describes the codecs of empty variants.
 
 ```ts twoslash
-import { getUnitCodec } from "@solana/kit";
+import { getUnitCodec } from '@solana/kit';
 const anyBytes = null as unknown as Uint8Array;
 // ---cut-before---
 getUnitCodec().encode(undefined); // Empty Uint8Array

--- a/docs/content/docs/concepts/keypairs.mdx
+++ b/docs/content/docs/concepts/keypairs.mdx
@@ -10,10 +10,10 @@ Kit uses the primitives built-in to JavaScript’s Web Crypto API to perform cry
 Ed25519 keys created or imported using the native APIs are compatible with all of Kit's cryptographic features. Kit also offers several helpers to generate, import, and transform key material.
 
 <Callout title="Looking for Signers instead?">
-  Keys are a low-level primitive. While it's important to know how they work, in a Solana application it's often more
-  appropriate to deal with key material in terms of the accounts and wallets that sign a transaction or message. The
-  [Signers](/concepts/signers) API offers an ergonomic way to build and sign transactions using accounts and their
-  associated keys.
+    Keys are a low-level primitive. While it's important to know how they work, in a Solana
+    application it's often more appropriate to deal with key material in terms of the accounts and
+    wallets that sign a transaction or message. The [Signers](/concepts/signers) API offers an
+    ergonomic way to build and sign transactions using accounts and their associated keys.
 </Callout>
 
 ## Installation
@@ -25,9 +25,9 @@ Key management functions are **included within the `@solana/kit` library** but y
 ```
 
 <Callout title="Not all runtimes support the cryptography required by Solana" type="warn">
-  When deploying your application to a JavaScript runtime that lacks support for the Ed25519 digital signature
-  algorithm, [import our polyfill](#polyfill) before invoking any operations that create or make use of `CryptoKey`
-  objects.
+    When deploying your application to a JavaScript runtime that lacks support for the Ed25519
+    digital signature algorithm, [import our polyfill](#polyfill) before invoking any operations
+    that create or make use of `CryptoKey` objects.
 </Callout>
 
 ## What is a key pair?
@@ -36,8 +36,8 @@ A key pair is a data type composed of 256-bits of random data (the private key) 
 
 ```ts
 interface CryptoKeyPair {
-  privateKey: CryptoKey;
-  publicKey: CryptoKey;
+    privateKey: CryptoKey;
+    publicKey: CryptoKey;
 }
 ```
 
@@ -78,23 +78,23 @@ This is useful in cases where you need to sign for the creation of a new account
 You can create a `CryptoKeyPair` using the 64 bytes of a pre-generated key. This is possible to do with the native [`SubtleCrypto#importKey`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey) API, but it is more convenient to use the helpers in Kit.
 
 ```ts twoslash
-import { createKeyPairFromBytes } from "@solana/kit";
+import { createKeyPairFromBytes } from '@solana/kit';
 const keyPair = await createKeyPairFromBytes(
-  new Uint8Array([
-    /* 32 bytes representing the private key */
-    /* 32 bytes representing the public key */
-  ]),
+    new Uint8Array([
+        /* 32 bytes representing the private key */
+        /* 32 bytes representing the public key */
+    ]),
 );
 ```
 
 In cases where you have only the 32 bytes representing the private key but not its associated public key, you can use a different function that will automatically derive the public key from the private key.
 
 ```ts twoslash
-import { createKeyPairFromPrivateKeyBytes } from "@solana/kit";
+import { createKeyPairFromPrivateKeyBytes } from '@solana/kit';
 const keyPair = await createKeyPairFromPrivateKeyBytes(
-  new Uint8Array([
-    /* 32 bytes representing the private key */
-  ]),
+    new Uint8Array([
+        /* 32 bytes representing the private key */
+    ]),
 );
 ```
 
@@ -106,17 +106,17 @@ Given an instance of an `IDBDatabase` with an object store called `'MyKeyPairSto
 
 ```ts twoslash
 const db = await new Promise<IDBDatabase>((resolve, reject) => {
-  const request = indexedDB.open("MyDatabase", 1);
-  request.onupgradeneeded = (e) => {
-    const db = (e.target as IDBOpenDBRequest).result;
-    db.createObjectStore("MyKeyPairStore");
-  };
-  request.onsuccess = (e) => {
-    resolve((e.target as IDBOpenDBRequest).result);
-  };
-  request.onerror = (e) => {
-    reject((e.target as IDBOpenDBRequest).error);
-  };
+    const request = indexedDB.open('MyDatabase', 1);
+    request.onupgradeneeded = (e) => {
+        const db = (e.target as IDBOpenDBRequest).result;
+        db.createObjectStore('MyKeyPairStore');
+    };
+    request.onsuccess = (e) => {
+        resolve((e.target as IDBOpenDBRequest).result);
+    };
+    request.onerror = (e) => {
+        reject((e.target as IDBOpenDBRequest).error);
+    };
 });
 ```
 
@@ -126,12 +126,12 @@ You can store a key pair like this:
 const db = null as unknown as IDBDatabase;
 const keyPair = null as unknown as CryptoKeyPair;
 // ---cut-before---
-const transaction = db.transaction("MyKeyPairStore", "readwrite");
-const store = transaction.objectStore("MyKeyPairStore");
+const transaction = db.transaction('MyKeyPairStore', 'readwrite');
+const store = transaction.objectStore('MyKeyPairStore');
 await new Promise<void>((resolve, reject) => {
-  const request = store.put(keyPair, "myStoredKey");
-  request.onsuccess = () => resolve();
-  request.onerror = () => reject(request.error);
+    const request = store.put(keyPair, 'myStoredKey');
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
 });
 ```
 
@@ -140,26 +140,27 @@ And then later retrieve it like this:
 ```ts twoslash
 const db = null as unknown as IDBDatabase;
 // ---cut-before---
-const transaction = db.transaction("MyKeyPairStore", "readonly");
-const store = transaction.objectStore("MyKeyPairStore");
+const transaction = db.transaction('MyKeyPairStore', 'readonly');
+const store = transaction.objectStore('MyKeyPairStore');
 const loadedKeyPair = await new Promise<CryptoKeyPair>((resolve, reject) => {
-  const request = store.get("myStoredKey");
-  request.onsuccess = () => {
-    if (request.result) {
-      resolve(request.result);
-    } else {
-      reject(new Error("Key not found"));
-    }
-  };
-  request.onerror = () => reject(request.error);
+    const request = store.get('myStoredKey');
+    request.onsuccess = () => {
+        if (request.result) {
+            resolve(request.result);
+        } else {
+            reject(new Error('Key not found'));
+        }
+    };
+    request.onerror = () => reject(request.error);
 });
 ```
 
 <Callout type="warn">
-  Keys stored in IndexedDB are local to the host, are subject to its [storage limits and eviction
-  criteria](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API#storage_limits_and_eviction_criteria), and
-  can not be accessed from a domain other than the one that stored them when the host is a web browser. Keys that are
-  evicted from storage or erased by the user can generally not be recovered.
+    Keys stored in IndexedDB are local to the host, are subject to its [storage limits and eviction
+    criteria](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API#storage_limits_and_eviction_criteria),
+    and can not be accessed from a domain other than the one that stored them when the host is a web
+    browser. Keys that are evicted from storage or erased by the user can generally not be
+    recovered.
 </Callout>
 
 ### Exporting a key
@@ -169,17 +170,17 @@ You can obtain the 32 bytes of any public key like this:
 ```ts twoslash
 const keyPair = null as unknown as CryptoKeyPair;
 // ---cut-before---
-const publicKeyBytes = new Uint8Array(await crypto.subtle.exportKey("raw", keyPair.publicKey));
+const publicKeyBytes = new Uint8Array(await crypto.subtle.exportKey('raw', keyPair.publicKey));
 ```
 
 Exporting private key material requires a specially constructed `CryptoKey` with its extractable property set to `true`.
 
 ```ts twoslash
 const keyPair = await crypto.subtle.generateKey(
-  /* algorithm */ { name: "Ed25519" },
-  /* extractable */ true,
-  //                ^^^^
-  /* usages */ ["sign", "verify"],
+    /* algorithm */ { name: 'Ed25519' },
+    /* extractable */ true,
+    //                ^^^^
+    /* usages */ ['sign', 'verify'],
 );
 ```
 
@@ -188,14 +189,15 @@ You can then use that `CryptoKey` with the [`SubtleCrypto#exportKey`](https://de
 ```ts twoslash
 const keyPair = null as unknown as CryptoKeyPair;
 // ---cut-before---
-const exportedPrivateKey = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+const exportedPrivateKey = await crypto.subtle.exportKey('pkcs8', keyPair.privateKey);
 const privateKeyBytes = new Uint8Array(exportedPrivateKey, exportedPrivateKey.byteLength - 32, 32);
 ```
 
 <Callout title="Security warning" type="warn">
-  Exporting private key material in JavaScript is not recommended, and you should take extreme care when doing so.
-  Private key bytes exported through these APIs are vulnerable to theft (eg. by code running in your JavaScript sandbox)
-  and accidental logging (eg. to the console or to a third-party logger).
+    Exporting private key material in JavaScript is not recommended, and you should take extreme
+    care when doing so. Private key bytes exported through these APIs are vulnerable to theft (eg.
+    by code running in your JavaScript sandbox) and accidental logging (eg. to the console or to a
+    third-party logger).
 </Callout>
 
 ## Using private keys
@@ -209,10 +211,10 @@ Private keys can be used by their owner to produce a digital signature of a spec
 Any data that you can serialize as a `Uint8Array` can be signed with a `CryptoKey`.
 
 ```ts twoslash
-import { ReadonlyUint8Array } from "@solana/kit";
+import { ReadonlyUint8Array } from '@solana/kit';
 // ---cut-before---
-import { getU32Encoder, getUtf8Encoder } from "@solana/kit";
-const messageFromText = getUtf8Encoder().encode("🎉");
+import { getU32Encoder, getUtf8Encoder } from '@solana/kit';
+const messageFromText = getUtf8Encoder().encode('🎉');
 const messageFromU32 = getU32Encoder().encode(0xdeadbeef);
 const messageOfBytes = new Uint8Array([1, 2, 3]);
 ```
@@ -222,18 +224,19 @@ Supply a message and a private key to the [`signBytes()`](/api/functions/signByt
 ```ts twoslash
 const bobsKeyPair = null as unknown as CryptoKeyPair;
 // ---cut-before---
-import { getUtf8Encoder, signBytes } from "@solana/kit";
-const message = getUtf8Encoder().encode("The meeting is at 6:00pm");
+import { getUtf8Encoder, signBytes } from '@solana/kit';
+const message = getUtf8Encoder().encode('The meeting is at 6:00pm');
 const bobsSignature = await signBytes(bobsKeyPair.privateKey, message);
 console.log(bobsSignature);
 // @log: Uint8Array(64) [79, 43, 140, 65, 177, 35, 169, 61, 62, 228, 190, 202, 205, 143, 4, 35, 83, 228, 47, 76, 68, 62, 125, 140, 21, 102, 182, 105, 24, 238, 67, 40, 179, 255, 247, 136, 95, 119, 46, 244, 44, 224, 100, 111, 68, 110, 189, 224, 159, 144, 197, 181, 210, 132, 101, 226, 120, 200, 0, 102, 104, 65, 216, 3]
 ```
 
 <Callout type="info">
-  The same message and private key might produce a different signature every time you call this function. Some runtimes
-  produce randomized signatures as per
-  [draft-irtf-cfrg-det-sigs-with-noise](https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/) while
-  others produce deterministic signatures as per [RFC 8032](https://www.rfc-editor.org/rfc/rfc8032).
+    The same message and private key might produce a different signature every time you call this
+    function. Some runtimes produce randomized signatures as per
+    [draft-irtf-cfrg-det-sigs-with-noise](https://datatracker.ietf.org/doc/draft-irtf-cfrg-det-sigs-with-noise/)
+    while others produce deterministic signatures as per [RFC
+    8032](https://www.rfc-editor.org/rfc/rfc8032).
 </Callout>
 
 ### Signing transactions
@@ -241,11 +244,11 @@ console.log(bobsSignature);
 In Kit, private keys are used to digitally sign transactions on behalf of account owners, to approve spending, transfers, and modifications to account data on the blockchain.
 
 ```ts twoslash
-import { Transaction } from "@solana/kit";
+import { Transaction } from '@solana/kit';
 const transaction = null as unknown as Transaction;
 const bobsKeyPair = null as unknown as CryptoKeyPair;
 // ---cut-before---
-import { signTransaction } from "@solana/kit";
+import { signTransaction } from '@solana/kit';
 const signedTransaction = await signTransaction([bobsKeyPair], transaction);
 ```
 
@@ -264,37 +267,48 @@ The public key associated with a given private key can be used by anyone to veri
 If someone sends us a message and signature that they claim to be from the example above, we could use Bob's public key to verify that the signature was in fact the one produced by Bob and that the message was not modified in transit.
 
 ```ts twoslash
-import { SignatureBytes } from "@solana/kit";
+import { SignatureBytes } from '@solana/kit';
 const bobsPublicKey = null as unknown as CryptoKey;
 const supposedlyBobsSignature = null as unknown as SignatureBytes;
 // ---cut-before---
-import { getUtf8Encoder, verifySignature } from "@solana/kit";
+import { getUtf8Encoder, verifySignature } from '@solana/kit';
 const verificationSucceeded = await verifySignature(
-  bobsPublicKey,
-  supposedlyBobsSignature,
-  getUtf8Encoder().encode("The meeting is at 6:00pm"),
+    bobsPublicKey,
+    supposedlyBobsSignature,
+    getUtf8Encoder().encode('The meeting is at 6:00pm'),
 );
 if (!verificationSucceeded) {
-  throw new Error("Either the message was modified, the signature was not produced by Bob, or both");
+    throw new Error(
+        'Either the message was modified, the signature was not produced by Bob, or both',
+    );
 }
 ```
 
 Verification protects equally against false claims of who produced the signature as it does against false claims about what message was signed. Both of these will return `false`;
 
+{/* prettier-ignore */}
 ```ts twoslash
-import { SignatureBytes } from "@solana/kit";
+import { SignatureBytes } from '@solana/kit';
 const bobsPublicKey = null as unknown as CryptoKey;
 const bobsSignature = null as unknown as SignatureBytes;
 const mallorysSignature = null as unknown as SignatureBytes;
 const signature = null as unknown as SignatureBytes;
 // ---cut-before---
-import { getUtf8Encoder, verifySignature } from "@solana/kit";
+import { getUtf8Encoder, verifySignature } from '@solana/kit';
 // False claim that Bob signed the message when it was in fact Mallory
-await verifySignature(bobsPublicKey, mallorysSignature, getUtf8Encoder().encode("The meeting is at 6:00pm"));
-//                                   ^^^^^^^^^^^^^^^^^
+await verifySignature(
+    bobsPublicKey,
+    mallorysSignature,
+  //^^^^^^^^^^^^^^^^^
+    getUtf8Encoder().encode('The meeting is at 6:00pm'),
+);
 // False claim about the contents of the message
-await verifySignature(bobsPublicKey, bobsSignature, getUtf8Encoder().encode("The meeting is at 6:00am"));
-//                                                                                             ^^^^^^
+await verifySignature(
+    bobsPublicKey,
+    bobsSignature,
+    getUtf8Encoder().encode('The meeting is at 6:00am'),
+    //                                         ^^^^^^
+);
 ```
 
 ### Deriving addresses
@@ -304,7 +318,7 @@ The Solana address associated with any public key can be derived using the [`get
 ```ts twoslash
 const keyPair = null as unknown as CryptoKeyPair;
 // ---cut-before---
-import { getAddressFromPublicKey } from "@solana/kit";
+import { getAddressFromPublicKey } from '@solana/kit';
 const address = await getAddressFromPublicKey(keyPair.publicKey);
 ```
 
@@ -316,61 +330,63 @@ When you acquire a string that you expect to be a base58-encoded signature (eg. 
 
 ```ts twoslash
 // @noErrors: 1308
-import { GetSignatureStatusesApi, Rpc } from "@solana/kit";
+import { GetSignatureStatusesApi, Rpc } from '@solana/kit';
 const rpc = null as unknown as Rpc<GetSignatureStatusesApi>;
 const signatureInput = null as unknown as HTMLInputElement;
 // ---cut-before---
-import { assertIsSignature } from "@solana/kit";
+import { assertIsSignature } from '@solana/kit';
 
 // Imagine a function that asserts whether a user-supplied signature is valid or not.
 function handleSubmit() {
-  // We know only that what the user typed conforms to the `string` type.
-  const signature: string = signatureInput.value;
-  try {
-    // If this type assertion function doesn't throw, then
-    // Typescript will upcast `signature` to `Signature`.
-    assertIsSignature(signature);
-    // At this point, `signature` is a `Signature` that can be used with the RPC.
-    const {
-      value: [status],
-    } = await rpc.getSignatureStatuses([signature]).send();
-  } catch (e) {
-    // `signature` turned out not to be a base58-encoded signature
-  }
+    // We know only that what the user typed conforms to the `string` type.
+    const signature: string = signatureInput.value;
+    try {
+        // If this type assertion function doesn't throw, then
+        // Typescript will upcast `signature` to `Signature`.
+        assertIsSignature(signature);
+        // At this point, `signature` is a `Signature` that can be used with the RPC.
+        const {
+            value: [status],
+        } = await rpc.getSignatureStatuses([signature]).send();
+    } catch (e) {
+        // `signature` turned out not to be a base58-encoded signature
+    }
 }
 ```
 
 Similarly, you can use the [`isSignature()`](/api/functions/isSignature) type guard. It will return `true` if the input string conforms to the `Signature` type and will refine the type for use in your program from that point onward. This method does not throw in the opposite case.
 
 ```ts twoslash
-import { GetSignatureStatusesApi, Rpc } from "@solana/kit";
+import { GetSignatureStatusesApi, Rpc } from '@solana/kit';
 const rpc = null as unknown as Rpc<GetSignatureStatusesApi>;
-const signature = "";
+const signature = '';
 function setError(s: string) {}
-function setSignatureStatus(s: ReturnType<GetSignatureStatusesApi["getSignatureStatuses"]>["value"][number]) {}
+function setSignatureStatus(
+    s: ReturnType<GetSignatureStatusesApi['getSignatureStatuses']>['value'][number],
+) {}
 // ---cut-before---
-import { isSignature } from "@solana/kit";
+import { isSignature } from '@solana/kit';
 
 if (isSignature(signature)) {
-  // At this point, `signature` has been refined to a
-  // `Signature` that can be used with the RPC.
-  const {
-    value: [status],
-  } = await rpc.getSignatureStatuses([signature]).send();
-  setSignatureStatus(status);
+    // At this point, `signature` has been refined to a
+    // `Signature` that can be used with the RPC.
+    const {
+        value: [status],
+    } = await rpc.getSignatureStatuses([signature]).send();
+    setSignatureStatus(status);
 } else {
-  setError(`${signature} is not a transaction signature`);
+    setError(`${signature} is not a transaction signature`);
 }
 ```
 
 The [`signature()`](/api/functions/signature) helper combines _asserting_ that a string is an Ed25519 signature with _coercing_ it to the `Signature` type. It's best used with untrusted input.
 
 ```ts
-import { signature } from "@solana/keys";
+import { signature } from '@solana/keys';
 
 const signature = signature(userSuppliedSignature);
 const {
-  value: [status],
+    value: [status],
 } = await rpc.getSignatureStatuses([signature]).send();
 ```
 
@@ -406,25 +422,25 @@ To use keys in a runtime without Ed25519 digital signature algorithm support, in
 Then import and install it before invoking any operations that create or make use of `CryptoKey` objects.
 
 ```ts twoslash
-import { install } from "@solana/webcrypto-ed25519-polyfill";
+import { install } from '@solana/webcrypto-ed25519-polyfill';
 
 // Calling this will shim methods on `SubtleCrypto`, adding Ed25519 support.
 install();
 
 // Now you can do this, in environments that do not otherwise support Ed25519.
-const keyPair = await crypto.subtle.generateKey({ name: "Ed25519" }, false, ["sign"]);
+const keyPair = await crypto.subtle.generateKey({ name: 'Ed25519' }, false, ['sign']);
 ```
 
 Wherever you call `install()`, make sure the call is made only once, and before any key operation requiring Ed25519 support is performed.
 
 <Callout title="Security warning" type="warn">
-  Because the polyfill's implementation of Ed25519 key generation exists in userspace, it can't guarantee that the keys
-  you generate with it are non-exportable. Untrusted code running in your JavaScript context may still be able to gain
-  access to and/or exfiltrate secret key material.
+    Because the polyfill's implementation of Ed25519 key generation exists in userspace, it can't
+    guarantee that the keys you generate with it are non-exportable. Untrusted code running in your
+    JavaScript context may still be able to gain access to and/or exfiltrate secret key material.
 </Callout>
 
 <Callout title="Storing polyfilled keys in IndexedDB" type="warn">
-  Native `CryptoKeys` can be stored in IndexedDB, but the keys created by this polyfill can not. This is because, unlike
-  native `CryptoKeys`, our polyfilled key objects can not implement the [structured clone
-  algorithm](https://www.w3.org/TR/WebCryptoAPI/#cryptokey-interface-clone).
+    Native `CryptoKeys` can be stored in IndexedDB, but the keys created by this polyfill can not.
+    This is because, unlike native `CryptoKeys`, our polyfilled key objects can not implement the
+    [structured clone algorithm](https://www.w3.org/TR/WebCryptoAPI/#cryptokey-interface-clone).
 </Callout>

--- a/docs/content/docs/concepts/meta.json
+++ b/docs/content/docs/concepts/meta.json
@@ -1,4 +1,4 @@
 {
-  "title": "Core concepts",
-  "defaultOpen": true
+    "title": "Core concepts",
+    "defaultOpen": true
 }

--- a/docs/content/docs/getting-started/build-transaction.mdx
+++ b/docs/content/docs/getting-started/build-transaction.mdx
@@ -10,13 +10,13 @@ Before we start building our transaction, let's take a moment to discuss immutab
 Consider the following mutable variable:
 
 ```ts twoslash
-let person = { name: "Alice" };
+let person = { name: 'Alice' };
 ```
 
 As you can see by hovering on top of the `person` variable, TypeScript assigns the type `{ name: string }` to it. Now imagine we wanted to gradually grow this type by adding more properties to it. Say we wanted to add an `age` and a `wallet` property to it by using the following functions:
 
 ```ts twoslash
-import { Address } from "@solana/kit";
+import { Address } from '@solana/kit';
 
 const setAge = <T extends object>(age: number, p: T) => ({ ...p, age });
 const setWallet = <T extends object>(wallet: Address, p: T) => ({ ...p, wallet });
@@ -26,18 +26,18 @@ One way to tackle this is to mutate the variable at each step like so.
 
 ```ts twoslash
 // @errors: 1360
-import { address, Address } from "@solana/kit";
+import { address, Address } from '@solana/kit';
 // ---cut-start---
 const setAge = <T extends object>(age: number, p: T) => ({ ...p, age });
 const setWallet = <T extends object>(wallet: Address, p: T) => ({
-  ...p,
-  wallet,
+    ...p,
+    wallet,
 });
 // ---cut-end---
 
-let person = { name: "Alice" };
+let person = { name: 'Alice' };
 person = setAge(30, person);
-person = setWallet(address("1234..5678"), person);
+person = setWallet(address('1234..5678'), person);
 
 person satisfies { name: string; age: number; wallet: Address };
 ```
@@ -47,18 +47,18 @@ But as you can see, even after updating our variable, TypeScript still believes 
 Fortunately, the Kit library offers a functional API which means its types are designed to be immutable. So, instead of trying to grow the `person` variable by mutating it, it creates new variables with new types at each step.
 
 ```ts twoslash
-import { address, Address } from "@solana/kit";
+import { address, Address } from '@solana/kit';
 // ---cut-start---
 const setAge = <T extends object>(age: number, p: T) => ({ ...p, age });
 const setWallet = <T extends object>(wallet: Address, p: T) => ({
-  ...p,
-  wallet,
+    ...p,
+    wallet,
 });
 // ---cut-end---
 
-const person = { name: "Alice" };
+const person = { name: 'Alice' };
 const personWithAge = setAge(30, person);
-const personWithAgeAndWallet = setWallet(address("1234..5678"), personWithAge);
+const personWithAgeAndWallet = setWallet(address('1234..5678'), personWithAge);
 
 personWithAgeAndWallet satisfies { name: string; age: number; wallet: Address };
 ```
@@ -66,19 +66,19 @@ personWithAgeAndWallet satisfies { name: string; age: number; wallet: Address };
 The downside is we now need to create a new variable at each step. This is where the `pipe` function comes in. It takes a starting value and runs it through a series of functions, one after the other, returning the final result. This lets us build up the value and its type without needing extra variables.
 
 ```ts twoslash
-import { pipe, address, Address } from "@solana/kit";
+import { pipe, address, Address } from '@solana/kit';
 // ---cut-start---
 const setAge = <T extends object>(age: number, p: T) => ({ ...p, age });
 const setWallet = <T extends object>(wallet: Address, p: T) => ({
-  ...p,
-  wallet,
+    ...p,
+    wallet,
 });
 // ---cut-end---
 
 const person = pipe(
-  { name: "Alice" },
-  (p) => setAge(30, p),
-  (p) => setWallet(address("1234..5678"), p),
+    { name: 'Alice' },
+    (p) => setAge(30, p),
+    (p) => setWallet(address('1234..5678'), p),
 );
 
 person satisfies { name: string; age: number; wallet: Address };
@@ -95,11 +95,11 @@ The first step in building a transaction is to create a new empty transaction me
 To create one, we can use the `createTransactionMessage` function. This function requires a `version` parameter which is used to determine the format of the transaction. At the time of writing, `0` is the latest version available so we'll use that.
 
 ```ts twoslash
-import { createTransactionMessage, pipe } from "@solana/kit";
+import { createTransactionMessage, pipe } from '@solana/kit';
 
 const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  // Customize the transaction message using helper functions here...
+    createTransactionMessage({ version: 0 }),
+    // Customize the transaction message using helper functions here...
 );
 ```
 
@@ -109,25 +109,25 @@ Next, we need to set a fee payer for our transaction. This is the wallet that wi
 
 ```ts twoslash
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-} from "@solana/kit";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+} from '@solana/kit';
 type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 const client = {} as Client;
 // ---cut-before---
-import { createTransactionMessage, pipe, setTransactionMessageFeePayerSigner } from "@solana/kit";
+import { createTransactionMessage, pipe, setTransactionMessageFeePayerSigner } from '@solana/kit';
 
 const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(client.wallet, tx), // [!code ++]
+    createTransactionMessage({ version: 0 }),
+    (tx) => setTransactionMessageFeePayerSigner(client.wallet, tx), // [!code ++]
 );
 ```
 
@@ -144,33 +144,33 @@ For this tutorial, we'll use the blockhash strategy. To do this, we can use the 
 
 ```ts twoslash
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-} from "@solana/kit";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+} from '@solana/kit';
 type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 const client = {} as Client;
 // ---cut-before---
 import {
-  createTransactionMessage,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-} from "@solana/kit";
+    createTransactionMessage,
+    pipe,
+    setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
+} from '@solana/kit';
 
 const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send(); // [!code ++]
 
 const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(client.wallet, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx), // [!code ++]
+    createTransactionMessage({ version: 0 }),
+    (tx) => setTransactionMessageFeePayerSigner(client.wallet, tx),
+    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx), // [!code ++]
 );
 ```
 
@@ -180,39 +180,39 @@ Last but not least, we need to add our instructions to the transaction message. 
 
 ```ts twoslash
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-} from "@solana/kit";
-import { getCreateAccountInstruction } from "@solana-program/system";
-import { getInitializeMintInstruction } from "@solana-program/token";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+} from '@solana/kit';
+import { getCreateAccountInstruction } from '@solana-program/system';
+import { getInitializeMintInstruction } from '@solana-program/token';
 type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 const client = {} as Client;
 const createAccountIx = null as unknown as ReturnType<typeof getCreateAccountInstruction>;
 const initializeMintIx = null as unknown as ReturnType<typeof getInitializeMintInstruction>;
 // ---cut-before---
 import {
-  appendTransactionMessageInstructions,
-  createTransactionMessage,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-} from "@solana/kit";
+    appendTransactionMessageInstructions,
+    createTransactionMessage,
+    pipe,
+    setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
+} from '@solana/kit';
 
 const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
 
 const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(client.wallet, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions([createAccountIx, initializeMintIx], tx), // [!code ++]
+    createTransactionMessage({ version: 0 }),
+    (tx) => setTransactionMessageFeePayerSigner(client.wallet, tx),
+    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+    (tx) => appendTransactionMessageInstructions([createAccountIx, initializeMintIx], tx), // [!code ++]
 );
 ```
 
@@ -224,37 +224,42 @@ A good way to estimate how much compute unit a transaction will need is to simul
 
 ```ts twoslash
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-  CompilableTransactionMessage,
-} from "@solana/kit";
-import { getCreateAccountInstruction } from "@solana-program/system";
-import { getInitializeMintInstruction } from "@solana-program/token";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+    CompilableTransactionMessage,
+} from '@solana/kit';
+import { getCreateAccountInstruction } from '@solana-program/system';
+import { getInitializeMintInstruction } from '@solana-program/token';
 type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 const client = {} as Client;
 const transactionMessage = null as unknown as CompilableTransactionMessage;
 // ---cut-before---
-import { getComputeUnitEstimateForTransactionMessageFactory, prependTransactionMessageInstruction } from "@solana/kit";
-import { getSetComputeUnitLimitInstruction } from "@solana-program/compute-budget";
+import {
+    getComputeUnitEstimateForTransactionMessageFactory,
+    prependTransactionMessageInstruction,
+} from '@solana/kit';
+import { getSetComputeUnitLimitInstruction } from '@solana-program/compute-budget';
 
 // Build the function to estimate compute units.
-const estimateComputeUnitLimit = getComputeUnitEstimateForTransactionMessageFactory({ rpc: client.rpc });
+const estimateComputeUnitLimit = getComputeUnitEstimateForTransactionMessageFactory({
+    rpc: client.rpc,
+});
 
 // Estimate compute units.
 const computeUnitsEstimate = await estimateComputeUnitLimit(transactionMessage);
 
 // Prepend the compute unit limit instruction to the transaction message.
 const transactionMessageWithComputeUnitLimit = prependTransactionMessageInstruction(
-  getSetComputeUnitLimitInstruction({ units: computeUnitsEstimate }),
-  transactionMessage,
+    getSetComputeUnitLimitInstruction({ units: computeUnitsEstimate }),
+    transactionMessage,
 );
 ```
 
@@ -262,24 +267,26 @@ Since this is a common operation, let's add a helper function to our `Client` ty
 
 ```ts twoslash title="src/client.ts"
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-} from "@solana/kit";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+} from '@solana/kit';
 // ---cut-before---
 import {
-  CompilableTransactionMessage, // [!code ++]
-  // ...
-} from "@solana/kit";
+    CompilableTransactionMessage, // [!code ++]
+    // ...
+} from '@solana/kit';
 
 export type Client = {
-  estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(transactionMessage: T) => Promise<T>; // [!code ++]
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(
+        transactionMessage: T,
+    ) => Promise<T>; // [!code ++]
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 ```
 
@@ -287,52 +294,58 @@ Next, we'll implement this function in the `createClient` method by adding the f
 
 ```ts twoslash title="src/client.ts"
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-  CompilableTransactionMessage,
-} from "@solana/kit";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+    CompilableTransactionMessage,
+} from '@solana/kit';
 export type Client = {
-  estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(transactionMessage: T) => Promise<T>; // [!code ++]
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(
+        transactionMessage: T,
+    ) => Promise<T>; // [!code ++]
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 const rpc = {} as Rpc<SolanaRpcApi>;
 const rpcSubscriptions = {} as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
 const wallet = {} as TransactionSigner & MessageSigner;
 // ---cut-before---
 import {
-  getComputeUnitEstimateForTransactionMessageFactory, // [!code ++]
-  prependTransactionMessageInstruction, // [!code ++]
-  // ...
-} from "@solana/kit";
-import { getSetComputeUnitLimitInstruction } from "@solana-program/compute-budget"; // [!code ++]
+    getComputeUnitEstimateForTransactionMessageFactory, // [!code ++]
+    prependTransactionMessageInstruction, // [!code ++]
+    // ...
+} from '@solana/kit';
+import { getSetComputeUnitLimitInstruction } from '@solana-program/compute-budget'; // [!code ++]
 
 let client: Client | undefined;
 export async function createClient(): Promise<Client> {
-  if (!client) {
-    // ...
+    if (!client) {
+        // ...
 
-    // Create a function to estimate and set the compute unit limit. // [!code ++]
-    const estimateComputeUnitLimit = getComputeUnitEstimateForTransactionMessageFactory({ rpc }); // [!code ++]
-    const estimateAndSetComputeUnitLimit = async <T extends CompilableTransactionMessage>(transactionMessage: T) => {
-      // [!code ++]
-      const computeUnitsEstimate = await estimateComputeUnitLimit(transactionMessage); // [!code ++]
-      return prependTransactionMessageInstruction(
-        // [!code ++]
-        getSetComputeUnitLimitInstruction({ units: computeUnitsEstimate }), // [!code ++]
-        transactionMessage, // [!code ++]
-      ); // [!code ++]
-    }; // [!code ++]
+        // Create a function to estimate and set the compute unit limit. // [!code ++]
+        const estimateComputeUnitLimit = getComputeUnitEstimateForTransactionMessageFactory({
+            rpc,
+        }); // [!code ++]
+        const estimateAndSetComputeUnitLimit = async <T extends CompilableTransactionMessage>(
+            transactionMessage: T,
+        ) => {
+            // [!code ++]
+            const computeUnitsEstimate = await estimateComputeUnitLimit(transactionMessage); // [!code ++]
+            return prependTransactionMessageInstruction(
+                // [!code ++]
+                getSetComputeUnitLimitInstruction({ units: computeUnitsEstimate }), // [!code ++]
+                transactionMessage, // [!code ++]
+            ); // [!code ++]
+        }; // [!code ++]
 
-    // Store the client.
-    client = { estimateAndSetComputeUnitLimit, rpc, rpcSubscriptions, wallet };
-  }
-  return client;
+        // Store the client.
+        client = { estimateAndSetComputeUnitLimit, rpc, rpcSubscriptions, wallet };
+    }
+    return client;
 }
 ```
 
@@ -340,43 +353,45 @@ Finally, we can now use this new `estimateAndSetComputeUnitLimit` helper at the 
 
 ```ts twoslash
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-  CompilableTransactionMessage,
-} from "@solana/kit";
-import { getCreateAccountInstruction } from "@solana-program/system";
-import { getInitializeMintInstruction } from "@solana-program/token";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+    CompilableTransactionMessage,
+} from '@solana/kit';
+import { getCreateAccountInstruction } from '@solana-program/system';
+import { getInitializeMintInstruction } from '@solana-program/token';
 type Client = {
-  estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(transactionMessage: T) => Promise<T>;
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(
+        transactionMessage: T,
+    ) => Promise<T>;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 const client = {} as Client;
 const createAccountIx = null as unknown as ReturnType<typeof getCreateAccountInstruction>;
 const initializeMintIx = null as unknown as ReturnType<typeof getInitializeMintInstruction>;
 // ---cut-before---
 import {
-  appendTransactionMessageInstructions,
-  createTransactionMessage,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-} from "@solana/kit";
+    appendTransactionMessageInstructions,
+    createTransactionMessage,
+    pipe,
+    setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
+} from '@solana/kit';
 
 const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
 
 // [!code word:await]
 const transactionMessage = await pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(client.wallet, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions([createAccountIx, initializeMintIx], tx),
-  (tx) => client.estimateAndSetComputeUnitLimit(tx), // [!code ++]
+    createTransactionMessage({ version: 0 }),
+    (tx) => setTransactionMessageFeePayerSigner(client.wallet, tx),
+    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+    (tx) => appendTransactionMessageInstructions([createAccountIx, initializeMintIx], tx),
+    (tx) => client.estimateAndSetComputeUnitLimit(tx), // [!code ++]
 );
 ```
 
@@ -385,10 +400,10 @@ const transactionMessage = await pipe(
 Our transaction message is now fully configured and ready to be signed. Since we have been providing signer objects every step of the way, our transaction message already knows how to sign itself. All that is left to do is call `signTransactionMessageWithSigners`. This helper function will extract and deduplicate all the signers from the transaction message and use them to sign the message. As the message is signed, it is compiled into a new `Transaction` type that contains the compiled message and all of its signatures.
 
 ```ts twoslash
-import { CompilableTransactionMessage } from "@solana/kit";
+import { CompilableTransactionMessage } from '@solana/kit';
 const transactionMessage = null as unknown as CompilableTransactionMessage;
 // ---cut-before---
-import { signTransactionMessageWithSigners } from "@solana/kit";
+import { signTransactionMessageWithSigners } from '@solana/kit';
 
 const signedTransaction = await signTransactionMessageWithSigners(transactionMessage);
 ```
@@ -400,73 +415,79 @@ And we finally have our fully signed transaction! In the next article, we'll lea
 ```ts twoslash title="src/create-mint.ts"
 // @filename: client.ts
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-  CompilableTransactionMessage,
-} from "@solana/kit";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+    CompilableTransactionMessage,
+} from '@solana/kit';
 export type Client = {
-  estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(transactionMessage: T) => Promise<T>;
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(
+        transactionMessage: T,
+    ) => Promise<T>;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 // @filename: create-mint.ts
 // ---cut-before---
 import {
-  appendTransactionMessageInstructions,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
-} from "@solana/kit";
-import { getCreateAccountInstruction } from "@solana-program/system";
-import { getInitializeMintInstruction, getMintSize, TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+    appendTransactionMessageInstructions,
+    createTransactionMessage,
+    generateKeyPairSigner,
+    pipe,
+    setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
+    signTransactionMessageWithSigners,
+} from '@solana/kit';
+import { getCreateAccountInstruction } from '@solana-program/system';
+import {
+    getInitializeMintInstruction,
+    getMintSize,
+    TOKEN_PROGRAM_ADDRESS,
+} from '@solana-program/token';
 
-import type { Client } from "./client";
+import type { Client } from './client';
 
 export async function createMint(client: Client, options: { decimals?: number } = {}) {
-  // Prepare inputs.
-  const mintSize = getMintSize();
-  const [mint, mintRent, { value: latestBlockhash }] = await Promise.all([
-    generateKeyPairSigner(),
-    client.rpc.getMinimumBalanceForRentExemption(BigInt(mintSize)).send(),
-    client.rpc.getLatestBlockhash().send(),
-  ]);
+    // Prepare inputs.
+    const mintSize = getMintSize();
+    const [mint, mintRent, { value: latestBlockhash }] = await Promise.all([
+        generateKeyPairSigner(),
+        client.rpc.getMinimumBalanceForRentExemption(BigInt(mintSize)).send(),
+        client.rpc.getLatestBlockhash().send(),
+    ]);
 
-  // Build instructions.
-  const createAccountIx = getCreateAccountInstruction({
-    payer: client.wallet,
-    newAccount: mint,
-    space: mintSize,
-    lamports: mintRent,
-    programAddress: TOKEN_PROGRAM_ADDRESS,
-  });
-  const initializeMintIx = getInitializeMintInstruction({
-    mint: mint.address,
-    decimals: options.decimals ?? 0,
-    mintAuthority: client.wallet.address,
-    freezeAuthority: client.wallet.address,
-  });
+    // Build instructions.
+    const createAccountIx = getCreateAccountInstruction({
+        payer: client.wallet,
+        newAccount: mint,
+        space: mintSize,
+        lamports: mintRent,
+        programAddress: TOKEN_PROGRAM_ADDRESS,
+    });
+    const initializeMintIx = getInitializeMintInstruction({
+        mint: mint.address,
+        decimals: options.decimals ?? 0,
+        mintAuthority: client.wallet.address,
+        freezeAuthority: client.wallet.address,
+    });
 
-  // Build the transaction message.
-  const transactionMessage = await pipe(
-    createTransactionMessage({ version: 0 }),
-    (tx) => setTransactionMessageFeePayerSigner(client.wallet, tx),
-    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-    (tx) => appendTransactionMessageInstructions([createAccountIx, initializeMintIx], tx),
-    (tx) => client.estimateAndSetComputeUnitLimit(tx),
-  );
+    // Build the transaction message.
+    const transactionMessage = await pipe(
+        createTransactionMessage({ version: 0 }),
+        (tx) => setTransactionMessageFeePayerSigner(client.wallet, tx),
+        (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+        (tx) => appendTransactionMessageInstructions([createAccountIx, initializeMintIx], tx),
+        (tx) => client.estimateAndSetComputeUnitLimit(tx),
+    );
 
-  // Compile the transaction message and sign it.
-  const signedTransaction = await signTransactionMessageWithSigners(transactionMessage);
+    // Compile the transaction message and sign it.
+    const signedTransaction = await signTransactionMessageWithSigners(transactionMessage);
 
-  // Send the transaction and wait for confirmation.
-  // TODO: Next article!
+    // Send the transaction and wait for confirmation.
+    // TODO: Next article!
 }
 ```

--- a/docs/content/docs/getting-started/fetch-account.mdx
+++ b/docs/content/docs/getting-started/fetch-account.mdx
@@ -10,13 +10,13 @@ In the previous article of this series, we've learned how to send a transaction 
 RPC methods such as `getAccountInfo` or `getMultipleAccounts` can be used to fetch on-chain accounts from their addresses. These take a variety of options and return different outputs based on these options. For instance, the `encoding` option will determine which string format to use when returning the account's encoded data.
 
 ```ts twoslash
-import { Rpc, SolanaRpcApi } from "@solana/kit";
+import { Rpc, SolanaRpcApi } from '@solana/kit';
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 // ---cut-before---
-import { address } from "@solana/kit";
+import { address } from '@solana/kit';
 
-const { value: account } = await rpc.getAccountInfo(address("1234..5678")).send();
-const { value: accounts } = await rpc.getMultipleAccounts([address("1234..5678")]).send();
+const { value: account } = await rpc.getAccountInfo(address('1234..5678')).send();
+const { value: accounts } = await rpc.getMultipleAccounts([address('1234..5678')]).send();
 ```
 
 ## Fetch using helpers
@@ -28,13 +28,18 @@ Additionally, when trying to fetch an account that does not exist on-chain, the 
 Therefore, Kit offers a set of types and helpers that aim to unify these APIs and make them easier to work with. For instance, the `fetchEncodedAccount` and `fetchEncodedAccounts` helpers can be used to fetch one or multiple accounts and return them in a unified format.
 
 ```ts twoslash
-import { Rpc, SolanaRpcApi } from "@solana/kit";
+import { Rpc, SolanaRpcApi } from '@solana/kit';
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 // ---cut-before---
-import { address, fetchEncodedAccount, fetchEncodedAccounts, MaybeEncodedAccount } from "@solana/kit";
+import {
+    address,
+    fetchEncodedAccount,
+    fetchEncodedAccounts,
+    MaybeEncodedAccount,
+} from '@solana/kit';
 
-const account = await fetchEncodedAccount(rpc, address("1234..5678"));
-const accounts = await fetchEncodedAccounts(rpc, [address("1234..5678")]);
+const account = await fetchEncodedAccount(rpc, address('1234..5678'));
+const accounts = await fetchEncodedAccounts(rpc, [address('1234..5678')]);
 
 account satisfies MaybeEncodedAccount;
 accounts satisfies MaybeEncodedAccount[];
@@ -43,31 +48,43 @@ accounts satisfies MaybeEncodedAccount[];
 As you can see, the return types are all `MaybeAccounts`. This means the account may or may not exist on-chain. It contains an `exists` field indicating whether the account exists. If it does, we have access to all its fields. Otherwise, we just know its address — since it was provided as an input.
 
 ```ts twoslash
-import { Rpc, SolanaRpcApi } from "@solana/kit";
+import { Rpc, SolanaRpcApi } from '@solana/kit';
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 // ---cut-before---
-import { EncodedAccount, address, Address, fetchEncodedAccount, fetchEncodedAccounts } from "@solana/kit";
+import {
+    EncodedAccount,
+    address,
+    Address,
+    fetchEncodedAccount,
+    fetchEncodedAccounts,
+} from '@solana/kit';
 
-const account = await fetchEncodedAccount(rpc, address("1234..5678"));
+const account = await fetchEncodedAccount(rpc, address('1234..5678'));
 
 if (account.exists) {
-  // If it exists, we have access to all its fields.
-  account satisfies EncodedAccount<"1234..5678">;
+    // If it exists, we have access to all its fields.
+    account satisfies EncodedAccount<'1234..5678'>;
 } else {
-  // Otherwise, we just know its address.
-  account satisfies { address: Address<"1234..5678">; exists: false };
+    // Otherwise, we just know its address.
+    account satisfies { address: Address<'1234..5678'>; exists: false };
 }
 ```
 
 We can also assert the existence of an account using the `assertAccountExists` helper. This will throw an error if the account does not exist and tell TypeScript that our `MaybeAccount` is actually an `Account` moving forward.
 
 ```ts twoslash
-import { Rpc, SolanaRpcApi } from "@solana/kit";
+import { Rpc, SolanaRpcApi } from '@solana/kit';
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 // ---cut-before---
-import { assertAccountExists, EncodedAccount, address, fetchEncodedAccount, fetchEncodedAccounts } from "@solana/kit";
+import {
+    assertAccountExists,
+    EncodedAccount,
+    address,
+    fetchEncodedAccount,
+    fetchEncodedAccounts,
+} from '@solana/kit';
 
-const account = await fetchEncodedAccount(rpc, address("1234..5678"));
+const account = await fetchEncodedAccount(rpc, address('1234..5678'));
 assertAccountExists(account);
 
 account satisfies EncodedAccount;
@@ -92,41 +109,41 @@ Mint accounts are composed of the following data:
 By composing various Codec functions — such as `getStructCodec` to create objects or `getOptionCodec` to create optional data — we can design a Codec object that describes the byte layout of the `Mint` account. Here's an example illustrating that. Note that the layout of the `Mint` account was slightly simplified for this example.
 
 ```ts twoslash
-import { Rpc, SolanaRpcApi } from "@solana/kit";
+import { Rpc, SolanaRpcApi } from '@solana/kit';
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 // ---cut-before---
 import {
-  address,
-  Address,
-  assertAccountExists,
-  fetchEncodedAccount,
-  getAddressCodec,
-  getBooleanCodec,
-  getOptionCodec,
-  getStructCodec,
-  getU64Codec,
-  getU8Codec,
-  Option,
-} from "@solana/kit";
+    address,
+    Address,
+    assertAccountExists,
+    fetchEncodedAccount,
+    getAddressCodec,
+    getBooleanCodec,
+    getOptionCodec,
+    getStructCodec,
+    getU64Codec,
+    getU8Codec,
+    Option,
+} from '@solana/kit';
 
-const account = await fetchEncodedAccount(rpc, address("1234..5678"));
+const account = await fetchEncodedAccount(rpc, address('1234..5678'));
 assertAccountExists(account);
 
 const mintCodec = getStructCodec([
-  ["mintAuthority", getOptionCodec(getAddressCodec())], // [simplified]
-  ["supply", getU64Codec()],
-  ["decimals", getU8Codec()],
-  ["isInitialized", getBooleanCodec()],
-  ["freezeAuthority", getOptionCodec(getAddressCodec())], // [simplified]
+    ['mintAuthority', getOptionCodec(getAddressCodec())], // [simplified]
+    ['supply', getU64Codec()],
+    ['decimals', getU8Codec()],
+    ['isInitialized', getBooleanCodec()],
+    ['freezeAuthority', getOptionCodec(getAddressCodec())], // [simplified]
 ]);
 
 const decodedData = mintCodec.decode(account.data);
 decodedData satisfies {
-  mintAuthority: Option<Address>;
-  supply: bigint;
-  decimals: number;
-  isInitialized: boolean;
-  freezeAuthority: Option<Address>;
+    mintAuthority: Option<Address>;
+    supply: bigint;
+    decimals: number;
+    isInitialized: boolean;
+    freezeAuthority: Option<Address>;
 };
 ```
 
@@ -137,13 +154,13 @@ Fortunately for us, we often don't need to manually create these Codec objects a
 For instance, here's how we can access the `Mint` codec from the `@solana-program/token` library.
 
 ```ts twoslash
-import { Rpc, SolanaRpcApi } from "@solana/kit";
+import { Rpc, SolanaRpcApi } from '@solana/kit';
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 // ---cut-before---
-import { address, assertAccountExists, fetchEncodedAccount } from "@solana/kit";
-import { getMintCodec, Mint } from "@solana-program/token";
+import { address, assertAccountExists, fetchEncodedAccount } from '@solana/kit';
+import { getMintCodec, Mint } from '@solana-program/token';
 
-const account = await fetchEncodedAccount(rpc, address("1234..5678"));
+const account = await fetchEncodedAccount(rpc, address('1234..5678'));
 assertAccountExists(account);
 
 const mintCodec = getMintCodec();
@@ -154,13 +171,13 @@ decodedData satisfies Mint;
 This can be simplified even further by using the `decodeX` helpers from program clients. These helpers accept an `EncodedAccount` or a `MaybeEncodedAccount` and return an `Account<T>` or a `MaybeAccount<T>` respectively, where `T` is the type of the account data.
 
 ```ts twoslash
-import { Rpc, SolanaRpcApi } from "@solana/kit";
+import { Rpc, SolanaRpcApi } from '@solana/kit';
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 // ---cut-before---
-import { Account, address, assertAccountExists, fetchEncodedAccount } from "@solana/kit";
-import { decodeMint, Mint } from "@solana-program/token";
+import { Account, address, assertAccountExists, fetchEncodedAccount } from '@solana/kit';
+import { decodeMint, Mint } from '@solana-program/token';
 
-const account = decodeMint(await fetchEncodedAccount(rpc, address("1234..5678")));
+const account = decodeMint(await fetchEncodedAccount(rpc, address('1234..5678')));
 assertAccountExists(account);
 account satisfies Account<Mint>;
 ```
@@ -172,13 +189,13 @@ Last but not least, it is possible to fetch and decode an account in a single st
 This means, everything we've been doing so far can be simplified into a single line of code.
 
 ```ts twoslash
-import { Rpc, SolanaRpcApi } from "@solana/kit";
+import { Rpc, SolanaRpcApi } from '@solana/kit';
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 // ---cut-before---
-import { Account, address } from "@solana/kit";
-import { fetchMint, Mint } from "@solana-program/token";
+import { Account, address } from '@solana/kit';
+import { fetchMint, Mint } from '@solana-program/token';
 
-const account = await fetchMint(rpc, address("1234..5678"));
+const account = await fetchMint(rpc, address('1234..5678'));
 account satisfies Account<Mint>;
 ```
 
@@ -191,48 +208,50 @@ Since some of its data is optional, we'll use the `unwrapOption` helper to conve
 ```ts twoslash title="src/index.ts"
 // @filename: client.ts
 import {
-  CompilableTransactionMessage,
-  MessageSigner,
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  sendAndConfirmTransactionFactory,
-} from "@solana/kit";
+    CompilableTransactionMessage,
+    MessageSigner,
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    sendAndConfirmTransactionFactory,
+} from '@solana/kit';
 export type Client = {
-  estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(transactionMessage: T) => Promise<T>;
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  sendAndConfirmTransaction: ReturnType<typeof sendAndConfirmTransactionFactory>;
-  wallet: TransactionSigner & MessageSigner;
+    estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(
+        transactionMessage: T,
+    ) => Promise<T>;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    sendAndConfirmTransaction: ReturnType<typeof sendAndConfirmTransactionFactory>;
+    wallet: TransactionSigner & MessageSigner;
 };
 export async function createClient() {
-  return {} as Client;
+    return {} as Client;
 }
 // @filename: create-mint.ts
-import { Address } from "@solana/kit";
-import { Client } from "./client";
+import { Address } from '@solana/kit';
+import { Client } from './client';
 export async function createMint(client: Client, options: { decimals?: number } = {}) {
-  return "" as Address;
+    return '' as Address;
 }
 // @filename: index.ts
 // ---cut-before---
-import { unwrapOption } from "@solana/kit"; // [!code ++]
-import { fetchMint } from "@solana-program/token"; // [!code ++]
+import { unwrapOption } from '@solana/kit'; // [!code ++]
+import { fetchMint } from '@solana-program/token'; // [!code ++]
 
-import { createClient } from "./client";
-import { createMint } from "./create-mint";
+import { createClient } from './client';
+import { createMint } from './create-mint';
 
 async function tutorial() {
-  const client = await createClient();
-  const mintAddress = await createMint(client, { decimals: 2 });
-  const mintAccount = await fetchMint(client.rpc, mintAddress); // [!code ++]
-  console.log(`Mint created: ${mintAddress}.`);
-  console.log(`Mint lamports: ${mintAccount.lamports}.`); // [!code ++]
-  console.log(`Mint authority: ${unwrapOption(mintAccount.data.mintAuthority)}.`); // [!code ++]
-  console.log(`Mint decimals: ${mintAccount.data.decimals}.`); // [!code ++]
-  console.log(`Mint supply: ${mintAccount.data.supply}.`); // [!code ++]
+    const client = await createClient();
+    const mintAddress = await createMint(client, { decimals: 2 });
+    const mintAccount = await fetchMint(client.rpc, mintAddress); // [!code ++]
+    console.log(`Mint created: ${mintAddress}.`);
+    console.log(`Mint lamports: ${mintAccount.lamports}.`); // [!code ++]
+    console.log(`Mint authority: ${unwrapOption(mintAccount.data.mintAuthority)}.`); // [!code ++]
+    console.log(`Mint decimals: ${mintAccount.data.decimals}.`); // [!code ++]
+    console.log(`Mint supply: ${mintAccount.data.supply}.`); // [!code ++]
 }
 ```
 

--- a/docs/content/docs/getting-started/instructions.mdx
+++ b/docs/content/docs/getting-started/instructions.mdx
@@ -21,24 +21,24 @@ We'll accept our `Client` object as the first argument and some options as the s
 ```ts twoslash title="src/create-mint.ts"
 // @filename: client.ts
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-} from "@solana/kit";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+} from '@solana/kit';
 export type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 // @filename: create-mint.ts
 // ---cut-before---
-import type { Client } from "./client";
+import type { Client } from './client';
 
 export async function createMint(client: Client, options: { decimals?: number } = {}) {
-  // ...
+    // ...
 }
 ```
 
@@ -51,17 +51,17 @@ To allocate a new account on the Solana blockchain, we need to use the `CreateAc
 ```ts twoslash title="src/create-mint.ts"
 // @filename: client.ts
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-} from "@solana/kit";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+} from '@solana/kit';
 export type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 // @filename: create-mint.ts
 const payer = null as any;
@@ -70,121 +70,121 @@ const lamports = null as any;
 const space = null as any;
 const programAddress = null as any;
 // ---cut-before---
-import { getCreateAccountInstruction } from "@solana-program/system";
+import { getCreateAccountInstruction } from '@solana-program/system';
 
-import type { Client } from "./client";
+import type { Client } from './client';
 
 export async function createMint(client: Client, options: { decimals?: number } = {}) {
-  // Build instructions.
-  const createAccountIx = getCreateAccountInstruction({
-    payer,
-    newAccount,
-    space,
-    lamports,
-    programAddress,
-  });
+    // Build instructions.
+    const createAccountIx = getCreateAccountInstruction({
+        payer,
+        newAccount,
+        space,
+        lamports,
+        programAddress,
+    });
 }
 ```
 
 As you can see, the `getCreateAccountInstruction` helper requires a handful of inputs that we need to provide:
 
 - The `payer` signer that will pay for the storage fees of the newly allocated account. In our case, we'll use the `wallet` signer of our `Client` object.
-  ```ts twoslash
-  import {
-    Rpc,
-    RpcSubscriptions,
-    SolanaRpcApi,
-    SolanaRpcSubscriptionsApi,
-    TransactionSigner,
-    MessageSigner,
-  } from "@solana/kit";
-  type Client = {
-    rpc: Rpc<SolanaRpcApi>;
-    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-    wallet: TransactionSigner & MessageSigner;
-  };
-  const client = {} as Client;
-  // ---cut-before---
-  const payer = client.wallet;
-  ```
+    ```ts twoslash
+    import {
+        Rpc,
+        RpcSubscriptions,
+        SolanaRpcApi,
+        SolanaRpcSubscriptionsApi,
+        TransactionSigner,
+        MessageSigner,
+    } from '@solana/kit';
+    type Client = {
+        rpc: Rpc<SolanaRpcApi>;
+        rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        wallet: TransactionSigner & MessageSigner;
+    };
+    const client = {} as Client;
+    // ---cut-before---
+    const payer = client.wallet;
+    ```
 - The `newAccount` itself as a signer. Since this can be any address, we'll generate a new one and save it as a `mint` variable.
-  ```ts twoslash
-  import { generateKeyPairSigner } from "@solana/kit";
-  const mint = await generateKeyPairSigner();
-  ```
+    ```ts twoslash
+    import { generateKeyPairSigner } from '@solana/kit';
+    const mint = await generateKeyPairSigner();
+    ```
 - The `space` we want to allocated for the new account. For this, we can use the `getMintSize` helper from the `@solana-program/token` library.
-  ```ts twoslash
-  import { getMintSize } from "@solana-program/token";
-  const mintSize = getMintSize();
-  ```
+    ```ts twoslash
+    import { getMintSize } from '@solana-program/token';
+    const mintSize = getMintSize();
+    ```
 - The number of `lamports` to transfer to the new account in order to pay for the storage fees. This can be deduced from the size we want to allocate for the account by using `getMinimumBalanceForRentExemption` RPC method. This method returns the minimum lamports required for an account of the given size.
-  ```ts twoslash
-  import {
-    Rpc,
-    RpcSubscriptions,
-    SolanaRpcApi,
-    SolanaRpcSubscriptionsApi,
-    TransactionSigner,
-    MessageSigner,
-  } from "@solana/kit";
-  import { getMintSize } from "@solana-program/token";
-  type Client = {
-    rpc: Rpc<SolanaRpcApi>;
-    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-    wallet: TransactionSigner & MessageSigner;
-  };
-  const client = {} as Client;
-  const mintSize = getMintSize();
-  // ---cut-before---
-  const mintRent = await client.rpc.getMinimumBalanceForRentExemption(BigInt(mintSize)).send();
-  ```
+    ```ts twoslash
+    import {
+        Rpc,
+        RpcSubscriptions,
+        SolanaRpcApi,
+        SolanaRpcSubscriptionsApi,
+        TransactionSigner,
+        MessageSigner,
+    } from '@solana/kit';
+    import { getMintSize } from '@solana-program/token';
+    type Client = {
+        rpc: Rpc<SolanaRpcApi>;
+        rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        wallet: TransactionSigner & MessageSigner;
+    };
+    const client = {} as Client;
+    const mintSize = getMintSize();
+    // ---cut-before---
+    const mintRent = await client.rpc.getMinimumBalanceForRentExemption(BigInt(mintSize)).send();
+    ```
 - The `programAddress` of the program that will own the new account. In our case, that's the Token program whose address is accessible via the `TOKEN_PROGRAM_ADDRESS` constant of the `@solana-program/token` library.
-  ```ts twoslash
-  import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
-  const programAddress = TOKEN_PROGRAM_ADDRESS;
-  ```
+    ```ts twoslash
+    import { TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
+    const programAddress = TOKEN_PROGRAM_ADDRESS;
+    ```
 
 We end up with the following code. Notice how we wrapped a few promises that could be executed in parallel in a `Promise.all` to make the code more efficient.
 
 ```ts twoslash title="src/create-mint.ts"
 // @filename: client.ts
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-} from "@solana/kit";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+} from '@solana/kit';
 export type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 // @filename: create-mint.ts
 // ---cut-before---
-import { generateKeyPairSigner } from "@solana/kit";
-import { getCreateAccountInstruction } from "@solana-program/system";
-import { getMintSize, TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import { generateKeyPairSigner } from '@solana/kit';
+import { getCreateAccountInstruction } from '@solana-program/system';
+import { getMintSize, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
 
-import type { Client } from "./client";
+import type { Client } from './client';
 
 export async function createMint(client: Client, options: { decimals?: number } = {}) {
-  // Prepare inputs.
-  const mintSize = getMintSize();
-  const [mint, mintRent] = await Promise.all([
-    generateKeyPairSigner(),
-    client.rpc.getMinimumBalanceForRentExemption(BigInt(mintSize)).send(),
-  ]);
+    // Prepare inputs.
+    const mintSize = getMintSize();
+    const [mint, mintRent] = await Promise.all([
+        generateKeyPairSigner(),
+        client.rpc.getMinimumBalanceForRentExemption(BigInt(mintSize)).send(),
+    ]);
 
-  // Build instructions.
-  const createAccountIx = getCreateAccountInstruction({
-    payer: client.wallet,
-    newAccount: mint,
-    space: mintSize,
-    lamports: mintRent,
-    programAddress: TOKEN_PROGRAM_ADDRESS,
-  });
+    // Build instructions.
+    const createAccountIx = getCreateAccountInstruction({
+        payer: client.wallet,
+        newAccount: mint,
+        space: mintSize,
+        lamports: mintRent,
+        programAddress: TOKEN_PROGRAM_ADDRESS,
+    });
 }
 ```
 
@@ -198,13 +198,13 @@ const decimals = null as any;
 const mintAuthority = null as any;
 const freezeAuthority = null as any;
 // ---cut-before---
-import { getInitializeMintInstruction } from "@solana-program/token";
+import { getInitializeMintInstruction } from '@solana-program/token';
 
 const initializeMintIx = getInitializeMintInstruction({
-  mint,
-  decimals,
-  mintAuthority,
-  freezeAuthority,
+    mint,
+    decimals,
+    mintAuthority,
+    freezeAuthority,
 });
 ```
 
@@ -220,48 +220,52 @@ We end up with the following code:
 ```ts twoslash title="src/create-mint.ts"
 // @filename: client.ts
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-} from "@solana/kit";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+} from '@solana/kit';
 export type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 // @filename: create-mint.ts
 // ---cut-before---
-import { generateKeyPairSigner } from "@solana/kit";
-import { getCreateAccountInstruction } from "@solana-program/system";
-import { getInitializeMintInstruction, getMintSize, TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import { generateKeyPairSigner } from '@solana/kit';
+import { getCreateAccountInstruction } from '@solana-program/system';
+import {
+    getInitializeMintInstruction,
+    getMintSize,
+    TOKEN_PROGRAM_ADDRESS,
+} from '@solana-program/token';
 
-import type { Client } from "./client";
+import type { Client } from './client';
 
 export async function createMint(client: Client, options: { decimals?: number } = {}) {
-  // Prepare inputs.
-  const mintSize = getMintSize();
-  const [mint, mintRent] = await Promise.all([
-    generateKeyPairSigner(),
-    client.rpc.getMinimumBalanceForRentExemption(BigInt(mintSize)).send(),
-  ]);
+    // Prepare inputs.
+    const mintSize = getMintSize();
+    const [mint, mintRent] = await Promise.all([
+        generateKeyPairSigner(),
+        client.rpc.getMinimumBalanceForRentExemption(BigInt(mintSize)).send(),
+    ]);
 
-  // Build instructions.
-  const createAccountIx = getCreateAccountInstruction({
-    payer: client.wallet,
-    newAccount: mint,
-    space: mintSize,
-    lamports: mintRent,
-    programAddress: TOKEN_PROGRAM_ADDRESS,
-  });
-  const initializeMintIx = getInitializeMintInstruction({
-    mint: mint.address,
-    decimals: options.decimals ?? 0,
-    mintAuthority: client.wallet.address,
-    freezeAuthority: client.wallet.address,
-  });
+    // Build instructions.
+    const createAccountIx = getCreateAccountInstruction({
+        payer: client.wallet,
+        newAccount: mint,
+        space: mintSize,
+        lamports: mintRent,
+        programAddress: TOKEN_PROGRAM_ADDRESS,
+    });
+    const initializeMintIx = getInitializeMintInstruction({
+        mint: mint.address,
+        decimals: options.decimals ?? 0,
+        mintAuthority: client.wallet.address,
+        freezeAuthority: client.wallet.address,
+    });
 }
 ```
 
@@ -272,13 +276,16 @@ On top of any instructions we might need in our transactions, we may also use in
 If we wanted to include these instructions explicitly in our transaction, we could use the `getSetComputeUnitLimitInstruction` and `getSetComputeUnitPriceInstruction` helpers from the `@solana-program/compute-budget` library.
 
 ```ts twoslash
-import { getSetComputeUnitLimitInstruction, getSetComputeUnitPriceInstruction } from "@solana-program/compute-budget";
+import {
+    getSetComputeUnitLimitInstruction,
+    getSetComputeUnitPriceInstruction,
+} from '@solana-program/compute-budget';
 
 const setComputeLimitIx = getSetComputeUnitLimitInstruction({
-  units: 50_000, // 50k CUs per transaction.
+    units: 50_000, // 50k CUs per transaction.
 });
 const setComputePriceIx = getSetComputeUnitPriceInstruction({
-  microLamports: 10_000, // 10k micro-lamports per CU, as priority fees.
+    microLamports: 10_000, // 10k micro-lamports per CU, as priority fees.
 });
 ```
 

--- a/docs/content/docs/getting-started/meta.json
+++ b/docs/content/docs/getting-started/meta.json
@@ -1,5 +1,12 @@
 {
-  "title": "Getting Started",
-  "defaultOpen": true,
-  "pages": ["setup", "signers", "instructions", "build-transaction", "send-transaction", "fetch-account"]
+    "title": "Getting Started",
+    "defaultOpen": true,
+    "pages": [
+        "setup",
+        "signers",
+        "instructions",
+        "build-transaction",
+        "send-transaction",
+        "fetch-account"
+    ]
 }

--- a/docs/content/docs/getting-started/send-transaction.mdx
+++ b/docs/content/docs/getting-started/send-transaction.mdx
@@ -12,27 +12,41 @@ The most common way to send transactions is via the `sendTransaction` RPC method
 One way to tackle this would be to encode the transaction ourselves using `getBase64EncodedWireTransaction` and pass it to the `sendTransaction` RPC method like so.
 
 ```ts twoslash
-import { FullySignedTransaction, TransactionWithBlockhashLifetime, Rpc, SolanaRpcApi } from "@solana/kit";
-const signedTransaction = null as unknown as FullySignedTransaction & TransactionWithBlockhashLifetime;
+import {
+    FullySignedTransaction,
+    TransactionWithBlockhashLifetime,
+    Rpc,
+    SolanaRpcApi,
+} from '@solana/kit';
+const signedTransaction = null as unknown as FullySignedTransaction &
+    TransactionWithBlockhashLifetime;
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 // ---cut-before---
-import { getBase64EncodedWireTransaction } from "@solana/kit";
+import { getBase64EncodedWireTransaction } from '@solana/kit';
 
 const encodedTransaction = getBase64EncodedWireTransaction(signedTransaction);
-await rpc.sendTransaction(encodedTransaction, { preflightCommitment: "confirmed", encoding: "base64" }).send();
+await rpc
+    .sendTransaction(encodedTransaction, { preflightCommitment: 'confirmed', encoding: 'base64' })
+    .send();
 ```
 
 However, Kit offers a helper function that does that for us whilst providing some sensible default values. This function is called `sendTransactionWithoutConfirmingFactory` and, given an RPC object, it returns a function that sends transactions without waiting for confirmation.
 
 ```ts twoslash
-import { FullySignedTransaction, TransactionWithBlockhashLifetime, Rpc, SolanaRpcApi } from "@solana/kit";
-const signedTransaction = null as unknown as FullySignedTransaction & TransactionWithBlockhashLifetime;
+import {
+    FullySignedTransaction,
+    TransactionWithBlockhashLifetime,
+    Rpc,
+    SolanaRpcApi,
+} from '@solana/kit';
+const signedTransaction = null as unknown as FullySignedTransaction &
+    TransactionWithBlockhashLifetime;
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 // ---cut-before---
-import { sendTransactionWithoutConfirmingFactory } from "@solana/kit";
+import { sendTransactionWithoutConfirmingFactory } from '@solana/kit';
 
 const sendTransaction = sendTransactionWithoutConfirmingFactory({ rpc });
-await sendTransaction(signedTransaction, { commitment: "confirmed" });
+await sendTransaction(signedTransaction, { commitment: 'confirmed' });
 ```
 
 ## Confirmation strategies
@@ -50,21 +64,22 @@ Both accept RPC and RPC Subscriptions objects and return a function that sends a
 
 ```ts twoslash
 import {
-  FullySignedTransaction,
-  TransactionWithBlockhashLifetime,
-  Rpc,
-  SolanaRpcApi,
-  RpcSubscriptions,
-  SolanaRpcSubscriptionsApi,
-} from "@solana/kit";
-const signedTransaction = null as unknown as FullySignedTransaction & TransactionWithBlockhashLifetime;
+    FullySignedTransaction,
+    TransactionWithBlockhashLifetime,
+    Rpc,
+    SolanaRpcApi,
+    RpcSubscriptions,
+    SolanaRpcSubscriptionsApi,
+} from '@solana/kit';
+const signedTransaction = null as unknown as FullySignedTransaction &
+    TransactionWithBlockhashLifetime;
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 const rpcSubscriptions = null as unknown as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
 // ---cut-before---
-import { sendAndConfirmTransactionFactory } from "@solana/kit";
+import { sendAndConfirmTransactionFactory } from '@solana/kit';
 
 const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
-await sendAndConfirmTransaction(signedTransaction, { commitment: "confirmed" });
+await sendAndConfirmTransaction(signedTransaction, { commitment: 'confirmed' });
 ```
 
 ## Transaction signatures
@@ -77,25 +92,26 @@ As such, Kit decouples these two distinct concepts by offering a `getSignatureFr
 
 ```ts twoslash
 import {
-  FullySignedTransaction,
-  TransactionWithBlockhashLifetime,
-  Rpc,
-  SolanaRpcApi,
-  RpcSubscriptions,
-  SolanaRpcSubscriptionsApi,
-} from "@solana/kit";
-const signedTransaction = null as unknown as FullySignedTransaction & TransactionWithBlockhashLifetime;
+    FullySignedTransaction,
+    TransactionWithBlockhashLifetime,
+    Rpc,
+    SolanaRpcApi,
+    RpcSubscriptions,
+    SolanaRpcSubscriptionsApi,
+} from '@solana/kit';
+const signedTransaction = null as unknown as FullySignedTransaction &
+    TransactionWithBlockhashLifetime;
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 const rpcSubscriptions = null as unknown as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
 // ---cut-before---
-import { getSignatureFromTransaction, sendAndConfirmTransactionFactory } from "@solana/kit";
+import { getSignatureFromTransaction, sendAndConfirmTransactionFactory } from '@solana/kit';
 
 // Access the transaction signature.
 const signature = getSignatureFromTransaction(signedTransaction);
 
 // Send and confirm the transaction.
 const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
-await sendAndConfirmTransaction(signedTransaction, { commitment: "confirmed" });
+await sendAndConfirmTransaction(signedTransaction, { commitment: 'confirmed' });
 ```
 
 ## Update `client.ts`
@@ -104,52 +120,57 @@ With all that new knowledge in hand, let's update our `Client` object to include
 
 ```ts twoslash title="src/client.ts"
 import {
-  CompilableTransactionMessage,
-  MessageSigner,
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-} from "@solana/kit";
+    CompilableTransactionMessage,
+    MessageSigner,
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+} from '@solana/kit';
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 const rpcSubscriptions = null as unknown as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
 const wallet = null as unknown as TransactionSigner & MessageSigner;
 const estimateAndSetComputeUnitLimit = null as unknown as <T extends CompilableTransactionMessage>(
-  transactionMessage: T,
+    transactionMessage: T,
 ) => Promise<T>;
 // ---cut-before---
 import {
-  sendAndConfirmTransactionFactory, // [!code ++]
-  // ...
-} from "@solana/kit";
+    sendAndConfirmTransactionFactory, // [!code ++]
+    // ...
+} from '@solana/kit';
 
 export type Client = {
-  estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(transactionMessage: T) => Promise<T>;
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  sendAndConfirmTransaction: ReturnType<typeof sendAndConfirmTransactionFactory>; // [!code ++]
-  wallet: TransactionSigner & MessageSigner;
+    estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(
+        transactionMessage: T,
+    ) => Promise<T>;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    sendAndConfirmTransaction: ReturnType<typeof sendAndConfirmTransactionFactory>; // [!code ++]
+    wallet: TransactionSigner & MessageSigner;
 };
 
 let client: Client | undefined;
 export async function createClient(): Promise<Client> {
-  if (!client) {
-    // ...
+    if (!client) {
+        // ...
 
-    // Create a function to send and confirm transactions. // [!code ++]
-    const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions }); // [!code ++]
+        // Create a function to send and confirm transactions. // [!code ++]
+        const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
+            rpc,
+            rpcSubscriptions,
+        }); // [!code ++]
 
-    // Store the client.
-    client = {
-      estimateAndSetComputeUnitLimit,
-      rpc,
-      rpcSubscriptions,
-      sendAndConfirmTransaction, // [!code ++]
-      wallet,
-    };
-  }
-  return client;
+        // Store the client.
+        client = {
+            estimateAndSetComputeUnitLimit,
+            rpc,
+            rpcSubscriptions,
+            sendAndConfirmTransaction, // [!code ++]
+            wallet,
+        };
+    }
+    return client;
 }
 ```
 
@@ -164,79 +185,85 @@ And with that, our `createMint` function is complete!
 ```ts twoslash title="src/create-mint.ts"
 // @filename: client.ts
 import {
-  CompilableTransactionMessage,
-  MessageSigner,
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  sendAndConfirmTransactionFactory,
-} from "@solana/kit";
+    CompilableTransactionMessage,
+    MessageSigner,
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    sendAndConfirmTransactionFactory,
+} from '@solana/kit';
 export type Client = {
-  estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(transactionMessage: T) => Promise<T>;
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  sendAndConfirmTransaction: ReturnType<typeof sendAndConfirmTransactionFactory>;
-  wallet: TransactionSigner & MessageSigner;
+    estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(
+        transactionMessage: T,
+    ) => Promise<T>;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    sendAndConfirmTransaction: ReturnType<typeof sendAndConfirmTransactionFactory>;
+    wallet: TransactionSigner & MessageSigner;
 };
 // @filename: create-mint.ts
 // ---cut-before---
 import {
-  appendTransactionMessageInstructions,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
-} from "@solana/kit";
-import { getCreateAccountInstruction } from "@solana-program/system";
-import { getInitializeMintInstruction, getMintSize, TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+    appendTransactionMessageInstructions,
+    createTransactionMessage,
+    generateKeyPairSigner,
+    pipe,
+    setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
+    signTransactionMessageWithSigners,
+} from '@solana/kit';
+import { getCreateAccountInstruction } from '@solana-program/system';
+import {
+    getInitializeMintInstruction,
+    getMintSize,
+    TOKEN_PROGRAM_ADDRESS,
+} from '@solana-program/token';
 
-import type { Client } from "./client";
+import type { Client } from './client';
 
 export async function createMint(client: Client, options: { decimals?: number } = {}) {
-  // Prepare inputs.
-  const mintSize = getMintSize();
-  const [mint, mintRent, { value: latestBlockhash }] = await Promise.all([
-    generateKeyPairSigner(),
-    client.rpc.getMinimumBalanceForRentExemption(BigInt(mintSize)).send(),
-    client.rpc.getLatestBlockhash().send(),
-  ]);
+    // Prepare inputs.
+    const mintSize = getMintSize();
+    const [mint, mintRent, { value: latestBlockhash }] = await Promise.all([
+        generateKeyPairSigner(),
+        client.rpc.getMinimumBalanceForRentExemption(BigInt(mintSize)).send(),
+        client.rpc.getLatestBlockhash().send(),
+    ]);
 
-  // Build instructions.
-  const createAccountIx = getCreateAccountInstruction({
-    payer: client.wallet,
-    newAccount: mint,
-    space: mintSize,
-    lamports: mintRent,
-    programAddress: TOKEN_PROGRAM_ADDRESS,
-  });
-  const initializeMintIx = getInitializeMintInstruction({
-    mint: mint.address,
-    decimals: options.decimals ?? 0,
-    mintAuthority: client.wallet.address,
-    freezeAuthority: client.wallet.address,
-  });
+    // Build instructions.
+    const createAccountIx = getCreateAccountInstruction({
+        payer: client.wallet,
+        newAccount: mint,
+        space: mintSize,
+        lamports: mintRent,
+        programAddress: TOKEN_PROGRAM_ADDRESS,
+    });
+    const initializeMintIx = getInitializeMintInstruction({
+        mint: mint.address,
+        decimals: options.decimals ?? 0,
+        mintAuthority: client.wallet.address,
+        freezeAuthority: client.wallet.address,
+    });
 
-  // Build the transaction message.
-  const transactionMessage = await pipe(
-    createTransactionMessage({ version: 0 }),
-    (tx) => setTransactionMessageFeePayerSigner(client.wallet, tx),
-    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-    (tx) => appendTransactionMessageInstructions([createAccountIx, initializeMintIx], tx),
-    (tx) => client.estimateAndSetComputeUnitLimit(tx),
-  );
+    // Build the transaction message.
+    const transactionMessage = await pipe(
+        createTransactionMessage({ version: 0 }),
+        (tx) => setTransactionMessageFeePayerSigner(client.wallet, tx),
+        (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+        (tx) => appendTransactionMessageInstructions([createAccountIx, initializeMintIx], tx),
+        (tx) => client.estimateAndSetComputeUnitLimit(tx),
+    );
 
-  // Compile the transaction message and sign it.
-  const signedTransaction = await signTransactionMessageWithSigners(transactionMessage);
+    // Compile the transaction message and sign it.
+    const signedTransaction = await signTransactionMessageWithSigners(transactionMessage);
 
-  // Send the transaction and wait for confirmation.
-  await client.sendAndConfirmTransaction(signedTransaction, { commitment: "confirmed" }); // [!code ++]
+    // Send the transaction and wait for confirmation.
+    await client.sendAndConfirmTransaction(signedTransaction, { commitment: 'confirmed' }); // [!code ++]
 
-  // Return the address of the created mint account. // [!code ++]
-  return mint.address; // [!code ++]
+    // Return the address of the created mint account. // [!code ++]
+    return mint.address; // [!code ++]
 }
 ```
 
@@ -247,40 +274,42 @@ Finally, let's update our main `tutorial` function to execute the `createMint` f
 ```ts twoslash title="src/index.ts"
 // @filename: client.ts
 import {
-  CompilableTransactionMessage,
-  MessageSigner,
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  sendAndConfirmTransactionFactory,
-} from "@solana/kit";
+    CompilableTransactionMessage,
+    MessageSigner,
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    sendAndConfirmTransactionFactory,
+} from '@solana/kit';
 export type Client = {
-  estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(transactionMessage: T) => Promise<T>;
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  sendAndConfirmTransaction: ReturnType<typeof sendAndConfirmTransactionFactory>;
-  wallet: TransactionSigner & MessageSigner;
+    estimateAndSetComputeUnitLimit: <T extends CompilableTransactionMessage>(
+        transactionMessage: T,
+    ) => Promise<T>;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    sendAndConfirmTransaction: ReturnType<typeof sendAndConfirmTransactionFactory>;
+    wallet: TransactionSigner & MessageSigner;
 };
 export async function createClient() {
-  return {} as Client;
+    return {} as Client;
 }
 // @filename: create-mint.ts
-import { Address } from "@solana/kit";
-import { Client } from "./client";
+import { Address } from '@solana/kit';
+import { Client } from './client';
 export async function createMint(client: Client, options: { decimals?: number } = {}) {
-  return "" as Address;
+    return '' as Address;
 }
 // @filename: index.ts
 // ---cut-before---
-import { createClient } from "./client";
-import { createMint } from "./create-mint";
+import { createClient } from './client';
+import { createMint } from './create-mint';
 
 async function tutorial() {
-  const client = await createClient();
-  const mintAddress = await createMint(client, { decimals: 2 });
-  console.log(`Mint created: ${mintAddress}.`);
+    const client = await createClient();
+    const mintAddress = await createMint(client, { decimals: 2 });
+    console.log(`Mint created: ${mintAddress}.`);
 }
 ```
 

--- a/docs/content/docs/getting-started/setup.mdx
+++ b/docs/content/docs/getting-started/setup.mdx
@@ -17,16 +17,16 @@ Let's also create a `start` script that runs `tsx src/index.ts` and a `validator
 
 ```json
 {
-  "name": "kit-tutorial",
-  "version": "1.0.0",
-  "scripts": {
-    "start": "tsx src/index.ts",
-    "validator": "solana-test-validator"
-  },
-  "dependencies": {
-    "@solana/kit": "^2.1.0",
-    "tsx": "^4.19.3"
-  }
+    "name": "kit-tutorial",
+    "version": "1.0.0",
+    "scripts": {
+        "start": "tsx src/index.ts",
+        "validator": "solana-test-validator"
+    },
+    "dependencies": {
+        "@solana/kit": "^2.1.0",
+        "tsx": "^4.19.3"
+    }
 }
 ```
 
@@ -41,35 +41,35 @@ The first two things we need are the RPC and RPC Subscriptions objects which all
 Let's create a new `src/client.ts` file and add the following `Client` type:
 
 ```ts twoslash
-import { Rpc, RpcSubscriptions, SolanaRpcApi, SolanaRpcSubscriptionsApi } from "@solana/kit";
+import { Rpc, RpcSubscriptions, SolanaRpcApi, SolanaRpcSubscriptionsApi } from '@solana/kit';
 
 export type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
 };
 ```
 
 Then, let's create a helper function to create a new cached `Client` object that we can use throughout our application:
 
 ```ts twoslash
-import { Rpc, RpcSubscriptions, SolanaRpcApi, SolanaRpcSubscriptionsApi } from "@solana/kit";
+import { Rpc, RpcSubscriptions, SolanaRpcApi, SolanaRpcSubscriptionsApi } from '@solana/kit';
 
 export type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
 };
 // ---cut-before---
-import { createSolanaRpc, createSolanaRpcSubscriptions } from "@solana/kit";
+import { createSolanaRpc, createSolanaRpcSubscriptions } from '@solana/kit';
 
 let client: Client | undefined;
 export function createClient(): Client {
-  if (!client) {
-    client = {
-      rpc: createSolanaRpc("http://127.0.0.1:8899"),
-      rpcSubscriptions: createSolanaRpcSubscriptions("ws://127.0.0.1:8900"),
-    };
-  }
-  return client;
+    if (!client) {
+        client = {
+            rpc: createSolanaRpc('http://127.0.0.1:8899'),
+            rpcSubscriptions: createSolanaRpcSubscriptions('ws://127.0.0.1:8900'),
+        };
+    }
+    return client;
 }
 ```
 
@@ -84,27 +84,27 @@ We can do this by creating an `Address` type via the `address` helper and fetchi
 
 ```ts twoslash
 // @filename: client.ts
-import { Rpc, RpcSubscriptions, SolanaRpcApi, SolanaRpcSubscriptionsApi } from "@solana/kit";
+import { Rpc, RpcSubscriptions, SolanaRpcApi, SolanaRpcSubscriptionsApi } from '@solana/kit';
 export type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
 };
 export function createClient(): Client {
-  return {} as Client;
+    return {} as Client;
 }
 // @filename: index.ts
 // ---cut-before---
-import { address } from "@solana/kit";
-import { createClient } from "./client";
+import { address } from '@solana/kit';
+import { createClient } from './client';
 
 // Run the tutorial.
 tutorial();
 
 async function tutorial() {
-  const client = createClient();
-  const account = address("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
-  const { value: balance } = await client.rpc.getBalance(account).send();
-  console.log(`Balance: ${balance} lamports.`);
+    const client = createClient();
+    const account = address('TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb');
+    const { value: balance } = await client.rpc.getBalance(account).send();
+    console.log(`Balance: ${balance} lamports.`);
 }
 ```
 

--- a/docs/content/docs/getting-started/signers.mdx
+++ b/docs/content/docs/getting-started/signers.mdx
@@ -12,7 +12,7 @@ The Kit library uses the [native Crypto API](https://developer.mozilla.org/en-US
 To create a new keypair, you can use the `generateKeyPair` helper function. This will return an instance of the native `CryptoKeyPair` type.
 
 ```ts twoslash
-import { generateKeyPair } from "@solana/kit";
+import { generateKeyPair } from '@solana/kit';
 
 const wallet: CryptoKeyPair = await generateKeyPair();
 ```
@@ -30,7 +30,7 @@ Different types of signers are available for various use cases, but in this tuto
 We can use the `generateKeyPairSigner` function to create a new `KeyPairSigner` instance like so.
 
 ```ts twoslash
-import { generateKeyPairSigner } from "@solana/kit";
+import { generateKeyPairSigner } from '@solana/kit';
 
 const wallet = await generateKeyPairSigner();
 ```
@@ -40,11 +40,13 @@ As you can see, this is very similar to generating a `CryptoKeyPair`, but now we
 For instance, here's how we could replace our `KeyPairSigner` with a signer that uses an in-browser wallet instead.
 
 ```ts twoslash
-import { generateKeyPairSigner, KeyPairSigner, TransactionSigner } from "@solana/kit";
-import { useWalletAccountTransactionSendingSigner } from "@solana/react";
+import { generateKeyPairSigner, KeyPairSigner, TransactionSigner } from '@solana/kit';
+import { useWalletAccountTransactionSendingSigner } from '@solana/react';
 // ---cut-start---
 const account = null as unknown as Parameters<typeof useWalletAccountTransactionSendingSigner>[0];
-const currentChain = null as unknown as Parameters<typeof useWalletAccountTransactionSendingSigner>[1];
+const currentChain = null as unknown as Parameters<
+    typeof useWalletAccountTransactionSendingSigner
+>[1];
 // ---cut-end---
 
 let wallet: TransactionSigner;
@@ -60,24 +62,24 @@ Now that we know how to generate a new signer, let's make sure we give it some l
 
 ```ts twoslash
 import {
-  airdropFactory,
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  generateKeyPairSigner,
-  lamports,
-} from "@solana/kit";
+    airdropFactory,
+    createSolanaRpc,
+    createSolanaRpcSubscriptions,
+    generateKeyPairSigner,
+    lamports,
+} from '@solana/kit';
 
 // Create the RPC, RPC Subscriptions and airdrop function.
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
-const rpcSubscriptions = createSolanaRpcSubscriptions("ws://127.0.0.1:8900");
+const rpc = createSolanaRpc('http://127.0.0.1:8899');
+const rpcSubscriptions = createSolanaRpcSubscriptions('ws://127.0.0.1:8900');
 const airdrop = airdropFactory({ rpc, rpcSubscriptions });
 
 // Generate a new wallet with 1 SOL.
 const wallet = await generateKeyPairSigner();
 await airdrop({
-  recipientAddress: wallet.address,
-  lamports: lamports(1_000_000_000n),
-  commitment: "confirmed",
+    recipientAddress: wallet.address,
+    lamports: lamports(1_000_000_000n),
+    commitment: 'confirmed',
 });
 ```
 
@@ -87,42 +89,48 @@ Since we're going to rely on this signer for the rest of the tutorial, let's adj
 
 ```ts twoslash title="src/client.ts"
 import {
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-} from "@solana/kit";
+    createSolanaRpc,
+    createSolanaRpcSubscriptions,
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+} from '@solana/kit';
 // ---cut-before---
-import { airdropFactory, generateKeyPairSigner, lamports, MessageSigner, TransactionSigner } from "@solana/kit";
+import {
+    airdropFactory,
+    generateKeyPairSigner,
+    lamports,
+    MessageSigner,
+    TransactionSigner,
+} from '@solana/kit';
 
 export type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 
 let client: Client | undefined;
 export async function createClient(): Promise<Client> {
-  if (!client) {
-    // Create RPC objects and airdrop function.
-    const rpc = createSolanaRpc("http://127.0.0.1:8899");
-    const rpcSubscriptions = createSolanaRpcSubscriptions("ws://127.0.0.1:8900");
-    const airdrop = airdropFactory({ rpc, rpcSubscriptions });
+    if (!client) {
+        // Create RPC objects and airdrop function.
+        const rpc = createSolanaRpc('http://127.0.0.1:8899');
+        const rpcSubscriptions = createSolanaRpcSubscriptions('ws://127.0.0.1:8900');
+        const airdrop = airdropFactory({ rpc, rpcSubscriptions });
 
-    // Create a wallet with lamports.
-    const wallet = await generateKeyPairSigner();
-    await airdrop({
-      recipientAddress: wallet.address,
-      lamports: lamports(1_000_000_000n),
-      commitment: "confirmed",
-    });
+        // Create a wallet with lamports.
+        const wallet = await generateKeyPairSigner();
+        await airdrop({
+            recipientAddress: wallet.address,
+            lamports: lamports(1_000_000_000n),
+            commitment: 'confirmed',
+        });
 
-    // Store the client.
-    client = { rpc, rpcSubscriptions, wallet };
-  }
-  return client;
+        // Store the client.
+        client = { rpc, rpcSubscriptions, wallet };
+    }
+    return client;
 }
 ```
 
@@ -130,26 +138,26 @@ Notice how we had to make the `createClient` function asynchronous since it now 
 
 ```ts twoslash title="src/index.ts"
 import {
-  Rpc,
-  RpcSubscriptions,
-  SolanaRpcApi,
-  SolanaRpcSubscriptionsApi,
-  TransactionSigner,
-  MessageSigner,
-} from "@solana/kit";
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApi,
+    SolanaRpcSubscriptionsApi,
+    TransactionSigner,
+    MessageSigner,
+} from '@solana/kit';
 export type Client = {
-  rpc: Rpc<SolanaRpcApi>;
-  rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
-  wallet: TransactionSigner & MessageSigner;
+    rpc: Rpc<SolanaRpcApi>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+    wallet: TransactionSigner & MessageSigner;
 };
 export async function createClient() {
-  return {} as Client;
+    return {} as Client;
 }
 // ---cut-before---
 async function tutorial() {
-  const client = await createClient();
-  const { value: balance } = await client.rpc.getBalance(client.wallet.address).send();
-  console.log(`Balance: ${balance} lamports.`);
+    const client = await createClient();
+    const { value: balance } = await client.rpc.getBalance(client.wallet.address).send();
+    console.log(`Balance: ${balance} lamports.`);
 }
 ```
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -6,7 +6,7 @@ description: Get started with Kit
 Kit is a JavaScript SDK for building Solana apps across environments like Node, the web, and React Native. It provides a comprehensive set of data types and helper functions, forming the foundation for interacting with Solana in JavaScript.
 
 <Callout title="Coming from Web3.js?">
-  Check out our [Upgrade guide](/docs/upgrade-guide) to see how Kit compares to Web3.js.
+    Check out our [Upgrade guide](/docs/upgrade-guide) to see how Kit compares to Web3.js.
 </Callout>
 
 ## Quick start
@@ -50,10 +50,14 @@ Use primitives provided by Kit to set up your project and start interacting with
 For example, if you are planning on sending transactions, you will likely need an RPC API, an RPC Subscriptions API and a "send and confirm" strategy.
 
 ```ts twoslash
-import { createSolanaRpc, createSolanaRpcSubscriptions, sendAndConfirmTransactionFactory } from "@solana/kit";
+import {
+    createSolanaRpc,
+    createSolanaRpcSubscriptions,
+    sendAndConfirmTransactionFactory,
+} from '@solana/kit';
 
-const rpc = createSolanaRpc("https://api.devnet.solana.com");
-const rpcSubscriptions = createSolanaRpcSubscriptions("wss://api.devnet.solana.com");
+const rpc = createSolanaRpc('https://api.devnet.solana.com');
+const rpcSubscriptions = createSolanaRpcSubscriptions('wss://api.devnet.solana.com');
 const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
 ```
 

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -1,6 +1,6 @@
 {
-  "title": "Documentation",
-  "defaultOpen": true,
-  "root": true,
-  "pages": ["...", "compatible-clients", "getting-started", "concepts"]
+    "title": "Documentation",
+    "defaultOpen": true,
+    "root": true,
+    "pages": ["...", "compatible-clients", "getting-started", "concepts"]
 }

--- a/docs/content/docs/upgrade-guide.mdx
+++ b/docs/content/docs/upgrade-guide.mdx
@@ -8,9 +8,9 @@ description: Upgrade your Web3.js project to Kit
 Kit (formerly Web3.js v2) is a complete rewrite of [the Web3.js library](https://github.com/solana-labs/solana-web3.js/). It is designed to be more composable, customizable, and efficient than its predecessor. Its functional design enables the entire library to be tree-shaken, drastically reducing your bundle size. It also takes advantage of modern JavaScript features — such as native Ed25519 key support and `bigint` for large values — resulting in an even smaller bundle, better performance and most importantly, a reduced attack surface for your application.
 
 <Spread>
-  ![Tree-shaking illustration. The left side shows a bunch of imports from Web3.js all being bundled despite only a
-  couple being used. The right side shows an equivalent set of imports for Kit but only the used functions are
-  bundled.](./tree-shaking.svg)
+    ![Tree-shaking illustration. The left side shows a bunch of imports from Web3.js all being
+    bundled despite only a couple being used. The right side shows an equivalent set of imports for
+    Kit but only the used functions are bundled.](./tree-shaking.svg)
 </Spread>
 
 Unlike Web3.js, Kit doesn't rely on JavaScript classes or other non-tree-shakeable features. This brings us to our first key difference.
@@ -27,26 +27,26 @@ The former, `createSolanaRpc`, returns an `Rpc` object for making RPC requests t
 <div className="2xl:flex 2xl:*:flex-1 2xl:items-start 2xl:gap-4">
 
 ```ts title="Web3.js"
-import { Connection, PublicKey } from "@solana/web3.js";
+import { Connection, PublicKey } from '@solana/web3.js';
 
 // Create a `Connection` object.
-const connection = new Connection("https://api.devnet.solana.com", {
-  commitment: "confirmed",
+const connection = new Connection('https://api.devnet.solana.com', {
+    commitment: 'confirmed',
 });
 
 // Send RPC requests.
-const wallet = new PublicKey("1234..5678");
+const wallet = new PublicKey('1234..5678');
 const balance = await connection.getBalance(wallet);
 ```
 
 ```ts twoslash title="Kit"
-import { address, createSolanaRpc } from "@solana/kit";
+import { address, createSolanaRpc } from '@solana/kit';
 
 // Create an RPC proxy object.
-const rpc = createSolanaRpc("https://api.devnet.solana.com");
+const rpc = createSolanaRpc('https://api.devnet.solana.com');
 
 // Send RPC requests.
-const wallet = address("1234..5678");
+const wallet = address('1234..5678');
 const { value: balance } = await rpc.getBalance(wallet).send();
 ```
 
@@ -59,43 +59,43 @@ The latter, `createSolanaRpcSubscriptions`, returns an `RpcSubscriptions` object
 <div className="2xl:flex 2xl:*:flex-1 2xl:items-start 2xl:gap-4">
 
 ```ts title="Web3.js"
-import { Connection, PublicKey } from "@solana/web3.js";
+import { Connection, PublicKey } from '@solana/web3.js';
 
 // Create a `Connection` object with a WebSocket endpoint.
-const connection = new Connection("https://api.devnet.solana.com", {
-  wsEndpoint: "wss://api.devnet.solana.com",
-  commitment: "confirmed",
+const connection = new Connection('https://api.devnet.solana.com', {
+    wsEndpoint: 'wss://api.devnet.solana.com',
+    commitment: 'confirmed',
 });
 
 // Subscribe to RPC events and listen to notifications.
-const wallet = new PublicKey("1234..5678");
+const wallet = new PublicKey('1234..5678');
 connection.onAccountChange(wallet, (accountInfo) => {
-  console.log(accountInfo);
+    console.log(accountInfo);
 });
 ```
 
 ```ts twoslash title="Kit"
-import { address, createSolanaRpcSubscriptions } from "@solana/kit";
+import { address, createSolanaRpcSubscriptions } from '@solana/kit';
 
 // Create an RPC subscriptions proxy object.
-const rpcSubscriptions = createSolanaRpcSubscriptions("wss://api.devnet.solana.com");
+const rpcSubscriptions = createSolanaRpcSubscriptions('wss://api.devnet.solana.com');
 
 // Use an `AbortController` to cancel the subscriptions.
 const abortController = new AbortController();
 
 // Subscribe to RPC events.
-const wallet = address("1234..5678");
+const wallet = address('1234..5678');
 const accountNotifications = await rpcSubscriptions
-  .accountNotifications(wallet, { commitment: "confirmed" })
-  .subscribe({ abortSignal: abortController.signal });
+    .accountNotifications(wallet, { commitment: 'confirmed' })
+    .subscribe({ abortSignal: abortController.signal });
 
 try {
-  // Listen to event notifications.
-  for await (const accountInfo of accountNotifications) {
-    console.log(accountInfo);
-  }
+    // Listen to event notifications.
+    for await (const accountInfo of accountNotifications) {
+        console.log(accountInfo);
+    }
 } catch (e) {
-  // Gracefully handle subscription disconnects.
+    // Gracefully handle subscription disconnects.
 }
 ```
 
@@ -112,20 +112,20 @@ Now that we know how to send RPC requests, fetching one or more on-chain account
 <div className="2xl:flex 2xl:*:flex-1 2xl:items-start 2xl:gap-4">
 
 ```ts title="Web3.js"
-import { PublicKey } from "@solana/web3.js";
+import { PublicKey } from '@solana/web3.js';
 
-const wallet = new PublicKey("1234..5678");
+const wallet = new PublicKey('1234..5678');
 const account = await connection.getAccountInfo(wallet);
 ```
 
 ```ts twoslash title="Kit"
-import { address } from "@solana/kit";
+import { address } from '@solana/kit';
 // ---cut-start---
-import { createSolanaRpc } from "@solana/kit";
-const rpc = createSolanaRpc("https://api.devnet.solana.com");
+import { createSolanaRpc } from '@solana/kit';
+const rpc = createSolanaRpc('https://api.devnet.solana.com');
 // ---cut-end---
 
-const wallet = address("1234..5678");
+const wallet = address('1234..5678');
 const { value: account } = await rpc.getAccountInfo(wallet).send();
 ```
 
@@ -135,13 +135,13 @@ const { value: account } = await rpc.getAccountInfo(wallet).send();
 Kit also provides helper functions like `fetchEncodedAccount` and `fetchEncodedAccounts`, which return `MaybeAccount` objects. These objects store the account's address and include an `exists` boolean to indicate whether the account is present on-chain. If `exists` is `true`, the object also contains the expected account info. These helpers also unify the return type of accounts, ensuring consistency regardless of the encoding used to fetch them.
 
 ```ts twoslash title="Kit"
-import { address, assertAccountExists, fetchEncodedAccount } from "@solana/kit";
+import { address, assertAccountExists, fetchEncodedAccount } from '@solana/kit';
 // ---cut-start---
-import { createSolanaRpc } from "@solana/kit";
-const rpc = createSolanaRpc("https://api.devnet.solana.com");
+import { createSolanaRpc } from '@solana/kit';
+const rpc = createSolanaRpc('https://api.devnet.solana.com');
 // ---cut-end---
 
-const wallet = address("1234..5678");
+const wallet = address('1234..5678');
 const account = await fetchEncodedAccount(rpc, wallet);
 assertAccountExists(account);
 account.data satisfies Uint8Array;
@@ -151,36 +151,36 @@ In addition, Kit introduces a new serialization library called `codecs`. Codecs 
 
 ```ts twoslash title="Kit"
 import {
-  address,
-  Address,
-  addCodecSizePrefix,
-  Codec,
-  getAddressCodec,
-  getStructCodec,
-  getU32Codec,
-  getU8Codec,
-  getUtf8Codec,
-} from "@solana/kit";
+    address,
+    Address,
+    addCodecSizePrefix,
+    Codec,
+    getAddressCodec,
+    getStructCodec,
+    getU32Codec,
+    getU8Codec,
+    getUtf8Codec,
+} from '@solana/kit';
 
 type Person = {
-  age: number;
-  discriminator: number;
-  name: string;
-  wallet: Address;
+    age: number;
+    discriminator: number;
+    name: string;
+    wallet: Address;
 };
 
 const personCodec: Codec<Person> = getStructCodec([
-  ["discriminator", getU8Codec()], // A single-byte account discriminator.
-  ["wallet", getAddressCodec()], // A 32-byte account address.
-  ["age", getU8Codec()], // An 8-bit unsigned integer.
-  ["name", addCodecSizePrefix(getUtf8Codec(), getU32Codec())], // A UTF-8 string with a 32-bit length prefix.
+    ['discriminator', getU8Codec()], // A single-byte account discriminator.
+    ['wallet', getAddressCodec()], // A 32-byte account address.
+    ['age', getU8Codec()], // An 8-bit unsigned integer.
+    ['name', addCodecSizePrefix(getUtf8Codec(), getU32Codec())], // A UTF-8 string with a 32-bit length prefix.
 ]);
 
 const bytes = personCodec.encode({
-  age: 42,
-  discriminator: 0,
-  name: "Alice",
-  wallet: address("1234..5678"),
+    age: 42,
+    discriminator: 0,
+    name: 'Alice',
+    wallet: address('1234..5678'),
 });
 ```
 
@@ -189,39 +189,39 @@ const bytes = personCodec.encode({
 Once you have a codec for an account's data, you can use the `decodeAccount` function to transform an encoded account into a decoded account.
 
 ```ts twoslash title="Kit"
-import { address, Codec, decodeAccount, fetchEncodedAccount } from "@solana/kit";
+import { address, Codec, decodeAccount, fetchEncodedAccount } from '@solana/kit';
 // ---cut-start---
 import {
-  Address,
-  createSolanaRpc,
-  addCodecSizePrefix,
-  getAddressCodec,
-  getStructCodec,
-  getU32Codec,
-  getU8Codec,
-  getUtf8Codec,
-} from "@solana/kit";
-const rpc = createSolanaRpc("https://api.devnet.solana.com");
+    Address,
+    createSolanaRpc,
+    addCodecSizePrefix,
+    getAddressCodec,
+    getStructCodec,
+    getU32Codec,
+    getU8Codec,
+    getUtf8Codec,
+} from '@solana/kit';
+const rpc = createSolanaRpc('https://api.devnet.solana.com');
 type Person = {
-  age: number;
-  discriminator: number;
-  name: string;
-  wallet: Address;
+    age: number;
+    discriminator: number;
+    name: string;
+    wallet: Address;
 };
 const personCodec: Codec<Person> = getStructCodec([
-  ["discriminator", getU8Codec()],
-  ["wallet", getAddressCodec()],
-  ["age", getU8Codec()],
-  ["name", addCodecSizePrefix(getUtf8Codec(), getU32Codec())],
+    ['discriminator', getU8Codec()],
+    ['wallet', getAddressCodec()],
+    ['age', getU8Codec()],
+    ['name', addCodecSizePrefix(getUtf8Codec(), getU32Codec())],
 ]);
 // ---cut-end---
 
-const wallet = address("1234..5678");
+const wallet = address('1234..5678');
 const account = await fetchEncodedAccount(rpc, wallet);
 const decodedAccount = decodeAccount(account, personCodec);
 
 if (decodedAccount.exists) {
-  decodedAccount.data satisfies Person;
+    decodedAccount.data satisfies Person;
 }
 ```
 
@@ -232,14 +232,14 @@ Fortunately, you don't need to create a custom codec every time you decode an ac
 These libraries are [generated via Codama](https://github.com/codama-idl/codama), ensuring consistent structure across them. For instance, the `fetchNonce` function from `@solana-program/system` can be used to fetch and decode a `Nonce` account from its address.
 
 ```ts twoslash title="Kit"
-import { Account, address } from "@solana/kit";
-import { fetchNonce, Nonce } from "@solana-program/system";
+import { Account, address } from '@solana/kit';
+import { fetchNonce, Nonce } from '@solana-program/system';
 // ---cut-start---
-import { createSolanaRpc } from "@solana/kit";
-const rpc = createSolanaRpc("https://api.devnet.solana.com");
+import { createSolanaRpc } from '@solana/kit';
+const rpc = createSolanaRpc('https://api.devnet.solana.com');
 // ---cut-end---
 
-const account: Account<Nonce> = await fetchNonce(rpc, address("1234..5678"));
+const account: Account<Nonce> = await fetchNonce(rpc, address('1234..5678'));
 ```
 
 [Check out the "Compatible clients" page](/docs/compatible-clients) for a list of available program libraries compatible with Kit.
@@ -254,23 +254,23 @@ For example, here's how to create a `CreateAccount` instruction using the `Syste
 <div className="2xl:flex 2xl:*:flex-1 2xl:items-start 2xl:gap-4">
 
 ```ts title="Web3.js"
-import { PublicKey, SystemProgram } from "@solana/web3.js";
+import { PublicKey, SystemProgram } from '@solana/web3.js';
 
 const transferSol = SystemProgram.transfer({
-  fromPubkey: new PublicKey("2222..2222"),
-  toPubkey: new PublicKey("3333..3333"),
-  lamports: 1_000_000_000, // 1 SOL.
+    fromPubkey: new PublicKey('2222..2222'),
+    toPubkey: new PublicKey('3333..3333'),
+    lamports: 1_000_000_000, // 1 SOL.
 });
 ```
 
 ```ts twoslash title="Kit"
-import { address, createNoopSigner } from "@solana/kit";
-import { getTransferSolInstruction } from "@solana-program/system";
+import { address, createNoopSigner } from '@solana/kit';
+import { getTransferSolInstruction } from '@solana-program/system';
 
 const transferSol = getTransferSolInstruction({
-  source: createNoopSigner(address("2222..2222")),
-  destination: address("3333..3333"),
-  amount: 1_000_000_000, // 1 SOL.
+    source: createNoopSigner(address('2222..2222')),
+    destination: address('3333..3333'),
+    amount: 1_000_000_000, // 1 SOL.
 });
 ```
 
@@ -278,10 +278,11 @@ const transferSol = getTransferSolInstruction({
 </Spread>
 
 <Callout title="Transaction signers">
-  Notice the `createNoopSigner` function in the Kit example. Unlike Web3.js, Kit uses `TransactionSigner` objects when
-  an account needs to act as a signer for an instruction. This allows signers to be extracted from built transactions,
-  enabling automatic transaction signing without manually scanning instructions to find required signers. We'll explore
-  this further in the ["Signing transactions" section below](#signing-transactions).
+    Notice the `createNoopSigner` function in the Kit example. Unlike Web3.js, Kit uses
+    `TransactionSigner` objects when an account needs to act as a signer for an instruction. This
+    allows signers to be extracted from built transactions, enabling automatic transaction signing
+    without manually scanning instructions to find required signers. We'll explore this further in
+    the ["Signing transactions" section below](#signing-transactions).
 </Callout>
 
 Now that we know how to create instructions, let's see how to use them to build transactions.
@@ -298,29 +299,31 @@ Since TypeScript cannot re-declare the type of an existing variable, each transa
 <div className="2xl:flex 2xl:*:flex-1 2xl:items-start 2xl:gap-4">
 
 ```ts title="Web3.js"
-import { PublicKey, SystemProgram, Transaction } from "@solana/web3.js";
-import { createInitializeMintInstruction } from "@solana/spl-token";
+import { PublicKey, SystemProgram, Transaction } from '@solana/web3.js';
+import { createInitializeMintInstruction } from '@solana/spl-token';
 
 const latestBlockhash = await connection.getLatestBlockhash();
 const createAccount = SystemProgram.createAccount(createAccountInput);
 const initializeMint = createInitializeMintInstruction(initializeMintInput);
 
-const transaction = new Transaction({ feePayer, ...latestBlockhash }).add(createAccount).add(initializeMint);
+const transaction = new Transaction({ feePayer, ...latestBlockhash })
+    .add(createAccount)
+    .add(initializeMint);
 ```
 
 ```ts twoslash title="Kit"
 import {
-  appendTransactionMessageInstructions,
-  createTransactionMessage,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-} from "@solana/kit";
-import { getCreateAccountInstruction } from "@solana-program/system";
-import { getInitializeMintInstruction } from "@solana-program/token";
+    appendTransactionMessageInstructions,
+    createTransactionMessage,
+    pipe,
+    setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
+} from '@solana/kit';
+import { getCreateAccountInstruction } from '@solana-program/system';
+import { getInitializeMintInstruction } from '@solana-program/token';
 // ---cut-start---
-import { createSolanaRpc, TransactionSigner } from "@solana/kit";
-const rpc = createSolanaRpc("https://api.devnet.solana.com");
+import { createSolanaRpc, TransactionSigner } from '@solana/kit';
+const rpc = createSolanaRpc('https://api.devnet.solana.com');
 const payer = null as unknown as TransactionSigner;
 const createAccountInput = null as unknown as Parameters<typeof getCreateAccountInstruction>[0];
 const initializeMintInput = null as unknown as Parameters<typeof getInitializeMintInstruction>[0];
@@ -331,10 +334,10 @@ const createAccount = getCreateAccountInstruction(createAccountInput);
 const initializeMint = getInitializeMintInstruction(initializeMintInput);
 
 const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions([createAccount, initializeMint], tx),
+    createTransactionMessage({ version: 0 }),
+    (tx) => setTransactionMessageFeePayerSigner(payer, tx),
+    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+    (tx) => appendTransactionMessageInstructions([createAccount, initializeMint], tx),
 );
 ```
 
@@ -349,7 +352,7 @@ Both Web3.js and Kit allow keypairs to sign or partially sign transactions. Howe
 <div className="2xl:flex 2xl:*:flex-1 2xl:items-start 2xl:gap-4">
 
 ```ts title="Web3.js"
-import { Keypair, Transaction } from "@solana/web3.js";
+import { Keypair, Transaction } from '@solana/web3.js';
 
 const payer = Keypair.generate();
 const authority = Keypair.generate();
@@ -358,10 +361,11 @@ transaction.sign([payer, authority]);
 ```
 
 ```ts twoslash title="Kit"
-import { compileTransaction, generateKeyPair, signTransaction } from "@solana/kit";
+import { compileTransaction, generateKeyPair, signTransaction } from '@solana/kit';
 // ---cut-start---
-import { CompilableTransactionMessage, TransactionMessageWithBlockhashLifetime } from "@solana/kit";
-const transactionMessage = null as unknown as CompilableTransactionMessage & TransactionMessageWithBlockhashLifetime;
+import { CompilableTransactionMessage, TransactionMessageWithBlockhashLifetime } from '@solana/kit';
+const transactionMessage = null as unknown as CompilableTransactionMessage &
+    TransactionMessageWithBlockhashLifetime;
 // ---cut-end---
 
 const [payer, authority] = await Promise.all([generateKeyPair(), generateKeyPair()]);
@@ -376,11 +380,13 @@ const signedTransaction = await signTransaction([payer, authority], transaction)
 Additionally, as mentioned in the ["Creating instructions"](#creating-instructions) section, Kit introduces **signer objects**. These objects handle transaction and message signing while abstracting away the underlying signing mechanism. This could be using a Crypto KeyPair, a wallet adapter in the browser, a Noop signer, or anything we want. Here are some examples of how signers can be created:
 
 ```ts twoslash title="Kit"
-import { address, createNoopSigner, generateKeyPairSigner } from "@solana/kit";
-import { useWalletAccountTransactionSendingSigner } from "@solana/react";
+import { address, createNoopSigner, generateKeyPairSigner } from '@solana/kit';
+import { useWalletAccountTransactionSendingSigner } from '@solana/react';
 // ---cut-start---
 const account = null as unknown as Parameters<typeof useWalletAccountTransactionSendingSigner>[0];
-const currentChain = null as unknown as Parameters<typeof useWalletAccountTransactionSendingSigner>[1];
+const currentChain = null as unknown as Parameters<
+    typeof useWalletAccountTransactionSendingSigner
+>[1];
 // ---cut-end---
 
 // Using CryptoKeyPairs.
@@ -390,7 +396,7 @@ const myKeypairSigner = await generateKeyPairSigner();
 const myWalletSigner = useWalletAccountTransactionSendingSigner(account, currentChain);
 
 // Using a Noop signer.
-const myNoopSigner = createNoopSigner(address("1234..5678"));
+const myNoopSigner = createNoopSigner(address('1234..5678'));
 ```
 
 One key advantage of using signers is that they can be passed directly when creating instructions. This enables transaction messages to be aware of the required signers, eliminating the need to manually track them. When this is the case, the `signTransactionMessageWithSigners` function can be used to sign the transaction with all attached signers.
@@ -398,22 +404,24 @@ One key advantage of using signers is that they can be passed directly when crea
 Here's an example of passing signers to both instructions and the transaction fee payer. Notice that `signTransactionMessageWithSigners` doesn't require additional signers to be passed in — it already knows which ones are needed.
 
 ```ts twoslash title="Kit"
-import { signTransactionMessageWithSigners } from "@solana/kit";
-import { getCreateAccountInstruction } from "@solana-program/system";
-import { getInitializeMintInstruction, TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import { signTransactionMessageWithSigners } from '@solana/kit';
+import { getCreateAccountInstruction } from '@solana-program/system';
+import { getInitializeMintInstruction, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
 // ---cut-start---
 import {
-  address,
-  appendTransactionMessageInstructions,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-} from "@solana/kit";
-const latestBlockhash = null as unknown as Parameters<typeof setTransactionMessageLifetimeUsingBlockhash>[0];
-const space = null as unknown as Parameters<typeof getCreateAccountInstruction>[0]["space"];
-const lamports = null as unknown as Parameters<typeof getCreateAccountInstruction>[0]["lamports"];
+    address,
+    appendTransactionMessageInstructions,
+    createTransactionMessage,
+    generateKeyPairSigner,
+    pipe,
+    setTransactionMessageFeePayerSigner,
+    setTransactionMessageLifetimeUsingBlockhash,
+} from '@solana/kit';
+const latestBlockhash = null as unknown as Parameters<
+    typeof setTransactionMessageLifetimeUsingBlockhash
+>[0];
+const space = null as unknown as Parameters<typeof getCreateAccountInstruction>[0]['space'];
+const lamports = null as unknown as Parameters<typeof getCreateAccountInstruction>[0]['lamports'];
 // ---cut-end---
 
 // Create signers.
@@ -421,24 +429,24 @@ const [payer, mint] = await Promise.all([generateKeyPairSigner(), generateKeyPai
 
 // Create the instructions.
 const createAccount = getCreateAccountInstruction({
-  payer, // <- TransactionSigner // [!code highlight]
-  newAccount: mint, // <- TransactionSigner // [!code highlight]
-  space,
-  lamports,
-  programAddress: TOKEN_PROGRAM_ADDRESS,
+    payer, // <- TransactionSigner // [!code highlight]
+    newAccount: mint, // <- TransactionSigner // [!code highlight]
+    space,
+    lamports,
+    programAddress: TOKEN_PROGRAM_ADDRESS,
 });
 const initializeMint = getInitializeMintInstruction({
-  mint: mint.address,
-  mintAuthority: address("1234..5678"),
-  decimals: 2,
+    mint: mint.address,
+    mintAuthority: address('1234..5678'),
+    decimals: 2,
 });
 
 // Create the transaction.
 const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(payer, tx), // <- TransactionSigner // [!code highlight]
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions([createAccount, initializeMint], tx),
+    createTransactionMessage({ version: 0 }),
+    (tx) => setTransactionMessageFeePayerSigner(payer, tx), // <- TransactionSigner // [!code highlight]
+    (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+    (tx) => appendTransactionMessageInstructions([createAccount, initializeMint], tx),
 );
 
 // Sign the transaction.
@@ -455,28 +463,32 @@ Finally, we can send our signed transaction to the network and wait for confirma
 <div className="2xl:flex 2xl:*:flex-1 2xl:items-start 2xl:gap-4">
 
 ```ts title="Web3.js"
-import { Keypair, sendAndConfirmTransaction } from "@solana/web3.js";
+import { Keypair, sendAndConfirmTransaction } from '@solana/web3.js';
 
 // Create keypairs.
 const payer = Keypair.generate();
 const mint = Keypair.generate();
 
 // Sign, send and confirm the transaction.
-const transactionSignature = await sendAndConfirmTransaction(connection, transaction, [feePayer, mint]);
+const transactionSignature = await sendAndConfirmTransaction(connection, transaction, [
+    feePayer,
+    mint,
+]);
 ```
 
 ```ts twoslash title="Kit"
-import { sendAndConfirmTransactionFactory, getSignatureFromTransaction } from "@solana/kit";
+import { sendAndConfirmTransactionFactory, getSignatureFromTransaction } from '@solana/kit';
 // ---cut-start---
 import {
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  FullySignedTransaction,
-  TransactionWithBlockhashLifetime,
-} from "@solana/kit";
-const rpc = createSolanaRpc("https://api.devnet.solana.com");
-const rpcSubscriptions = createSolanaRpcSubscriptions("wss://api.devnet.solana.com");
-const signedTransaction = null as unknown as FullySignedTransaction & TransactionWithBlockhashLifetime;
+    createSolanaRpc,
+    createSolanaRpcSubscriptions,
+    FullySignedTransaction,
+    TransactionWithBlockhashLifetime,
+} from '@solana/kit';
+const rpc = createSolanaRpc('https://api.devnet.solana.com');
+const rpcSubscriptions = createSolanaRpcSubscriptions('wss://api.devnet.solana.com');
+const signedTransaction = null as unknown as FullySignedTransaction &
+    TransactionWithBlockhashLifetime;
 // ---cut-end---
 
 // Create a send and confirm function from your RPC and RPC Subscriptions objects.
@@ -484,7 +496,7 @@ const sendAndConfirm = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions 
 
 // Use it to send and confirm any signed transaction.
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
-await sendAndConfirm(signedTransaction, { commitment: "confirmed" });
+await sendAndConfirm(signedTransaction, { commitment: 'confirmed' });
 ```
 
 </div>
@@ -504,21 +516,23 @@ We've now explored the key differences between Web3.js and Kit, giving you a sol
 To ease the transition, Kit provides a `@solana/compat` package, which allows for incremental migration. This package includes functions that convert core types — such as public keys and transactions — between Web3.js and Kit. This means you can start integrating Kit without having to refactor your entire project at once.
 
 ```ts twoslash title="Kit"
-import { Keypair, PublicKey } from "@solana/web3.js";
-import { createSignerFromKeyPair } from "@solana/kit";
+import { Keypair, PublicKey } from '@solana/web3.js';
+import { createSignerFromKeyPair } from '@solana/kit';
 import {
-  fromLegacyKeypair,
-  fromLegacyPublicKey,
-  fromLegacyTransactionInstruction,
-  fromVersionedTransaction,
-} from "@solana/compat";
+    fromLegacyKeypair,
+    fromLegacyPublicKey,
+    fromLegacyTransactionInstruction,
+    fromVersionedTransaction,
+} from '@solana/compat';
 // ---cut-start---
-const transactionInstruction = null as unknown as Parameters<typeof fromLegacyTransactionInstruction>[0];
+const transactionInstruction = null as unknown as Parameters<
+    typeof fromLegacyTransactionInstruction
+>[0];
 const versionedTransaction = null as unknown as Parameters<typeof fromVersionedTransaction>[0];
 // ---cut-end---
 
 // Convert `PublicKeys`.
-const address = fromLegacyPublicKey(new PublicKey("1234..5678"));
+const address = fromLegacyPublicKey(new PublicKey('1234..5678'));
 
 // Convert `Keypairs`.
 const cryptoKeypair = await fromLegacyKeypair(Keypair.generate());


### PR DESCRIPTION
#### Summary of Changes

- Bring Prettier closer to Solana code style (4 tabs, single quotes, etc)
- Shorten the line length to that which fits on the screen when the docs site is viewed on a 13" M1 MacBook
- Ignore the `/docs/content/api` directory of autogenerated files

#### Test plan

```
cd docs/
pnpm prettier --check .
```