### PR TITLE
Pass `GITHUB_OUTPUT` through to the publish script in CI

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -53,7 +53,7 @@
                 "test:treeshakability:native",
                 "test:treeshakability:node"
             ],
-            "passThroughEnv": ["GH_TOKEN", "NPM_TOKEN", "PUBLISH_TAG"]
+            "passThroughEnv": ["GH_TOKEN", "GITHUB_OUTPUT", "GITHUB_TOKEN", "NPM_TOKEN", "PUBLISH_TAG"]
         },
         "style:fix": {
             "inputs": ["$TURBO_DEFAULT$", "*"],


### PR DESCRIPTION
This is almost certainly why our GitHub Release Notes script never runs. The publish script is trying to write to `$GITHUB_OUTPUT` but because we're running the publish scripts through Turborepo, that env variable is not being passed through.
