### PR TITLE
Add a typetest for types flowing through transaction message functions

### DIFF
--- a/.changeset/three-nights-decide.md
+++ b/.changeset/three-nights-decide.md
@@ -1,0 +1,11 @@
+---
+'@solana/transaction-messages': minor
+'@solana/instruction-plans': minor
+'@solana/transactions': minor
+'@solana/signers': minor
+'@solana/kit': minor
+---
+
+Return more precise types from transaction message functions
+
+Deprecate `BaseTransactionMessage` in favour of `TransactionMessage`

--- a/packages/kit/src/__typetests__/scenarios/transaction-message-decompile-modify-typetest.ts
+++ b/packages/kit/src/__typetests__/scenarios/transaction-message-decompile-modify-typetest.ts
@@ -26,19 +26,16 @@ const compiledTransactionMessage = null as unknown as CompiledTransactionMessage
     CompiledTransactionMessageWithLifetime;
 const rpc = null as unknown as Rpc<GetMultipleAccountsApi>;
 
-// A function that only accepts v0 transactions
 type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legacy' }>;
-function acceptsNonLegacyTransactionMessage(_msg: TransactionMessageNotLegacy) {}
 
 void (async () => {
     const transactionMessage = await decompileTransactionMessageFetchingLookupTables(compiledTransactionMessage, rpc);
 
     // @ts-expect-error Transaction has an unknown version
-    acceptsNonLegacyTransactionMessage(transactionMessage);
-
+    transactionMessage satisfies TransactionMessageNotLegacy;
     if (transactionMessage.version === 0) {
         // It typechecks when the transaction message is known to be v0
-        acceptsNonLegacyTransactionMessage(transactionMessage);
+        transactionMessage satisfies TransactionMessageNotLegacy;
     }
 
     // We update the transaction message using update functions to ensure the types flow correctly
@@ -61,10 +58,9 @@ void (async () => {
     );
 
     // @ts-expect-error Transaction has an unknown version
-    acceptsNonLegacyTransactionMessage(updatedMessage);
-
+    updatedMessage satisfies TransactionMessageNotLegacy;
     if (updatedMessage.version === 0) {
         // It typechecks when the transaction message is known to be v0
-        acceptsNonLegacyTransactionMessage(updatedMessage);
+        updatedMessage satisfies TransactionMessageNotLegacy;
     }
 })();


### PR DESCRIPTION
This PR adds a new typetest that does the following:

- Decompile a transaction message using `decompileTransactionMessageFetchingLookupTables`
- Apply each function that modifies a transaction message
- Verify that it can still be type narrowed correctly

Note that we don't have any typetests like this that combine functionality from multiple packages. I've put this in `packages/kit/__typetests__/scenarios`, but don't feel strongly about where it should live. I do think it's important to have this as part of the repo though because it would be very easy to introduce a regression. 

Supersedes https://github.com/anza-xyz/kit/pull/1103, by avoiding the need to introduce assertion functions

