### PR TITLE
A shared method for converting `Uint8Arrays` to `ArrayBuffers`

### DIFF
--- a/.changeset/spicy-teeth-roll.md
+++ b/.changeset/spicy-teeth-roll.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-core': patch
+---
+
+Created a function that gives you a non-shared `ArrayBuffer` given any kind of `Uint8Array`

--- a/packages/codecs-core/src/__tests__/array-buffers-test.ts
+++ b/packages/codecs-core/src/__tests__/array-buffers-test.ts
@@ -1,0 +1,47 @@
+import { toArrayBuffer } from '../array-buffers';
+
+describe('toArrayBuffer', () => {
+    it('converts shared array buffers to non-shared copies', () => {
+        const sharedArrayBuffer = new SharedArrayBuffer(1024);
+        const byteArray = new Uint8Array(sharedArrayBuffer);
+        const arrayBuffer = toArrayBuffer(byteArray);
+        expect(arrayBuffer).not.toBeInstanceOf(SharedArrayBuffer);
+    });
+    it('returns the buffer without modification when no slice is specified', () => {
+        const byteArray = new Uint8Array([1, 2, 3]);
+        expect(toArrayBuffer(byteArray)).toBe(byteArray.buffer);
+    });
+    it.each([
+        [0, 3],
+        [-3, 3],
+    ])(
+        'returns the buffer without modification when the specified slice encompasses the entire data (offset: %d, length: %d)',
+        (offset, length) => {
+            const byteArray = new Uint8Array([1, 2, 3]);
+            expect(toArrayBuffer(byteArray, offset, length)).toBe(byteArray.buffer);
+        },
+    );
+    it.each([
+        [-3, 0],
+        [-3, 1],
+        [-3, 2],
+        [-3, 2],
+        [-1, 0],
+        [-1, 1],
+        [-1, 2],
+        [-2, 0],
+        [-2, 1],
+        [0, 0],
+        [0, 1],
+        [0, 2],
+        [1, 0],
+        [1, 1],
+        [1, 2],
+        [2, 0],
+        [2, 1],
+        [2, 2],
+    ])('returns a new buffer when the slice reduces the data set (offset: %d, length: %d)', (offset, length) => {
+        const byteArray = new Uint8Array([1, 2, 3]);
+        expect(toArrayBuffer(byteArray, offset, length)).not.toBe(byteArray.buffer);
+    });
+});

--- a/packages/codecs-core/src/__typetests__/array-buffers-typetest.ts
+++ b/packages/codecs-core/src/__typetests__/array-buffers-typetest.ts
@@ -1,0 +1,10 @@
+import { toArrayBuffer } from '../array-buffers';
+
+// [DESCRIBE] toArrayBuffer.
+{
+    // It returns `ArrayBuffer` given a view with an underlying shared array buffer
+    {
+        const bytesWithSharedBuffer = null as unknown as Uint8Array<SharedArrayBuffer>;
+        toArrayBuffer(bytesWithSharedBuffer) satisfies ArrayBuffer;
+    }
+}

--- a/packages/codecs-core/src/array-buffers.ts
+++ b/packages/codecs-core/src/array-buffers.ts
@@ -1,0 +1,25 @@
+import { ReadonlyUint8Array } from './readonly-uint8array';
+
+/**
+ * Converts a `Uint8Array` to an `ArrayBuffer`. If the underlying buffer is a `SharedArrayBuffer`,
+ * it will be copied to a non-shared buffer, for safety.
+ *
+ * @remarks
+ * Source: https://stackoverflow.com/questions/37228285/uint8array-to-arraybuffer
+ */
+export function toArrayBuffer(bytes: ReadonlyUint8Array | Uint8Array, offset?: number, length?: number): ArrayBuffer {
+    const bytesOffset = bytes.byteOffset + (offset ?? 0);
+    const bytesLength = length ?? bytes.byteLength;
+    let buffer: ArrayBuffer;
+    if (typeof SharedArrayBuffer === 'undefined') {
+        buffer = bytes.buffer as ArrayBuffer;
+    } else if (bytes.buffer instanceof SharedArrayBuffer) {
+        buffer = new ArrayBuffer(bytes.length);
+        new Uint8Array(buffer).set(new Uint8Array(bytes));
+    } else {
+        buffer = bytes.buffer;
+    }
+    return (bytesOffset === 0 || bytesOffset === -bytes.byteLength) && bytesLength === bytes.byteLength
+        ? buffer
+        : buffer.slice(bytesOffset, bytesOffset + bytesLength);
+}

--- a/packages/codecs-core/src/index.ts
+++ b/packages/codecs-core/src/index.ts
@@ -653,6 +653,7 @@
  */
 export * from './add-codec-sentinel';
 export * from './add-codec-size-prefix';
+export * from './array-buffers';
 export * from './assertions';
 export * from './bytes';
 export * from './codec';

--- a/packages/codecs-numbers/src/utils.ts
+++ b/packages/codecs-numbers/src/utils.ts
@@ -6,7 +6,7 @@ import {
     FixedSizeDecoder,
     FixedSizeEncoder,
     Offset,
-    ReadonlyUint8Array,
+    toArrayBuffer,
 } from '@solana/codecs-core';
 
 import { assertNumberIsBetweenForCodec } from './assertions';
@@ -60,14 +60,4 @@ export function numberDecoderFactory<TTo extends bigint | number, TSize extends 
             return [input.get(view, isLittleEndian(input.config)), offset + input.size];
         },
     });
-}
-
-/**
- * Helper function to ensure that the ArrayBuffer is converted properly from a Uint8Array
- * Source: https://stackoverflow.com/questions/37228285/uint8array-to-arraybuffer
- */
-function toArrayBuffer(bytes: ReadonlyUint8Array | Uint8Array, offset?: number, length?: number): ArrayBuffer {
-    const bytesOffset = bytes.byteOffset + (offset ?? 0);
-    const bytesLength = length ?? bytes.byteLength;
-    return bytes.buffer.slice(bytesOffset, bytesOffset + bytesLength);
 }


### PR DESCRIPTION
#### Problem

This is going to be needed in multiple places, because there are points throughout the code (ie. where `SubtleCrypto` operations appear) where we will want to cast possible `SharedArrayBuffers` to `ArrayBuffers` by cloning them as non-shared.
