### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tag-release-manually.yml
+++ b/.github/workflows/tag-release-manually.yml
@@ -17,6 +17,8 @@ on:
 
 jobs:
   validate-version-exists:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/anza-xyz/kit/security/code-scanning/18](https://github.com/anza-xyz/kit/security/code-scanning/18)

To fix the problem, add an explicit `permissions` block to the `validate-version-exists` job, specifying the least privilege necessary. None of the steps in this job require write permissions to the repository or access to additional scopes: they only checkout code, install dependencies, and read from NPM (with no mutations). The minimal required permission is just `contents: read`. This change should be made by adding these lines directly under the `validate-version-exists:` job definition (after line 19 and before `runs-on:` line 20) in `.github/workflows/tag-release-manually.yml`. No extra packages or syntax changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
