### PR TITLE
Configure dependabot to bump all `@solana-program` clients at once

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,6 @@ updates:
           - '@eslint/*'
           - '@typescript-eslint/*'
           - 'typescript'
+      solana-program-clients:
+        patterns:
+          - '@solana-program/*'


### PR DESCRIPTION
#### Problem

Takes many dependabot PRs to upgrade program clients to the latest versions.

#### Summary of Changes

Configure dependabot to bump them all at once when there are new versions available.
