### PR TITLE
Update useWalletAccountTransactionSigner to return a LifetimeConstraint for the updated transaction

### DIFF
--- a/.changeset/sharp-falcons-end.md
+++ b/.changeset/sharp-falcons-end.md
@@ -1,0 +1,6 @@
+---
+'@solana/errors': patch
+'@solana/react': patch
+---
+
+Update useWalletAccountTransactionSigner to return a LifetimeConstraint for the updated transaction

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -78,6 +78,7 @@
         "@solana/keys": "workspace:*",
         "@solana/promises": "workspace:*",
         "@solana/signers": "workspace:*",
+        "@solana/transaction-messages": "workspace:*",
         "@solana/transactions": "workspace:*",
         "@solana/wallet-standard-features": "^1.3.0",
         "@wallet-standard/base": "^1.1.0",
@@ -87,6 +88,7 @@
     },
     "devDependencies": {
         "@solana/codecs-core": "workspace:*",
+        "@solana/rpc-types": "workspace:*",
         "@types/react": "^19",
         "@types/react-test-renderer": "^19",
         "react": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -766,6 +766,9 @@ importers:
       '@solana/signers':
         specifier: workspace:*
         version: link:../signers
+      '@solana/transaction-messages':
+        specifier: workspace:*
+        version: link:../transaction-messages
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
@@ -788,6 +791,9 @@ importers:
       '@solana/codecs-core':
         specifier: workspace:*
         version: link:../codecs-core
+      '@solana/rpc-types':
+        specifier: workspace:*
+        version: link:../rpc-types
       '@types/react':
         specifier: ^19
         version: 19.2.0


### PR DESCRIPTION
#### Problem

Currently this signer only returns what is required for the signer interface, a `Transaction`. However, per #891 this interface needs to be changed to return a `Transaction & TransactionWithLifetime`, ie augmented with a `lifetimeConstraint` field.

#### Summary of Changes

The signer now returns a lifetime, by decoding the returned `messageBytes` and comparing the returned `lifetimeToken` with the existing lifetime of the input transaction.

- If the input transaction does not have a lifetime, then we create one for the signed transaction using #918. Otherwise:
- If the input transaction and signed transaction have identical message bytes, then we return the existing lifetime. Ie if the wallet returns the transaction unchanged.
- If the message bytes differ, but the `lifetimeToken` of the signed transaction matches the existing lifetime (either blockhash or nonce field), then we return the existing lifetime. Ie if the wallet modifies the transaction but not its lifetime.
- If the lifetime token of the signed transaction differs from that of the input transaction, then we create a new lifetime for the signed transaction using #918. 

This pre-emptively makes `useWalletAccountTransactionSigner` comply with a stricter interface for `TransactionModifyingSigner` that will require returning `Transaction & TransactionWithLifetime`. 