### PR TITLE
Check for changesets before publishing canary builds

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -98,11 +98,15 @@ jobs:
 
       - name: Publish Canary Releases
         run: |
-          find packages/* -maxdepth 0 -type d -print0 | \
-            xargs -t0 -n 1 -I {} \
-              sh -c 'cd {} && pnpm pkg delete devDependencies'
-          pnpm changeset version --snapshot canary
-          pnpm turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-1}
+          if [ -n "$(find .changeset -name '*.md')" ]; then
+            find packages/* -maxdepth 0 -type d -print0 | \
+              xargs -t0 -n 1 -I {} \
+                sh -c 'cd {} && pnpm pkg delete devDependencies'
+            pnpm changeset version --snapshot canary
+            pnpm turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-1}
+          else
+            echo "No changesets found, skipping canary publish"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#### Problem

In this CI job: https://github.com/anza-xyz/kit/actions/runs/20788100035/job/59703126688

The publish snapshots output has the following:

```
:butterfly:  warn No unreleased changesets found, exiting.
• Packages in scope: @solana/accounts, <snip>
• Running publish-packages in 61 packages
```

The job does this:

```
pnpm changeset version --snapshot canary
pnpm turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-1}
```

I think what happened here was it didn't detect any changesets (unsure if this is a bug), so didn't change the versions of the packages. But `pnpm changeset version` exited with status code 0 and carried on. And then `publish-packages` went ahead and published the 5.2.0 line with the `canary` tag.

See https://github.com/changesets/changesets/issues/1815

Then the publish-to-npm-for-real job came along, tried to publish 5.2.0 as latest, and got an error because they were already published as canary

#### Summary of Changes

This PR attempts to defend against this. If there are no changesets in the repo, then the publish snapshots job will not publish packages.  
