### PR TITLE
Allow non-enumerable properties in error contexts

### DIFF
--- a/.changeset/common-zoos-live.md
+++ b/.changeset/common-zoos-live.md
@@ -1,0 +1,5 @@
+---
+'@solana/errors': patch
+---
+
+Allow `SolanaError` context objects to use non-enumerable properties. This is useful when it's appropriate for an object to appear in the error context at runtime, but when that object can't be serialized for use by the production mode error decoder. Prior to this, non-enumerable properties would be deleted from context objects when creating new `SolanaErrors`.

--- a/packages/errors/src/__tests__/context-test.ts
+++ b/packages/errors/src/__tests__/context-test.ts
@@ -84,4 +84,11 @@ describe('encodeContextObject', () => {
         const encodedContext = encodeContextObject(context);
         expect(atob(encodedContext)).toBe(EXPECTED_URL_ENCODED_CONTEXT);
     });
+    it('does not encode non-enumerable properties', () => {
+        const context = { a: 1, c: 3 };
+        Object.defineProperty(context, 'b', { enumerable: false, value: 2 });
+
+        const encodedContext = encodeContextObject(context);
+        expect(atob(encodedContext)).toBe('a=1&c=3');
+    });
 });

--- a/packages/errors/src/__tests__/error-test.ts
+++ b/packages/errors/src/__tests__/error-test.ts
@@ -23,7 +23,7 @@ describe('SolanaError', () => {
             expect(errorWithContext.cause).toBeUndefined();
         });
         it('calls the message formatter with the code and context', () => {
-            expect(getErrorMessage).toHaveBeenCalledWith(123, { foo: 'bar' });
+            expect(getErrorMessage).toHaveBeenCalledWith(123, expect.objectContaining({ foo: 'bar' }));
         });
     });
     describe('given an error with no context', () => {


### PR DESCRIPTION
This PR allows `SolanaErrors` to use non-enumerable properties in their context object. Prior to this PR, non-enumerable properties would always be deleted from the context when instantiating new `SolanaErrors` due to the spread operator — i.e. `this.context = { ...context }`.