### PR TITLE
Try one more Turbo passthrough to get the publish working

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -76,6 +76,8 @@
                 "GH_TOKEN",
                 "GITHUB_OUTPUT",
                 "GITHUB_TOKEN",
+                "NODE_AUTH_TOKEN",
+                "NPM_CONFIG_USERCONFIG",
                 "PUBLISH_TAG"
             ]
         },


### PR DESCRIPTION
#### Summary of Changes

On the basis of having found this in the CI logs:

```
 Run find packages/* -maxdepth 0 -type d -print0 | \
  find packages/* -maxdepth 0 -type d -print0 | \
    xargs -t0 -n 1 -I {} \
      sh -c 'cd {} && pnpm pkg delete devDependencies'
  pnpm changeset version --snapshot canary
  pnpm turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-1}
  shell: /usr/bin/bash -e {0}
  env:
    DO_NOT_TRACK: 1
    TURBO_REMOTE_CACHE_SIGNATURE_KEY: ***
    TURBO_TOKEN: ***
    TURBO_TEAM: anza-tech
    PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
    NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
    NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
    GH_TOKEN: ***
    GITHUB_TOKEN: ***
    PUBLISH_TAG: canary
```

I'm adding those NPM things to passthrough to see if that makes the publish scripts work.
