### PR TITLE
Narrow the type of transaction plan executor to return only successful transactions

### DIFF
--- a/.changeset/mighty-foxes-film.md
+++ b/.changeset/mighty-foxes-film.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': patch
+---
+
+Clarify the return type of transaction plan executor is always successful plans

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
@@ -59,4 +59,33 @@ import type { TransactionPlanResult } from '../transaction-plan-result';
             },
         });
     }
+
+    // It returns a successful result, which may be nested.
+    void (async () => {
+        const executor = null as unknown as TransactionPlanExecutor;
+        const transactionPlan = null as unknown as TransactionPlan;
+        const result = await executor(transactionPlan);
+
+        function _checkRecursive(r: typeof result) {
+            switch (r.kind) {
+                case 'single': {
+                    r.status.kind satisfies 'successful';
+                    return;
+                }
+                case 'sequential': {
+                    for (const subResult of r.plans) {
+                        _checkRecursive(subResult);
+                    }
+                    return;
+                }
+                case 'parallel': {
+                    for (const subResult of r.plans) {
+                        _checkRecursive(subResult);
+                    }
+                    return;
+                }
+            }
+        }
+        void _checkRecursive(result);
+    })();
 }

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -22,6 +22,7 @@ import {
     sequentialTransactionPlanResult,
     successfulSingleTransactionPlanResult,
     successfulSingleTransactionPlanResultFromSignature,
+    SuccessfulTransactionPlanResult,
     type TransactionPlanResult,
     type TransactionPlanResultContext,
 } from './transaction-plan-result';
@@ -29,7 +30,7 @@ import {
 export type TransactionPlanExecutor<TContext extends TransactionPlanResultContext = TransactionPlanResultContext> = (
     transactionPlan: TransactionPlan,
     config?: { abortSignal?: AbortSignal },
-) => Promise<TransactionPlanResult<TContext>>;
+) => Promise<SuccessfulTransactionPlanResult<TContext>>;
 
 type ExecuteResult<TContext extends TransactionPlanResultContext> = {
     context?: TContext;
@@ -79,7 +80,7 @@ export type TransactionPlanExecutorConfig = {
  * @see {@link TransactionPlannerConfig}
  */
 export function createTransactionPlanExecutor(config: TransactionPlanExecutorConfig): TransactionPlanExecutor {
-    return async (plan, { abortSignal } = {}): Promise<TransactionPlanResult> => {
+    return async (plan, { abortSignal } = {}): Promise<SuccessfulTransactionPlanResult> => {
         const context: TraverseContext = {
             ...config,
             abortSignal: abortSignal,
@@ -112,7 +113,8 @@ export function createTransactionPlanExecutor(config: TransactionPlanExecutorCon
             throw new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, context);
         }
 
-        return transactionPlanResult;
+        // If we didn't throw, the transaction plan execution was successful.
+        return transactionPlanResult as SuccessfulTransactionPlanResult;
     };
 }
 


### PR DESCRIPTION
#### Problem

Currently if a transaction plan fails to execute, this is thrown as a `SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN` error which includes the cause and the `TransactionPlanResult` that includes the failed/canceled transactions.

If the transaction plan successfully executes then the result is a `TransactionPlanResult`, which according to the types may include failed/canceled transactions, but in fact will only contain successful transaction results because otherwise the executor will have thrown.

This means that consumers that don't know this implementation detail think they need to handle failed/canceled transactions in multiple places - both in the response, and in a catch narrowed on `SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN`.

#### Summary of Changes

- Change the return type of the transaction plan executor to only return successful transaction plan results
- Can still be any of the shapes (single/nested/parallel)
- Consumers would only need to handle the error cases in the catch error case, if it doesn't thrown then they only need to handle successful transactions. This is already the case in practice but the types now clarify this

Fixes #1201 (alternative to #1203) 