### PR TITLE
Make `ws` a direct dependency

### DIFF
--- a/.changeset/yummy-ghosts-push.md
+++ b/.changeset/yummy-ghosts-push.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-subscriptions-channel-websocket': patch
+---
+
+Node users no longer need to manually install `ws`. Browser builds remain unaffected as conditional exports ensure `ws` is never bundled for browser environments.

--- a/packages/rpc-subscriptions-channel-websocket/package.json
+++ b/packages/rpc-subscriptions-channel-websocket/package.json
@@ -76,7 +76,8 @@
         "@solana/errors": "workspace:*",
         "@solana/functional": "workspace:*",
         "@solana/rpc-subscriptions-spec": "workspace:*",
-        "@solana/subscribable": "workspace:*"
+        "@solana/subscribable": "workspace:*",
+        "ws": "^8.18.0"
     },
     "devDependencies": {
         "@solana/event-target-impl": "workspace:*",
@@ -84,13 +85,7 @@
         "jest-websocket-mock": "^2.5.0"
     },
     "peerDependencies": {
-        "typescript": ">=5.9.3",
-        "ws": "^8.18.0"
-    },
-    "peerDependenciesMeta": {
-        "ws": {
-            "optional": true
-        }
+        "typescript": ">=5.9.3"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/ws-impl/package.json
+++ b/packages/ws-impl/package.json
@@ -51,16 +51,11 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "devDependencies": {
-        "@types/ws": "^8.18.1"
-    },
-    "peerDependencies": {
+    "dependencies": {
         "ws": "^8.18.0"
     },
-    "peerDependenciesMeta": {
-        "ws": {
-            "optional": true
-        }
+    "devDependencies": {
+        "@types/ws": "^8.18.1"
     },
     "engines": {
         "node": ">=20.18.0"


### PR DESCRIPTION
#### Problem

Currently, Node users must explicitly install `ws` as a peer dependency to use RPC Subscription features. This creates onboarding friction as users need to understand what is `ws`, which environment requires it and why it is required just to get started with Kit.

#### Summary of Changes

This PR move `ws` from `peerDependencies` to `dependencies`. Since the packages use conditional exports with separate entry points for Node and browser environments, browser builds will never include `ws` as the browser entry point simply doesn't import it.

This means Node users get `ws` out of the box while browser bundle sizes remain unaffected.
