### PR TITLE
Improve the type of `flattenTransactionPlanResult` to carry a successful status to the returned plan results

### DIFF
--- a/.changeset/fifty-toes-throw.md
+++ b/.changeset/fifty-toes-throw.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': patch
+---
+
+Improve the type of `flattenTransactionPlanResult` to carry a successful status to the returned plan results

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
@@ -4,6 +4,7 @@ import type { Transaction } from '@solana/transactions';
 import {
     canceledSingleTransactionPlanResult,
     failedSingleTransactionPlanResult,
+    flattenTransactionPlanResult,
     nonDivisibleSequentialTransactionPlanResult,
     ParallelTransactionPlanResult,
     parallelTransactionPlanResult,
@@ -11,6 +12,7 @@ import {
     sequentialTransactionPlanResult,
     SingleTransactionPlanResult,
     successfulSingleTransactionPlanResult,
+    SuccessfulTransactionPlanResult,
     TransactionPlanResult,
     TransactionPlanResultContext,
 } from '../transaction-plan-result';
@@ -166,5 +168,23 @@ type CustomContext = { customData: string };
         const result = canceledSingleTransactionPlanResult(messageA);
         result satisfies SingleTransactionPlanResult<TransactionPlanResultContext, typeof messageA>;
         result satisfies TransactionPlanResult;
+    }
+}
+
+// [DESCRIBE] flattenTransactionPlanResult
+{
+    // It returns SingleTransactionPlanResult[] when given a TransactionPlanResult.
+    {
+        const result = null as unknown as TransactionPlanResult;
+        const flattened = flattenTransactionPlanResult(result);
+        flattened satisfies SingleTransactionPlanResult[];
+    }
+
+    // It returns successful single results when given a SuccessfulTransactionPlanResult.
+    {
+        const result = null as unknown as SuccessfulTransactionPlanResult;
+        const flattened = flattenTransactionPlanResult(result);
+        flattened satisfies (SingleTransactionPlanResult & { status: { kind: 'successful' } })[];
+        flattened[0].status.kind satisfies 'successful';
     }
 }

--- a/packages/instruction-plans/src/transaction-plan-result.ts
+++ b/packages/instruction-plans/src/transaction-plan-result.ts
@@ -421,6 +421,10 @@ export function canceledSingleTransactionPlanResult<
  * @param result The transaction plan result to flatten
  * @returns An array of single transaction plan results
  */
+export function flattenTransactionPlanResult(
+    result: SuccessfulTransactionPlanResult,
+): (SingleTransactionPlanResult & { status: { kind: 'successful' } })[];
+export function flattenTransactionPlanResult(result: TransactionPlanResult): SingleTransactionPlanResult[];
 export function flattenTransactionPlanResult(result: TransactionPlanResult): SingleTransactionPlanResult[] {
     const transactionPlanResults: SingleTransactionPlanResult[] = [];
 


### PR DESCRIPTION
#### Summary of Changes

This PR adds an overload to `flattenTransactionPlanResult` such that if the input is `SuccessfulTransactionPlanResult`, then the `status.kind` of all returned `SingleTransactionPlanResult` will be successful. This is already the case by definition, but this adds it to the type.
