### PR TITLE
Run CI with Agave 2.3

### DIFF
--- a/scripts/get-latest-validator-release-version.sh
+++ b/scripts/get-latest-validator-release-version.sh
@@ -2,7 +2,7 @@
 (
     set -e
     version=$(node -e \
-      'fetch("https://api.github.com/repos/anza-xyz/agave/releases").then(res => res.json().then(rs => rs.filter(r => !r.prerelease && r.tag_name.startsWith("v2.2."))).then(x => console.log(x[0].tag_name)));'
+      'fetch("https://api.github.com/repos/anza-xyz/agave/releases").then(res => res.json().then(rs => rs.filter(r => !r.prerelease && r.tag_name.startsWith("v2.3."))).then(x => console.log(x[0].tag_name)));'
     )
     if [ -z $version ]; then
       exit 3


### PR DESCRIPTION
#### Problem

Now that #521 is landed we have to run CI with Agave 2.3

#### Summary of Changes

Install the test validator from 2.3.
