### PR TITLE
Allow signing a transaction that does not have TransactionWithLifetime

### DIFF
--- a/.changeset/proud-terms-heal.md
+++ b/.changeset/proud-terms-heal.md
@@ -1,0 +1,5 @@
+---
+'@solana/transactions': patch
+---
+
+Remove `TransactionWithLifetime` from required input type for `signTransaction` and `partiallySignTransaction`

--- a/packages/transactions/src/__typetests__/signatures-typetest.ts
+++ b/packages/transactions/src/__typetests__/signatures-typetest.ts
@@ -8,7 +8,6 @@ import {
     isFullySignedTransaction,
     partiallySignTransaction,
     signTransaction,
-    TransactionWithLifetime,
 } from '..';
 import { Transaction } from '../transaction';
 
@@ -20,13 +19,13 @@ import { Transaction } from '../transaction';
 
 // partiallySignTransaction
 {
-    const transaction = null as unknown as Transaction & TransactionWithLifetime & { some: 1 };
+    const transaction = null as unknown as Transaction & { some: 1 };
     partiallySignTransaction([], transaction) satisfies Promise<Transaction & { some: 1 }>;
 }
 
 // signTransaction
 {
-    const transaction = null as unknown as Transaction & TransactionWithLifetime & { some: 1 };
+    const transaction = null as unknown as Transaction & { some: 1 };
     signTransaction([], transaction) satisfies Promise<FullySignedTransaction & Transaction & { some: 1 }>;
 }
 

--- a/packages/transactions/src/signatures.ts
+++ b/packages/transactions/src/signatures.ts
@@ -10,7 +10,6 @@ import {
 import { Signature, SignatureBytes, signBytes } from '@solana/keys';
 import { NominalType } from '@solana/nominal-types';
 
-import { TransactionWithLifetime } from './lifetime';
 import { Transaction } from './transaction';
 
 /**
@@ -71,7 +70,7 @@ function uint8ArraysEqual(arr1: Uint8Array, arr2: Uint8Array) {
  * @see {@link signTransaction} if you want to assert that the transaction has all of its required
  * signatures after signing.
  */
-export async function partiallySignTransaction<TTransaction extends Transaction & TransactionWithLifetime>(
+export async function partiallySignTransaction<TTransaction extends Transaction>(
     keyPairs: CryptoKeyPair[],
     transaction: TTransaction,
 ): Promise<TTransaction> {
@@ -147,7 +146,7 @@ export async function partiallySignTransaction<TTransaction extends Transaction 
  * @see {@link partiallySignTransaction} if you want to sign the transaction without asserting that
  * the resulting transaction is fully signed.
  */
-export async function signTransaction<TTransaction extends Transaction & TransactionWithLifetime>(
+export async function signTransaction<TTransaction extends Transaction>(
     keyPairs: CryptoKeyPair[],
     transaction: TTransaction,
 ): Promise<FullySignedTransaction & TTransaction> {


### PR DESCRIPTION
#### Problem

I think we went a bit far here. It's important that `signTransaction` and `partiallySignTransaction` return the same `TTransaction extends Transaction` that is passed to them, so that they eg. preserve the lifetime. But I think it is ok to sign a `Transaction` that does not have a lifetime field attached to it. One place this is useful is a server that receives serialized transactions to sign, it should be able to sign the result of `transactionDecoder.decode(transactionBytes)` without concerning itself with that transaction's lifetime.

#### Summary of Changes

Remove `TransactionWithLifetime` from the required input type of `signTransaction` and `partiallySignTransaction`.