### PR TITLE
The offchain message signer functions can now accept a mix of signers and non-signers

### DIFF
--- a/packages/signers/src/__tests__/__setup__.ts
+++ b/packages/signers/src/__tests__/__setup__.ts
@@ -5,6 +5,8 @@ import {
     OffchainMessageApplicationDomain,
     OffchainMessageContentFormat,
     OffchainMessageContentRestrictedAsciiOf1232BytesMax,
+    OffchainMessageSignatory,
+    OffchainMessageWithRequiredSignatories,
 } from '@solana/offchain-messages';
 import type { Blockhash } from '@solana/rpc-types';
 import {
@@ -22,7 +24,7 @@ import {
 import { AccountSignerMeta, InstructionWithSigners, TransactionMessageWithSigners } from '../account-signer-meta';
 import { MessageModifyingSigner } from '../message-modifying-signer';
 import { MessagePartialSigner } from '../message-partial-signer';
-import { OffchainMessageSignatorySigner, OffchainMessageWithSigners } from '../offchain-message-signer';
+import { OffchainMessageSignatorySigner } from '../offchain-message-signer';
 import { TransactionModifyingSigner } from '../transaction-modifying-signer';
 import { TransactionPartialSigner } from '../transaction-partial-signer';
 import { TransactionSendingSigner } from '../transaction-sending-signer';
@@ -45,7 +47,8 @@ export function createMockInstructionWithSigners(signers: TransactionSigner[]): 
 
 export function createMockOffchainMessageWithSigners(
     signers: OffchainMessageSignatorySigner[],
-): OffchainMessage & OffchainMessageWithSigners {
+): OffchainMessageWithRequiredSignatories<OffchainMessageSignatory | OffchainMessageSignatorySigner> &
+    Omit<OffchainMessage, 'requiredSignatories'> {
     return Object.freeze({
         applicationDomain: APPLICATION_DOMAIN_BYTES as unknown as OffchainMessageApplicationDomain,
         content: {

--- a/packages/signers/src/__typetests__/offchain-message-signer-typetest.ts
+++ b/packages/signers/src/__typetests__/offchain-message-signer-typetest.ts
@@ -59,4 +59,16 @@ import { TransactionSigner } from '../transaction-signer';
             requiredSignatories: [{ address: 'non-signer' as Address }],
         });
     }
+
+    // It accepts a mix of signers and non signers among the `requiredSignatories`
+    {
+        getSignersFromOffchainMessage({
+            requiredSignatories: [
+                { address: 'non-signer' as Address },
+                null as unknown as MessageModifyingSigner,
+                null as unknown as MessagePartialSigner,
+                null as unknown as MessageSigner,
+            ],
+        });
+    }
 }

--- a/packages/signers/src/__typetests__/sign-offchain-message-typetest.ts
+++ b/packages/signers/src/__typetests__/sign-offchain-message-typetest.ts
@@ -1,23 +1,96 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
+import { Address } from '@solana/addresses';
 import {
     FullySignedOffchainMessageEnvelope,
     OffchainMessage,
     OffchainMessageEnvelope,
 } from '@solana/offchain-messages';
 
-import { OffchainMessageWithSigners } from '../offchain-message-signer';
+import { MessageModifyingSigner } from '../message-modifying-signer';
+import { MessagePartialSigner } from '../message-partial-signer';
+import { MessageSigner } from '../message-signer';
 import { partiallySignOffchainMessageWithSigners, signOffchainMessageWithSigners } from '../sign-offchain-message';
 
+// [DESCRIBE] `partiallySignOffchainMessageWithSigners`
 {
-    // [partiallySignOffchainMessageWithSigners]: returns an offchain message envelope
-    const offchainMessage = null as unknown as OffchainMessage & OffchainMessageWithSigners;
-    partiallySignOffchainMessageWithSigners(offchainMessage) satisfies Promise<Readonly<OffchainMessageEnvelope>>;
+    // It returns an offchain message envelope
+    {
+        const offchainMessage = null as unknown as OffchainMessage;
+        partiallySignOffchainMessageWithSigners(offchainMessage) satisfies Promise<Readonly<OffchainMessageEnvelope>>;
+    }
+
+    // It accepts an offchain message with only non-signers
+    {
+        const offchainMessage = null as unknown as Omit<OffchainMessage, 'requiredSignatories'>;
+        partiallySignOffchainMessageWithSigners({
+            ...offchainMessage,
+            requiredSignatories: [{ address: '123' as Address<'123'> }],
+        });
+    }
+
+    // It accepts an offchain message with a mix of signers and non-signers
+    {
+        const offchainMessage = null as unknown as Omit<OffchainMessage, 'requiredSignatories'>;
+        partiallySignOffchainMessageWithSigners({
+            ...offchainMessage,
+            requiredSignatories: [
+                { address: '123' as Address<'123'> },
+                {} as MessageModifyingSigner,
+                {} as MessagePartialSigner,
+                {} as MessageSigner,
+            ],
+        });
+    }
+
+    // It accepts an offchain message with only signers
+    {
+        const offchainMessage = null as unknown as Omit<OffchainMessage, 'requiredSignatories'>;
+        partiallySignOffchainMessageWithSigners({
+            ...offchainMessage,
+            requiredSignatories: [{} as MessageModifyingSigner, {} as MessagePartialSigner, {} as MessageSigner],
+        });
+    }
 }
 
+// [DESCRIBE] `signOffchainMessageWithSigners`
 {
-    // [signOffchainMessageWithSigners]: returns a fully signed offchain-message envelope
-    const offchainMessage = null as unknown as OffchainMessage & OffchainMessageWithSigners;
-    signOffchainMessageWithSigners(offchainMessage) satisfies Promise<
-        Readonly<FullySignedOffchainMessageEnvelope & OffchainMessageEnvelope>
-    >;
+    // It returns a fully signed offchain-message envelope
+    {
+        const offchainMessage = null as unknown as OffchainMessage;
+        signOffchainMessageWithSigners(offchainMessage) satisfies Promise<
+            Readonly<FullySignedOffchainMessageEnvelope & OffchainMessageEnvelope>
+        >;
+    }
+
+    // It accepts an offchain message with only non-signers
+    {
+        const offchainMessage = null as unknown as Omit<OffchainMessage, 'requiredSignatories'>;
+        signOffchainMessageWithSigners({
+            ...offchainMessage,
+            requiredSignatories: [{ address: '123' as Address<'123'> }],
+        });
+    }
+
+    // It accepts an offchain message with a mix of signers and non-signers
+    {
+        const offchainMessage = null as unknown as Omit<OffchainMessage, 'requiredSignatories'>;
+        signOffchainMessageWithSigners({
+            ...offchainMessage,
+            requiredSignatories: [
+                { address: '123' as Address<'123'> },
+                {} as MessageModifyingSigner,
+                {} as MessagePartialSigner,
+                {} as MessageSigner,
+            ],
+        });
+    }
+
+    // It accepts an offchain message with only signers
+    {
+        const offchainMessage = null as unknown as Omit<OffchainMessage, 'requiredSignatories'>;
+        signOffchainMessageWithSigners({
+            ...offchainMessage,
+            requiredSignatories: [{} as MessageModifyingSigner, {} as MessagePartialSigner, {} as MessageSigner],
+        });
+    }
 }

--- a/packages/signers/src/offchain-message-signer.ts
+++ b/packages/signers/src/offchain-message-signer.ts
@@ -6,38 +6,7 @@ import { isMessageSigner, MessageSigner } from './message-signer';
 /**
  * Represents a {@link Signer} that is required to sign an offchain message for it to be valid.
  */
-export type OffchainMessageSignatorySigner<
-    TAddress extends string = string,
-    TSigner extends MessageSigner<TAddress> = MessageSigner<TAddress>,
-> = TSigner;
-
-/**
- * An {@link OffchainMessage} type extension that allows {@link MessageSigner | MessageSigners} to
- * be used as required signatories.
- * *
- * @typeParam TAddress - Supply a string literal to define a signatory having a particular address.
- * @typeParam TSigner - Optionally provide a narrower type for {@link MessageSigner | MessageSigners}.
- *
- * @example
- * ```ts
- * import { OffchainMessage } from '@solana/offchain-messages';
- * import { generateKeyPairSigner, InstructionWithSigners, OffchainMessageWithSigners } from '@solana/signers';
- *
- * const signer = await generateKeyPairSigner();
- * const firstSignatory: OffchainMessageSignatory = { ... };
- * const secondSignatory: OffchainMessageSignatorySigner = { ... };
- * const offchainMessage: OffchainMessage & OffchainMessageWithSigners = {
- *     /* ... *\/
- *     requiredSignatories: [firstSignatory, secondSignatory],
- * }
- * ```
- */
-export interface OffchainMessageWithSigners<
-    TAddress extends string = string,
-    TSigner extends MessageSigner<TAddress> = MessageSigner<TAddress>,
-> {
-    requiredSignatories: readonly OffchainMessageSignatorySigner<TAddress, TSigner>[];
-}
+export type OffchainMessageSignatorySigner<TAddress extends string = string> = MessageSigner<TAddress>;
 
 /**
  * Extracts and deduplicates all {@link MessageSigner | MessageSigners} stored inside a given

--- a/packages/signers/src/sign-offchain-message.ts
+++ b/packages/signers/src/sign-offchain-message.ts
@@ -4,6 +4,8 @@ import {
     FullySignedOffchainMessageEnvelope,
     OffchainMessage,
     OffchainMessageEnvelope,
+    OffchainMessageSignatory,
+    OffchainMessageWithRequiredSignatories,
 } from '@solana/offchain-messages';
 
 import {
@@ -13,7 +15,7 @@ import {
 } from './message-modifying-signer';
 import { isMessagePartialSigner, MessagePartialSigner, MessagePartialSignerConfig } from './message-partial-signer';
 import { MessageSigner } from './message-signer';
-import { getSignersFromOffchainMessage, OffchainMessageWithSigners } from './offchain-message-signer';
+import { getSignersFromOffchainMessage, OffchainMessageSignatorySigner } from './offchain-message-signer';
 import { SignableMessage } from './signable-message';
 
 /**
@@ -43,7 +45,8 @@ import { SignableMessage } from './signable-message';
  * @see {@link signOffchainMessageWithSigners}
  */
 export async function partiallySignOffchainMessageWithSigners(
-    offchainMessage: OffchainMessage & OffchainMessageWithSigners,
+    offchainMessage: OffchainMessageWithRequiredSignatories<OffchainMessageSignatory | OffchainMessageSignatorySigner> &
+        Omit<OffchainMessage, 'requiredSignatories'>,
     config?: MessagePartialSignerConfig,
 ): Promise<OffchainMessageEnvelope> {
     const { partialSigners, modifyingSigners } = categorizeMessageSigners(
@@ -76,7 +79,8 @@ export async function partiallySignOffchainMessageWithSigners(
  * @see {@link partiallySignOffchainMessageWithSigners}
  */
 export async function signOffchainMessageWithSigners(
-    offchainMessage: OffchainMessage & OffchainMessageWithSigners,
+    offchainMessage: OffchainMessageWithRequiredSignatories<OffchainMessageSignatory | OffchainMessageSignatorySigner> &
+        Omit<OffchainMessage, 'requiredSignatories'>,
     config?: MessagePartialSignerConfig,
 ): Promise<FullySignedOffchainMessageEnvelope & OffchainMessageEnvelope> {
     const signedOffchainMessageEnvelope = await partiallySignOffchainMessageWithSigners(offchainMessage, config);
@@ -129,7 +133,8 @@ function identifyMessageModifyingSigners(
  * {@link MessagePartialSigner | MessagePartialSigners} in parallel.
  */
 async function signModifyingAndPartialMessageSigners(
-    offchainMessage: OffchainMessage,
+    offchainMessage: OffchainMessageWithRequiredSignatories<OffchainMessageSignatory | OffchainMessageSignatorySigner> &
+        Omit<OffchainMessage, 'requiredSignatories'>,
     modifyingSigners: readonly MessageModifyingSigner[] = [],
     partialSigners: readonly MessagePartialSigner[] = [],
     config?: MessageModifyingSignerConfig,


### PR DESCRIPTION
#### Problem

Functions like `partiallySignOffchainMessageWithSigners()` were supposed to accept a mix of signatories that support the signers API and ones that don't.

#### Summary of Changes

Now they do.
