### PR TITLE
Fix `onTransactionMessageUpdated` signature

### DIFF
--- a/.changeset/hungry-jeans-enjoy.md
+++ b/.changeset/hungry-jeans-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': patch
+---
+
+Fix the `onTransactionMessageUpdated` signature of the `createTransactionPlanner` helper by removing the unnecessary `TTransactionMessage` type parameter.

--- a/packages/instruction-plans/src/__typetests__/transaction-planner-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-planner-typetest.ts
@@ -1,8 +1,15 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
+import { Instruction } from '@solana/instructions';
+import {
+    appendTransactionMessageInstruction,
+    BaseTransactionMessage,
+    TransactionMessageWithFeePayer,
+} from '@solana/transaction-messages';
+
 import type { InstructionPlan } from '../instruction-plan';
 import type { TransactionPlan } from '../transaction-plan';
-import type { TransactionPlanner } from '../transaction-planner';
+import { createTransactionPlanner, type TransactionPlanner } from '../transaction-planner';
 
 // [DESCRIBE] TransactionPlanner
 {
@@ -12,5 +19,33 @@ import type { TransactionPlanner } from '../transaction-planner';
         const planner = null as unknown as TransactionPlanner;
         const transactionPlan = planner(instructionPlan);
         transactionPlan satisfies Promise<TransactionPlan>;
+    }
+}
+
+// [DESCRIBE] createTransactionPlanner
+{
+    // `onTransactionMessageUpdated` always receives a transaction message with fee payer.
+    {
+        createTransactionPlanner({
+            createTransactionMessage: {} as unknown as Parameters<
+                typeof createTransactionPlanner
+            >[0]['createTransactionMessage'],
+            onTransactionMessageUpdated: message => {
+                message satisfies BaseTransactionMessage & TransactionMessageWithFeePayer;
+                return message;
+            },
+        });
+    }
+
+    // `onTransactionMessageUpdated` may return a different transaction message then the one received.
+    {
+        createTransactionPlanner({
+            createTransactionMessage: {} as unknown as Parameters<
+                typeof createTransactionPlanner
+            >[0]['createTransactionMessage'],
+            onTransactionMessageUpdated: message => {
+                return appendTransactionMessageInstruction({} as unknown as Instruction, message);
+            },
+        });
     }
 }

--- a/packages/instruction-plans/src/transaction-planner.ts
+++ b/packages/instruction-plans/src/transaction-planner.ts
@@ -53,12 +53,12 @@ type CreateTransactionMessage = (config?: {
     | Promise<BaseTransactionMessage & TransactionMessageWithFeePayer>
     | (BaseTransactionMessage & TransactionMessageWithFeePayer);
 
-type OnTransactionMessageUpdated = <
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer,
->(
-    transactionMessage: TTransactionMessage,
+type OnTransactionMessageUpdated = (
+    transactionMessage: BaseTransactionMessage & TransactionMessageWithFeePayer,
     config?: { abortSignal?: AbortSignal },
-) => Promise<TTransactionMessage> | TTransactionMessage;
+) =>
+    | Promise<BaseTransactionMessage & TransactionMessageWithFeePayer>
+    | (BaseTransactionMessage & TransactionMessageWithFeePayer);
 
 /**
  * Configuration object for creating a new transaction planner.


### PR DESCRIPTION
This PR adjusts the `onTransactionMessageUpdated ` signature of the `createTransactionPlanner` helper in order to [address this comment](https://github.com/anza-xyz/kit/pull/740#discussion_r2273507075).