### PR TITLE
Change dismiss-pr-reviews to use pull_request_target

### DIFF
--- a/.github/workflows/dismiss-stale-pr-reviews.yml
+++ b/.github/workflows/dismiss-stale-pr-reviews.yml
@@ -1,7 +1,7 @@
 name: Dismiss Stale PR Reviews
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
This allows updates to forks to dismiss PR reviews on our repo. This is safe as long as we trust the Graphite workflow used (which is locked to a fixed commit)

#### Problem

On forks, this workflow fails because forks have access to a more limited token. By using `pull_request_target`, the workflow should run with a read/write token:

> When a workflow is triggered by the [pull_request_target](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) event, the GITHUB_TOKEN is granted read/write repository permission, even when it is triggered from a public fork. For more information, see [Events that trigger workflows](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target).

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions

Usually we don't want that, but for the limited case of dismissing PR reviews, this permission makes sense. It also runs the code from main rather than the PR, which further reduces any risk. 

Fixes dismiss-stale-pr-reviews workflow failing when triggered on forks 