### PR TITLE
Actually fix the publish script

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -52,16 +52,13 @@ jobs:
         id: changesets
         uses: changesets/action@06245a4e0a36c064a573d4150030f5ec548e4fcc # v1.4.10
         with:
-          # * Some tasks slow down considerably on GitHub Actions runners when concurrency is high
-          # * Changesets will only create the tags/release if it sees "New tag:" in the publish command's output
-          #   See https://github.com/changesets/action/blob/06245a4e0a36c064a573d4150030f5ec548e4fcc/src/run.ts#L176
-          publish: |
-            pnpm turbo publish-packages --concurrency=1
-            echo 'New tag:'
+          publish: pnpm changeset:publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           PUBLISH_TAG: latest
+          # Some tasks slow down considerably on GitHub Actions runners when concurrency is high
+          TURBO_CONCURRENCY: 1
 
       - name: Push Git Tag
         if: steps.changesets.outputs.published == 'true'

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "private": true,
     "scripts": {
         "build": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} build",
+        "changeset:publish": "turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-95.84%} && `# Changesets will only create the tags/release if it sees \"New tag:\" in the publish command's output. See https://github.com/changesets/action/blob/06245a4e0a36c064a573d4150030f5ec548e4fcc/src/run.ts#L176` echo \"New tag:\"",
         "compile": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} compile:js compile:typedefs",
         "lint": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:lint",
         "style:fix": "turbo  run --concurrency=${TURBO_CONCURRENCY:-95.84%} style:fix && pnpm prettier --log-level warn --ignore-unknown --write '{.,!packages}/*'",


### PR DESCRIPTION
#### Problem

OK, so turns out #500 was never tested until now. The reason this doesn't work is because of some [aggressively adversarial developer tooling](https://github.com/changesets/changesets/blob/b57c77f8648daa11357547dda8bb85643049cc63/packages/release-utils/src/run.ts#L33). We can't presume that this is just a shell script here.

#### Summary of Changes

- Create a `pnpm` script just for Changesets that encapsulates all the commands that need to be run.
- Specify that one command to the changesets action
