### PR TITLE
Make Union codecs FixedSize if all their variants are FixedSize 

### DIFF
--- a/.changeset/hip-shirts-brake.md
+++ b/.changeset/hip-shirts-brake.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-data-structures': patch
+---
+
+Make Union codecs FixedSize if all their variants are FixedSize

--- a/packages/codecs-data-structures/src/__typetests__/discriminated-union-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/discriminated-union-typetest.ts
@@ -1,4 +1,4 @@
-import { Codec, Decoder, Encoder } from '@solana/codecs-core';
+import { Codec, Decoder, Encoder, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 import { getU64Codec } from '@solana/codecs-numbers';
 
 import {
@@ -49,6 +49,25 @@ import { getUnitCodec } from '../unit';
             [Event.KeyPress, {} as Encoder<{ key: string }>],
         ]) satisfies Encoder<{ __kind: Event.Click; x: number; y: number } | { __kind: Event.KeyPress; key: string }>;
     }
+
+    // It returns a fixed size encoder if all variants are fixed size.
+    {
+        getDiscriminatedUnionEncoder([
+            ['A', {} as FixedSizeEncoder<{ value: string }>],
+            ['B', {} as FixedSizeEncoder<{ x: number; y: number }>],
+        ]) satisfies FixedSizeEncoder<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+    }
+
+    // It does not return a fixed size encoder if any variant is variable size.
+    {
+        const encoder = getDiscriminatedUnionEncoder([
+            ['A', {} as Encoder<{ value: string }>],
+            ['B', {} as FixedSizeEncoder<{ x: number; y: number }>],
+        ]);
+        encoder satisfies Encoder<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+        // @ts-expect-error Encoder is not fixed size.
+        encoder satisfies FixedSizeEncoder<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+    }
 }
 
 // [DESCRIBE] getDiscriminatedUnionDecoder.
@@ -90,6 +109,25 @@ import { getUnitCodec } from '../unit';
             [Event.Click, {} as Decoder<{ x: number; y: number }>],
             [Event.KeyPress, {} as Decoder<{ key: string }>],
         ]) satisfies Decoder<{ __kind: Event.Click; x: number; y: number } | { __kind: Event.KeyPress; key: string }>;
+    }
+
+    // It returns a fixed size decoder if all variants are fixed size.
+    {
+        getDiscriminatedUnionDecoder([
+            ['A', {} as FixedSizeDecoder<{ value: string }>],
+            ['B', {} as FixedSizeDecoder<{ x: number; y: number }>],
+        ]) satisfies FixedSizeDecoder<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+    }
+
+    // It does not return a fixed size decoder if any variant is variable size.
+    {
+        const decoder = getDiscriminatedUnionDecoder([
+            ['A', {} as Decoder<{ value: string }>],
+            ['B', {} as FixedSizeDecoder<{ x: number; y: number }>],
+        ]);
+        decoder satisfies Decoder<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+        // @ts-expect-error Decoder is not fixed size.
+        decoder satisfies FixedSizeDecoder<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
     }
 }
 
@@ -167,5 +205,24 @@ import { getUnitCodec } from '../unit';
             { __kind: 'A' } | { __kind: 'B'; value: bigint | number },
             { __kind: 'A' } | { __kind: 'B'; value: bigint }
         >;
+    }
+
+    // It returns a fixed size codec if all variants are fixed size.
+    {
+        getDiscriminatedUnionCodec([
+            ['A', {} as FixedSizeCodec<{ value: string }>],
+            ['B', {} as FixedSizeCodec<{ x: number; y: number }>],
+        ]) satisfies FixedSizeCodec<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+    }
+
+    // It does not return a fixed size codec if any variant is variable size.
+    {
+        const codec = getDiscriminatedUnionCodec([
+            ['A', {} as Codec<{ value: string }>],
+            ['B', {} as FixedSizeCodec<{ x: number; y: number }>],
+        ]);
+        codec satisfies Codec<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
+        // @ts-expect-error Codec is not fixed size.
+        codec satisfies FixedSizeCodec<{ __kind: 'A'; value: string } | { __kind: 'B'; x: number; y: number }>;
     }
 }

--- a/packages/codecs-data-structures/src/__typetests__/union-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/union-typetest.ts
@@ -1,45 +1,119 @@
-import { Codec, Decoder, Encoder } from '@solana/codecs-core';
+import { Codec, Decoder, Encoder, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
 
 import { getUnionCodec, getUnionDecoder, getUnionEncoder } from '../union';
 
 const getIndex = () => 0;
 
-// [getUnionEncoder] It constructs unions from a list of encoder variants.
+// [DESCRIBE] getUnionEncoder.
 {
-    getUnionEncoder(
-        [
-            {} as Encoder<null>,
-            {} as Encoder<bigint | number>,
-            {} as Encoder<{ value: string }>,
-            {} as Encoder<{ x: number; y: number }>,
-        ],
-        getIndex,
-    ) satisfies Encoder<bigint | number | { value: string } | { x: number; y: number } | null>;
+    // It constructs unions from a list of encoder variants.
+    {
+        getUnionEncoder(
+            [
+                {} as Encoder<null>,
+                {} as Encoder<bigint | number>,
+                {} as Encoder<{ value: string }>,
+                {} as Encoder<{ x: number; y: number }>,
+            ],
+            getIndex,
+        ) satisfies Encoder<bigint | number | { value: string } | { x: number; y: number } | null>;
+    }
+
+    // It returns a fixed size encoder if all variants are fixed size.
+    {
+        getUnionEncoder(
+            [
+                {} as FixedSizeEncoder<null>,
+                {} as FixedSizeEncoder<bigint | number>,
+                {} as FixedSizeEncoder<{ value: string }>,
+                {} as FixedSizeEncoder<{ x: number; y: number }>,
+            ],
+            getIndex,
+        ) satisfies FixedSizeEncoder<bigint | number | { value: string } | { x: number; y: number } | null>;
+    }
+
+    // It does not return a fixed size encoder if any variant is variable size.
+    {
+        const decoder = getUnionEncoder([{} as Encoder<number>, {} as FixedSizeEncoder<number>], getIndex);
+        decoder satisfies Encoder<number>;
+        // @ts-expect-error Encoder is not fixed size.
+        decoder satisfies FixedSizeEncoder<number>;
+    }
 }
 
-// [getUnionDecoder] It constructs unions from a list of decoder variants.
+// [DESCRIBE] getUnionDecoder.
 {
-    getUnionDecoder(
-        [
-            {} as Decoder<null>,
-            {} as Decoder<bigint | number>,
-            {} as Decoder<{ value: string }>,
-            {} as Decoder<{ x: number; y: number }>,
-        ],
-        getIndex,
-    ) satisfies Decoder<bigint | number | { value: string } | { x: number; y: number } | null>;
+    // It constructs unions from a list of decoder variants.
+    {
+        getUnionDecoder(
+            [
+                {} as Decoder<null>,
+                {} as Decoder<bigint | number>,
+                {} as Decoder<{ value: string }>,
+                {} as Decoder<{ x: number; y: number }>,
+            ],
+            getIndex,
+        ) satisfies Decoder<bigint | number | { value: string } | { x: number; y: number } | null>;
+    }
+
+    // It returns a fixed size decoder if all variants are fixed size.
+    {
+        const decoder = getUnionDecoder(
+            [
+                {} as FixedSizeDecoder<null>,
+                {} as FixedSizeDecoder<bigint | number>,
+                {} as FixedSizeDecoder<{ value: string }>,
+                {} as FixedSizeDecoder<{ x: number; y: number }>,
+            ],
+            getIndex,
+        );
+        decoder satisfies FixedSizeDecoder<bigint | number | { value: string } | { x: number; y: number } | null>;
+    }
+
+    // It does not return a fixed size decoder if any variant is variable size.
+    {
+        const decoder = getUnionDecoder([{} as Decoder<number>, {} as FixedSizeDecoder<number>], getIndex);
+        decoder satisfies Decoder<number>;
+        // @ts-expect-error Decoder is not fixed size.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
 }
 
-// [getUnionCodec] It constructs unions from a list of codec variants.
+// [DESCRIBE] getUnionCodec.
 {
-    getUnionCodec(
-        [
-            {} as Codec<null>,
-            {} as Codec<bigint | number>,
-            {} as Codec<{ value: string }>,
-            {} as Codec<{ x: number; y: number }>,
-        ],
-        getIndex,
-        getIndex,
-    ) satisfies Codec<bigint | number | { value: string } | { x: number; y: number } | null>;
+    // It constructs unions from a list of codec variants.
+    {
+        getUnionCodec(
+            [
+                {} as Codec<null>,
+                {} as Codec<bigint | number>,
+                {} as Codec<{ value: string }>,
+                {} as Codec<{ x: number; y: number }>,
+            ],
+            getIndex,
+            getIndex,
+        ) satisfies Codec<bigint | number | { value: string } | { x: number; y: number } | null>;
+    }
+
+    // It returns a fixed size codec if all variants are fixed size.
+    {
+        getUnionCodec(
+            [
+                {} as FixedSizeCodec<null>,
+                {} as FixedSizeCodec<bigint | number>,
+                {} as FixedSizeCodec<{ value: string }>,
+                {} as FixedSizeCodec<{ x: number; y: number }>,
+            ],
+            getIndex,
+            getIndex,
+        ) satisfies FixedSizeCodec<bigint | number | { value: string } | { x: number; y: number } | null>;
+    }
+
+    // It does not return a fixed size codec if any variant is variable size.
+    {
+        const codec = getUnionCodec([{} as Codec<number>, {} as FixedSizeCodec<number>], getIndex, getIndex);
+        codec satisfies Codec<number>;
+        // @ts-expect-error Codec is not fixed size.
+        codec satisfies FixedSizeCodec<number>;
+    }
 }


### PR DESCRIPTION
#### Problem

Currently codec functions like `getUnionEncoder` return an `Encoder<something>`, but at runtime they may return a `FixedSizeEncoder<something>` depending on their variants.

This means that `getUnionEncoder(fixedSizeThings)` returns a fixed size encoder, but not the type `FixedSizeEncoder<something>`

This causes difficulties for Codama, eg https://github.com/codama-idl/codama/pull/730

#### Summary of Changes

We add some type gymnastics to `getUnion{Encoder}` and `getDiscriminatedUnion{Encoder}` (which calls Union)

If all variants are `FixedSize{Encoder}` then we return a `FixedSize{Encoder}<something>`, else we continue to return `{Encoder}<something>` as we currently do.

This means that when Codama generates `getDiscriminatedUnionEncoder([['V1', getStructEncoder([['amount', getU64Encoder()]])]])` it will correctly be typed as a `FixedSizeEncoder<something>`. 

Note that I also tried to do this using overloads instead of a conditional type, but I got type errors when the codec function calls the encoder/decoder. I think it's because the variable codec would be incompatible with calls to the fixed encoder/decoder overload. It'd be a type-only issue but I figured this is cleaner than suppressing confusing errors in that approach. 