### PR TITLE
Rename `test:live-with-test-validator:setup` to `test:setup` and remove `test:live-with-test-validator` task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@ Kit is developed in public and we encourage and appreciate contributions.
 ## Getting Started
 
 1. Install dependencies: `pnpm install`
-2. The first time you build Kit, you will need to install the Agave test validator, which is used for some tests. `pnpm test:live-with-test-validator:setup`
+2. The first time you build Kit, you will need to install the Agave test validator, which is used for some tests. `pnpm test:setup`
 3. Start a test validator before running tests. `./scripts/start-shared-test-validator.sh`
 4. Build + test all packages: `pnpm build`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,7 +11,7 @@ pnpm install
 Most examples use a local test Solana validator. Install one by running the following command in the root of this monorepo.
 
 ```shell
-pnpm test:live-with-test-validator:setup
+pnpm test:setup
 ```
 
 ## Run an example

--- a/examples/deserialize-transaction/src/example.ts
+++ b/examples/deserialize-transaction/src/example.ts
@@ -3,7 +3,7 @@
  * Deserialize and inspect a transaction with @solana/kit
  *
  * Before running any of the examples in this monorepo, make sure to set up a test validator by
- * running `pnpm test:live-with-test-validator:setup` in the root directory.
+ * running `pnpm test:setup` in the root directory.
  *
  * To run this example, execute `pnpm start` in this directory.
  */

--- a/examples/rpc-transport-throttled/src/example.ts
+++ b/examples/rpc-transport-throttled/src/example.ts
@@ -3,7 +3,7 @@
  * Create a custom RPC transport that will only send a certain number of requests per second.
  *
  * Before running any of the examples in this monorepo, make sure to set up a test validator by
- * running `pnpm test:live-with-test-validator:setup` in the root directory.
+ * running `pnpm test:setup` in the root directory.
  *
  * To run this example, execute `pnpm start` in this directory.
  */

--- a/examples/signers/src/example.ts
+++ b/examples/signers/src/example.ts
@@ -3,7 +3,7 @@
  * Create and use signers with @solana/kit.
  *
  * Before running any of the examples in this monorepo, make sure to set up a test validator by
- * running `pnpm test:live-with-test-validator:setup` in the root directory.
+ * running `pnpm test:setup` in the root directory.
  *
  * To run this example, execute `pnpm start` in this directory.
  */

--- a/examples/token-airdrop/src/example.ts
+++ b/examples/token-airdrop/src/example.ts
@@ -3,7 +3,7 @@
  * Create a new token mint and airdrop it to 100 recipients.
  *
  * Before running any of the examples in this monorepo, make sure to set up a test validator by
- * running `pnpm test:live-with-test-validator:setup` in the root directory.
+ * running `pnpm test:setup` in the root directory.
  *
  * To run this example, execute `pnpm start` in this directory.
  */

--- a/examples/transfer-lamports/src/example.ts
+++ b/examples/transfer-lamports/src/example.ts
@@ -3,7 +3,7 @@
  * Transfer Lamports from one account to another with @solana/kit.
  *
  * Before running any of the examples in this monorepo, make sure to set up a test validator by
- * running `pnpm test:live-with-test-validator:setup` in the root directory.
+ * running `pnpm test:setup` in the root directory.
  *
  * To run this example, execute `pnpm start` in this directory.
  */

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
         "lint": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:lint",
         "style:fix": "turbo  run --concurrency=${TURBO_CONCURRENCY:-95.84%} style:fix && pnpm prettier --log-level warn --ignore-unknown --write '{.,!packages}/*'",
         "test": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:unit:browser test:unit:node",
-        "test:live-with-test-validator": "turbo run --concurrency=${TURBO_CONCURRENCY:-95.84%} test:live-with-test-validator",
-        "test:live-with-test-validator:setup": "./scripts/setup-test-validator.sh"
+        "test:setup": "./scripts/setup-test-validator.sh"
     },
     "devDependencies": {
         "@changesets/changelog-github": "^0.5.1",

--- a/scripts/start-shared-test-validator.sh
+++ b/scripts/start-shared-test-validator.sh
@@ -12,7 +12,7 @@ TEST_VALIDATOR_LEDGER="$( cd "$(dirname "${BASH_SOURCE[0]}")/.." ; pwd -P )/test
 FIXTURE_ACCOUNTS_DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")/fixtures" ; pwd -P)"
 
 if [ ! -x "$TEST_VALIDATOR" ]; then
-    echo "ERROR: No test validator is installed. Install one using the following command: pnpm test:live-with-test-validator:setup" >&2
+    echo "ERROR: No test validator is installed. Install one using the following command: pnpm test:setup" >&2
     exit 1
 fi
 

--- a/turbo.json
+++ b/turbo.json
@@ -101,16 +101,6 @@
             ],
             "outputs": []
         },
-        "test:live-with-test-validator": {
-            "dependsOn": [
-                "^compile:js"
-            ],
-            "inputs": [
-                "$TURBO_DEFAULT$",
-                "src/**"
-            ],
-            "outputs": []
-        },
         "test:prettier": {
             "inputs": [
                 "$TURBO_DEFAULT$",


### PR DESCRIPTION
#### Problem

`test:live-with-test-validator` is a holdover from web3.js. All of our tests (may) hit the test validator.

#### Summary of Changes

- Eliminated the `test:live-with-test-validator` task
- Renamed `test:live-with-test-validator:setup` to `test:setup`
