### PR TITLE
Server render all of the homepage examples

### DIFF
--- a/docs/content/home/example-codecs.mdx
+++ b/docs/content/home/example-codecs.mdx
@@ -4,15 +4,7 @@ title: Codecs Example
 
 {/* Please keep visible code between 4 to 8 lines of code. */}
 
-```ts twoslash
-import {
-    getStructCodec,
-    addCodecSizePrefix,
-    getU8Codec,
-    getU16Codec,
-    getUtf8Codec,
-} from '@solana/kit';
-// ---cut-before---
+```ts
 const personCodec = getStructCodec([
     ['age', getU8Codec()],
     ['name', addCodecSizePrefix(getUtf8Codec(), getU16Codec())],

--- a/docs/content/home/example-rpc-subscriptions.mdx
+++ b/docs/content/home/example-rpc-subscriptions.mdx
@@ -4,11 +4,7 @@ title: RPC Subscriptions Example
 
 {/* Please keep visible code between 4 to 8 lines of code. */}
 
-```ts twoslash
-import { address, createSolanaRpcSubscriptions } from '@solana/kit';
-const myAccount = address('GLipcrdsjNDBguPeutYhm1fvZfvhCoYdVR5zQLaNLT2s');
-const abortController = new AbortController();
-// ---cut-before---
+```ts
 const rpcSubscriptions = createSolanaRpcSubscriptions('ws://api.mainnet-beta.solana.com');
 const accountNotifications = await rpcSubscriptions
     .accountNotifications(myAccount, { commitment: 'confirmed' })

--- a/docs/content/home/example-rpc.mdx
+++ b/docs/content/home/example-rpc.mdx
@@ -4,11 +4,7 @@ title: RPC Example
 
 {/* Please keep visible code between 4 to 8 lines of code. */}
 
-```ts twoslash
-import { address, createSolanaRpc } from '@solana/kit';
-const myWallet = address('6sXDDdsHDDodYmrsFWKGriKXvjw25sqsk6PBgnQcE88A');
-const myAccount = address('64dTb3y5ExuKWHdi3ZHkyCfpdyqwRSiNVWMkdj3TbQ2N');
-// ---cut-before---
+```ts
 const rpc = createSolanaRpc('https://api.mainnet-beta.solana.com');
 
 const { value: balance } = await rpc.getBalance(myWallet).send();

--- a/docs/content/home/example-signers.mdx
+++ b/docs/content/home/example-signers.mdx
@@ -4,12 +4,7 @@ title: Signers Example
 
 {/* Please keep visible code between 4 to 8 lines of code. */}
 
-```tsx twoslash
-import { address, generateKeyPairSigner, createNoopSigner } from '@solana/kit';
-import { useWalletAccountTransactionSigner } from '@solana/react';
-const wallet = {} as Parameters<typeof useWalletAccountTransactionSigner>[0];
-const myAddress = address('52Xv7LMtgFagZfVwDhHjTA6yY7C26gk7hpT1yWB2NqS9');
-// ---cut-before---
+```ts
 const keypairSigner = await generateKeyPairSigner();
 
 const walletSigner = useWalletAccountTransactionSigner(wallet, 'solana:mainnet-beta');

--- a/docs/content/home/example-solana-programs.mdx
+++ b/docs/content/home/example-solana-programs.mdx
@@ -4,14 +4,7 @@ title: Solana Programs Example
 
 {/* Please keep visible code between 4 to 8 lines of code. */}
 
-```ts twoslash
-import { address, TransactionSigner, createSolanaRpc } from '@solana/kit';
-const source = {} as TransactionSigner;
-const destination = address('HjZE9hMaReTCXbbJUBfF8dpJs8Dx1L41MuAUtMTXg17W');
-const amount = 1_000_000_000;
-const mintAddress = address('GXnSPD4Hb2xTCKR6UXwPjus2JrgvaXvz8ebBxYGVsrL');
-const rpc = createSolanaRpc('https://api.mainnet-beta.solana.com');
-// ---cut-before---
+```ts
 import { getTransferSolInstruction } from '@solana-program/system';
 const transferSol = getTransferSolInstruction({ source, destination, amount });
 

--- a/docs/content/home/example-transactions.mdx
+++ b/docs/content/home/example-transactions.mdx
@@ -4,23 +4,7 @@ title: Transactions Example
 
 {/* Please keep visible code between 4 to 8 lines of code. */}
 
-```ts twoslash
-import {
-    GetLatestBlockhashApi,
-    TransactionSigner,
-    appendTransactionMessageInstructions,
-    createTransactionMessage,
-    pipe,
-    setTransactionMessageFeePayerSigner,
-    setTransactionMessageLifetimeUsingBlockhash,
-} from '@solana/kit';
-import { getCreateAccountInstruction } from '@solana-program/system';
-import { getInitializeMintInstruction } from '@solana-program/token';
-const payer = {} as TransactionSigner;
-const latestBlockhash = {} as ReturnType<GetLatestBlockhashApi['getLatestBlockhash']>['value'];
-const createAccountIx = null as unknown as ReturnType<typeof getCreateAccountInstruction>;
-const initializeMintIx = null as unknown as ReturnType<typeof getInitializeMintInstruction>;
-// ---cut-before---
+```ts
 const transactionMessage = pipe(
     createTransactionMessage({ version: 0 }),
     (tx) => setTransactionMessageFeePayerSigner(payer, tx),

--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -1,3 +1,7 @@
+import { home } from '@/.source';
+import React from 'react';
+
+import { mdxComponents } from '../layout.config';
 import HeroSection from './page/hero';
 import CodeSection from './page/code';
 import FeaturesSection from './page/features';
@@ -5,12 +9,25 @@ import CtaSection from './page/cta';
 import FooterSection from './page/footer';
 import { ExampleProvider } from './page/example-context';
 
+function getExamples(): Record<string, React.ReactElement> {
+    const examples: Record<string, React.ReactElement> = {};
+    home.docs.forEach(doc => {
+        const match = doc._file.path.match(/^example-(.*)\.mdx$/);
+        if (match) {
+            const MDXContent = doc.body;
+            examples[match[1]] = <MDXContent components={mdxComponents} />;
+        }
+    });
+    return examples;
+}
+
 export default function HomePage() {
+    const examples = getExamples();
     return (
         <main className="flex flex-1 flex-col">
             <HeroSection />
             <ExampleProvider>
-                <CodeSection />
+                <CodeSection examples={examples} />
                 <FeaturesSection />
             </ExampleProvider>
             <CtaSection />

--- a/docs/src/app/(home)/page/code.tsx
+++ b/docs/src/app/(home)/page/code.tsx
@@ -1,20 +1,15 @@
 'use client';
 
-import { home } from '@/.source';
-import { mdxComponents } from '@/app/layout.config';
-import { useContext, useMemo } from 'react';
+import React, { useContext } from 'react';
 import { ExampleContext } from './example-context';
 import { Play } from 'lucide-react';
-import { MDXContent } from 'mdx/types';
 
-function getExampleMDX(example: string) {
-    const doc = home.docs.find(doc => doc._file.path === `example-${example}.mdx`)!;
-    return (doc as { body: MDXContent }).body;
-}
+type Props = Readonly<{
+    examples: Record<string, React.ReactElement>;
+}>;
 
-export default function CodeSection() {
+export default function CodeSection({ examples }: Props) {
     const { example, progress, paused, resume } = useContext(ExampleContext);
-    const MDX = useMemo(() => getExampleMDX(example), [example]);
 
     return (
         <section className="relative">
@@ -35,7 +30,7 @@ export default function CodeSection() {
                             <Play size={14} fill="currentColor" strokeWidth={0} />
                         </button>
                     )}
-                    <MDX components={mdxComponents} />
+                    {examples[example]}
                 </div>
             </div>
         </section>


### PR DESCRIPTION
#### Problem

We're importing `.source/index.ts` in a client component, which means that we're getting the entire MDX runtime on the client (ie. on the homepage). This is bad for two reasons.

1. Increased bundle size on the homepage
2. We now depend on node browser-side polyfills for stuff in the MDX runtime (like `node:fs`). This also consequently makes it impossible to upgrade next.js.

Unfortunately, just straight up server rendering all of the examples and passing them down as props to the `<CodeContent />` component doesn't seem to work either, presumably because Twoslash components are themselves client components, and they’re missing type information or something in the browser, making half of the code disappear when rendered.

![image.png](https://app.graphite.dev/user-attachments/assets/ca1f3425-23c6-41d5-a103-0644aae12f34.png)

#### Summary of Changes

- Remove twoslash markup from the homepage examples
- Server render all of the homepage examples and pass them down as props