### PR TITLE
Remove BaseTransactionMessage from transaction-message feepayer functions

### DIFF
--- a/packages/transaction-messages/src/__typetests__/fee-payer-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/fee-payer-typetest.ts
@@ -100,4 +100,17 @@ type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
             TransactionMessageWithDurableNonceLifetime &
             TransactionMessageWithFeePayer<'mockFeePayer'>;
     }
+
+    // It can narrow the result by transaction version
+    {
+        type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legacy' }>;
+
+        const message = null as unknown as TransactionMessage;
+        const messageWithFeePayer = setTransactionMessageFeePayer(mockFeePayer, message);
+        // @ts-expect-error Could be legacy
+        messageWithFeePayer satisfies TransactionMessageNotLegacy;
+        if (messageWithFeePayer.version === 0) {
+            messageWithFeePayer satisfies TransactionMessageNotLegacy;
+        }
+    }
 }


### PR DESCRIPTION
#### Problem

Our `TransactionMessage` functions operate on `BaseTransactionMessage` instead of `TransactionMessage`, which limits the ability to type narrow the resulting transaction messages

#### Summary of Changes

- Change to use `TransactionMessage` in input/output types

Part of a stack that eventually supersedes https://github.com/anza-xyz/kit/pull/1103