### PR TITLE
moved uint8arrayequal fn to packages/codecs-core folder

### DIFF
--- a/packages/codecs-core/src/uint8-arrays-equal.ts
+++ b/packages/codecs-core/src/uint8-arrays-equal.ts
@@ -1,0 +1,44 @@
+import { ReadonlyUint8Array } from "./readonly-uint8array";
+
+/**
+ * Compares two Uint8Arrays for byte-by-byte equality.
+ *
+ * This utility function performs a length check followed by element-wise comparison
+ * to determine if two byte arrays contain identical values. It accepts both mutable
+ * `Uint8Array` and `ReadonlyUint8Array` instances, making it suitable for comparing
+ * cryptographic signatures, hashes, and other binary data regardless of mutability.
+ *
+ * The function uses a generic type parameter to ensure type consistency between both
+ * arguments, preventing accidental comparisons between mixed array types while still
+ * accepting both mutable and readonly variants.
+ *
+ * @template T - The type of the arrays being compared, constrained to `Uint8Array` or `ReadonlyUint8Array`
+ * @param arr1 - The first array to compare
+ * @param arr2 - The second array to compare
+ * @returns `true` if both arrays have the same length and contain identical byte values at each index, `false` otherwise
+ *
+ * @example
+ * ```ts
+ * const signature1 = new Uint8Array([1, 2, 3, 4]);
+ * const signature2 = new Uint8Array([1, 2, 3, 4]);
+ * const signature3 = new Uint8Array([1, 2, 3, 5]);
+ *
+ * uint8ArraysEqual(signature1, signature2); // true
+ * uint8ArraysEqual(signature1, signature3); // false
+ * ```
+ *
+ * @example
+ * ```ts
+ * const readonlyBytes: ReadonlyUint8Array = new Uint8Array([10, 20, 30]);
+ * const mutableBytes = new Uint8Array([10, 20, 30]);
+ *
+ * uint8ArraysEqual(readonlyBytes, readonlyBytes); // true - comparing readonly arrays
+ * uint8ArraysEqual(mutableBytes, mutableBytes); // true - comparing mutable arrays
+ * ```
+ */
+export function uint8ArraysEqual<T extends Uint8Array | ReadonlyUint8Array>(
+    arr1: T,
+    arr2: T,
+): boolean {
+    return arr1.length === arr2.length && arr1.every((value, index) => value === arr2[index]);
+}

--- a/packages/offchain-messages/src/signatures.ts
+++ b/packages/offchain-messages/src/signatures.ts
@@ -1,5 +1,5 @@
 import { Address, getAddressFromPublicKey, getPublicKeyFromAddress } from '@solana/addresses';
-import { ReadonlyUint8Array } from '@solana/codecs-core';
+import { ReadonlyUint8Array, uint8ArraysEqual } from '@solana/codecs-core';
 import {
     SOLANA_ERROR__OFFCHAIN_MESSAGE__ADDRESSES_CANNOT_SIGN_OFFCHAIN_MESSAGE,
     SOLANA_ERROR__OFFCHAIN_MESSAGE__SIGNATURE_VERIFICATION_FAILURE,
@@ -263,8 +263,4 @@ export async function verifyOffchainMessageEnvelope(offchainMessageEnvelope: Off
     if (errorContext) {
         throw new SolanaError(SOLANA_ERROR__OFFCHAIN_MESSAGE__SIGNATURE_VERIFICATION_FAILURE, errorContext);
     }
-}
-
-function uint8ArraysEqual(arr1: ReadonlyUint8Array, arr2: ReadonlyUint8Array) {
-    return arr1.length === arr2.length && arr1.every((value, index) => value === arr2[index]);
 }

--- a/packages/react/src/useWalletAccountTransactionSigner.ts
+++ b/packages/react/src/useWalletAccountTransactionSigner.ts
@@ -1,5 +1,5 @@
 import { address } from '@solana/addresses';
-import { ReadonlyUint8Array } from '@solana/codecs-core';
+import { ReadonlyUint8Array, uint8ArraysEqual } from '@solana/codecs-core';
 import { SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED, SolanaError } from '@solana/errors';
 import { getAbortablePromise } from '@solana/promises';
 import { TransactionModifyingSigner } from '@solana/signers';
@@ -143,8 +143,4 @@ export function useWalletAccountTransactionSigner<TWalletAccount extends UiWalle
         }),
         [uiWalletAccount.address, signTransaction],
     );
-}
-
-function uint8ArraysEqual(arr1: ReadonlyUint8Array, arr2: ReadonlyUint8Array) {
-    return arr1.length === arr2.length && arr1.every((value, index) => value === arr2[index]);
 }

--- a/packages/transactions/src/signatures.ts
+++ b/packages/transactions/src/signatures.ts
@@ -1,5 +1,5 @@
 import { Address, getAddressFromPublicKey } from '@solana/addresses';
-import { Decoder } from '@solana/codecs-core';
+import { Decoder, uint8ArraysEqual } from '@solana/codecs-core';
 import { getBase58Decoder } from '@solana/codecs-strings';
 import {
     SOLANA_ERROR__TRANSACTION__ADDRESSES_CANNOT_SIGN_TRANSACTION,
@@ -45,10 +45,6 @@ export function getSignatureFromTransaction(transaction: Transaction): Signature
     }
     const transactionSignature = base58Decoder.decode(signatureBytes);
     return transactionSignature as Signature;
-}
-
-function uint8ArraysEqual(arr1: Uint8Array, arr2: Uint8Array) {
-    return arr1.length === arr2.length && arr1.every((value, index) => value === arr2[index]);
 }
 
 /**


### PR DESCRIPTION
Removed all copies of the `uint8ArraysEqual` function scattered around the codebase and moved them to `@solana/codecs-core`. The function was previously duplicated in [packages/transactions/src/signatures.ts](https://github.com/anza-xyz/kit/blob/ba4e3be066ae9d88c22a0ab3c1972b74fd830843/packages/transactions/src/signatures.ts#L50), [packages/react/src/useWalletAccountTransactionSigner.ts](https://github.com/anza-xyz/kit/blob/ba4e3be066ae9d88c22a0ab3c1972b74fd830843/packages/react/src/useWalletAccountTransactionSigner.ts#L147), and [packages/offchain-messages/src/signatures.ts](https://github.com/anza-xyz/kit/blob/ba4e3be066ae9d88c22a0ab3c1972b74fd830843/packages/offchain-messages/src/signatures.ts#L267), and has been consolidated into `uint8-arrays-equal.ts` in the `packages/codecs-core` folder.