### PR TITLE
Subscriptions coalescer can now track more than a single subscription, eliminating bug where subscriptions would not unsubscribe

### DIFF
--- a/.changeset/cute-trees-kick.md
+++ b/.changeset/cute-trees-kick.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-subscriptions-spec': patch
+---
+
+Repaired a bug that could cause subscriptions to become 'stuck' and fail to send their unsubscribe message to the RPC, despite the last consumer in your app having released the subscription by calling `AbortController#abort()`


### PR DESCRIPTION
#### Problem

This data structure only ever tracked one subscription at a time. Untracked subscriptions could become stuck and never send their unsubscribe message, even after the last consumer aborted the subscription.

#### Summary of Changes

Write it like you mean it.

#### Test Plan

```ts
import { address, createSolanaRpcSubscriptions } from './index';

const rpcSubscriptions = createSolanaRpcSubscriptions('wss://api.devnet.solana.com');

void (async () => {
    const accountNotifications = await rpcSubscriptions
        .accountNotifications(address('Ftk9ELv51cE7zZ8swsCLtcx8Vt8rt7dZC8gKMRSfKEgV'))
        .subscribe({ abortSignal: AbortSignal.timeout(10000) });
    const slotNotifications = await rpcSubscriptions
        .slotNotifications()
        .subscribe({ abortSignal: AbortSignal.timeout(1000) });

    void (async () => {
        for await (const notif of accountNotifications) {
            console.log('Account notification', notif);
        }
        console.log('Done accounts');
    })();
    void (async () => {
        for await (const notif of slotNotifications) {
            console.log('Slot notification', notif);
        }
        console.log('Done slots');
    })();
})();
```

Observe that the unsubscribe message is sent when the slot subscription is aborted.

Fixes #603.
