### PR TITLE
Use `mdxComponents` helper in API layout

### DIFF
--- a/docs/src/app/api/[[...slug]]/page.tsx
+++ b/docs/src/app/api/[[...slug]]/page.tsx
@@ -1,12 +1,7 @@
+import { mdxComponents } from '@/app/layout.config';
 import { apiSource } from '@/lib/source';
-import { Spread } from '@/lib/Spread';
-import { DocsPage, DocsBody, DocsDescription, DocsTitle } from 'fumadocs-ui/page';
+import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/page';
 import { notFound } from 'next/navigation';
-import defaultMdxComponents from 'fumadocs-ui/mdx';
-import { ImageZoom } from 'fumadocs-ui/components/image-zoom';
-import { Step, Steps } from 'fumadocs-ui/components/steps';
-import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
-import { Popup, PopupContent, PopupTrigger } from 'fumadocs-twoslash/ui';
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
     const params = await props.params;
@@ -20,20 +15,7 @@ export default async function Page(props: { params: Promise<{ slug?: string[] }>
             <DocsTitle>{page.data.title}</DocsTitle>
             <DocsDescription className="mb-16">{page.data.description}</DocsDescription>
             <DocsBody>
-                <MDX
-                    components={{
-                        ...defaultMdxComponents,
-                        img: props => <ImageZoom {...props} />,
-                        Popup,
-                        PopupContent,
-                        PopupTrigger,
-                        Spread,
-                        Step,
-                        Steps,
-                        Tab,
-                        Tabs,
-                    }}
-                />
+                <MDX components={mdxComponents} />
             </DocsBody>
         </DocsPage>
     );


### PR DESCRIPTION
I missed a spot when I was previously extracting all `mdxComponents` into a single reusable constant. This PR fixes this.