### PR TITLE
Add `every` predicate helpers for instruction plan types

### DIFF
--- a/.changeset/dark-showers-hunt.md
+++ b/.changeset/dark-showers-hunt.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Add `everyInstructionPlan`, `everyTransactionPlan` and `everyTransactionPlanResult` functions that can be used to ensure a given predicate holds for all nodes inside their respective plan structures.

--- a/packages/instruction-plans/src/instruction-plan.ts
+++ b/packages/instruction-plans/src/instruction-plan.ts
@@ -398,6 +398,7 @@ function parseSingleInstructionPlans(plans: (Instruction | InstructionPlan)[]): 
  * ```
  *
  * @see {@link InstructionPlan}
+ * @see {@link everyInstructionPlan}
  */
 export function findInstructionPlan(
     instructionPlan: InstructionPlan,
@@ -416,6 +417,59 @@ export function findInstructionPlan(
         }
     }
     return undefined;
+}
+
+/**
+ * Checks if every instruction plan in the tree satisfies the given predicate.
+ *
+ * This function performs a depth-first traversal through the instruction plan tree,
+ * returning `true` only if the predicate returns `true` for every plan in the tree
+ * (including the root plan and all nested plans).
+ *
+ * @param instructionPlan - The instruction plan tree to check.
+ * @param predicate - A function that returns `true` if the plan satisfies the condition.
+ * @return `true` if every plan in the tree satisfies the predicate, `false` otherwise.
+ *
+ * @example
+ * Checking if all plans are divisible.
+ * ```ts
+ * const plan = sequentialInstructionPlan([
+ *   parallelInstructionPlan([instructionA, instructionB]),
+ *   sequentialInstructionPlan([instructionC, instructionD]),
+ * ]);
+ *
+ * const allDivisible = everyInstructionPlan(
+ *   plan,
+ *   (p) => p.kind !== 'sequential' || p.divisible,
+ * );
+ * // Returns true because all sequential plans are divisible.
+ * ```
+ *
+ * @example
+ * Checking if all single instructions use a specific program.
+ * ```ts
+ * const plan = parallelInstructionPlan([instructionA, instructionB, instructionC]);
+ *
+ * const allUseSameProgram = everyInstructionPlan(
+ *   plan,
+ *   (p) => p.kind !== 'single' || p.instruction.programAddress === myProgramAddress,
+ * );
+ * ```
+ *
+ * @see {@link InstructionPlan}
+ * @see {@link findInstructionPlan}
+ */
+export function everyInstructionPlan(
+    instructionPlan: InstructionPlan,
+    predicate: (plan: InstructionPlan) => boolean,
+): boolean {
+    if (!predicate(instructionPlan)) {
+        return false;
+    }
+    if (instructionPlan.kind === 'single' || instructionPlan.kind === 'messagePacker') {
+        return true;
+    }
+    return instructionPlan.plans.every(p => everyInstructionPlan(p, predicate));
 }
 
 /**

--- a/packages/instruction-plans/src/transaction-plan.ts
+++ b/packages/instruction-plans/src/transaction-plan.ts
@@ -316,6 +316,7 @@ export function getAllSingleTransactionPlans(transactionPlan: TransactionPlan): 
  * ```
  *
  * @see {@link TransactionPlan}
+ * @see {@link everyTransactionPlan}
  * @see {@link getAllSingleTransactionPlans}
  */
 export function findTransactionPlan(
@@ -335,4 +336,58 @@ export function findTransactionPlan(
         }
     }
     return undefined;
+}
+
+/**
+ * Checks if every transaction plan in the tree satisfies the given predicate.
+ *
+ * This function performs a depth-first traversal through the transaction plan tree,
+ * returning `true` only if the predicate returns `true` for every plan in the tree
+ * (including the root plan and all nested plans).
+ *
+ * @param transactionPlan - The transaction plan tree to check.
+ * @param predicate - A function that returns `true` if the plan satisfies the condition.
+ * @return `true` if every plan in the tree satisfies the predicate, `false` otherwise.
+ *
+ * @example
+ * Checking if all plans are divisible.
+ * ```ts
+ * const plan = sequentialTransactionPlan([
+ *   parallelTransactionPlan([messageA, messageB]),
+ *   sequentialTransactionPlan([messageC, messageD]),
+ * ]);
+ *
+ * const allDivisible = everyTransactionPlan(
+ *   plan,
+ *   (p) => p.kind !== 'sequential' || p.divisible,
+ * );
+ * // Returns true because all sequential plans are divisible.
+ * ```
+ *
+ * @example
+ * Checking if all single plans have a specific fee payer.
+ * ```ts
+ * const plan = parallelTransactionPlan([messageA, messageB, messageC]);
+ *
+ * const allUseSameFeePayer = everyTransactionPlan(
+ *   plan,
+ *   (p) => p.kind !== 'single' || p.message.feePayer.address === myFeePayer,
+ * );
+ * ```
+ *
+ * @see {@link TransactionPlan}
+ * @see {@link findTransactionPlan}
+ * @see {@link getAllSingleTransactionPlans}
+ */
+export function everyTransactionPlan(
+    transactionPlan: TransactionPlan,
+    predicate: (plan: TransactionPlan) => boolean,
+): boolean {
+    if (!predicate(transactionPlan)) {
+        return false;
+    }
+    if (transactionPlan.kind === 'single') {
+        return true;
+    }
+    return transactionPlan.plans.every(p => everyTransactionPlan(p, predicate));
 }


### PR DESCRIPTION
#### Problem

`InstructionPlan`, `TransactionPlan` and `TransactionPlanResult` are nested tree structures which makes asserting predicates hold for all nodes inside a plan non-trivial.

#### Summary of Changes

This PR adds `everyInstructionPlan`, `everyTransactionPlan` and `everyTransactionPlanResult` functions. These work similarly to `Array.prototype.every()` but operate on tree structures, performing depth-first traversal and returning true only if the given predicate returns true for every node in the tree (including the root and all nested nodes).

This complements the existing `find*` functions (introduced in #1232) by providing a way to assert conditions across entire plan trees rather than searching for a single matching node.

#### Example usage

```ts
// Check if all instructions are from a given program.
const allFromMyProgram = everyInstructionPlan(
  plan,
  (p) => p.kind !== 'single' || p.instruction.programAddress === myProgramAddress,
);

// Check if all sequential plans are divisible.
const allDivisible = everyTransactionPlan(
  plan,
  (p) => p.kind !== 'sequential' || p.divisible,
);

// Check if all transactions were successful.
const allSuccessful = everyTransactionPlanResult(
  result,
  (r) => r.kind !== 'single' || r.status.kind === 'successful',
);
```