### PR TITLE
Ensure that the version validator in the `tag-release-manually` workflow has access to pnpm

### DIFF
--- a/.github/workflows/tag-release-manually.yml
+++ b/.github/workflows/tag-release-manually.yml
@@ -1,4 +1,3 @@
-# .github/workflows/manual-release.yml
 name: Tag Release Manually
 
 on:
@@ -20,6 +19,12 @@ jobs:
   validate-version-exists:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        uses: ./.github/workflows/actions/install-dependencies
+
       - name: Validate that a package at the given version has already been published
         run: |
           echo '${{ github.event.inputs.version }}' | grep -E "^([0-9]+\.){0,2}[0-9]+$" > /dev/null || echo 'Version must be of the form X.Y.Z'


### PR DESCRIPTION
Missed this in #839.
