### PR TITLE
Mark BaseTransactionMessage as deprecated

### DIFF
--- a/packages/transaction-messages/src/transaction-message.ts
+++ b/packages/transaction-messages/src/transaction-message.ts
@@ -1,5 +1,9 @@
 import { AccountMeta, Instruction } from '@solana/instructions';
 
+/**
+ * @deprecated Use `TransactionMessage` instead.
+ */
+// TODO(#1147) Stop exporting this in a future major version.
 export type BaseTransactionMessage<
     TVersion extends TransactionVersion = TransactionVersion,
     TInstruction extends Instruction = Instruction,


### PR DESCRIPTION
#### Problem

We exported `BaseTransactionMessage`, but as this stack shows in practice it's strictly better to use `TransactionMessage` instead.

#### Summary of Changes

- Mark `BaseTransactionMessage` as deprecated. This will encourage Kit users (and us) to gradually migrate to `TransactionMessage`
- In a future major version, we can stop exporting `BaseTransactionMessage` and just have it as implementation detail for the structure of `TransactionMessage`
