### PR TITLE
Allow Origin header to be set (for non-browser platforms).

### DIFF
--- a/.changeset/eager-lizards-stand.md
+++ b/.changeset/eager-lizards-stand.md
@@ -2,4 +2,4 @@
 '@solana/rpc-transport-http': minor
 ---
 
-Remove Origin from list of forbidden RPC headers
+The React Native and Node builds now permit you to set the `Origin` header. This header continues to be forbidden in the browser build, as it features on the list of forbidden request headers: https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_request_header

--- a/.changeset/eager-lizards-stand.md
+++ b/.changeset/eager-lizards-stand.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-transport-http': minor
+---
+
+Remove Origin from list of forbidden RPC headers

--- a/packages/rpc-transport-http/src/__tests__/http-transport-headers-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-headers-test.ts
@@ -27,7 +27,6 @@ describe('assertIsAllowedHttpRequestHeader', () => {
         'Expect',
         'Host',
         'Keep-Alive',
-        'Origin',
         'Permissions-Policy',
         'Proxy-Anything',
         'Proxy-Authenticate',
@@ -60,6 +59,17 @@ describe('assertIsAllowedHttpRequestHeader', () => {
             }).toThrow(
                 new SolanaError(SOLANA_ERROR__RPC__TRANSPORT_HTTP_HEADER_FORBIDDEN, {
                     headers: ['Accept-Encoding'],
+                }),
+            );
+        });
+    }
+    if (__BROWSER__) {
+        it('throws when called with the `Origin` header', () => {
+            expect(() => {
+                assertIsAllowedHttpRequestHeaders({ Origin: 'https://spoofed.site' });
+            }).toThrow(
+                new SolanaError(SOLANA_ERROR__RPC__TRANSPORT_HTTP_HEADER_FORBIDDEN, {
+                    headers: ['Origin'],
                 }),
             );
         });

--- a/packages/rpc-transport-http/src/http-transport-headers.ts
+++ b/packages/rpc-transport-http/src/http-transport-headers.ts
@@ -34,8 +34,8 @@ type ForbiddenHeaders =
     | 'Host'
     | 'Keep-Alive'
     // Similar to `Accept-Encoding`, we don't have a way to target TypeScript types depending on
-    // which platform you are authoring for. `Origin` is therefore omitted from the forbidden headers
-    // type, but is still a runtime error in dev mode when supplied in a browser or Node context.
+    // which platform you are authoring for. `Origin` is therefore omitted from the forbidden
+    // headers type, but is still a runtime error in dev mode when supplied in a browser context.
     // | 'Origin'
     | 'Permissions-Policy'
     | 'Referer'
@@ -79,7 +79,7 @@ const FORBIDDEN_HEADERS: Record<string, boolean> = /* @__PURE__ */ Object.assign
         via: true,
     },
     __NODEJS__ ? undefined : { 'accept-encoding': true },
-    __REACTNATIVE__ ? undefined : { origin: true },
+    __BROWSER__ ? { origin: true } : undefined,
 );
 
 export function assertIsAllowedHttpRequestHeaders(

--- a/packages/rpc-transport-http/src/http-transport-headers.ts
+++ b/packages/rpc-transport-http/src/http-transport-headers.ts
@@ -33,7 +33,6 @@ type ForbiddenHeaders =
     | 'Expect'
     | 'Host'
     | 'Keep-Alive'
-    | 'Origin'
     | 'Permissions-Policy'
     | 'Referer'
     | 'TE'
@@ -64,7 +63,6 @@ const FORBIDDEN_HEADERS: Record<string, boolean> = /* @__PURE__ */ Object.assign
         expect: true,
         host: true,
         'keep-alive': true,
-        origin: true,
         'permissions-policy': true,
         // Prefix matching is implemented in code, below.
         // 'proxy-': true,

--- a/packages/rpc-transport-http/src/http-transport-headers.ts
+++ b/packages/rpc-transport-http/src/http-transport-headers.ts
@@ -33,6 +33,10 @@ type ForbiddenHeaders =
     | 'Expect'
     | 'Host'
     | 'Keep-Alive'
+    // Similar to `Accept-Encoding`, we don't have a way to target TypeScript types depending on
+    // which platform you are authoring for. `Origin` is therefore omitted from the forbidden headers
+    // type, but is still a runtime error in dev mode when supplied in a browser or Node context.
+    // | 'Origin'
     | 'Permissions-Policy'
     | 'Referer'
     | 'TE'
@@ -75,6 +79,7 @@ const FORBIDDEN_HEADERS: Record<string, boolean> = /* @__PURE__ */ Object.assign
         via: true,
     },
     __NODEJS__ ? undefined : { 'accept-encoding': true },
+    __REACTNATIVE__ ? undefined : { origin: true },
 );
 
 export function assertIsAllowedHttpRequestHeaders(


### PR DESCRIPTION
#### Problem
As described in the ticket, React Native clients do not automatically set an Origin header. This is preventing us from using Triton's SWQOS since it restricts access by Origin header. 


#### Summary of Changes
Remove Origin from list of forbidden headers.


Fixes #887