### PR TITLE
make ReadonlyUint8Array fully immutable

### DIFF
--- a/packages/codecs-core/src/readonly-uint8array.ts
+++ b/packages/codecs-core/src/readonly-uint8array.ts
@@ -4,6 +4,10 @@
  * This type prevents modifications to the array by omitting mutable methods such as `copyWithin`,
  * `fill`, `reverse`, `set`, and `sort`, while still allowing indexed access to elements.
  *
+ * It also overrides the `subarray` method to return a `ReadonlyUint8Array` instead of a
+ * `Uint8Array`, prevents modification from functions taking a callback, and removes the
+ * `setFrom<Format>` methods that were recently added to `Uint8Array`.
+ *
  * @example
  * ```ts
  * const bytes: ReadonlyUint8Array = new Uint8Array([1, 2, 3]);
@@ -11,8 +15,36 @@
  * bytes[0] = 42; // Type error: Cannot assign to '0' because it is a read-only property.
  * ```
  */
-export interface ReadonlyUint8Array extends Omit<Uint8Array, TypedArrayMutableProperties> {
-    readonly [n: number]: number;
+//  eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface ReadonlyUint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike>
+  extends ReadonlyUint8ArrayBase<ReadonlyUint8Array<TArrayBuffer>, TArrayBuffer> {}
+
+declare const roBrand: unique symbol;
+interface Marker<TArrayBuffer extends ArrayBufferLike>
+    extends Uint8Array<TArrayBuffer> {
+  [roBrand]: true;
 }
 
-type TypedArrayMutableProperties = 'copyWithin' | 'fill' | 'reverse' | 'set' | 'sort';
+type ReplaceMarker<T, Self, TArrayBuffer extends ArrayBufferLike> =
+  T extends Marker<TArrayBuffer>
+  ? Self
+  : T extends ArrayBuffer | IteratorObject<unknown> | Uint8Array
+  ? T
+  : T extends (...args: infer A) => infer R
+  ? (...args: ReplaceMarker<A, Self, TArrayBuffer>) => ReplaceMarker<R, Self, TArrayBuffer>
+  : T extends readonly unknown[]
+  ? { readonly [K in keyof T]: ReplaceMarker<T[K], Self, TArrayBuffer> }
+  : T extends object
+  ? { [K in keyof T]: ReplaceMarker<T[K], Self, TArrayBuffer> }
+  : T;
+
+type TypedArrayMutableProperties = "copyWithin" | "fill" | "reverse" | "set" | "sort";
+type Uint8ArrayMutableProperties = "setFromBase64" | "setFromHex";
+type Uint8ArrayOmittedProperties =
+  TypedArrayMutableProperties | Uint8ArrayMutableProperties | typeof roBrand | "subarray";
+
+type ReadonlyUint8ArrayBase<Self, TArrayBuffer extends ArrayBufferLike> =
+  ReplaceMarker<Omit<Marker<TArrayBuffer>, Uint8ArrayOmittedProperties>, Self, TArrayBuffer> & {
+    readonly [n: number]: number;
+    subarray(...params: Parameters<Uint8Array["subarray"]>): Self;
+  };

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -196,10 +196,39 @@ type ReadonlyContextValue<T> = {
     [P in keyof T]: Readonly<T[P]>;
 };
 
-type TypedArrayMutableProperties = 'copyWithin' | 'fill' | 'reverse' | 'set' | 'sort';
-interface ReadonlyUint8Array extends Omit<Uint8Array, TypedArrayMutableProperties> {
-    readonly [n: number]: number;
+//  eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface ReadonlyUint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike>
+  extends ReadonlyUint8ArrayBase<ReadonlyUint8Array<TArrayBuffer>, TArrayBuffer> {}
+
+declare const roBrand: unique symbol;
+interface Marker<TArrayBuffer extends ArrayBufferLike>
+    extends Uint8Array<TArrayBuffer> {
+  [roBrand]: true;
 }
+
+type ReplaceMarker<T, Self, TArrayBuffer extends ArrayBufferLike> =
+  T extends Marker<TArrayBuffer>
+  ? Self
+  : T extends ArrayBuffer | IteratorObject<unknown> | Uint8Array
+  ? T
+  : T extends (...args: infer A) => infer R
+  ? (...args: ReplaceMarker<A, Self, TArrayBuffer>) => ReplaceMarker<R, Self, TArrayBuffer>
+  : T extends readonly unknown[]
+  ? { readonly [K in keyof T]: ReplaceMarker<T[K], Self, TArrayBuffer> }
+  : T extends object
+  ? { [K in keyof T]: ReplaceMarker<T[K], Self, TArrayBuffer> }
+  : T;
+
+type TypedArrayMutableProperties = "copyWithin" | "fill" | "reverse" | "set" | "sort";
+type Uint8ArrayMutableProperties = "setFromBase64" | "setFromHex";
+type Uint8ArrayOmittedProperties =
+  TypedArrayMutableProperties | Uint8ArrayMutableProperties | typeof roBrand | "subarray";
+
+type ReadonlyUint8ArrayBase<Self, TArrayBuffer extends ArrayBufferLike> =
+  ReplaceMarker<Omit<Marker<TArrayBuffer>, Uint8ArrayOmittedProperties>, Self, TArrayBuffer> & {
+    readonly [n: number]: number;
+    subarray(...params: Parameters<Uint8Array["subarray"]>): Self;
+  };
 
 /** A amount of bytes. */
 type Bytes = number;


### PR DESCRIPTION
The current version of ReadonlyUint8Array is incomplete because `.subarray` returns a normal `Uint8Array` and likewise the various methods that take a callback provide the array itself as a `Uint8Array` as a third parameter.

Additionally, new mutable methods were recently added that are not omitted by the current definiton.

I pioneered this implementation in my own SDK which also gives an explanation of wtf I am doing [here](https://github.com/XLabs/ts-sdk/blob/main/packages/const-utils/RoUint8Array.md).

And while I have your attention, you may be interested in my [fork-svm package](https://github.com/XLabs/ts-sdk/tree/main/packages/fork-svm) which is built on top of kit as a proper way to test Solana programs.