### PR TITLE
Add ‘homepage’ links to NPM packages

### DIFF
--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/accounts",
     "version": "3.0.0",
     "description": "Helpers for representing, fetching and decoding Solana accounts",
+    "homepage": "https://www.solanakit.com/api#solanaaccounts",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/addresses",
     "version": "3.0.0",
     "description": "Helpers for generating account addresses",
+    "homepage": "https://www.solanakit.com/api#solanaaddresses",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/assertions",
     "version": "3.0.0",
     "description": "Helpers for asserting that a JavaScript environment supports certain features necessary for the operation of the Solana JavaScript SDK",
+    "homepage": "https://www.solanakit.com/api#solanaassertions",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/codecs-core",
     "version": "3.0.0",
     "description": "Core types and helpers for encoding and decoding byte arrays on Solana",
+    "homepage": "https://www.solanakit.com/api#solanacodecs-core",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/codecs-data-structures",
     "version": "3.0.0",
     "description": "Codecs for various data structures",
+    "homepage": "https://www.solanakit.com/api#solanacodecs-data-structures",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/codecs-numbers",
     "version": "3.0.0",
     "description": "Codecs for numbers of different sizes and endianness",
+    "homepage": "https://www.solanakit.com/api#solanacodecs-numbers",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/codecs-strings",
     "version": "3.0.0",
     "description": "Codecs for strings of different sizes and encodings",
+    "homepage": "https://www.solanakit.com/api#solanacodecs-strings",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/codecs",
     "version": "3.0.0",
     "description": "A library for encoding and decoding any data structure",
+    "homepage": "https://www.solanakit.com/api#solanacodecs",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/compat",
     "version": "3.0.0",
     "description": "Helpers for converting from legacy web3js classes",
+    "homepage": "https://www.solanakit.com/api#solanacompat",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/errors",
     "version": "3.0.0",
     "description": "Throw, identify, and decode Solana JavaScript errors",
+    "homepage": "https://www.solanakit.com/api#solanaerrors",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/functional",
     "version": "3.0.0",
     "description": "Functional JavaScript helpers",
+    "homepage": "https://www.solanakit.com/api#solanafunctional",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/instruction-plans/package.json
+++ b/packages/instruction-plans/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/instruction-plans",
     "version": "3.0.0",
     "description": "Construct, plan and execute transactions from multiple instructions.",
+    "homepage": "https://www.solanakit.com/api#solanainstruction-plans",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/instructions",
     "version": "3.0.0",
     "description": "Helpers for creating transaction instructions",
+    "homepage": "https://www.solanakit.com/api#solanainstructions",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/keys",
     "version": "3.0.0",
     "description": "Helpers for generating and transforming key material",
+    "homepage": "https://www.solanakit.com/api#solanakeys",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/kit",
     "version": "3.0.0",
     "description": "Solana Javascript API",
+    "homepage": "https://www.solanakit.com",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/nominal-types/package.json
+++ b/packages/nominal-types/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/nominal-types",
     "version": "3.0.0",
     "description": "Type utilties for creating nominal/branded types in TypeScript",
+    "homepage": "https://www.solanakit.com/api#solananominal-types",
     "types": "./dist/types/index.d.ts",
     "type": "commonjs",
     "files": [

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/options",
     "version": "3.0.0",
     "description": "Managing and serializing Rust-like Option types in JavaScript",
+    "homepage": "https://www.solanakit.com/api#solanaoptions",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/programs/package.json
+++ b/packages/programs/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/programs",
     "version": "3.0.0",
     "description": "Helpers for defining programs and resolving program errors",
+    "homepage": "https://www.solanakit.com/api#solanaprograms",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/promises/package.json
+++ b/packages/promises/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/promises",
     "version": "3.0.0",
     "description": "Helpers for using JavaScript promises",
+    "homepage": "https://www.solanakit.com/api#solanapromises",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/react",
     "version": "3.0.0",
     "description": "React hooks for building Solana apps",
+    "homepage": "https://www.solanakit.com/api#solanareact",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc-api/package.json
+++ b/packages/rpc-api/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc-api",
     "version": "3.0.0",
     "description": "Defines all default Solana RPC methods as types",
+    "homepage": "https://www.solanakit.com/api#solanarpc-api",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc-graphql",
     "version": "3.0.0",
     "description": "A library for resolving GraphQl query calls to the Solana JSON RPC API",
+    "homepage": "https://www.solanakit.com/api#solanarpc-graphql",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc-parsed-types/package.json
+++ b/packages/rpc-parsed-types/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc-parsed-types",
     "version": "3.0.0",
     "description": "Type definitions for parsed types used in the Solana RPC",
+    "homepage": "https://www.solanakit.com/api#solanarpc-parsed-types",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc-spec-types/package.json
+++ b/packages/rpc-spec-types/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc-spec-types",
     "version": "3.0.0",
     "description": "Shared generic JSON RPC specifications",
+    "homepage": "https://www.solanakit.com/api#solanarpc-spec-types",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc-spec/package.json
+++ b/packages/rpc-spec/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc-spec",
     "version": "3.0.0",
     "description": "A generic implementation of JSON RPCs using proxies",
+    "homepage": "https://www.solanakit.com/api#solanarpc-spec",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc-subscriptions-api",
     "version": "3.0.0",
     "description": "Defines all default Solana RPC subscriptions as types",
+    "homepage": "https://www.solanakit.com/api#solanarpc-subscriptions-api",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc-subscriptions-channel-websocket/package.json
+++ b/packages/rpc-subscriptions-channel-websocket/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc-subscriptions-channel-websocket",
     "version": "3.0.0",
     "description": "An RPC Subscriptions transport that uses WebSockets",
+    "homepage": "https://www.solanakit.com/api#solanarpc-subscriptions-channel-websocket",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc-subscriptions-spec/package.json
+++ b/packages/rpc-subscriptions-spec/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc-subscriptions-spec",
     "version": "3.0.0",
     "description": "A generic implementation of JSON RPC Subscriptions using proxies",
+    "homepage": "https://www.solanakit.com/api#solanarpc-subscriptions-spec",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc-subscriptions",
     "version": "3.0.0",
     "description": "A library for subscribing to Solana RPC notifications",
+    "homepage": "https://www.solanakit.com/api#solanarpc-subscriptions",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc-transformers",
     "version": "3.0.0",
     "description": "Reusable transformers for patching RPC inputs and outputs",
+    "homepage": "https://www.solanakit.com/api#solanarpc-transformers",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc-transport-http/package.json
+++ b/packages/rpc-transport-http/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc-transport-http",
     "version": "3.0.0",
     "description": "An RPC transport that uses HTTP requests",
+    "homepage": "https://www.solanakit.com/api#solanarpc-transport-http",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc-types",
     "version": "3.0.0",
     "description": "Type definitions for values used in the Solana RPC, and helper functions for working with them",
+    "homepage": "https://www.solanakit.com/api#solanarpc-types",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/rpc",
     "version": "3.0.0",
     "description": "A library for sending JSON RPC requests to Solana RPCs",
+    "homepage": "https://www.solanakit.com/api#solanarpc",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/signers",
     "version": "3.0.0",
     "description": "An abstraction layer over signing messages and transactions in Solana",
+    "homepage": "https://www.solanakit.com/api#solanasigners",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/subscribable/package.json
+++ b/packages/subscribable/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/subscribable",
     "version": "3.0.0",
     "description": "Helpers for creating subscription-based event emitters",
+    "homepage": "https://www.solanakit.com/api#solanasubscribable",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/sysvars",
     "version": "3.0.0",
     "description": "An abstraction layer over signing messages and transactions in Solana",
+    "homepage": "https://www.solanakit.com/api#solanasysvars",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/transaction-confirmation",
     "version": "3.0.0",
     "description": "Helpers for confirming Solana transactions",
+    "homepage": "https://www.solanakit.com/api#solanatransaction-confirmation",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/transaction-messages/package.json
+++ b/packages/transaction-messages/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/transaction-messages",
     "version": "3.0.0",
     "description": "Helpers for creating transaction messages",
+    "homepage": "https://www.solanakit.com/api#solanatransaction-messages",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/transactions",
     "version": "3.0.0",
     "description": "Helpers for creating and serializing transactions",
+    "homepage": "https://www.solanakit.com/api#solanatransactions",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -2,6 +2,7 @@
     "name": "@solana/webcrypto-ed25519-polyfill",
     "version": "3.0.0",
     "description": "A polyfill that adds Ed25519 key manipulation capabilities to `SubtleCrypto` in environments where it is not yet supported",
+    "homepage": "https://www.solanakit.com/api#solanawebcrypto-ed25519-polyfill",
     "exports": {
         "edge-light": {
             "import": "./dist/index.node.mjs",


### PR DESCRIPTION
#### Problem

We have a website we can link NPM registry visitors to now.

#### Summary of Changes

- Added links to the API pages for everything
- …except for `@solana/kit` which I linked to `https://www.solanakit.com`
