### PR TITLE
Fix broken links in concepts guides

### DIFF
--- a/docs/content/docs/concepts/keypairs.mdx
+++ b/docs/content/docs/concepts/keypairs.mdx
@@ -12,7 +12,7 @@ Ed25519 keys created or imported using the native APIs are compatible with all o
 <Callout title="Looking for Signers instead?">
     Keys are a low-level primitive. While it's important to know how they work, in a Solana
     application it's often more appropriate to deal with key material in terms of the accounts and
-    wallets that sign a transaction or message. The [Signers](/concepts/signers) API offers an
+    wallets that sign a transaction or message. The [Signers](/docs/concepts/signers) API offers an
     ergonomic way to build and sign transactions using accounts and their associated keys.
 </Callout>
 

--- a/docs/content/docs/concepts/transactions.mdx
+++ b/docs/content/docs/concepts/transactions.mdx
@@ -111,7 +111,7 @@ The [`TransactionMessageWithFeePayer`](/api/interfaces/TransactionMessageWithFee
 
 #### Using a signer [!toc] [#building-transaction-messages-fee-payer-using-a-signer]
 
-Given a [`TransactionSigner`](/api/type-aliases/TransactionSigner), this method will return a new transaction message having the same type as the one supplied plus the [`TransactionMessageWithFeePayer`](/api/interfaces/TransactionMessageWithFeePayer) type. Additionally, the resulting message will have the capability to self-sign using the [`signTransactionMessageWithSigners`](/api/interfaces/signTransactionMessageWithSigners) function.
+Given a [`TransactionSigner`](/api/type-aliases/TransactionSigner), this method will return a new transaction message having the same type as the one supplied plus the [`TransactionMessageWithFeePayer`](/api/interfaces/TransactionMessageWithFeePayer) type. Additionally, the resulting message will have the capability to self-sign using the [`signTransactionMessageWithSigners`](/api/functions/signTransactionMessageWithSigners) function.
 
 ```ts twoslash
 import { TransactionMessage } from '@solana/kit';


### PR DESCRIPTION
Used this script:

```ts
(async () => {
  const anchors = Array.from(
    document.querySelectorAll(
      'a[href]:not([href^="javascript"]):not([href^="#"])'
    )
  );
  for (const a of anchors) {
    fetch(a.href, { method: "HEAD", mode: "no-cors" })
      .then((response) => {
        // Due to CORS, non-OK status won't always be reliable, but visible on same-origin
        if (response.status >= 400 || response.status === 0) {
          console.warn(
            `Broken link: ${a.href} (status: ${response.status})`,
            a
          );
        }
      })
      .catch((err) => {
        console.warn(`Broken link (fetch error): ${a.href}`, a, err);
      });
  }
})();
```
