### PR TITLE
Export more helpers from instruction plans package

### DIFF
--- a/.changeset/fuzzy-years-laugh.md
+++ b/.changeset/fuzzy-years-laugh.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': patch
+---
+
+Export more types and functions from the `@solana/instruction-plans` package.

--- a/packages/instruction-plans/src/index.ts
+++ b/packages/instruction-plans/src/index.ts
@@ -4,3 +4,7 @@
  * @packageDocumentation
  */
 export * from './instruction-plan';
+export * from './transaction-plan-executor';
+export * from './transaction-plan-result';
+export * from './transaction-plan';
+export * from './transaction-planner';


### PR DESCRIPTION
This PR exports all types and functions from the `@solana/instruction-plans` package. Currently it only exports the `InstructionPlan` factory helpers. It was a mistake on my side not to update the `index.ts` file as I was building the package.