### PR TITLE
3.x backport releases now get made with their own npm tag

### DIFF
--- a/.github/workflows/publish-canary-releases.yml
+++ b/.github/workflows/publish-canary-releases.yml
@@ -58,7 +58,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          PUBLISH_TAG: canary
+          PUBLISH_TAG: canary-3.x
 
       - name: Stop Test Validator
         if: always() && steps.start-test-validator.outcome == 'success'

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          PUBLISH_TAG: latest
+          PUBLISH_TAG: 3.x
           # Some tasks slow down considerably on GitHub Actions runners when concurrency is high
           TURBO_CONCURRENCY: 1
 


### PR DESCRIPTION
Prevents them from overwriting `latest` and `canary` in npm.