### PR TITLE
Fix `executeTransactionMessage` signature

### DIFF
--- a/.changeset/twelve-singers-switch.md
+++ b/.changeset/twelve-singers-switch.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': patch
+---
+
+Fix the `executeTransactionMessage` signature of the `createTransactionPlanExecutor` helper by removing the unnecessary `TTransactionMessage` type parameter.

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
@@ -1,7 +1,15 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
+import {
+    BaseTransactionMessage,
+    setTransactionMessageLifetimeUsingBlockhash,
+    TransactionMessageWithBlockhashLifetime,
+    TransactionMessageWithFeePayer,
+} from '@solana/transaction-messages';
+import { compileTransaction, Transaction, TransactionWithBlockhashLifetime } from '@solana/transactions';
+
 import type { TransactionPlan } from '../transaction-plan';
-import type { TransactionPlanExecutor } from '../transaction-plan-executor';
+import { createTransactionPlanExecutor, type TransactionPlanExecutor } from '../transaction-plan-executor';
 import type { TransactionPlanResult } from '../transaction-plan-result';
 
 // [DESCRIBE] TransactionPlanExecutor
@@ -21,5 +29,34 @@ import type { TransactionPlanResult } from '../transaction-plan-result';
         const executor = null as unknown as TransactionPlanExecutor<CustomContext>;
         const result = executor(transactionPlan);
         result satisfies Promise<TransactionPlanResult<CustomContext>>;
+    }
+}
+
+// [DESCRIBE] createTransactionPlanExecutor
+{
+    // It always receives a transaction message with fee payer.
+    {
+        createTransactionPlanExecutor({
+            executeTransactionMessage: message => {
+                message satisfies BaseTransactionMessage & TransactionMessageWithFeePayer;
+                return Promise.resolve({ transaction: {} as Transaction });
+            },
+        });
+    }
+
+    // It transfers the lifetime to the compiled transaction.
+    {
+        createTransactionPlanExecutor({
+            executeTransactionMessage: message => {
+                const latestBlockhash = {} as unknown as Parameters<
+                    typeof setTransactionMessageLifetimeUsingBlockhash
+                >[0];
+                const messageWithBlockhash = setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, message);
+                messageWithBlockhash satisfies TransactionMessageWithBlockhashLifetime;
+                const transaction = compileTransaction(messageWithBlockhash);
+                transaction satisfies TransactionWithBlockhashLifetime;
+                return Promise.resolve({ transaction });
+            },
+        });
     }
 }

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -29,11 +29,8 @@ export type TransactionPlanExecutor<TContext extends TransactionPlanResultContex
     config?: { abortSignal?: AbortSignal },
 ) => Promise<TransactionPlanResult<TContext>>;
 
-type ExecuteTransactionMessage = <
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer,
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
->(
-    transactionMessage: TTransactionMessage,
+type ExecuteTransactionMessage = <TContext extends TransactionPlanResultContext = TransactionPlanResultContext>(
+    transactionMessage: BaseTransactionMessage & TransactionMessageWithFeePayer,
     config?: { abortSignal?: AbortSignal },
 ) => Promise<{ context?: TContext; transaction: Transaction }>;
 


### PR DESCRIPTION
This PR adjusts the `executeTransactionMessage` signature of the `createTransactionPlanExecutor` helper in order to [address this comment](https://github.com/anza-xyz/kit/pull/740#discussion_r2273513440).