### PR TITLE
Attempt to repair the broken publish script

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -53,10 +53,10 @@ jobs:
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
           # Some tasks slow down considerably on GitHub Actions runners when concurrency is high
-          publish: |
-            pnpm turbo publish-packages --concurrency=1 && \
-            # Changesets will only create the tags/release if it sees "New tag:" in the publish command's output
-            # See https://github.com/changesets/action/blob/06245a4e0a36c064a573d4150030f5ec548e4fcc/src/run.ts#L176
+          publish: >
+            pnpm turbo publish-packages --concurrency=1 && 
+            `# Changesets will only create the tags/release if it sees "New tag:" in the publish command's output`
+            `# See https://github.com/changesets/action/blob/06245a4e0a36c064a573d4150030f5ec548e4fcc/src/run.ts#L176`
             echo 'New tag:'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Problem

This part of YAML does not respect newlines for some reason, resulting in this command being executed:

```
/home/runner/setup-pnpm/node_modules/.bin/pnpm turbo publish-packages --concurrency=1 && \ # Changesets will only create the tags/release if it sees "New tag:" in the publish command's output # See https://github.com/changesets/action/blob/06245a4e0a36c064a573d4150030f5ec548e4fcc/src/run.ts#L176 echo 'New tag:'
```

…instead of this one

```
/home/runner/setup-pnpm/node_modules/.bin/pnpm turbo publish-packages --concurrency=1 && \
  # Changesets will only create the tags/release if it sees "New tag:" in the publish command's output
  # See https://github.com/changesets/action/blob/06245a4e0a36c064a573d4150030f5ec548e4fcc/src/run.ts#L176
  echo 'New tag:'
```

#### Summary of Changes

Rewrite it so that it works even when folded on to one line.
