### PR TITLE
The recent transaction confirmation strategy now throws transaction errors from the one-shot test

### DIFF
--- a/.changeset/rotten-weeks-enjoy.md
+++ b/.changeset/rotten-weeks-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-confirmation': patch
+---
+
+Fixed a bug where transaction errors discovered during recent transaction confirmation might not be thrown

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-signature-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-signature-test.ts
@@ -111,6 +111,20 @@ describe('createSignatureConfirmationPromiseFactory', () => {
         });
         await expect(signatureConfirmationPromise).resolves.toBeUndefined();
     });
+    it('fatals when the signature status returned by the one-shot query is an error', async () => {
+        expect.assertions(1);
+        getSignatureStatusesMock.mockResolvedValue({
+            value: [{ err: 'o no' }],
+        });
+        const signatureConfirmationPromise = getSignatureConfirmationPromise({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            signature: 'abc' as Signature,
+        });
+        await expect(signatureConfirmationPromise).rejects.toThrow(
+            new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__UNKNOWN, { errorName: 'o no' }),
+        );
+    });
     it('resolves when a signature status notification is returned by the signature subscription', async () => {
         expect.assertions(1);
         signatureNotificationGenerator.mockImplementation(async function* () {

--- a/packages/transaction-confirmation/src/confirmation-strategy-recent-signature.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-recent-signature.ts
@@ -110,11 +110,12 @@ export function createRecentSignatureConfirmationPromiseFactory<
                 .send({ abortSignal: abortController.signal });
             const signatureStatus = signatureStatusResults[0];
             if (
-                signatureStatus &&
-                signatureStatus.confirmationStatus &&
+                signatureStatus?.confirmationStatus &&
                 commitmentComparator(signatureStatus.confirmationStatus, commitment) >= 0
             ) {
                 return;
+            } else if (signatureStatus?.err) {
+                throw getSolanaErrorFromTransactionError(signatureStatus.err);
             } else {
                 await new Promise(() => {
                     /* never resolve */


### PR DESCRIPTION
#### Problem

The recent signature transaction strategy does two things:

- Subscribes for changes to a signature's status
- Does a point lookup of the signature's status

It was reported that if the signature's status is an error, the one-shot lookup would not throw it.

#### Summary of Changes

Throw any transaction errors discovered during the one-shot lookup.

Fixes #711.