### PR TITLE
A Jest matcher that lets you write expectations about the equality of `ArrayBuffers`

### DIFF
--- a/packages/test-config/browser-environment.ts
+++ b/packages/test-config/browser-environment.ts
@@ -4,10 +4,11 @@ export default class BrowserEnvironment extends TestEnvironment {
     async setup() {
         await super.setup();
         /**
-         * Here we inject Node's `Uint8Array` as a global so that `instanceof` checks inside
-         * `SubtleCrypto.digest()` work with `Uint8Array#buffer`. Read more here:
-         * https://github.com/jestjs/jest/issues/7780#issuecomment-615890410
+         * Here we inject Node's binary array types as globals so that - among other things -
+         * `instanceof` checks inside `SubtleCrypto.digest()` work with `Uint8Array#buffer`. Read
+         * more here: https://github.com/jestjs/jest/issues/7780#issuecomment-615890410
          */
+        this.global.ArrayBuffer = globalThis.ArrayBuffer;
         this.global.Uint8Array = globalThis.Uint8Array;
     }
 }

--- a/packages/test-matchers/toEqualArrayBuffer.ts
+++ b/packages/test-matchers/toEqualArrayBuffer.ts
@@ -1,0 +1,37 @@
+expect.extend({
+    toEqualArrayBuffer(received: ArrayBuffer, expected: ArrayBuffer) {
+        if (!(received instanceof ArrayBuffer) || !(expected instanceof ArrayBuffer)) {
+            return {
+                message: () => 'Expected to compare two `ArrayBuffers`',
+                pass: false,
+            };
+        }
+        let pass = false;
+        if (received.byteLength === expected.byteLength) {
+            const receivedView = new Uint8Array(received);
+            const expectedView = new Uint8Array(expected);
+            pass = expectedView.every((b, ii) => b === receivedView[ii]);
+        }
+        return {
+            message: () =>
+                this.isNot
+                    ? 'Expected `ArrayBuffers` to differ'
+                    : `${this.utils.diff(expected, received, { expand: true })}`,
+            pass,
+        };
+    },
+});
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace jest {
+        interface AsymmetricMatchers {
+            toEqualArrayBuffer(expected: ArrayBuffer): void;
+        }
+        interface Matchers<R> {
+            toEqualArrayBuffer(expected: ArrayBuffer): R;
+        }
+    }
+}
+
+export {};


### PR DESCRIPTION
#### Problem

So, fun fact, Jest equality matchers do nothing useful on `ArrayBuffers`.

Make this change:

```
- expect(decode("aGVsbG8=")).toStrictEqual(encoder.encode("hello"));
+ expect(decode("aGVsbG8=")).toStrictEqual(encoder.encode("goodbye"));
```

Tests still pass!

#### Summary of Changes

In this PR we create a custom matcher that actually walks the bytes and compares them.