### PR TITLE
fix: off curve check

### DIFF
--- a/.changeset/cute-peaches-brake.md
+++ b/.changeset/cute-peaches-brake.md
@@ -1,0 +1,5 @@
+---
+'@solana/addresses': patch
+---
+
+corrected offCurve check

--- a/packages/addresses/src/__tests__/curve-test.ts
+++ b/packages/addresses/src/__tests__/curve-test.ts
@@ -30,13 +30,14 @@ const ON_CURVE_KEY_BYTES = [
     ]),
 ];
 
-const OFF_CURVE_ADDRESSES = [
+const ON_CURVE_ADDRESSES = [
     'nick6zJc6HpW3kfBm4xS2dmbuVRyb5F3AnUvj5ymzR5', // "wallet" account
     '11111111111111111111111111111111', // system program
     'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA', // legacy token program
     'SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf', // Squads multi-sig program
 ].map(address);
-const ON_CURVE_ADDRESSES = [
+
+const OFF_CURVE_ADDRESSES = [
     'CCMCWh4FudPEmY6Q1AVi5o8mQMXkHYkJUmZfzRGdcJ9P', // ATA
     '2DRxyJDsDccGL6mb8PLMsKQTCU3C7xUq8aprz53VcW4k', // random Squads multi-sig account
 ].map(address);

--- a/packages/addresses/src/curve.ts
+++ b/packages/addresses/src/curve.ts
@@ -34,7 +34,7 @@ export function isOffCurveAddress<TAddress extends Address>(
     putativeOffCurveAddress: TAddress,
 ): putativeOffCurveAddress is OffCurveAddress<TAddress> {
     const addressBytes = getAddressCodec().encode(putativeOffCurveAddress);
-    return compressedPointBytesAreOnCurve(addressBytes);
+    return compressedPointBytesAreOnCurve(addressBytes) == false;
 }
 
 /**


### PR DESCRIPTION
#### Problem

The recently added `isOffCurveAddress` function incorrectly checks for off curve or not. It returns the opposite of what it should...

#### Summary of Changes

- fixed the `isOffCurveAddress` response
- corrected the tests to check addresses on and off curve

Fixes #602