### PR TITLE
Stop setting cause on `SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN` errors

### DIFF
--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -430,7 +430,7 @@ export const SolanaErrorMessages: Readonly<{
     [SOLANA_ERROR__INSTRUCTION_PLANS__NON_DIVISIBLE_TRANSACTION_PLANS_NOT_SUPPORTED]:
         'This transaction plan executor does not support non-divisible sequential plans. To support them, you may create your own executor such that multi-transaction atomicity is preserved — e.g. by targetting RPCs that support transaction bundles.',
     [SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN]:
-        'The provided transaction plan failed to execute. See the `transactionPlanResult` attribute and the `cause` error for more details.',
+        'The provided transaction plan failed to execute. See the `transactionPlanResult` attribute for more details.',
     [SOLANA_ERROR__INSTRUCTION_PLANS__MESSAGE_CANNOT_ACCOMMODATE_PLAN]:
         'The provided message has insufficient capacity to accommodate the next instruction(s) in this plan. Expected at least $numBytesRequired free byte(s), got $numFreeBytes byte(s).',
     [SOLANA_ERROR__INVARIANT_VIOLATION__INVALID_TRANSACTION_PLAN_KIND]: 'Invalid transaction plan kind: $kind.',

--- a/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
@@ -103,7 +103,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: failedSingleTransactionPlanResult(messageA, cause),
                 }),
             );
@@ -120,7 +119,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: failedSingleTransactionPlanResult(messageA, cause),
                 }),
             );
@@ -142,7 +140,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: failedSingleTransactionPlanResult(messageA, cause),
                 }),
             );
@@ -163,7 +160,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: canceledSingleTransactionPlanResult(messageA),
                 }),
             );
@@ -276,7 +272,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: sequentialTransactionPlanResult([
                         successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
                         failedSingleTransactionPlanResult(messageB, cause),
@@ -297,7 +292,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: sequentialTransactionPlanResult([
                         failedSingleTransactionPlanResult(messageA, cause),
                         canceledSingleTransactionPlanResult(messageB),
@@ -341,7 +335,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: sequentialTransactionPlanResult([
                         successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
                         failedSingleTransactionPlanResult(messageB, cause),
@@ -372,7 +365,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: sequentialTransactionPlanResult([
                         canceledSingleTransactionPlanResult(messageA),
                         canceledSingleTransactionPlanResult(messageB),
@@ -465,7 +457,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: parallelTransactionPlanResult([
                         successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
                         failedSingleTransactionPlanResult(messageB, cause),
@@ -498,7 +489,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: parallelTransactionPlanResult([
                         successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
                         failedSingleTransactionPlanResult(messageB, cause),
@@ -525,7 +515,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: parallelTransactionPlanResult([
                         canceledSingleTransactionPlanResult(messageA),
                         canceledSingleTransactionPlanResult(messageB),
@@ -614,7 +603,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: parallelTransactionPlanResult([
                         sequentialTransactionPlanResult([
                             successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
@@ -669,7 +657,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: parallelTransactionPlanResult([
                         sequentialTransactionPlanResult([
                             successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
@@ -717,7 +704,6 @@ describe('createTransactionPlanExecutor', () => {
             await expectFailedToExecute(
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
-                    cause,
                     transactionPlanResult: parallelTransactionPlanResult([
                         sequentialTransactionPlanResult([
                             canceledSingleTransactionPlanResult(messageA),

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -98,8 +98,6 @@ export function createTransactionPlanExecutor(config: TransactionPlanExecutorCon
         abortSignal?.removeEventListener('abort', cancelHandler);
 
         if (context.canceled) {
-            const abortReason = abortSignal?.aborted ? abortSignal.reason : undefined;
-            const context = { cause: findErrorFromTransactionPlanResult(transactionPlanResult) ?? abortReason };
             // Here we want the `transactionPlanResult` to be available in the error context
             // so applications can create recovery plans but we don't want this object to be
             // serialized with the error. This is why we set it as a non-enumerable property.
@@ -187,18 +185,6 @@ async function traverseSingle(
     } catch (error) {
         context.canceled = true;
         return failedSingleTransactionPlanResult(transactionPlan.message, error as Error);
-    }
-}
-
-function findErrorFromTransactionPlanResult(result: TransactionPlanResult): Error | undefined {
-    if (result.kind === 'single') {
-        return result.status.kind === 'failed' ? result.status.error : undefined;
-    }
-    for (const plan of result.plans) {
-        const error = findErrorFromTransactionPlanResult(plan);
-        if (error) {
-            return error;
-        }
     }
 }
 


### PR DESCRIPTION
#### Problem

Currently error handling for transaction plans can be confusing, because there's the `error.cause` providing the first failure (or abort reason), and there's also the `transactionPlanResult` object which contains all the failed/cancelled transactions and provides detail on them all.

Consumers should use the plan, and explicitly choose to only handle the first error etc if they'd like to.

#### Summary of Changes

This PR stops setting `cause` when we throw this error. Consumers will need to check the plan to find out why the transaction failed.

Draft:
- We might not want to merge this until we have helpers to make processing the plan easier
- We might want to consider this a breaking change 
