### PR TITLE
Remove typescript peerDependency from all packages

### DIFF
--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -80,9 +80,6 @@
         "@solana/rpc-spec": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -79,9 +79,6 @@
         "@solana/errors": "workspace:*",
         "@solana/nominal-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -75,9 +75,6 @@
     "dependencies": {
         "@solana/errors": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -79,9 +79,6 @@
     "devDependencies": {
         "tinybench": "^6.0.0"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -80,9 +80,6 @@
     "devDependencies": {
         "@solana/codecs-strings": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -76,9 +76,6 @@
         "@solana/codecs-core": "workspace:*",
         "@solana/errors": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -83,8 +83,7 @@
         "tinybench": "^6.0.0"
     },
     "peerDependencies": {
-        "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "typescript": ">=5.9.3"
+        "fastestsmallesttextencoderdecoder": "^1.0.22"
     },
     "peerDependenciesMeta": {
         "fastestsmallesttextencoderdecoder": {

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -77,9 +77,6 @@
         "@solana/codecs-strings": "workspace:*",
         "@solana/options": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -83,9 +83,6 @@
     "devDependencies": {
         "@solana/web3.js": "^1"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -77,9 +77,6 @@
         "chalk": "5.6.2",
         "commander": "14.0.2"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/fast-stable-stringify/package.json
+++ b/packages/fast-stable-stringify/package.json
@@ -77,9 +77,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -72,9 +72,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/instruction-plans/package.json
+++ b/packages/instruction-plans/package.json
@@ -85,9 +85,6 @@
         "@solana/codecs": "workspace:*",
         "@solana/functional": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -79,9 +79,6 @@
     "devDependencies": {
         "@solana/addresses": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -80,9 +80,6 @@
         "@solana/errors": "workspace:*",
         "@solana/nominal-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "devDependencies": {
         "tinybench": "^6.0.0"
     },

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -99,9 +99,6 @@
         "@solana/transaction-messages": "workspace:*",
         "@solana/transactions": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/nominal-types/package.json
+++ b/packages/nominal-types/package.json
@@ -38,9 +38,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/offchain-messages/package.json
+++ b/packages/offchain-messages/package.json
@@ -82,9 +82,6 @@
         "@solana/keys": "workspace:*",
         "@solana/nominal-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -79,9 +79,6 @@
         "@solana/codecs-strings": "workspace:*",
         "@solana/errors": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -72,9 +72,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "peerDependencies": {
-        "typescript": ">=5.3.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/programs/package.json
+++ b/packages/programs/package.json
@@ -80,9 +80,6 @@
         "@solana/functional": "workspace:*",
         "@solana/transaction-messages": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/promises/package.json
+++ b/packages/promises/package.json
@@ -72,9 +72,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc-api/package.json
+++ b/packages/rpc-api/package.json
@@ -89,9 +89,6 @@
         "@solana/rpc-spec-types": "workspace:*",
         "@solana/rpc-transport-http": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -85,9 +85,6 @@
         "@solana/rpc-types": "workspace:*",
         "@solana/transactions": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc-parsed-types/package.json
+++ b/packages/rpc-parsed-types/package.json
@@ -74,9 +74,6 @@
         "@solana/addresses": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc-spec-types/package.json
+++ b/packages/rpc-spec-types/package.json
@@ -72,9 +72,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc-spec/package.json
+++ b/packages/rpc-spec/package.json
@@ -76,9 +76,6 @@
         "@solana/errors": "workspace:*",
         "@solana/rpc-spec-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -84,9 +84,6 @@
     "devDependencies": {
         "@solana/rpc-subscriptions-channel-websocket": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc-subscriptions-channel-websocket/package.json
+++ b/packages/rpc-subscriptions-channel-websocket/package.json
@@ -84,9 +84,6 @@
         "@solana/ws-impl": "workspace:*",
         "jest-websocket-mock": "^2.5.0"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc-subscriptions-spec/package.json
+++ b/packages/rpc-subscriptions-spec/package.json
@@ -81,9 +81,6 @@
     "devDependencies": {
         "@solana/event-target-impl": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -89,9 +89,6 @@
         "@solana/addresses": "workspace:*",
         "@solana/event-target-impl": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -79,9 +79,6 @@
         "@solana/rpc-spec-types": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc-transport-http/package.json
+++ b/packages/rpc-transport-http/package.json
@@ -84,9 +84,6 @@
         "undici": "^7.18.2",
         "zx": "^8.8.5"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -80,9 +80,6 @@
         "@solana/errors": "workspace:*",
         "@solana/nominal-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -86,9 +86,6 @@
     "devDependencies": {
         "@solana/event-target-impl": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -87,9 +87,6 @@
         "@solana/rpc-types": "workspace:*",
         "@solana/text-encoding-impl": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/subscribable/package.json
+++ b/packages/subscribable/package.json
@@ -78,9 +78,6 @@
     "devDependencies": {
         "@solana/event-target-impl": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -85,9 +85,6 @@
         "@solana/rpc-spec": "workspace:*",
         "@solana/rpc-transport-http": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -88,9 +88,6 @@
         "@solana/event-target-impl": "workspace:*",
         "@solana/instructions": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/transaction-messages/package.json
+++ b/packages/transaction-messages/package.json
@@ -86,9 +86,6 @@
     "devDependencies": {
         "@solana/codecs-strings": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -86,9 +86,6 @@
         "@solana/rpc-types": "workspace:*",
         "@solana/transaction-messages": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -75,9 +75,6 @@
     "devDependencies": {
         "@solana/crypto-impl": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": ">=5.9.3"
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -341,9 +341,6 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
   packages/addresses:
     dependencies:
@@ -362,18 +359,12 @@ importers:
       '@solana/nominal-types':
         specifier: workspace:*
         version: link:../nominal-types
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
   packages/assertions:
     dependencies:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
   packages/build-scripts:
     devDependencies:
@@ -425,18 +416,12 @@ importers:
       '@solana/options':
         specifier: workspace:*
         version: link:../options
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
   packages/codecs-core:
     dependencies:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       tinybench:
         specifier: ^6.0.0
@@ -453,9 +438,6 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/codecs-strings':
         specifier: workspace:*
@@ -469,9 +451,6 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
   packages/codecs-strings:
     dependencies:
@@ -487,9 +466,6 @@ importers:
       fastestsmallesttextencoderdecoder:
         specifier: ^1.0.22
         version: 1.0.22
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/text-encoding-impl':
         specifier: workspace:*
@@ -518,9 +494,6 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/web3.js':
         specifier: ^1
@@ -536,9 +509,6 @@ importers:
       commander:
         specifier: 14.0.2
         version: 14.0.2
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
   packages/eslint-config:
     dependencies:
@@ -580,10 +550,6 @@ importers:
   packages/event-target-impl: {}
 
   packages/fast-stable-stringify:
-    dependencies:
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@types/json-stable-stringify':
         specifier: ^1.2.0
@@ -601,11 +567,7 @@ importers:
         specifier: ^7.18.2
         version: 7.18.2
 
-  packages/functional:
-    dependencies:
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
+  packages/functional: {}
 
   packages/instruction-plans:
     dependencies:
@@ -627,9 +589,6 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -649,9 +608,6 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -674,9 +630,6 @@ importers:
       '@solana/nominal-types':
         specifier: workspace:*
         version: link:../nominal-types
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       tinybench:
         specifier: ^6.0.0
@@ -750,15 +703,8 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
-  packages/nominal-types:
-    dependencies:
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
+  packages/nominal-types: {}
 
   packages/offchain-messages:
     dependencies:
@@ -786,9 +732,6 @@ importers:
       '@solana/nominal-types':
         specifier: workspace:*
         version: link:../nominal-types
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
   packages/options:
     dependencies:
@@ -807,15 +750,8 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
-  packages/plugin-core:
-    dependencies:
-      typescript:
-        specifier: '>=5.3.3'
-        version: 5.9.3
+  packages/plugin-core: {}
 
   packages/programs:
     dependencies:
@@ -825,9 +761,6 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/functional':
         specifier: workspace:*
@@ -836,11 +769,7 @@ importers:
         specifier: workspace:*
         version: link:../transaction-messages
 
-  packages/promises:
-    dependencies:
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
+  packages/promises: {}
 
   packages/react:
     dependencies:
@@ -944,9 +873,6 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
         specifier: workspace:*
@@ -987,9 +913,6 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/rpc-spec-types':
         specifier: workspace:*
@@ -1015,9 +938,6 @@ importers:
       graphql:
         specifier: ^16.12.0
         version: 16.12.0
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -1036,10 +956,6 @@ importers:
         version: link:../transactions
 
   packages/rpc-parsed-types:
-    dependencies:
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -1056,15 +972,8 @@ importers:
       '@solana/rpc-spec-types':
         specifier: workspace:*
         version: link:../rpc-spec-types
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
-  packages/rpc-spec-types:
-    dependencies:
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
+  packages/rpc-spec-types: {}
 
   packages/rpc-subscriptions:
     dependencies:
@@ -1101,9 +1010,6 @@ importers:
       '@solana/subscribable':
         specifier: workspace:*
         version: link:../subscribable
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -1135,9 +1041,6 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/rpc-subscriptions-channel-websocket':
         specifier: workspace:*
@@ -1157,9 +1060,6 @@ importers:
       '@solana/subscribable':
         specifier: workspace:*
         version: link:../subscribable
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
       ws:
         specifier: ^8.19.0
         version: 8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -1188,9 +1088,6 @@ importers:
       '@solana/subscribable':
         specifier: workspace:*
         version: link:../subscribable
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
         specifier: workspace:*
@@ -1213,9 +1110,6 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
   packages/rpc-transport-http:
     dependencies:
@@ -1228,9 +1122,6 @@ importers:
       '@solana/rpc-spec-types':
         specifier: workspace:*
         version: link:../rpc-spec-types
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
       undici-types:
         specifier: ^7.16.0
         version: 7.16.0
@@ -1265,9 +1156,6 @@ importers:
       '@solana/nominal-types':
         specifier: workspace:*
         version: link:../nominal-types
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
   packages/signers:
     dependencies:
@@ -1298,9 +1186,6 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/rpc-types':
         specifier: workspace:*
@@ -1314,9 +1199,6 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
         specifier: workspace:*
@@ -1336,9 +1218,6 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -1416,9 +1295,6 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/codecs-core':
         specifier: workspace:*
@@ -1459,9 +1335,6 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/codecs-strings':
         specifier: workspace:*
@@ -1505,9 +1378,6 @@ importers:
       '@solana/transaction-messages':
         specifier: workspace:*
         version: link:../transaction-messages
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
 
   packages/tsconfig: {}
 
@@ -1516,9 +1386,6 @@ importers:
       '@noble/ed25519':
         specifier: ^3.0.0
         version: 3.0.0
-      typescript:
-        specifier: '>=5.9.3'
-        version: 5.9.3
     devDependencies:
       '@solana/crypto-impl':
         specifier: workspace:*


### PR DESCRIPTION
## Problem

See #1161 for full context.

## Summary

  - Remove `typescript` peerDependency from 42 packages
  - Packages ship pre-compiled JavaScript in `dist/`, so consumers don't need TypeScript to use them
  - Type definitions (`.d.ts`) work regardless of consumer's TypeScript version
  - Eliminates peer dependency warnings for downstream projects that don't use the exact TypeScript version

## Context

The TypeScript peerDependency was causing excessive warnings for consumers, especially those using `@solana/kit` as a transitive dependency. Since the packages are published as a "Solana JavaScript SDK" with compiled output, there's no strict requirement for consumers to have any specific TypeScript version (or TypeScript at all).

Fixes #1161
Replaces #1187 