### PR TITLE
Enforce that any `SharedArrayBuffers` that get passed to crypto operations get cloned as non-shared

### DIFF
--- a/.changeset/tall-bobcats-marry.md
+++ b/.changeset/tall-bobcats-marry.md
@@ -1,0 +1,9 @@
+---
+'@solana/codecs-numbers': patch
+'@solana/codecs-strings': patch
+'@solana/codecs-core': patch
+'@solana/compat': patch
+'@solana/keys': patch
+---
+
+Any `SharedArrayBuffer` that gets passed to a crypto operation like `signBytes` or `verifySignature` will now be copied as non-shared. Crypto operations like `sign` and `verify` reject `SharedArrayBuffers` otherwise

--- a/packages/codecs-core/src/codec.ts
+++ b/packages/codecs-core/src/codec.ts
@@ -24,7 +24,7 @@ export type Offset = number;
  */
 type BaseEncoder<TFrom> = {
     /** Encode the provided value and return the encoded bytes directly. */
-    readonly encode: (value: TFrom) => ReadonlyUint8Array;
+    readonly encode: (value: TFrom) => ReadonlyUint8Array<ArrayBuffer>;
     /**
      * Writes the encoded value into the provided byte array at the given offset.
      * Returns the offset of the next byte after the encoded value.

--- a/packages/codecs-core/src/readonly-uint8array.ts
+++ b/packages/codecs-core/src/readonly-uint8array.ts
@@ -11,7 +11,8 @@
  * bytes[0] = 42; // Type error: Cannot assign to '0' because it is a read-only property.
  * ```
  */
-export interface ReadonlyUint8Array extends Omit<Uint8Array, TypedArrayMutableProperties> {
+export interface ReadonlyUint8Array<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike>
+    extends Omit<Uint8Array<TArrayBuffer>, TypedArrayMutableProperties> {
     readonly [n: number]: number;
 }
 

--- a/packages/codecs-strings/src/base64.ts
+++ b/packages/codecs-strings/src/base64.ts
@@ -2,6 +2,7 @@ import {
     combineCodec,
     createDecoder,
     createEncoder,
+    toArrayBuffer,
     transformDecoder,
     transformEncoder,
     VariableSizeCodec,
@@ -112,7 +113,7 @@ export const getBase64Decoder = (): VariableSizeDecoder<string> => {
 
     if (__NODEJS__) {
         return createDecoder({
-            read: (bytes, offset = 0) => [Buffer.from(bytes, offset).toString('base64'), bytes.length],
+            read: (bytes, offset = 0) => [Buffer.from(toArrayBuffer(bytes), offset).toString('base64'), bytes.length],
         });
     }
 

--- a/packages/compat/src/__tests__/instruction-test.ts
+++ b/packages/compat/src/__tests__/instruction-test.ts
@@ -1,7 +1,5 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
-import { ImplicitArrayBuffer } from 'node:buffer';
-
 import { address } from '@solana/addresses';
 import { AccountRole, Instruction } from '@solana/instructions';
 import { PublicKey, TransactionInstruction } from '@solana/web3.js';
@@ -9,13 +7,11 @@ import { PublicKey, TransactionInstruction } from '@solana/web3.js';
 import { fromLegacyPublicKey } from '../address';
 import { fromLegacyTransactionInstruction } from '../instruction';
 
-function toLegacyByteArrayAppropriateForPlatform<TArrayBuffer extends ArrayBufferLike>(
-    data: ImplicitArrayBuffer<TArrayBuffer>,
-) {
+function toLegacyByteArrayAppropriateForPlatform<TArrayBuffer extends ArrayBuffer>(data: Uint8Array<TArrayBuffer>) {
     if (__NODEJS__) {
         return Buffer.from(data);
     } else {
-        return new Uint8Array(data as TArrayBuffer) as Buffer<TArrayBuffer>;
+        return new Uint8Array(data) as Buffer<TArrayBuffer>;
     }
 }
 

--- a/packages/keys/src/private-key.ts
+++ b/packages/keys/src/private-key.ts
@@ -3,7 +3,7 @@ import { SOLANA_ERROR__KEYS__INVALID_PRIVATE_KEY_BYTE_LENGTH, SolanaError } from
 
 import { ED25519_ALGORITHM_IDENTIFIER } from './algorithm';
 
-function addPkcs8Header(bytes: ReadonlyUint8Array): ReadonlyUint8Array {
+function addPkcs8Header(bytes: ReadonlyUint8Array): ReadonlyUint8Array<ArrayBuffer> {
     // prettier-ignore
     return new Uint8Array([
         /**

--- a/packages/keys/src/signatures.ts
+++ b/packages/keys/src/signatures.ts
@@ -1,5 +1,5 @@
 import { assertSigningCapabilityIsAvailable, assertVerificationCapabilityIsAvailable } from '@solana/assertions';
-import { Encoder, ReadonlyUint8Array } from '@solana/codecs-core';
+import { Encoder, ReadonlyUint8Array, toArrayBuffer } from '@solana/codecs-core';
 import { getBase58Encoder } from '@solana/codecs-strings';
 import {
     SOLANA_ERROR__KEYS__INVALID_SIGNATURE_BYTE_LENGTH,
@@ -185,7 +185,7 @@ export function isSignatureBytes(putativeSignatureBytes: ReadonlyUint8Array): pu
  */
 export async function signBytes(key: CryptoKey, data: ReadonlyUint8Array): Promise<SignatureBytes> {
     assertSigningCapabilityIsAvailable();
-    const signedData = await crypto.subtle.sign(ED25519_ALGORITHM_IDENTIFIER, key, data);
+    const signedData = await crypto.subtle.sign(ED25519_ALGORITHM_IDENTIFIER, key, toArrayBuffer(data));
     return new Uint8Array(signedData) as SignatureBytes;
 }
 
@@ -249,5 +249,5 @@ export async function verifySignature(
     data: ReadonlyUint8Array,
 ): Promise<boolean> {
     assertVerificationCapabilityIsAvailable();
-    return await crypto.subtle.verify(ED25519_ALGORITHM_IDENTIFIER, key, signature, data);
+    return await crypto.subtle.verify(ED25519_ALGORITHM_IDENTIFIER, key, toArrayBuffer(signature), toArrayBuffer(data));
 }


### PR DESCRIPTION
#### Problem

When you pass a `SharedArrayBuffer` to a crypto operation (eg. `SubtleCrypto#sign`) it fatals. TypeScript recently got more strict about this, resulting in type errors that make this PR necessary.

#### Summary of Changes

In this PR we clone `SharedArrayBuffer` as non-shared when it's used in a crypto operation.
