### PR TITLE
Add contributing.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+Kit is developed in public and we encourage and appreciate contributions.
+
+## Getting Started
+
+1. Install dependencies: `pnpm install`
+2. The first time you build Kit, you will need to install the Agave test validator, which is used for some tests. `pnpm test:live-with-test-validator:setup`
+3. Start a test validator before running tests. `./scripts/start-shared-test-validator.sh`
+4. Build + test all packages: `pnpm build`
+
+## Development Environment
+
+Kit is developed as a monorepo using [pnpm](https://pnpm.io/) and [turborepo](https://turborepo.com/).
+
+Often your changes will only apply to a single package. You can run tests for a single package and watch for changes:
+
+```shell
+cd packages/accounts
+pnpm turbo compile:js compile:typedefs
+pnpm dev
+```


### PR DESCRIPTION
I noticed we don't have any instructions for running Kit locally as I was setting up on a new dev server. Just adding a simple CONTRIBUTING.md that should get any developer who wants to contribute to a point where they can make and test changes to Kit. 