### PR TITLE
Introduce SendableTransaction in getting started guide

### DIFF
--- a/docs/content/docs/getting-started/build-transaction.mdx
+++ b/docs/content/docs/getting-started/build-transaction.mdx
@@ -418,12 +418,35 @@ const transactionMessage = null as unknown as BaseTransactionMessage &
 // ---cut-before---
 import { signTransactionMessageWithSigners } from '@solana/kit';
 
-const signedTransaction = await signTransactionMessageWithSigners(transactionMessage);
+const transaction = await signTransactionMessageWithSigners(transactionMessage);
+```
+
+## Ensure the transaction is sendable
+
+One last step before we can send our transaction is to ensure it is in a valid state. We already know that the transaction is fully signed since the `signTransactionMessageWithSigners` ensures that for us. However, another requirement we need to consider is whether or not the size of the transaction exceeds the maximum size allowed by the Solana network.
+
+Fortunately for us, there is a helper function called `assertIsSendableTransaction` that will check all these requirements for us and throw an error if the transaction is not valid. After a successful call to this function, the provided transaction will be upgraded to a `SendableTransaction` type which is a requirement for helper functions that send transactions to the network.
+
+```ts twoslash
+import {
+    BaseTransactionMessage,
+    TransactionMessageWithFeePayer,
+    signTransactionMessageWithSigners,
+} from '@solana/kit';
+const transactionMessage = null as unknown as BaseTransactionMessage &
+    TransactionMessageWithFeePayer;
+// ---cut-before---
+import { assertIsSendableTransaction, SendableTransaction } from '@solana/kit';
+
+const transaction = await signTransactionMessageWithSigners(transactionMessage);
+assertIsSendableTransaction(transaction);
+
+transaction satisfies SendableTransaction;
 ```
 
 ## The `createMint` helper
 
-And we finally have our fully signed transaction! In the next article, we'll learn how to send it and wait for its confirmation but before we do, here's our updated `createMint` function including everything we've learned so far.
+And we finally have our fully signed and sendable transaction! In the next article, we'll learn how to send it and wait for its confirmation but before we do, here's our updated `createMint` function including everything we've learned so far.
 
 ```ts twoslash title="src/create-mint.ts"
 // @filename: client.ts
@@ -451,6 +474,7 @@ export type Client = {
 // ---cut-before---
 import {
     appendTransactionMessageInstructions,
+    assertIsSendableTransaction,
     createTransactionMessage,
     generateKeyPairSigner,
     pipe,
@@ -501,7 +525,8 @@ export async function createMint(client: Client, options: { decimals?: number } 
     );
 
     // Compile the transaction message and sign it.
-    const signedTransaction = await signTransactionMessageWithSigners(transactionMessage);
+    const transaction = await signTransactionMessageWithSigners(transactionMessage);
+    assertIsSendableTransaction(transaction);
 
     // Send the transaction and wait for confirmation.
     // TODO: Next article!

--- a/docs/content/docs/getting-started/send-transaction.mdx
+++ b/docs/content/docs/getting-started/send-transaction.mdx
@@ -14,19 +14,19 @@ One way to tackle this would be to encode the transaction ourselves using `getBa
 ```ts twoslash
 import {
     Transaction,
-    FullySignedTransaction,
+    SendableTransaction,
     TransactionWithBlockhashLifetime,
     Rpc,
     SolanaRpcApi,
 } from '@solana/kit';
-const signedTransaction = null as unknown as Transaction &
-    FullySignedTransaction &
+const transaction = null as unknown as Transaction &
+    SendableTransaction &
     TransactionWithBlockhashLifetime;
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 // ---cut-before---
 import { getBase64EncodedWireTransaction } from '@solana/kit';
 
-const encodedTransaction = getBase64EncodedWireTransaction(signedTransaction);
+const encodedTransaction = getBase64EncodedWireTransaction(transaction);
 await rpc
     .sendTransaction(encodedTransaction, { preflightCommitment: 'confirmed', encoding: 'base64' })
     .send();
@@ -34,26 +34,23 @@ await rpc
 
 However, Kit offers a helper function that does that for us whilst providing some sensible default values. This function is called `sendTransactionWithoutConfirmingFactory` and, given an RPC object, it returns a function that sends transactions without waiting for confirmation.
 
-Note that it the `assertIsSendableTransaction` function may be used prior to calling this function to ensure the transaction matches all the requirements to be sent to the network. This includes being fully signed but also ensuring the transaction is not exceeding its size limit.
-
 ```ts twoslash
 import {
     Transaction,
-    FullySignedTransaction,
+    SendableTransaction,
     TransactionWithBlockhashLifetime,
     Rpc,
     SolanaRpcApi,
 } from '@solana/kit';
-const signedTransaction = null as unknown as Transaction &
-    FullySignedTransaction &
+const transaction = null as unknown as Transaction &
+    SendableTransaction &
     TransactionWithBlockhashLifetime;
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 // ---cut-before---
-import { assertIsSendableTransaction, sendTransactionWithoutConfirmingFactory } from '@solana/kit';
+import { sendTransactionWithoutConfirmingFactory } from '@solana/kit';
 
 const sendTransaction = sendTransactionWithoutConfirmingFactory({ rpc });
-assertIsSendableTransaction(signedTransaction);
-await sendTransaction(signedTransaction, { commitment: 'confirmed' });
+await sendTransaction(transaction, { commitment: 'confirmed' });
 ```
 
 ## Confirmation strategies
@@ -71,17 +68,16 @@ Both accept RPC and RPC Subscriptions objects and return a function that sends a
 
 ```ts twoslash
 import {
-    assertIsSendableTransaction,
     Transaction,
-    FullySignedTransaction,
+    SendableTransaction,
     TransactionWithBlockhashLifetime,
     Rpc,
     SolanaRpcApi,
     RpcSubscriptions,
     SolanaRpcSubscriptionsApi,
 } from '@solana/kit';
-const signedTransaction = null as unknown as Transaction &
-    FullySignedTransaction &
+const transaction = null as unknown as Transaction &
+    SendableTransaction &
     TransactionWithBlockhashLifetime;
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 const rpcSubscriptions = null as unknown as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
@@ -89,8 +85,7 @@ const rpcSubscriptions = null as unknown as RpcSubscriptions<SolanaRpcSubscripti
 import { sendAndConfirmTransactionFactory } from '@solana/kit';
 
 const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
-assertIsSendableTransaction(signedTransaction);
-await sendAndConfirmTransaction(signedTransaction, { commitment: 'confirmed' });
+await sendAndConfirmTransaction(transaction, { commitment: 'confirmed' });
 ```
 
 ## Transaction signatures
@@ -105,15 +100,15 @@ As such, Kit decouples these two distinct concepts by offering a `getSignatureFr
 import {
     assertIsSendableTransaction,
     Transaction,
-    FullySignedTransaction,
+    SendableTransaction,
     TransactionWithBlockhashLifetime,
     Rpc,
     SolanaRpcApi,
     RpcSubscriptions,
     SolanaRpcSubscriptionsApi,
 } from '@solana/kit';
-const signedTransaction = null as unknown as Transaction &
-    FullySignedTransaction &
+const transaction = null as unknown as Transaction &
+    SendableTransaction &
     TransactionWithBlockhashLifetime;
 const rpc = null as unknown as Rpc<SolanaRpcApi>;
 const rpcSubscriptions = null as unknown as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
@@ -122,12 +117,11 @@ import { getSignatureFromTransaction, sendAndConfirmTransactionFactory } from '@
 
 // [!code ++:2]
 // Access the transaction signature.
-const signature = getSignatureFromTransaction(signedTransaction);
+const signature = getSignatureFromTransaction(transaction);
 
 // Send and confirm the transaction.
 const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
-assertIsSendableTransaction(signedTransaction);
-await sendAndConfirmTransaction(signedTransaction, { commitment: 'confirmed' });
+await sendAndConfirmTransaction(transaction, { commitment: 'confirmed' });
 ```
 
 ## Update `client.ts`
@@ -283,12 +277,11 @@ export async function createMint(client: Client, options: { decimals?: number } 
     );
 
     // Compile the transaction message and sign it.
-    const signedTransaction = await signTransactionMessageWithSigners(transactionMessage);
+    const transaction = await signTransactionMessageWithSigners(transactionMessage);
+    assertIsSendableTransaction(transaction);
 
     // Send the transaction and wait for confirmation.
-    // [!code ++:2]
-    assertIsSendableTransaction(signedTransaction);
-    await client.sendAndConfirmTransaction(signedTransaction, { commitment: 'confirmed' });
+    await client.sendAndConfirmTransaction(transaction, { commitment: 'confirmed' }); // [!code ++]
 
     // [!code ++:2]
     // Return the address of the created mint account.


### PR DESCRIPTION
This PR reshapes the content of our getting started guide so that the `assertIsSendableTransaction` helper is properly introduce before being used.