### PR TITLE
feat: Add clientId field to getClusterNodes response

### DIFF
--- a/.changeset/nasty-days-wash.md
+++ b/.changeset/nasty-days-wash.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-api': minor
+---
+
+Add clientId field to getClusterNodes response

--- a/packages/rpc-api/src/__tests__/get-cluster-nodes-test.ts
+++ b/packages/rpc-api/src/__tests__/get-cluster-nodes-test.ts
@@ -72,6 +72,7 @@ describe('getClusterNodes', () => {
             const [featureSet, gossip, pubkey, rpc, shredVersion, version] = await getNodeInfoFromLogFile();
             const res = await mockRpc.getClusterNodes().send();
             expect(res[0]).toStrictEqual({
+                clientId: expect.any(Number),
                 featureSet,
                 gossip,
                 pubkey,

--- a/packages/rpc-api/src/getClusterNodes.ts
+++ b/packages/rpc-api/src/getClusterNodes.ts
@@ -1,6 +1,8 @@
 import { Address } from '@solana/addresses';
 
 type ClusterNode = Readonly<{
+    /** The Client Id of the node, or `null` if the Client Id is not available */
+    clientId: number | null;
     /**
      * The unique identifier of the node's feature set.
      *
@@ -35,8 +37,6 @@ type ClusterNode = Readonly<{
     tvu: string | null;
     /** The software version of the node, or `null` if the version information is not available */
     version: string | null;
-    /** The Client Id of the node, or `null` if the Client Id is not available */
-    clientId: number | null;
 }>;
 
 type GetClusterNodesApiResponse = readonly ClusterNode[];

--- a/packages/rpc-api/src/getClusterNodes.ts
+++ b/packages/rpc-api/src/getClusterNodes.ts
@@ -35,6 +35,8 @@ type ClusterNode = Readonly<{
     tvu: string | null;
     /** The software version of the node, or `null` if the version information is not available */
     version: string | null;
+    /** The Client Id of the node, or `null` if the Client Id is not available */
+    clientId: number | null;
 }>;
 
 type GetClusterNodesApiResponse = readonly ClusterNode[];

--- a/packages/rpc-api/src/index.ts
+++ b/packages/rpc-api/src/index.ts
@@ -292,6 +292,7 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
                 ['rewards', KEYPATH_WILDCARD, 'commission'],
             ],
             getClusterNodes: [
+                [KEYPATH_WILDCARD, 'clientId'],
                 [KEYPATH_WILDCARD, 'featureSet'],
                 [KEYPATH_WILDCARD, 'shredVersion'],
             ],


### PR DESCRIPTION
#### Problem

The Agave RPC now returns a `clientId` field in the getClusterNodes response (see anza-xyz/agave#7817), but the JavaScript client doesn't include this field in its type definitions.

#### Summary of Changes

- Add `clientId: number | null` field to the `ClusterNode` type
- Update tests to expect the clientId field in responses
- Add JSDoc documentation for the new field

#### References

- Depends on: anza-xyz/agave#7817