### PR TITLE
Use same sidebar on API and docs layouts

### DIFF
--- a/docs/src/app/api/layout.tsx
+++ b/docs/src/app/api/layout.tsx
@@ -1,19 +1,21 @@
-import { DocsLayout } from 'fumadocs-ui/layouts/docs';
+import { DocsLayout, DocsLayoutProps } from 'fumadocs-ui/layouts/docs';
 import type { ReactNode } from 'react';
 import { baseOptions } from '@/app/layout.config';
 import { apiSource } from '@/lib/source';
+import { Sidebar } from '../docs/sidebar';
+import { Navbar } from '../docs/navbar';
 
 export default function Layout({ children }: { children: ReactNode }) {
-    return (
-        <DocsLayout
-            // tree={{
-            //     ...apiSource.pageTree,
-            //     children: apiSource.pageTree.children.filter(node => node.type !== 'page' || node.url !== '/api'),
-            // }}
-            tree={apiSource.pageTree}
-            {...baseOptions}
-        >
-            {children}
-        </DocsLayout>
-    );
+    const baseProps: DocsLayoutProps = {
+        ...baseOptions,
+        tree: apiSource.pageTree,
+    };
+
+    const apiProps: DocsLayoutProps = {
+        ...baseProps,
+        sidebar: { ...baseProps.sidebar, component: Sidebar(baseProps) },
+        nav: { ...baseProps.nav, component: Navbar(baseProps) },
+    };
+
+    return <DocsLayout {...apiProps}>{children}</DocsLayout>;
 }


### PR DESCRIPTION
This PR fixes the API layout of the documentation such that it matches the ones used by the "Docs" layout — that is, the part of the documentation that contains guides.

In other words, it ensures the sidebar and navbar are the same regardless of whether we are in the "Documentation" area or the "API References" area.