### PR TITLE
Update the signer API to return Transaction & TransactionWithLifetime

### DIFF
--- a/.changeset/public-showers-remain.md
+++ b/.changeset/public-showers-remain.md
@@ -1,0 +1,12 @@
+---
+'@solana/signers': major
+'@solana/react': major
+---
+
+Update the signer API to return Transaction & TransactionWithLifetime
+
+The `modifyAndSignTransactions` function for a `TransactionModifyingSigner` must now return a `Transaction & TransactionWithLifetime & TransactionWithinSizeLimit`. Previously it technically needed to return a type derived from the input `TransactionMessage`, but this wasn't checked.
+
+If you have written a `TransactionModifyingSigner` then you should review the changes to `useWalletAccountTransactionSigner` in the React package for guidance. You may need to use the new `getTransactionLifetimeConstraintFromCompiledTransactionMessage` function to obtain a lifetime for the transaction being returned.
+
+If you are using a `TransactionModifyingSigner` such as `useWalletAccountTransactionSigner`, then you will now receive a transaction with `TransactionWithLifetime` when you would previously have received a type with a lifetime matching the input transaction message. This was never guaranteed to match at runtime, but we incorrectly returned a stronger type than can be guaranteed. You may need to use the new `isTransactionWithBlockhashLifetime` or `isTransactionWithDurableNonceLifetime` functions to check the lifetime type of the returned transaction. For example, if you want to pass it to a function returned by `sendAndConfirmTransactionFactory` then you must use `isTransactionWithBlockhashLifetime` or `assertIsTransactionWithBlockhashLifetime` to check its lifetime first.

--- a/examples/signers/src/example.ts
+++ b/examples/signers/src/example.ts
@@ -11,6 +11,7 @@ import { createLogger } from '@solana/example-utils/createLogger.js';
 import {
     address,
     appendTransactionMessageInstruction,
+    assertIsTransactionWithinSizeLimit,
     Blockhash,
     compileTransaction,
     createKeyPairSignerFromBytes,
@@ -92,6 +93,7 @@ async function signTransaction(
     transactionMessage: TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime,
 ) {
     const transaction = compileTransaction(transactionMessage);
+    assertIsTransactionWithinSizeLimit(transaction);
     const [signatureDictionary] = await signer.signTransactions([transaction]);
     const signature = signatureDictionary[signer.address];
     log.info(

--- a/examples/transfer-lamports/src/example.ts
+++ b/examples/transfer-lamports/src/example.ts
@@ -13,6 +13,7 @@ import {
     address,
     appendTransactionMessageInstruction,
     assertIsSendableTransaction,
+    assertIsTransactionWithBlockhashLifetime,
     createKeyPairSignerFromBytes,
     createSolanaRpc,
     createSolanaRpcSubscriptions,
@@ -184,6 +185,7 @@ log.warn(
 );
 try {
     assertIsSendableTransaction(signedTransaction);
+    assertIsTransactionWithBlockhashLifetime(signedTransaction);
     await sendAndConfirmTransaction(signedTransaction, { commitment: 'confirmed' });
     log.info('[success] Transfer confirmed');
     await pressAnyKeyPrompt('Press any key to quit');

--- a/packages/signers/src/__tests__/keypair-signer-test.ts
+++ b/packages/signers/src/__tests__/keypair-signer-test.ts
@@ -3,7 +3,12 @@ import '@solana/test-matchers/toBeFrozenObject';
 import { address, getAddressFromPublicKey } from '@solana/addresses';
 import { SOLANA_ERROR__SIGNER__EXPECTED_KEY_PAIR_SIGNER, SolanaError } from '@solana/errors';
 import { generateKeyPair, SignatureBytes, signBytes } from '@solana/keys';
-import { partiallySignTransaction, Transaction, TransactionWithLifetime } from '@solana/transactions';
+import {
+    partiallySignTransaction,
+    Transaction,
+    TransactionWithinSizeLimit,
+    TransactionWithLifetime,
+} from '@solana/transactions';
 
 import {
     assertIsKeyPairSigner,
@@ -145,8 +150,8 @@ describe('createSignerFromKeyPair', () => {
 
         // And given we have a couple of mock transactions to sign.
         const mockTransactions = [
-            {} as Transaction & TransactionWithLifetime,
-            {} as Transaction & TransactionWithLifetime,
+            {} as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+            {} as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
         ];
 
         // And given we mock the next two calls of the partiallySignTransaction function.

--- a/packages/signers/src/__tests__/noop-signer-test.ts
+++ b/packages/signers/src/__tests__/noop-signer-test.ts
@@ -1,7 +1,7 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
 import { address } from '@solana/addresses';
-import { Transaction, TransactionWithLifetime } from '@solana/transactions';
+import { Transaction, TransactionWithinSizeLimit, TransactionWithLifetime } from '@solana/transactions';
 
 import { createNoopSigner, NoopSigner } from '../noop-signer';
 import { createSignableMessage } from '../signable-message';
@@ -53,8 +53,8 @@ describe('createNoopSigner', () => {
 
         // And given we have a couple of mock transactions to sign.
         const mockTransactions = [
-            {} as Transaction & TransactionWithLifetime,
-            {} as Transaction & TransactionWithLifetime,
+            {} as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+            {} as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
         ];
 
         // When we sign both transactions using that signer.
@@ -75,8 +75,8 @@ describe('createNoopSigner', () => {
 
         // And given we have a couple of mock transactions to sign.
         const mockTransactions = [
-            {} as Transaction & TransactionWithLifetime,
-            {} as Transaction & TransactionWithLifetime,
+            {} as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
+            {} as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime,
         ];
 
         // When we sign both transactions using that signer.

--- a/packages/signers/src/__typetests__/sign-transaction-typetest.ts
+++ b/packages/signers/src/__typetests__/sign-transaction-typetest.ts
@@ -11,8 +11,6 @@ import {
 import {
     FullySignedTransaction,
     Transaction,
-    TransactionWithBlockhashLifetime,
-    TransactionWithDurableNonceLifetime,
     TransactionWithinSizeLimit,
     TransactionWithLifetime,
 } from '@solana/transactions';
@@ -26,29 +24,29 @@ import {
 import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-single-sending-signer';
 
 {
-    // [partiallySignTransactionMessageWithSigners]: returns a transaction with a blockhash lifetime
+    // [partiallySignTransactionMessageWithSigners]: returns a transaction with a lifetime when the input message has a blockhash lifetime
     const transactionMessage = null as unknown as BaseTransactionMessage &
         TransactionMessageWithBlockhashLifetime &
         TransactionMessageWithFeePayer &
         TransactionMessageWithSigners;
     partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
-        Readonly<Transaction & TransactionWithBlockhashLifetime>
+        Readonly<Transaction & TransactionWithLifetime>
     >;
 }
 
 {
-    // [partiallySignTransactionMessageWithSigners]: returns a transaction with a durable nonce lifetime
+    // [partiallySignTransactionMessageWithSigners]: returns a transaction with a lifetime when the input message has a durable nonce lifetime
     const transactionMessage = null as unknown as BaseTransactionMessage &
         TransactionMessageWithDurableNonceLifetime &
         TransactionMessageWithFeePayer &
         TransactionMessageWithSigners;
     partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
-        Readonly<Transaction & TransactionWithDurableNonceLifetime>
+        Readonly<Transaction & TransactionWithLifetime>
     >;
 }
 
 {
-    // [partiallySignTransactionMessageWithSigners]: returns a transaction with an unknown lifetime
+    // [partiallySignTransactionMessageWithSigners]: returns a transaction with an unknown lifetime when the input message has an unknown lifetime
     const transactionMessage = null as unknown as BaseTransactionMessage &
         TransactionMessageWithFeePayer &
         TransactionMessageWithLifetime &
@@ -59,12 +57,11 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 }
 
 {
-    // [partiallySignTransactionMessageWithSigners]: returns a transaction with no lifetime constraint
+    // [partiallySignTransactionMessageWithSigners]: returns a transaction with a lifetime when the input message has no lifetime
     const transactionMessage = null as unknown as BaseTransactionMessage &
         TransactionMessageWithFeePayer &
         TransactionMessageWithSigners;
     partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<Readonly<Transaction>>;
-    // @ts-expect-error Expects no lifetime constraint
     partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<
         Readonly<Transaction & TransactionWithLifetime>
     >;
@@ -83,29 +80,29 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 }
 
 {
-    // [signTransactionMessageWithSigners]: returns a fully signed transaction with a blockhash lifetime
+    // [signTransactionMessageWithSigners]: returns a fully signed transaction with a lifetime when the input message has a blockhash lifetime
     const transactionMessage = null as unknown as BaseTransactionMessage &
         TransactionMessageWithBlockhashLifetime &
         TransactionMessageWithFeePayer &
         TransactionMessageWithSigners;
     signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
-        Readonly<FullySignedTransaction & Transaction & TransactionWithBlockhashLifetime>
+        Readonly<FullySignedTransaction & Transaction & TransactionWithLifetime>
     >;
 }
 
 {
-    // [signTransactionMessageWithSigners]: returns a fully signed transaction with a durable nonce lifetime
+    // [signTransactionMessageWithSigners]: returns a fully signed transaction with a lifetime when the input message has a durable nonce lifetime
     const transactionMessage = null as unknown as BaseTransactionMessage &
         TransactionMessageWithDurableNonceLifetime &
         TransactionMessageWithFeePayer &
         TransactionMessageWithSigners;
     signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
-        Readonly<FullySignedTransaction & Transaction & TransactionWithDurableNonceLifetime>
+        Readonly<FullySignedTransaction & Transaction & TransactionWithLifetime>
     >;
 }
 
 {
-    // [signTransactionMessageWithSigners]: returns a fully signed transaction with an unknown lifetime
+    // [signTransactionMessageWithSigners]: returns a fully signed transaction with an unknown lifetime when the input message has an unknown lifetime
     const transactionMessage = null as unknown as BaseTransactionMessage &
         TransactionMessageWithFeePayer &
         TransactionMessageWithLifetime &
@@ -116,12 +113,11 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 }
 
 {
-    // [signTransactionMessageWithSigners]: returns a transaction with no lifetime constraint
+    // [signTransactionMessageWithSigners]: returns a transaction with a lifetime when the input message has no lifetime
     const transactionMessage = null as unknown as BaseTransactionMessage &
         TransactionMessageWithFeePayer &
         TransactionMessageWithSigners;
     signTransactionMessageWithSigners(transactionMessage) satisfies Promise<Readonly<Transaction>>;
-    // @ts-expect-error Expects no lifetime constraint
     signTransactionMessageWithSigners(transactionMessage) satisfies Promise<
         Readonly<Transaction & TransactionWithLifetime>
     >;

--- a/packages/signers/src/transaction-modifying-signer.ts
+++ b/packages/signers/src/transaction-modifying-signer.ts
@@ -1,6 +1,6 @@
 import { Address } from '@solana/addresses';
 import { SOLANA_ERROR__SIGNER__EXPECTED_TRANSACTION_MODIFYING_SIGNER, SolanaError } from '@solana/errors';
-import { Transaction } from '@solana/transactions';
+import { Transaction, TransactionWithinSizeLimit, TransactionWithLifetime } from '@solana/transactions';
 
 import { BaseTransactionSignerConfig } from './types';
 
@@ -21,7 +21,8 @@ export type TransactionModifyingSignerConfig = BaseTransactionSignerConfig;
  * {@link SignatureDictionary}, its
  * {@link TransactionModifyingSigner#modifyAndSignTransactions | modifyAndSignTransactions} function
  * returns an updated {@link Transaction} with a potentially modified set of instructions and
- * signature dictionary.
+ * signature dictionary. The returned transaction must be within the transaction size limit,
+ * and include a `lifetimeConstraint`.
  *
  * @typeParam TAddress - Supply a string literal to define a signer having a particular address.
  *
@@ -29,9 +30,9 @@ export type TransactionModifyingSignerConfig = BaseTransactionSignerConfig;
  * ```ts
  * const signer: TransactionModifyingSigner<'1234..5678'> = {
  *     address: address('1234..5678'),
- *     modifyAndSignTransactions: async <T extends Transaction>(
- *         transactions: T[]
- *     ): Promise<T[]> => {
+ *     modifyAndSignTransactions: async (
+ *         transactions: Transaction[]
+ *     ): Promise<(Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[]> => {
  *         // My custom signing logic.
  *     },
  * };
@@ -55,10 +56,10 @@ export type TransactionModifyingSignerConfig = BaseTransactionSignerConfig;
  */
 export type TransactionModifyingSigner<TAddress extends string = string> = Readonly<{
     address: Address<TAddress>;
-    modifyAndSignTransactions<T extends Transaction>(
-        transactions: readonly T[],
+    modifyAndSignTransactions(
+        transactions: readonly (Transaction | (Transaction & TransactionWithLifetime))[],
         config?: TransactionModifyingSignerConfig,
-    ): Promise<readonly T[]>;
+    ): Promise<readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[]>;
 }>;
 
 /**

--- a/packages/signers/src/transaction-partial-signer.ts
+++ b/packages/signers/src/transaction-partial-signer.ts
@@ -1,6 +1,6 @@
 import { Address } from '@solana/addresses';
 import { SOLANA_ERROR__SIGNER__EXPECTED_TRANSACTION_PARTIAL_SIGNER, SolanaError } from '@solana/errors';
-import { Transaction, TransactionWithLifetime } from '@solana/transactions';
+import { Transaction, TransactionWithinSizeLimit, TransactionWithLifetime } from '@solana/transactions';
 
 import { BaseTransactionSignerConfig, SignatureDictionary } from './types';
 
@@ -49,7 +49,7 @@ export type TransactionPartialSignerConfig = BaseTransactionSignerConfig;
 export type TransactionPartialSigner<TAddress extends string = string> = Readonly<{
     address: Address<TAddress>;
     signTransactions(
-        transactions: readonly (Transaction & TransactionWithLifetime)[],
+        transactions: readonly (Transaction & TransactionWithinSizeLimit & TransactionWithLifetime)[],
         config?: TransactionPartialSignerConfig,
     ): Promise<readonly SignatureDictionary[]>;
 }>;

--- a/packages/signers/src/transaction-sending-signer.ts
+++ b/packages/signers/src/transaction-sending-signer.ts
@@ -1,7 +1,7 @@
 import { Address } from '@solana/addresses';
 import { SOLANA_ERROR__SIGNER__EXPECTED_TRANSACTION_SENDING_SIGNER, SolanaError } from '@solana/errors';
 import { SignatureBytes } from '@solana/keys';
-import { Transaction } from '@solana/transactions';
+import { Transaction, TransactionWithLifetime } from '@solana/transactions';
 
 import { BaseTransactionSignerConfig } from './types';
 
@@ -61,7 +61,7 @@ export type TransactionSendingSignerConfig = BaseTransactionSignerConfig;
 export type TransactionSendingSigner<TAddress extends string = string> = Readonly<{
     address: Address<TAddress>;
     signAndSendTransactions(
-        transactions: readonly Transaction[],
+        transactions: readonly (Transaction | (Transaction & TransactionWithLifetime))[],
         config?: TransactionSendingSignerConfig,
     ): Promise<readonly SignatureBytes[]>;
 }>;


### PR DESCRIPTION
#### Problem

The `TransactionModifyingSigner` was previously typed to return the exact same type `T` as its input transactions. This is incorrect, as we always intended for signers to be able to eg change the lifetime of a transaction. In practice one example of `TransactionModifyingSigner` returns signed transactions from wallet-standard wallets, which can make arbitrary changes to the transaction before signing it.

This also meant that such a signer could not return a `TransactionWithLifetime`, ie a `lifetimeConstraint` field. Casts in signer functions would treat the signer as having returned the expected type, but there was no type safety.

In practice, this meant `useWalletAccountTransactionSigner` and third-party `TransactionModifyingSigner` did not return a `lifetimeConstraint`, but appeared to do so to Typescript. This led to a runtime error when attempting to confirm transactions (#891) 

#### Summary of Changes

This PR changes the type of modifying signers to:
**input**: (Transaction | (Transaction & TransactionWithLifetime))[]
**output**: (Transaction & TransactionWithLifetime & TransactionWithinSizeLimit)[]

Note that an upstream PR (#919) already made `useWalletAccountTransactionSigner` satisfy the `TransactionWithLifetime` part of this interface.

It also changes the return type of `signModifyingAndPartialTransactionSigners` to `Transaction & TransactionWithLifetime & TransactionWithinSizeLimit`, and removes the cast to the expected return type that limited type safety in this function.

Fixes #891
