### PR TITLE
Export instruction plans from main library

### DIFF
--- a/.changeset/green-chicken-visit.md
+++ b/.changeset/green-chicken-visit.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit': minor
+---
+
+Re-export `@solana/instruction-plans` from `@solana/kit`.

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -81,6 +81,7 @@
         "@solana/errors": "workspace:*",
         "@solana/functional": "workspace:*",
         "@solana/instructions": "workspace:*",
+        "@solana/instruction-plans": "workspace:*",
         "@solana/keys": "workspace:*",
         "@solana/programs": "workspace:*",
         "@solana/rpc": "workspace:*",

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -12,6 +12,7 @@ export * from '@solana/codecs';
 export * from '@solana/errors';
 export * from '@solana/functional';
 export * from '@solana/instructions';
+export * from '@solana/instruction-plans';
 export * from '@solana/keys';
 export * from '@solana/programs';
 export * from '@solana/rpc';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -647,6 +647,9 @@ importers:
       '@solana/functional':
         specifier: workspace:*
         version: link:../functional
+      '@solana/instruction-plans':
+        specifier: workspace:*
+        version: link:../instruction-plans
       '@solana/instructions':
         specifier: workspace:*
         version: link:../instructions


### PR DESCRIPTION
This PR re-exports `@solana/instruction-plans` from the main `@solana/kit` library.