### PR TITLE
Use major changesets for lifetime refactoring

### DIFF
--- a/.changeset/major-guests-shine.md
+++ b/.changeset/major-guests-shine.md
@@ -1,6 +1,6 @@
 ---
-'@solana/transaction-messages': minor
-'@solana/kit': minor
+'@solana/transaction-messages': major
+'@solana/kit': major
 ---
 
 Extract lifetime token from `CompiledTransactionMessage`. `CompiledTransactionMessage & CompiledTransactionMessageWithLifetime` may now be used to refer to a compiled transaction message with a lifetime token. This enables `CompiledTransactionMessages` to be encoded without the need to specify a mock lifetime token.

--- a/.changeset/shiny-rocks-shout.md
+++ b/.changeset/shiny-rocks-shout.md
@@ -1,6 +1,6 @@
 ---
-'@solana/transactions': minor
-'@solana/signers': minor
+'@solana/transactions': major
+'@solana/signers': major
 ---
 
 Add the `TransactionWithLifetime` requirement when signing transactions. This is because, whilst a lifetime may not always be required before compile a transaction message, it is always required when signing a transaction. Otherwise, the transaction signatures will be invalid when one is added later.

--- a/.changeset/social-keys-rest.md
+++ b/.changeset/social-keys-rest.md
@@ -1,6 +1,6 @@
 ---
 '@solana/transaction-messages': minor
-'@solana/transactions': minor
+'@solana/transactions': major
 '@solana/signers': minor
 ---
 


### PR DESCRIPTION
This PR adjusts some of the changesets of a [previously merged PR stack](https://github.com/anza-xyz/kit/pull/584) such that `major` bumps are used when breaking changes are introduced.