### PR TITLE
Include the abort signal reason on cancelled transaction plans

### DIFF
--- a/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
@@ -120,8 +120,7 @@ describe('createTransactionPlanExecutor', () => {
             abortController.abort(cause);
             const promise = executor(singleTransactionPlan(messageA), { abortSignal });
 
-            // TODO: loses the abort cause, add that to `canceledSingleTransactionPlanResult`?
-            await expect(promise).resolves.toStrictEqual(canceledSingleTransactionPlanResult(messageA));
+            await expect(promise).resolves.toStrictEqual(canceledSingleTransactionPlanResult(messageA, cause));
             expect(executeTransactionMessage).not.toHaveBeenCalled();
         });
 
@@ -288,7 +287,7 @@ describe('createTransactionPlanExecutor', () => {
                 sequentialTransactionPlanResult([
                     successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
                     failedSingleTransactionPlanResult(messageB, cause),
-                    canceledSingleTransactionPlanResult(messageC),
+                    canceledSingleTransactionPlanResult(messageC, cause),
                 ]),
             );
 
@@ -313,8 +312,8 @@ describe('createTransactionPlanExecutor', () => {
 
             await expect(promise).resolves.toStrictEqual(
                 sequentialTransactionPlanResult([
-                    canceledSingleTransactionPlanResult(messageA),
-                    canceledSingleTransactionPlanResult(messageB),
+                    canceledSingleTransactionPlanResult(messageA, cause),
+                    canceledSingleTransactionPlanResult(messageB, cause),
                 ]),
             );
 
@@ -454,9 +453,9 @@ describe('createTransactionPlanExecutor', () => {
 
             await expect(promise).resolves.toStrictEqual(
                 parallelTransactionPlanResult([
-                    canceledSingleTransactionPlanResult(messageA),
-                    canceledSingleTransactionPlanResult(messageB),
-                    canceledSingleTransactionPlanResult(messageC),
+                    canceledSingleTransactionPlanResult(messageA, cause),
+                    canceledSingleTransactionPlanResult(messageB, cause),
+                    canceledSingleTransactionPlanResult(messageC, cause),
                 ]),
             );
         });
@@ -596,7 +595,7 @@ describe('createTransactionPlanExecutor', () => {
                             successfulSingleTransactionPlanResult(messageB, createTransaction('B')),
                             failedSingleTransactionPlanResult(messageC, cause),
                         ]),
-                        canceledSingleTransactionPlanResult(messageD),
+                        canceledSingleTransactionPlanResult(messageD, cause),
                     ]),
                     successfulSingleTransactionPlanResult(messageE, createTransaction('E')),
                     sequentialTransactionPlanResult([
@@ -635,17 +634,17 @@ describe('createTransactionPlanExecutor', () => {
             await expect(promise).resolves.toStrictEqual(
                 parallelTransactionPlanResult([
                     sequentialTransactionPlanResult([
-                        canceledSingleTransactionPlanResult(messageA),
+                        canceledSingleTransactionPlanResult(messageA, cause),
                         parallelTransactionPlanResult([
-                            canceledSingleTransactionPlanResult(messageB),
-                            canceledSingleTransactionPlanResult(messageC),
+                            canceledSingleTransactionPlanResult(messageB, cause),
+                            canceledSingleTransactionPlanResult(messageC, cause),
                         ]),
-                        canceledSingleTransactionPlanResult(messageD),
+                        canceledSingleTransactionPlanResult(messageD, cause),
                     ]),
-                    canceledSingleTransactionPlanResult(messageE),
+                    canceledSingleTransactionPlanResult(messageE, cause),
                     sequentialTransactionPlanResult([
-                        canceledSingleTransactionPlanResult(messageF),
-                        canceledSingleTransactionPlanResult(messageG),
+                        canceledSingleTransactionPlanResult(messageF, cause),
+                        canceledSingleTransactionPlanResult(messageG, cause),
                     ]),
                 ]),
             );

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -151,7 +151,7 @@ async function traverseSingle(
     context: TraverseContext,
 ): Promise<TransactionPlanResult> {
     if (context.canceled) {
-        return canceledSingleTransactionPlanResult(transactionPlan.message);
+        return canceledSingleTransactionPlanResult(transactionPlan.message, context.abortSignal?.reason);
     }
 
     try {

--- a/packages/instruction-plans/src/transaction-plan-result.ts
+++ b/packages/instruction-plans/src/transaction-plan-result.ts
@@ -170,7 +170,7 @@ export type SingleTransactionPlanResult<
 export type TransactionPlanResultStatus<TContext extends TransactionPlanResultContext = TransactionPlanResultContext> =
     | Readonly<{ context: TContext; kind: 'successful'; signature: Signature; transaction?: Transaction }>
     | Readonly<{ error: Error; kind: 'failed' }>
-    | Readonly<{ kind: 'canceled' }>;
+    | Readonly<{ kind: 'canceled'; reason?: unknown }>;
 
 /**
  * Creates a divisible {@link SequentialTransactionPlanResult} from an array of nested results.
@@ -397,11 +397,14 @@ export function canceledSingleTransactionPlanResult<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
     TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
         TransactionMessageWithFeePayer,
->(transactionMessage: TTransactionMessage): SingleTransactionPlanResult<TContext, TTransactionMessage> {
+>(
+    transactionMessage: TTransactionMessage,
+    reason?: unknown,
+): SingleTransactionPlanResult<TContext, TTransactionMessage> {
     return Object.freeze({
         kind: 'single',
         message: transactionMessage,
-        status: Object.freeze({ kind: 'canceled' }),
+        status: Object.freeze({ kind: 'canceled' as const, reason }),
     });
 }
 


### PR DESCRIPTION
#### Problem

After the previous PR, if a transaction plan is aborted then we don't throw `SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN`, which allowed us to access the reason for the abort (as cause). 

#### Summary of Changes

Add an optional field `reason?: unknown` to `canceledSingleTransactionPlanResult`. When executing a transaction plan, if it is aborted, the reason on the abort signal is returned here. This means that we can access the cause of a canceled plan result once again.