### PR TITLE
Add a function to summarize a `TransactionPlanResult`

### DIFF
--- a/.changeset/fast-apples-decide.md
+++ b/.changeset/fast-apples-decide.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Add a function to summarize a `TransactionPlanResult`


### PR DESCRIPTION
#### Problem

The `TransactionPlanResult` can be a bit unweildy, mostly because of its nesting.

A previous PR added a flatten function, this goes a step further by giving a top-level `successful` boolean, and grouping the flattened results into successful/failed/canceled transactions.

#### Summary of Changes

Adds a new function `summarizeTransactionPlanResult` + tests
