### PR TITLE
Fix API links with hash fragments

### DIFF
--- a/typedoc.plugin.mjs
+++ b/typedoc.plugin.mjs
@@ -74,9 +74,9 @@ export function load(app) {
     // - strip the .mdx extension
     app.renderer.on(td.MarkdownPageEvent.END, page => {
         if (!page.contents) return;
-        page.contents = page.contents.replace(/\(((?:[^\/\)]+\/)*[^\/\)]+)\.mdx\)/gm, (_, path) => {
+        page.contents = page.contents.replace(/\(((?:[^\/\)]+\/)*[^\/\)]+)\.mdx([^)]*)?\)/gm, (_, path, suffix) => {
             const rootRelativeUrl = resolve('/api', dirname(page.url), path);
-            return `(${rootRelativeUrl})`;
+            return `(${rootRelativeUrl}${suffix ?? ''})`;
         });
     });
 }


### PR DESCRIPTION
This PR fixes an issue in the way URLs are generated in the "API References" section of our documentation website.

Prior to this PR, if a URL contained a hash fragment — e.g. `"/api/enumerations/AccountRole.mdx#readonly"` — it would not be recognised by our custom regex and therefore the `.mdx` extension would not be removed as expected.

This PR fixes this by adjusting the regex so it removes the `.mdx` extension even if the URL contains something afterwards.