### PR TITLE
A manual workflow you can use to add a tag to an npm release, by version

### DIFF
--- a/.github/workflows/tag-release-manually.yml
+++ b/.github/workflows/tag-release-manually.yml
@@ -1,0 +1,47 @@
+# .github/workflows/manual-release.yml
+name: Tag Release Manually
+
+on:
+  workflow_dispatch:
+    branches:
+      - main
+      - backport/**
+    inputs:
+      version:
+        description: 'Version'
+        required: true
+        type: string
+      tag:
+        description: 'Tag name'
+        required: true
+        type: string
+
+jobs:
+  validate-version-exists:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate that a package at the given version has already been published
+        run: |
+          echo '${{ github.event.inputs.version }}' | grep -E "^([0-9]+\.){0,2}[0-9]+$" > /dev/null || echo 'Version must be of the form X.Y.Z'
+          pnpm view '@solana/kit@${{ github.event.inputs.version }}'
+
+  tag-release-manually:
+    permissions:
+      contents: write
+    needs: validate-version-exists
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        uses: ./.github/workflows/actions/install-dependencies
+
+      - name: Configure NPM token
+        run: |
+          pnpm config set '//registry.npmjs.org/:_authToken' "${NPM_TOKEN}"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Tag Release Manually
+        run: ./packages/build-scripts/tag-release-manually.ts --version '${{ github.event.inputs.version }}' --tag '${{ github.event.inputs.tag }}'

--- a/packages/build-scripts/tag-release-manually.ts
+++ b/packages/build-scripts/tag-release-manually.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env -S pnpm dlx tsx --
+
+// @ts-check
+import { execSync } from 'node:child_process';
+
+import minimist from 'minimist';
+
+import { getCurrentLinkedVersion } from './current-linked-version.js';
+
+const config = minimist(process.argv.slice(2), {
+    boolean: 'dry-run',
+    string: ['tag', 'version'],
+});
+
+const { packages } = await getCurrentLinkedVersion();
+
+packages
+    .filter(pkg => pkg.packageJson.private !== true)
+    .forEach(pkg => {
+        const command = `pnpm dist-tag add ${pkg.packageJson.name}@${config.version} ${config.tag}`;
+        if (config['dry-run']) {
+            console.log(`Would have run: \`${command}\``);
+        } else {
+            execSync(command);
+        }
+    });


### PR DESCRIPTION
#### Problem

Sometimes the publish script fails to apply the right tag, and you have to go ask Solana Foundation to run a script to patch it up.

#### Summary of Changes

Instead, create a script that runs in the Kit CI, with access to the npm token, whose sole job is to apply tags.
