### PR TITLE
Accept any `Error` object in failed `SingleTransactionPlanResult`

### DIFF
--- a/.changeset/loud-teams-obey.md
+++ b/.changeset/loud-teams-obey.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Accept any `Error` object in failed `SingleTransactionPlanResult`

--- a/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
@@ -102,12 +102,29 @@ describe('createTransactionPlanExecutor', () => {
             );
         });
 
+        it('can use any error object as a failure cause', async () => {
+            expect.assertions(2);
+            const messageA = createMessage('A');
+            const cause = new Error('Custom error message');
+            const executeTransactionMessage = jest.fn().mockRejectedValue(cause);
+            const executor = createTransactionPlanExecutor({ executeTransactionMessage });
+
+            const promise = executor(singleTransactionPlan(messageA));
+            await expectFailedToExecute(
+                promise,
+                new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
+                    cause,
+                    transactionPlanResult: failedSingleTransactionPlanResult(messageA, cause),
+                }),
+            );
+        });
+
         it('can abort single transaction plans', async () => {
             expect.assertions(2);
             const messageA = createMessage('A');
             const abortController = new AbortController();
             const abortSignal = abortController.signal;
-            const cause = new Error('Aborted during execution') as SolanaError;
+            const cause = new Error('Aborted during execution');
             const executeTransactionMessage = jest.fn().mockReturnValueOnce(FOREVER_PROMISE);
             const executor = createTransactionPlanExecutor({ executeTransactionMessage });
 
@@ -129,7 +146,7 @@ describe('createTransactionPlanExecutor', () => {
             const messageA = createMessage('A');
             const abortController = new AbortController();
             const abortSignal = abortController.signal;
-            const cause = new Error('Aborted before execution') as SolanaError;
+            const cause = new Error('Aborted before execution');
             const executeTransactionMessage = jest.fn().mockReturnValueOnce(FOREVER_PROMISE);
             const executor = createTransactionPlanExecutor({ executeTransactionMessage });
 
@@ -291,7 +308,7 @@ describe('createTransactionPlanExecutor', () => {
             const messageC = createMessage('C');
             const abortController = new AbortController();
             const abortSignal = abortController.signal;
-            const cause = new Error('Aborted during execution') as SolanaError;
+            const cause = new Error('Aborted during execution');
             const executeTransactionMessage = jest
                 .fn()
                 .mockImplementationOnce(forwardId)
@@ -327,7 +344,7 @@ describe('createTransactionPlanExecutor', () => {
             const messageB = createMessage('B');
             const abortController = new AbortController();
             const abortSignal = abortController.signal;
-            const cause = new Error('Aborted before execution') as SolanaError;
+            const cause = new Error('Aborted before execution');
             const executeTransactionMessage = jest.fn();
             const executor = createTransactionPlanExecutor({ executeTransactionMessage });
 
@@ -449,7 +466,7 @@ describe('createTransactionPlanExecutor', () => {
             const messageC = createMessage('C');
             const abortController = new AbortController();
             const abortSignal = abortController.signal;
-            const cause = new Error('Aborted during execution') as SolanaError;
+            const cause = new Error('Aborted during execution');
             const executeTransactionMessage = jest.fn().mockImplementation((message: { id: string }) => {
                 // eslint-disable-next-line jest/no-conditional-in-test
                 return message.id === 'B' ? FOREVER_PROMISE : forwardId(message);
@@ -480,7 +497,7 @@ describe('createTransactionPlanExecutor', () => {
             const messageC = createMessage('C');
             const abortController = new AbortController();
             const abortSignal = abortController.signal;
-            const cause = new Error('Aborted before execution') as SolanaError;
+            const cause = new Error('Aborted before execution');
             const executeTransactionMessage = jest.fn().mockImplementation(forwardId);
             const executor = createTransactionPlanExecutor({ executeTransactionMessage });
 
@@ -612,7 +629,7 @@ describe('createTransactionPlanExecutor', () => {
             const messageG = createMessage('G');
             const abortController = new AbortController();
             const abortSignal = abortController.signal;
-            const cause = new Error('Aborted during execution') as SolanaError;
+            const cause = new Error('Aborted during execution');
             const executeTransactionMessage = jest.fn().mockImplementation((message: { id: string }) => {
                 // eslint-disable-next-line jest/no-conditional-in-test
                 return message.id === 'C' ? FOREVER_PROMISE : forwardId(message);
@@ -665,7 +682,7 @@ describe('createTransactionPlanExecutor', () => {
             const messageG = createMessage('G');
             const abortController = new AbortController();
             const abortSignal = abortController.signal;
-            const cause = new Error('Aborted during execution') as SolanaError;
+            const cause = new Error('Aborted during execution');
             const executeTransactionMessage = jest.fn().mockImplementation(forwardId);
             const executor = createTransactionPlanExecutor({ executeTransactionMessage });
 

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
@@ -1,4 +1,3 @@
-import type { SolanaError } from '@solana/errors';
 import type { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 import type { Transaction } from '@solana/transactions';
 
@@ -21,7 +20,7 @@ const messageB = null as unknown as BaseTransactionMessage & TransactionMessageW
 const messageC = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer & { id: 'C' };
 const transactionA = null as unknown as Transaction;
 const transactionB = null as unknown as Transaction;
-const error = null as unknown as SolanaError;
+const error = null as unknown as Error;
 
 type CustomContext = { customData: string };
 

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -180,11 +180,11 @@ async function traverseSingle(
         }
     } catch (error) {
         context.canceled = true;
-        return failedSingleTransactionPlanResult(transactionPlan.message, error as SolanaError);
+        return failedSingleTransactionPlanResult(transactionPlan.message, error as Error);
     }
 }
 
-function findErrorFromTransactionPlanResult(result: TransactionPlanResult): SolanaError | undefined {
+function findErrorFromTransactionPlanResult(result: TransactionPlanResult): Error | undefined {
     if (result.kind === 'single') {
         return result.status.kind === 'failed' ? result.status.error : undefined;
     }

--- a/packages/instruction-plans/src/transaction-plan-result.ts
+++ b/packages/instruction-plans/src/transaction-plan-result.ts
@@ -1,4 +1,3 @@
-import { SolanaError } from '@solana/errors';
 import { Signature } from '@solana/keys';
 import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 import { getSignatureFromTransaction, Transaction } from '@solana/transactions';
@@ -170,7 +169,7 @@ export type SingleTransactionPlanResult<
  */
 export type TransactionPlanResultStatus<TContext extends TransactionPlanResultContext = TransactionPlanResultContext> =
     | Readonly<{ context: TContext; kind: 'successful'; signature: Signature; transaction?: Transaction }>
-    | Readonly<{ error: SolanaError; kind: 'failed' }>
+    | Readonly<{ error: Error; kind: 'failed' }>
     | Readonly<{ kind: 'canceled' }>;
 
 /**
@@ -368,10 +367,7 @@ export function failedSingleTransactionPlanResult<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
     TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
         TransactionMessageWithFeePayer,
->(
-    transactionMessage: TTransactionMessage,
-    error: SolanaError,
-): SingleTransactionPlanResult<TContext, TTransactionMessage> {
+>(transactionMessage: TTransactionMessage, error: Error): SingleTransactionPlanResult<TContext, TTransactionMessage> {
     return Object.freeze({
         kind: 'single',
         message: transactionMessage,


### PR DESCRIPTION
#### Problem

Currently, the failed status of `SinglePlanTransactionResults` accepts a `SolanaError` to capture the cause of the transaction failure.

Whilst internally to Kit we may have the ability to ensure `SolanaErrors` are thrown, this may not be the case for our consumers which have the implement the function that execute transactions and, therefore, find the "closest" `SolanaError` that matches their use-case.

#### Summary of Changes

This PR fixes this by loosening the error type we store in failed `SinglePlanTransactionResults` from `SolanaError` to any `Error` object.

This means we can continue to use the `isSolanaError(error, code)` helper to cherry-pick the use-cases we want to gracefully handle.
