### PR TITLE
Remove BaseTransactionMessage from transaction-message blockhash functions

### DIFF
--- a/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 
 import {
-    BaseTransactionMessage,
     setTransactionMessageLifetimeUsingBlockhash,
+    TransactionMessage,
     TransactionMessageWithBlockhashLifetime,
     TransactionMessageWithFeePayer,
 } from '@solana/transaction-messages';
@@ -38,7 +38,7 @@ import type { TransactionPlanResult } from '../transaction-plan-result';
     {
         createTransactionPlanExecutor({
             executeTransactionMessage: message => {
-                message satisfies BaseTransactionMessage & TransactionMessageWithFeePayer;
+                message satisfies TransactionMessage & TransactionMessageWithFeePayer;
                 return Promise.resolve({ transaction: {} as Transaction });
             },
         });

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -6,7 +6,7 @@ import {
 } from '@solana/errors';
 import { Signature } from '@solana/keys';
 import { getAbortablePromise } from '@solana/promises';
-import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 import { Transaction } from '@solana/transactions';
 
 import type {
@@ -36,7 +36,7 @@ type ExecuteResult<TContext extends TransactionPlanResultContext> = {
 } & ({ signature: Signature } | { transaction: Transaction });
 
 type ExecuteTransactionMessage = <TContext extends TransactionPlanResultContext = TransactionPlanResultContext>(
-    transactionMessage: BaseTransactionMessage & TransactionMessageWithFeePayer,
+    transactionMessage: TransactionMessage & TransactionMessageWithFeePayer,
     config?: { abortSignal?: AbortSignal },
 ) => Promise<ExecuteResult<TContext>>;
 

--- a/packages/transaction-messages/src/__tests__/blockhash-test.ts
+++ b/packages/transaction-messages/src/__tests__/blockhash-test.ts
@@ -8,7 +8,7 @@ import {
     setTransactionMessageLifetimeUsingBlockhash,
     TransactionMessageWithBlockhashLifetime,
 } from '../blockhash';
-import { BaseTransactionMessage } from '../transaction-message';
+import { TransactionMessage } from '../transaction-message';
 
 jest.mock('@solana/codecs-strings', () => ({
     ...jest.requireActual('@solana/codecs-strings'),
@@ -25,7 +25,7 @@ describe('assertIsTransactionMessageWithBlockhashLifetime', () => {
         jest.mocked(getBase58Encoder).mockReturnValue(originalGetBase58Encoder);
     });
     it('throws for a transaction with no lifetime constraint', () => {
-        const transaction: BaseTransactionMessage = {
+        const transaction: TransactionMessage = {
             instructions: [],
             version: 0,
         };
@@ -38,7 +38,7 @@ describe('assertIsTransactionMessageWithBlockhashLifetime', () => {
                 nonce: 'abcd',
             },
             version: 0,
-        } as BaseTransactionMessage;
+        } as TransactionMessage;
         expect(() => assertIsTransactionMessageWithBlockhashLifetime(transaction)).toThrow();
     });
     it('throws for a transaction with a blockhash but no lastValidBlockHeight in lifetimeConstraint', () => {
@@ -48,7 +48,7 @@ describe('assertIsTransactionMessageWithBlockhashLifetime', () => {
                 blockhash: '11111111111111111111111111111111',
             },
             version: 0,
-        } as BaseTransactionMessage;
+        } as TransactionMessage;
         expect(() => assertIsTransactionMessageWithBlockhashLifetime(transaction)).toThrow();
     });
     it('throws for a transaction with a lastValidBlockHeight but no blockhash in lifetimeConstraint', () => {
@@ -58,7 +58,7 @@ describe('assertIsTransactionMessageWithBlockhashLifetime', () => {
                 lastValidBlockHeight: 1234n,
             },
             version: 0,
-        } as BaseTransactionMessage;
+        } as TransactionMessage;
         expect(() => assertIsTransactionMessageWithBlockhashLifetime(transaction)).toThrow();
     });
     it('throws for a transaction with a blockhash lifetime but an invalid blockhash value', () => {
@@ -68,7 +68,7 @@ describe('assertIsTransactionMessageWithBlockhashLifetime', () => {
                 blockhash: 'not a valid blockhash value',
             },
             version: 0,
-        } as BaseTransactionMessage;
+        } as TransactionMessage;
         expect(() => assertIsTransactionMessageWithBlockhashLifetime(transaction)).toThrow();
     });
     it('does not throw for a transaction with a valid blockhash lifetime constraint', () => {
@@ -79,13 +79,13 @@ describe('assertIsTransactionMessageWithBlockhashLifetime', () => {
                 lastValidBlockHeight: 1234n,
             },
             version: 0,
-        } as BaseTransactionMessage;
+        } as TransactionMessage;
         expect(() => assertIsTransactionMessageWithBlockhashLifetime(transaction)).not.toThrow();
     });
 });
 
 describe('setTransactionMessageLifetimeUsingBlockhash', () => {
-    let baseTx: BaseTransactionMessage;
+    let baseTx: TransactionMessage;
     const BLOCKHASH_CONSTRAINT_A = {
         blockhash: 'F7vmkY3DTaxfagttWjQweib42b6ZHADSx94Tw8gHx3W7' as Blockhash,
         lastValidBlockHeight: 123n,
@@ -108,7 +108,7 @@ describe('setTransactionMessageLifetimeUsingBlockhash', () => {
         expect(txWithBlockhashLifetimeConstraint).toHaveProperty('lifetimeConstraint', BLOCKHASH_CONSTRAINT_A);
     });
     describe('given a transaction with a blockhash lifetime already set', () => {
-        let txWithBlockhashLifetimeConstraint: BaseTransactionMessage & TransactionMessageWithBlockhashLifetime;
+        let txWithBlockhashLifetimeConstraint: TransactionMessage & TransactionMessageWithBlockhashLifetime;
         beforeEach(() => {
             txWithBlockhashLifetimeConstraint = {
                 ...baseTx,

--- a/packages/transaction-messages/src/__typetests__/blockhash-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/blockhash-typetest.ts
@@ -6,7 +6,7 @@ import {
     setTransactionMessageLifetimeUsingBlockhash,
     TransactionMessageWithBlockhashLifetime,
 } from '../blockhash';
-import { BaseTransactionMessage, TransactionMessage } from '../transaction-message';
+import { TransactionMessage } from '../transaction-message';
 
 const mockBlockhash = null as unknown as Blockhash;
 const mockBlockhashLifetime = { blockhash: mockBlockhash, lastValidBlockHeight: 0n };
@@ -18,11 +18,11 @@ type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
 {
     // It narrows the transaction message type to one with a blockhash-based lifetime.
     {
-        const message = null as unknown as BaseTransactionMessage & { some: 1 };
+        const message = null as unknown as TransactionMessage & { some: 1 };
         if (isTransactionMessageWithBlockhashLifetime(message)) {
-            message satisfies BaseTransactionMessage & TransactionMessageWithBlockhashLifetime & { some: 1 };
+            message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime & { some: 1 };
         } else {
-            message satisfies BaseTransactionMessage & { some: 1 };
+            message satisfies TransactionMessage & { some: 1 };
             // @ts-expect-error It does not have a blockhash-based lifetime.
             message satisfies TransactionMessageWithBlockhashLifetime;
         }
@@ -33,7 +33,7 @@ type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
 {
     // It narrows the transaction message type to one with a blockhash-based lifetime.
     {
-        const message = null as unknown as BaseTransactionMessage & { some: 1 };
+        const message = null as unknown as TransactionMessage & { some: 1 };
         // @ts-expect-error Should not be blockhash lifetime
         message satisfies TransactionMessageWithBlockhashLifetime;
         // @ts-expect-error Should not satisfy has blockhash
@@ -41,7 +41,7 @@ type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
         // @ts-expect-error Should not satisfy has lastValidBlockHeight
         message satisfies { lifetimeConstraint: { lastValidBlockHeight: bigint } };
         assertIsTransactionMessageWithBlockhashLifetime(message);
-        message satisfies BaseTransactionMessage & TransactionMessageWithBlockhashLifetime & { some: 1 };
+        message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime & { some: 1 };
         message satisfies TransactionMessageWithBlockhashLifetime;
         message satisfies { lifetimeConstraint: { blockhash: Blockhash } };
         message satisfies { lifetimeConstraint: { lastValidBlockHeight: bigint } };

--- a/packages/transaction-messages/src/blockhash.ts
+++ b/packages/transaction-messages/src/blockhash.ts
@@ -2,7 +2,7 @@ import { SOLANA_ERROR__TRANSACTION__EXPECTED_BLOCKHASH_LIFETIME, SolanaError } f
 import { type Blockhash, isBlockhash } from '@solana/rpc-types';
 
 import { ExcludeTransactionMessageLifetime, TransactionMessageWithLifetime } from './lifetime';
-import { BaseTransactionMessage } from './transaction-message';
+import { TransactionMessage } from './transaction-message';
 
 /**
  * A constraint which, when applied to a transaction message, makes that transaction message
@@ -61,8 +61,8 @@ export interface TransactionMessageWithBlockhashLifetime {
  * ```
  */
 export function isTransactionMessageWithBlockhashLifetime(
-    transactionMessage: BaseTransactionMessage | (BaseTransactionMessage & TransactionMessageWithBlockhashLifetime),
-): transactionMessage is BaseTransactionMessage & TransactionMessageWithBlockhashLifetime {
+    transactionMessage: TransactionMessage | (TransactionMessage & TransactionMessageWithBlockhashLifetime),
+): transactionMessage is TransactionMessage & TransactionMessageWithBlockhashLifetime {
     return (
         'lifetimeConstraint' in transactionMessage &&
         typeof transactionMessage.lifetimeConstraint.blockhash === 'string' &&
@@ -94,8 +94,8 @@ export function isTransactionMessageWithBlockhashLifetime(
  * ```
  */
 export function assertIsTransactionMessageWithBlockhashLifetime(
-    transactionMessage: BaseTransactionMessage | (BaseTransactionMessage & TransactionMessageWithBlockhashLifetime),
-): asserts transactionMessage is BaseTransactionMessage & TransactionMessageWithBlockhashLifetime {
+    transactionMessage: TransactionMessage | (TransactionMessage & TransactionMessageWithBlockhashLifetime),
+): asserts transactionMessage is TransactionMessage & TransactionMessageWithBlockhashLifetime {
     if (!isTransactionMessageWithBlockhashLifetime(transactionMessage)) {
         throw new SolanaError(SOLANA_ERROR__TRANSACTION__EXPECTED_BLOCKHASH_LIFETIME);
     }
@@ -115,7 +115,7 @@ export function assertIsTransactionMessageWithBlockhashLifetime(
  * ```
  */
 export function setTransactionMessageLifetimeUsingBlockhash<
-    TTransactionMessage extends BaseTransactionMessage & Partial<TransactionMessageWithLifetime>,
+    TTransactionMessage extends Partial<TransactionMessageWithLifetime> & TransactionMessage,
 >(
     blockhashLifetimeConstraint: BlockhashLifetimeConstraint,
     transactionMessage: TTransactionMessage,

--- a/packages/transaction-messages/src/lifetime.ts
+++ b/packages/transaction-messages/src/lifetime.ts
@@ -1,6 +1,6 @@
 import { TransactionMessageWithBlockhashLifetime } from './blockhash';
 import { TransactionMessageWithDurableNonceLifetime } from './durable-nonce';
-import { BaseTransactionMessage } from './transaction-message';
+import { TransactionMessage } from './transaction-message';
 
 /**
  * A transaction message with any valid lifetime constraint.
@@ -12,7 +12,5 @@ export type TransactionMessageWithLifetime =
 /**
  * A helper type to exclude any lifetime constraint from a transaction message.
  */
-export type ExcludeTransactionMessageLifetime<TTransactionMessage extends BaseTransactionMessage> = Omit<
-    TTransactionMessage,
-    'lifetimeConstraint'
->;
+export type ExcludeTransactionMessageLifetime<TTransactionMessage extends TransactionMessage> =
+    TTransactionMessage extends unknown ? Omit<TTransactionMessage, 'lifetimeConstraint'> : never;

--- a/packages/transactions/src/compile-transaction.ts
+++ b/packages/transactions/src/compile-transaction.ts
@@ -1,9 +1,9 @@
 import {
-    BaseTransactionMessage,
     compileTransactionMessage,
     getCompiledTransactionMessageEncoder,
     isTransactionMessageWithBlockhashLifetime,
     isTransactionMessageWithDurableNonceLifetime,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/transaction-messages';
 
@@ -21,12 +21,12 @@ import type { SignaturesMap, TransactionFromTransactionMessage, TransactionMessa
  * level. In order to be signable, a transaction message must:
  *
  * - have a version and a list of zero or more instructions (ie. conform to
- *   {@link BaseTransactionMessage})
+ *   {@link TransactionMessage})
  * - have a fee payer set (ie. conform to {@link TransactionMessageWithFeePayer})
  * - have a lifetime specified (ie. conform to {@link TransactionMessageWithBlockhashLifetime} or
  *   {@link TransactionMessageWithDurableNonceLifetime})
  */
-export function compileTransaction<TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer>(
+export function compileTransaction<TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer>(
     transactionMessage: TTransactionMessage,
 ): Readonly<TransactionFromTransactionMessage<TTransactionMessage>> {
     type ReturnType = Readonly<TransactionFromTransactionMessage<TTransactionMessage>>;


### PR DESCRIPTION
#### Problem

Our `TransactionMessage` functions operate on `BaseTransactionMessage` instead of `TransactionMessage`, which limits the ability to type narrow the resulting transaction messages

#### Summary of Changes

- Change to use `TransactionMessage` in input/output types

Part of a stack that eventually supersedes https://github.com/anza-xyz/kit/pull/1103