### PR TITLE
allow number in getMinimumBalanceForRentException not just bigint

### DIFF
--- a/packages/kit/src/get-minimum-balance-for-rent-exemption.ts
+++ b/packages/kit/src/get-minimum-balance-for-rent-exemption.ts
@@ -12,14 +12,14 @@ import type { Lamports } from '@solana/rpc-types';
  *
  * @param space The number of bytes of account data.
  */
-export function getMinimumBalanceForRentExemption(space: bigint): Lamports {
+export function getMinimumBalanceForRentExemption(space: bigint | number): Lamports {
     const RENT = {
         ACCOUNT_STORAGE_OVERHEAD: 128n,
         DEFAULT_EXEMPTION_THRESHOLD: 2n,
         DEFAULT_LAMPORTS_PER_BYTE_YEAR: 3_480n,
     } as const;
     const requiredLamports =
-        (RENT.ACCOUNT_STORAGE_OVERHEAD + space) *
+        (RENT.ACCOUNT_STORAGE_OVERHEAD + BigInt(space)) *
         RENT.DEFAULT_LAMPORTS_PER_BYTE_YEAR *
         RENT.DEFAULT_EXEMPTION_THRESHOLD;
     return requiredLamports as Lamports;

--- a/packages/rpc-api/src/getMinimumBalanceForRentExemption.ts
+++ b/packages/rpc-api/src/getMinimumBalanceForRentExemption.ts
@@ -15,7 +15,7 @@ export type GetMinimumBalanceForRentExemptionApi = {
          * The number of bytes of account data for which an exemption from rent collection is being
          * sought.
          */
-        size: bigint,
+        size: bigint | number,
         config?: Readonly<{
             /**
              * Return the minimum balance as of the highest slot that has reached this level of


### PR DESCRIPTION
reason for this change is developer convenience
especially when using other function to calculate size like getMintSize

realistically account size doest exceed 10MB which can be represented by a number and does not require bigints

the rpc transformer will downcast bigints to numbers anyway so numbers can already be used
this is just to satifsy the type checker



#### Summary of Changes
add number support to getMinimumBalanceForRentException in kit and rpc-api

