### PR TITLE
Search Docs and API together (or separately)

### DIFF
--- a/docs/src/app/api/search/route.ts
+++ b/docs/src/app/api/search/route.ts
@@ -1,4 +1,24 @@
-import { docsSource } from '@/lib/source';
-import { createFromSource } from 'fumadocs-core/search/server';
+import { apiSource, docsSource } from '@/lib/source';
+import { AdvancedIndex, createSearchAPI } from 'fumadocs-core/search/server';
+import { LoaderConfig, LoaderOutput } from 'fumadocs-core/source';
 
-export const { GET } = createFromSource(docsSource);
+type PageFromSource<T extends LoaderOutput<LoaderConfig>> = ReturnType<T['getPages']>[number];
+
+function createIndexFromPage(tag: string, page: PageFromSource<typeof apiSource | typeof docsSource>): AdvancedIndex {
+    return {
+        title: page.data.title,
+        description: page.data.description,
+        url: page.url,
+        id: page.url,
+        structuredData: page.data.structuredData,
+        tag,
+    };
+}
+
+export const { GET } = createSearchAPI('advanced', {
+    language: 'english',
+    indexes: [
+        ...apiSource.getPages().map(createIndexFromPage.bind(null, 'api')),
+        ...docsSource.getPages().map(createIndexFromPage.bind(null, 'docs')),
+    ],
+});

--- a/docs/src/app/layout.tsx
+++ b/docs/src/app/layout.tsx
@@ -9,7 +9,24 @@ export default function Layout({ children }: { children: ReactNode }) {
                 <link rel="stylesheet" href="https://use.typekit.net/chp6nhs.css" />
             </head>
             <body className="flex flex-col min-h-screen">
-                <RootProvider>{children}</RootProvider>
+                <RootProvider
+                    search={{
+                        options: {
+                            tags: [
+                                {
+                                    name: 'Documentation',
+                                    value: 'docs',
+                                },
+                                {
+                                    name: 'API',
+                                    value: 'api',
+                                },
+                            ],
+                        },
+                    }}
+                >
+                    {children}
+                </RootProvider>
             </body>
         </html>
     );


### PR DESCRIPTION
#### Problem

The default implementation of Orama search in Fumadocs is single-source. The API docs were not searched.

#### Summary of Changes

- Merge the sources and tag each as `'api'` or `'docs'`
- Add a tag filter to the search dialog so that you filter out the category you are not interested in.

[Screen Recording 2025-08-18 at 4.06.12 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/user-attachments/thumbnails/44a582d8-1dde-4628-b120-161813bc6935.mov" />](https://app.graphite.dev/user-attachments/video/44a582d8-1dde-4628-b120-161813bc6935.mov)