### PR TITLE
Fixed reading 'length' of undefined

### DIFF
--- a/packages/errors/src/message-formatter.ts
+++ b/packages/errors/src/message-formatter.ts
@@ -18,7 +18,7 @@ export function getHumanReadableErrorMessage<TErrorCode extends SolanaErrorCode>
     code: TErrorCode,
     context: object = {},
 ): string {
-    const messageFormatString = SolanaErrorMessages[code];
+    const messageFormatString = SolanaErrorMessages[code] ?? "";
     if (messageFormatString.length === 0) {
         return '';
     }


### PR DESCRIPTION
Fixed `TypeError: Cannot read properties of undefined (reading 'length')` at getHumanReadableErrorMessage() (packages/errors/src/message-formatter.ts)

#### Problem

When the code is not found on the `SolanaErrorMessages` object, we'll have `messageFormatString = undefined`. Then we'll crash at `messageFormatString.length` on the following line.


#### Summary of Changes

Fallback to an empty string in case the code is not found on the object, as this is what the code assumes it'll have.


Fixes #317