### PR TITLE
Make Transaction optional in successful transaction plan result + add signature

### DIFF
--- a/.changeset/slow-stars-check.md
+++ b/.changeset/slow-stars-check.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Make Transaction optional in successful transaction plan result + add signature

--- a/packages/instruction-plans/package.json
+++ b/packages/instruction-plans/package.json
@@ -75,6 +75,7 @@
     "dependencies": {
         "@solana/errors": "workspace:*",
         "@solana/instructions": "workspace:*",
+        "@solana/keys": "workspace:*",
         "@solana/promises": "workspace:*",
         "@solana/transaction-messages": "workspace:*",
         "@solana/transactions": "workspace:*"

--- a/packages/instruction-plans/src/__tests__/transaction-plan-result-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-result-test.ts
@@ -1,6 +1,7 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
 import { SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE, SolanaError } from '@solana/errors';
+import { Signature } from '@solana/keys';
 
 import {
     canceledSingleTransactionPlanResult,
@@ -10,6 +11,7 @@ import {
     parallelTransactionPlanResult,
     sequentialTransactionPlanResult,
     successfulSingleTransactionPlanResult,
+    successfulSingleTransactionPlanResultFromSignature,
 } from '../transaction-plan-result';
 import { createMessage, createTransaction } from './__setup__';
 
@@ -21,7 +23,7 @@ describe('successfulSingleTransactionPlanResult', () => {
         expect(result).toEqual({
             kind: 'single',
             message: messageA,
-            status: { context: {}, kind: 'successful', transaction: transactionA },
+            status: { context: {}, kind: 'successful', signature: 'A', transaction: transactionA },
         });
     });
     it('accepts an optional context object', () => {
@@ -32,7 +34,7 @@ describe('successfulSingleTransactionPlanResult', () => {
         expect(result).toEqual({
             kind: 'single',
             message: messageA,
-            status: { context, kind: 'successful', transaction: transactionA },
+            status: { context, kind: 'successful', signature: 'A', transaction: transactionA },
         });
     });
     it('freezes created SingleTransactionPlanResult objects', () => {
@@ -45,6 +47,42 @@ describe('successfulSingleTransactionPlanResult', () => {
         const messageA = createMessage('A');
         const transactionA = createTransaction('A');
         const result = successfulSingleTransactionPlanResult(messageA, transactionA);
+        expect(result.status).toBeFrozenObject();
+    });
+});
+
+describe('successfulSingleTransactionPlanResultFromSignature', () => {
+    it('creates SingleTransactionPlanResult objects with successful status', () => {
+        const messageA = createMessage('A');
+        const signature = 'A' as Signature;
+        const result = successfulSingleTransactionPlanResultFromSignature(messageA, signature);
+        expect(result).toEqual({
+            kind: 'single',
+            message: messageA,
+            status: { context: {}, kind: 'successful', signature: 'A' },
+        });
+    });
+    it('accepts an optional context object', () => {
+        const messageA = createMessage('A');
+        const signature = 'A' as Signature;
+        const context = { foo: 'bar' };
+        const result = successfulSingleTransactionPlanResultFromSignature(messageA, signature, context);
+        expect(result).toEqual({
+            kind: 'single',
+            message: messageA,
+            status: { context, kind: 'successful', signature: 'A' },
+        });
+    });
+    it('freezes created SingleTransactionPlanResult objects', () => {
+        const messageA = createMessage('A');
+        const signature = 'A' as Signature;
+        const result = successfulSingleTransactionPlanResultFromSignature(messageA, signature);
+        expect(result).toBeFrozenObject();
+    });
+    it('freezes the status object of created SingleTransactionPlanResult objects', () => {
+        const messageA = createMessage('A');
+        const signature = 'A' as Signature;
+        const result = successfulSingleTransactionPlanResultFromSignature(messageA, signature);
         expect(result.status).toBeFrozenObject();
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,7 +210,7 @@ importers:
     devDependencies:
       '@solana/eslint-config-solana':
         specifier: ^5.0.0
-        version: 5.0.0(05eb3607f3b2b74d94f3161ec535633f)
+        version: 5.0.0(a75c074b419cff6286bc2273f9285a13)
       '@solana/wallet-standard-features':
         specifier: ^1.3.0
         version: 1.3.0
@@ -573,6 +573,9 @@ importers:
       '@solana/instructions':
         specifier: workspace:*
         version: link:../instructions
+      '@solana/keys':
+        specifier: workspace:*
+        version: link:../keys
       '@solana/promises':
         specifier: workspace:*
         version: link:../promises
@@ -11300,16 +11303,16 @@ snapshots:
       typescript: 5.8.3
       typescript-eslint: 8.17.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
 
-  '@solana/eslint-config-solana@5.0.0(05eb3607f3b2b74d94f3161ec535633f)':
+  '@solana/eslint-config-solana@5.0.0(a75c074b419cff6286bc2273f9285a13)':
     dependencies:
       '@eslint/js': 9.38.0
       '@types/eslint__js': 8.42.3
       eslint: 9.38.0(jiti@1.21.7)
-      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.47.0(@typescript-eslint/parser@8.17.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(jest@30.0.0-alpha.6(@types/node@24.10.0)(ts-node@10.9.2(@swc/core@1.13.19(@swc/helpers@0.5.17))(@types/node@24.10.0)(typescript@5.8.3)))(typescript@5.8.3)
+      eslint-plugin-jest: 28.11.0(@typescript-eslint/eslint-plugin@8.47.0(@typescript-eslint/parser@8.47.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(jest@30.0.0-alpha.6(@types/node@24.10.0)(ts-node@10.9.2(@swc/core@1.13.19(@swc/helpers@0.5.17))(@types/node@24.10.0)(typescript@5.8.3)))(typescript@5.8.3)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.38.0(jiti@1.21.7))
       eslint-plugin-simple-import-sort: 12.1.1(eslint@9.38.0(jiti@1.21.7))
       eslint-plugin-sort-keys-fix: 1.1.2
-      eslint-plugin-typescript-sort-keys: 3.3.0(@typescript-eslint/parser@8.17.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
+      eslint-plugin-typescript-sort-keys: 3.3.0(@typescript-eslint/parser@8.47.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
       globals: 16.5.0
       jest: 30.0.0-alpha.6(@types/node@24.10.0)(ts-node@10.9.2(@swc/core@1.13.19(@swc/helpers@0.5.17))(@types/node@24.10.0)(typescript@5.8.3))
       typescript: 5.8.3
@@ -11653,24 +11656,6 @@ snapshots:
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
-
-  '@typescript-eslint/eslint-plugin@8.47.0(@typescript-eslint/parser@8.17.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)':
-    dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.17.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
-      '@typescript-eslint/scope-manager': 8.47.0
-      '@typescript-eslint/type-utils': 8.47.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.47.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
-      '@typescript-eslint/visitor-keys': 8.47.0
-      eslint: 9.38.0(jiti@1.21.7)
-      graphemer: 1.4.0
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@typescript-eslint/eslint-plugin@8.47.0(@typescript-eslint/parser@8.47.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)':
     dependencies:
@@ -12750,17 +12735,6 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.47.0(@typescript-eslint/parser@8.17.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(jest@30.0.0-alpha.6(@types/node@24.10.0)(ts-node@10.9.2(@swc/core@1.13.19(@swc/helpers@0.5.17))(@types/node@24.10.0)(typescript@5.8.3)))(typescript@5.8.3):
-    dependencies:
-      '@typescript-eslint/utils': 8.26.1(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
-      eslint: 9.38.0(jiti@1.21.7)
-    optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.47.0(@typescript-eslint/parser@8.17.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
-      jest: 30.0.0-alpha.6(@types/node@24.10.0)(ts-node@10.9.2(@swc/core@1.13.19(@swc/helpers@0.5.17))(@types/node@24.10.0)(typescript@5.8.3))
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   eslint-plugin-jest@28.11.0(@typescript-eslint/eslint-plugin@8.47.0(@typescript-eslint/parser@8.47.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(jest@30.0.0-alpha.6(@types/node@24.10.0)(ts-node@10.9.2(@swc/core@1.13.19(@swc/helpers@0.5.17))(@types/node@24.10.0)(typescript@5.8.3)))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/utils': 8.26.1(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
@@ -12790,17 +12764,6 @@ snapshots:
       esutils: 2.0.3
       natural-compare: 1.4.0
       requireindex: 1.2.0
-
-  eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.17.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3):
-    dependencies:
-      '@typescript-eslint/experimental-utils': 5.62.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.17.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3)
-      eslint: 9.38.0(jiti@1.21.7)
-      json-schema: 0.4.0
-      natural-compare-lite: 1.4.0
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
 
   eslint-plugin-typescript-sort-keys@3.3.0(@typescript-eslint/parser@8.47.0(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.38.0(jiti@1.21.7))(typescript@5.8.3):
     dependencies:


### PR DESCRIPTION
#### Problem

- The `transaction: Transaction` field being required means that you can't use for example a sending signer in a `TransactionExecutor`, as they only return a signature (mirroring wallet-standard sign+send)
- It is useful to have the signature of successful transactions in the `TransactionPlanResult`

#### Summary of Changes

This PR modifies the successful status to make `transaction` optional, and adds a new mandatory `Signature` field.

The function `successfulSingleTransactionPlanResult` now uses `getSignatureFromTransaction` to extract the signature from the transaction it receives, which it includes in the `SingleTransactionPlanResult`.

A new function `successfulSingleTransactionPlanResultFromSignature` can be used to create a successful `SingleTransactionPlanResult` with a signature but no transaction.