### PR TITLE
Pin the `@solana/errors` CLI dependencies to fixed versions

### DIFF
--- a/.changeset/major-rockets-join.md
+++ b/.changeset/major-rockets-join.md
@@ -1,0 +1,5 @@
+---
+'@solana/errors': patch
+---
+
+When you use the `@solana/errors` CLI you will now _always_ get version 5.6.2 of `chalk` and version 14.0.0 of `commander`, which themselves are zero-dependency.

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -74,8 +74,8 @@
         "maintained node versions"
     ],
     "dependencies": {
-        "chalk": "^5.6.0",
-        "commander": "^14.0.0"
+        "chalk": "5.6.2",
+        "commander": "14.0.0"
     },
     "peerDependencies": {
         "typescript": ">=5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -523,10 +523,10 @@ importers:
   packages/errors:
     dependencies:
       chalk:
-        specifier: ^5.6.0
-        version: 5.6.0
+        specifier: 5.6.2
+        version: 5.6.2
       commander:
-        specifier: ^14.0.0
+        specifier: 14.0.0
         version: 14.0.0
       typescript:
         specifier: '>=5.3.3'
@@ -4913,8 +4913,8 @@ packages:
     resolution: {integrity: sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  chalk@5.6.0:
-    resolution: {integrity: sha512-46QrSQFyVSEyYAgQ22hQ+zDa60YHA4fBstHmtSApj1Y5vKtG27fWowW03jCk5KcbXEWPZUIR894aARCA/G1kfQ==}
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   char-regex@1.0.2:
@@ -10833,7 +10833,7 @@ snapshots:
 
   '@solana/errors@2.3.0(typescript@5.8.3)':
     dependencies:
-      chalk: 5.6.0
+      chalk: 5.6.2
       commander: 14.0.0
       typescript: 5.8.3
 
@@ -11411,7 +11411,7 @@ snapshots:
 
   '@wallet-standard/errors@0.1.1':
     dependencies:
-      chalk: 5.6.0
+      chalk: 5.6.2
       commander: 13.1.0
 
   '@wallet-standard/experimental-features@0.2.0':
@@ -11852,7 +11852,7 @@ snapshots:
 
   chalk@5.4.1: {}
 
-  chalk@5.6.0: {}
+  chalk@5.6.2: {}
 
   char-regex@1.0.2: {}
 


### PR DESCRIPTION
#### Problem

By and large, people will run this CLI with `pnpm dlx @solana/errors`. Every time they do so, fresh deps will be installed.

#### Summary of Changes

In order to prevent new updated dependencies from being installed when used with `npx`/`pnpm dlx`/`yarn dlx`/`bunx`, specify fixed versions of `chalk` and `commander`.
