### PR TITLE
nit: fix Bigint <> BigInt capitalization inconsistency

### DIFF
--- a/packages/rpc-spec-types/src/__tests__/stringify-json-with-bigints-test.ts
+++ b/packages/rpc-spec-types/src/__tests__/stringify-json-with-bigints-test.ts
@@ -1,9 +1,9 @@
-import { stringifyJsonWithBigints } from '../stringify-json-with-bigints';
+import { stringifyJsonWithBigInts } from '../stringify-json-with-bigints';
 
 const MAX_SAFE_INTEGER = BigInt(Number.MAX_SAFE_INTEGER);
 const MAX_SAFE_INTEGER_PLUS_ONE = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
 
-describe('stringifyJsonWithBigints', () => {
+describe('stringifyJsonWithBigInts', () => {
     it.each`
         input                        | expectedString
         ${0n}                        | ${'0'}
@@ -19,14 +19,14 @@ describe('stringifyJsonWithBigints', () => {
         ${MAX_SAFE_INTEGER}          | ${MAX_SAFE_INTEGER.toString()}
         ${MAX_SAFE_INTEGER_PLUS_ONE} | ${MAX_SAFE_INTEGER_PLUS_ONE.toString()}
     `('strigifies bigint $input as a numerical value', ({ expectedString, input }) => {
-        expect(stringifyJsonWithBigints(input)).toBe(expectedString);
+        expect(stringifyJsonWithBigInts(input)).toBe(expectedString);
     });
     it('strigifies BigInts within nested structures', () => {
         const input = {
             alice: 42n,
             bob: [3.14, BigInt(3e8), { baz: 1234567890123456789012345678901234567890n }],
         };
-        expect(stringifyJsonWithBigints(input)).toBe(
+        expect(stringifyJsonWithBigInts(input)).toBe(
             '{"alice":42,"bob":[3.14,300000000,{"baz":1234567890123456789012345678901234567890}]}',
         );
     });
@@ -41,7 +41,7 @@ describe('stringifyJsonWithBigints', () => {
         ${1e-32}       | ${'1e-32'}
         ${-1189e-32}   | ${'-1.189e-29'}
     `('strigifies number $input as a numerical value', ({ expectedString, input }) => {
-        expect(stringifyJsonWithBigints(input)).toBe(expectedString);
+        expect(stringifyJsonWithBigInts(input)).toBe(expectedString);
     });
     it.each([
         null,
@@ -68,6 +68,6 @@ describe('stringifyJsonWithBigints', () => {
         { message_200: 'Hello to the "2nd World"' },
         { data: ['', 'base64'] },
     ])('does not alter the value of %s', input => {
-        expect(stringifyJsonWithBigints(input)).toBe(JSON.stringify(input));
+        expect(stringifyJsonWithBigInts(input)).toBe(JSON.stringify(input));
     });
 });

--- a/packages/rpc-spec-types/src/stringify-json-with-bigints.ts
+++ b/packages/rpc-spec-types/src/stringify-json-with-bigints.ts
@@ -1,7 +1,7 @@
 /**
  * Transforms a value into a JSON string, whilst rendering bigints as large unsafe integers.
  */
-export function stringifyJsonWithBigints(value: unknown, space?: number | string): string {
+export function stringifyJsonWithBigInts(value: unknown, space?: number | string): string {
     return unwrapBigIntValueObject(
         JSON.stringify(value, (_, v) => (typeof v === 'bigint' ? wrapBigIntValueObject(v) : v), space),
     );

--- a/packages/rpc-subscriptions/src/rpc-subscriptions-json-bigint.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions-json-bigint.ts
@@ -1,5 +1,5 @@
 import { pipe } from '@solana/functional';
-import { parseJsonWithBigInts, stringifyJsonWithBigints } from '@solana/rpc-spec-types';
+import { parseJsonWithBigInts, stringifyJsonWithBigInts } from '@solana/rpc-spec-types';
 import {
     RpcSubscriptionsChannel,
     transformChannelInboundMessages,
@@ -19,6 +19,6 @@ export function getRpcSubscriptionsChannelWithBigIntJSONSerialization(
     return pipe(
         channel,
         c => transformChannelInboundMessages(c, parseJsonWithBigInts),
-        c => transformChannelOutboundMessages(c, stringifyJsonWithBigints),
+        c => transformChannelOutboundMessages(c, stringifyJsonWithBigInts),
     );
 }

--- a/packages/rpc-transport-http/src/http-transport-for-solana-rpc.ts
+++ b/packages/rpc-transport-http/src/http-transport-for-solana-rpc.ts
@@ -1,5 +1,5 @@
 import { RpcTransport } from '@solana/rpc-spec';
-import { parseJsonWithBigInts, stringifyJsonWithBigints } from '@solana/rpc-spec-types';
+import { parseJsonWithBigInts, stringifyJsonWithBigInts } from '@solana/rpc-spec-types';
 
 import { createHttpTransport } from './http-transport';
 import { HttpTransportConfig } from './http-transport-config';
@@ -27,6 +27,6 @@ export function createHttpTransportForSolanaRpc(config: Config): RpcTransport {
         fromJson: (rawResponse: string, payload: unknown) =>
             isSolanaRequest(payload) ? parseJsonWithBigInts(rawResponse) : JSON.parse(rawResponse),
         toJson: (payload: unknown) =>
-            isSolanaRequest(payload) ? stringifyJsonWithBigints(payload) : JSON.stringify(payload),
+            isSolanaRequest(payload) ? stringifyJsonWithBigInts(payload) : JSON.stringify(payload),
     });
 }


### PR DESCRIPTION
This sort of stuff drives me nuts, especially when there is a `parseJsonWithBigInts` where the `I` is correctly capitalized.