### PR TITLE
fix(react): correct featureName in `signTransaction` error

### DIFF
--- a/.changeset/lazy-cats-shave.md
+++ b/.changeset/lazy-cats-shave.md
@@ -1,0 +1,5 @@
+---
+'@solana/react': patch
+---
+
+Correct featureName in `signTransaction` error

--- a/packages/react/src/__tests__/useSignTransaction-test.ts
+++ b/packages/react/src/__tests__/useSignTransaction-test.ts
@@ -89,6 +89,9 @@ describe('useSignTransaction', () => {
                 supportedFeatures: ['solana:signTransaction'],
             }),
         );
+        expect(result.current).toMatchObject({
+            context: { featureName: 'solana:signTransaction' },
+        });
     });
     it('fatals when the wallet account lookup for the supplied React wallet account fails', () => {
         jest.mocked(getWalletAccountForUiWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED).mockImplementation(() => {
@@ -181,6 +184,9 @@ describe('useSignTransaction', () => {
                     supportedFeatures: ['solana:signTransaction'],
                 }),
             );
+            expect(result.current).toMatchObject({
+                context: { featureName: 'solana:signTransaction' },
+            });
         });
     });
 });

--- a/packages/react/src/useSignTransaction.ts
+++ b/packages/react/src/useSignTransaction.ts
@@ -1,5 +1,4 @@
 import {
-    SolanaSignAndSendTransaction,
     SolanaSignTransaction,
     SolanaSignTransactionFeature,
     SolanaSignTransactionInput,
@@ -127,7 +126,7 @@ export function useSignTransactions<TWalletAccount extends UiWalletAccount>(
         throw new WalletStandardError(WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED, {
             address: uiWalletAccount.address,
             chain,
-            featureName: SolanaSignAndSendTransaction,
+            featureName: SolanaSignTransaction,
             supportedChains: [...uiWalletAccount.chains],
             supportedFeatures: [...uiWalletAccount.features],
         });


### PR DESCRIPTION
#### Problem

Incorrect feature name in `useSignTransaction` error case

#### Summary of Changes

correct `featureName` in `signTransaction` error and assert context in tests.

Fixes https://github.com/anza-xyz/kit/issues/1181
