### PR TITLE
Make sure that the backport branches never create release notes with `latest` on GitHub

### DIFF
--- a/packages/build-scripts/create-github-release.ts
+++ b/packages/build-scripts/create-github-release.ts
@@ -264,7 +264,11 @@ const aggregateReleaseNotes =
  */
 const createReleaseParams: RestEndpointMethodTypes['repos']['createRelease']['parameters'] = {
     body: aggregateReleaseNotes,
-    make_latest: 'false',
+    make_latest: releases.every(
+        release => cmpVersions(release.tag_name.replace(/^v/, ''), version.replace(/^v/, '')) <= 0,
+    )
+        ? 'true'
+        : 'false',
     name: tag,
     owner: ORG_NAME,
     repo: REPO_NAME,


### PR DESCRIPTION
This now reads from the actual releases to determine whether this is the latest or not.