### PR TITLE
Unify dependencies of documentation website

### DIFF
--- a/docs/content/docs/concepts/keypairs.mdx
+++ b/docs/content/docs/concepts/keypairs.mdx
@@ -382,7 +382,7 @@ if (isSignature(signature)) {
 The [`signature()`](/api/functions/signature) helper combines _asserting_ that a string is an Ed25519 signature with _coercing_ it to the `Signature` type. It's best used with untrusted input.
 
 ```ts
-import { signature } from '@solana/keys';
+import { signature } from '@solana/kit';
 
 const signature = signature(userSuppliedSignature);
 const {

--- a/docs/content/docs/concepts/signers.mdx
+++ b/docs/content/docs/concepts/signers.mdx
@@ -228,7 +228,7 @@ import { address, SignableMessage, Transaction } from '@solana/kit';
 const myMessage = null as unknown as SignableMessage;
 const myTransaction = null as unknown as Transaction;
 // ---cut-before---
-import { createNoopSigner } from '@solana/signers';
+import { createNoopSigner } from '@solana/kit';
 
 const myNoopSigner = createNoopSigner(address('1234..5678'));
 const [myMessageSignatures] = await myNoopSigner.signMessages([myMessage]); // <- Empty signature dictionary.
@@ -253,8 +253,7 @@ A key pair signer uses a `CryptoKeyPair` to sign messages and transactions. It i
 Creates a `KeyPairSigner` from a provided Crypto KeyPair. The `signMessages` and `signTransactions` functions of the returned signer will use the private key of the provided key pair to sign messages and transactions. Note that both the `signMessages` and `signTransactions` implementations are parallelized, meaning that they will sign all provided messages and transactions in parallel.
 
 ```ts twoslash
-import { generateKeyPair } from '@solana/keys';
-import { createSignerFromKeyPair, KeyPairSigner } from '@solana/signers';
+import { createSignerFromKeyPair, generateKeyPair, KeyPairSigner } from '@solana/kit';
 
 const myKeyPair: CryptoKeyPair = await generateKeyPair();
 const myKeyPairSigner: KeyPairSigner = await createSignerFromKeyPair(myKeyPair);
@@ -265,7 +264,7 @@ const myKeyPairSigner: KeyPairSigner = await createSignerFromKeyPair(myKeyPair);
 A convenience function that generates a new Crypto KeyPair and immediately creates a `KeyPairSigner` from it.
 
 ```ts twoslash
-import { generateKeyPairSigner } from '@solana/signers';
+import { generateKeyPairSigner } from '@solana/kit';
 
 const myKeyPairSigner = await generateKeyPairSigner();
 ```
@@ -276,7 +275,7 @@ A convenience function that creates a new KeyPair from a 64-bytes `Uint8Array` s
 
 ```ts twoslash
 import fs from 'fs';
-import { createKeyPairSignerFromBytes } from '@solana/signers';
+import { createKeyPairSignerFromBytes } from '@solana/kit';
 
 // Get bytes from local keypair file.
 const keypairFile = fs.readFileSync('~/.config/solana/id.json');
@@ -291,8 +290,7 @@ const signer = await createKeyPairSignerFromBytes(keypairBytes);
 A convenience function that creates a new KeyPair from a 32-bytes `Uint8Array` private key and immediately creates a `KeyPairSigner` from it.
 
 ```ts twoslash
-import { getUtf8Encoder } from '@solana/codecs-strings';
-import { createKeyPairSignerFromPrivateKeyBytes } from '@solana/signers';
+import { createKeyPairSignerFromPrivateKeyBytes, getUtf8Encoder } from '@solana/kit';
 
 const message = getUtf8Encoder().encode('Hello, World!');
 const seed = new Uint8Array(await crypto.subtle.digest('SHA-256', message));

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,13 +11,6 @@
         "predev": "./build-api-docs.sh"
     },
     "dependencies": {
-        "@solana-program/compute-budget": "^0.7.0",
-        "@solana-program/system": "^0.7.0",
-        "@solana-program/token": "^0.5.1",
-        "@solana/compat": "^2.1.0",
-        "@solana/kit": "^2.1.0",
-        "@solana/react": "^2.1.0",
-        "@solana/web3.js": "^1.98.2",
         "fumadocs-core": "15.2.10",
         "fumadocs-docgen": "^2.0.0",
         "fumadocs-mdx": "11.6.1",
@@ -30,10 +23,13 @@
         "twoslash": "^0.3.1"
     },
     "devDependencies": {
-        "@solana/codecs-strings": "^2.1.0",
-        "@solana/keys": "^2.1.0",
+        "@solana-program/compute-budget": "^0.7.0",
+        "@solana-program/system": "^0.7.0",
+        "@solana-program/token": "^0.5.1",
+        "@solana/compat": "^2.1.0",
         "@solana/kit": "^2.1.0",
-        "@solana/signers": "^2.1.0",
+        "@solana/react": "^2.1.0",
+        "@solana/web3.js": "^1.98.2",
         "@solana/webcrypto-ed25519-polyfill": "^2.1.0",
         "@tailwindcss/postcss": "^4.1.4",
         "@types/mdx": "^2.0.13",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -8,27 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@solana-program/compute-budget':
-        specifier: ^0.7.0
-        version: 0.7.0(@solana/kit@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/system':
-        specifier: ^0.7.0
-        version: 0.7.0(@solana/kit@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana-program/token':
-        specifier: ^0.5.1
-        version: 0.5.1(@solana/kit@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
-      '@solana/compat':
-        specifier: ^2.1.0
-        version: 2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/kit':
-        specifier: ^2.1.0
-        version: 2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/react':
-        specifier: ^2.1.0
-        version: 2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(react@19.0.0)(typescript@5.8.3)
-      '@solana/web3.js':
-        specifier: ^1.98.2
-        version: 1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       fumadocs-core:
         specifier: 15.2.10
         version: 15.2.10(@types/react@19.0.12)(next@15.3.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -60,15 +39,27 @@ importers:
         specifier: ^0.3.1
         version: 0.3.1(typescript@5.8.3)
     devDependencies:
-      '@solana/codecs-strings':
+      '@solana-program/compute-budget':
+        specifier: ^0.7.0
+        version: 0.7.0(@solana/kit@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/system':
+        specifier: ^0.7.0
+        version: 0.7.0(@solana/kit@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana-program/token':
+        specifier: ^0.5.1
+        version: 0.5.1(@solana/kit@2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+      '@solana/compat':
         specifier: ^2.1.0
         version: 2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/keys':
+      '@solana/kit':
         specifier: ^2.1.0
-        version: 2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      '@solana/signers':
+        version: 2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/react':
         specifier: ^2.1.0
-        version: 2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+        version: 2.1.0(fastestsmallesttextencoderdecoder@1.0.22)(react@19.0.0)(typescript@5.8.3)
+      '@solana/web3.js':
+        specifier: ^1.98.2
+        version: 1.98.2(bufferutil@4.0.9)(typescript@5.8.3)(utf-8-validate@5.0.10)
       '@solana/webcrypto-ed25519-polyfill':
         specifier: ^2.1.0
         version: 2.1.1(typescript@5.8.3)
@@ -5521,8 +5512,8 @@ snapshots:
       '@typescript-eslint/parser': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -5541,7 +5532,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -5552,22 +5543,22 @@ snapshots:
       tinyglobby: 0.2.12
       unrs-resolver: 1.3.2
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.28.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5578,7 +5569,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.28.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
The documentation website imports various packages from Solana Kit in order to use "twoslash" in code examples — i.e. the engine that provided TS checks and type hovering to our docs.

These helpers were imported inconsistently. Some were imported as `dependencies`, some as `devDependencies`. Some were imported via the main `@solana/kit` library, some using the more granular packages.

This PR adds consistency to the way we import Solana Kit libraries to our documentation website such that:
- They are always imported as `devDependencies`
- They are always imported as part of the main `@solana/kit` library unless these packages are not re-exported by `@solana/kit`.