### PR TITLE
Add `passthroughFailedTransactionPlanExecution` helper

### DIFF
--- a/.changeset/puny-camels-sort.md
+++ b/.changeset/puny-camels-sort.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Add `passthroughFailedTransactionPlanExecution` helper function that wraps a transaction plan execution promise to return a `TransactionPlanResult` even on execution failure. This allows handling execution results in a unified way without try/catch.

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
@@ -9,8 +9,18 @@ import {
 import { compileTransaction, Transaction, TransactionWithBlockhashLifetime } from '@solana/transactions';
 
 import type { TransactionPlan } from '../transaction-plan';
-import { createTransactionPlanExecutor, type TransactionPlanExecutor } from '../transaction-plan-executor';
-import type { TransactionPlanResult } from '../transaction-plan-result';
+import {
+    createTransactionPlanExecutor,
+    passthroughFailedTransactionPlanExecution,
+    type TransactionPlanExecutor,
+} from '../transaction-plan-executor';
+import {
+    CanceledSingleTransactionPlanResult,
+    FailedSingleTransactionPlanResult,
+    SingleTransactionPlanResult,
+    SuccessfulSingleTransactionPlanResult,
+    type TransactionPlanResult,
+} from '../transaction-plan-result';
 
 // [DESCRIBE] TransactionPlanExecutor
 {
@@ -58,5 +68,49 @@ import type { TransactionPlanResult } from '../transaction-plan-result';
                 return Promise.resolve({ transaction });
             },
         });
+    }
+}
+
+// [DESCRIBE] passthroughFailedTransactionPlanExecution
+{
+    // It returns a single result when the provided promise expects a single result.
+    {
+        const promise = null as unknown as Promise<SingleTransactionPlanResult>;
+        const result = passthroughFailedTransactionPlanExecution(promise);
+        void (result satisfies Promise<SingleTransactionPlanResult>);
+    }
+
+    // It widens the result of successful single results to include all possible single results.
+    {
+        const promise = null as unknown as Promise<SuccessfulSingleTransactionPlanResult>;
+        const result = passthroughFailedTransactionPlanExecution(promise);
+        void (result satisfies Promise<SingleTransactionPlanResult>);
+        // @ts-expect-error Can no longer expect successful result only.
+        void (result satisfies Promise<SuccessfulSingleTransactionPlanResult>);
+    }
+
+    // It widens the result of canceled single results to include all possible single results.
+    {
+        const promise = null as unknown as Promise<CanceledSingleTransactionPlanResult>;
+        const result = passthroughFailedTransactionPlanExecution(promise);
+        void (result satisfies Promise<SingleTransactionPlanResult>);
+        // @ts-expect-error Can no longer expect canceled result only.
+        void (result satisfies Promise<CanceledSingleTransactionPlanResult>);
+    }
+
+    // It widens the result of failed single results to include all possible single results.
+    {
+        const promise = null as unknown as Promise<FailedSingleTransactionPlanResult>;
+        const result = passthroughFailedTransactionPlanExecution(promise);
+        void (result satisfies Promise<SingleTransactionPlanResult>);
+        // @ts-expect-error Can no longer expect failed result only. It could be canceled too.
+        void (result satisfies Promise<FailedSingleTransactionPlanResult>);
+    }
+
+    // It returns any TransactionPlanResult otherwise.
+    {
+        const promise = null as unknown as Promise<TransactionPlanResult>;
+        const result = passthroughFailedTransactionPlanExecution(promise);
+        void (result satisfies Promise<TransactionPlanResult>);
     }
 }

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -1,4 +1,5 @@
 import {
+    isSolanaError,
     SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
     SOLANA_ERROR__INSTRUCTION_PLANS__NON_DIVISIBLE_TRANSACTION_PLANS_NOT_SUPPORTED,
     SOLANA_ERROR__INVARIANT_VIOLATION__INVALID_TRANSACTION_PLAN_KIND,
@@ -20,12 +21,28 @@ import {
     failedSingleTransactionPlanResult,
     parallelTransactionPlanResult,
     sequentialTransactionPlanResult,
+    SingleTransactionPlanResult,
     successfulSingleTransactionPlanResult,
     successfulSingleTransactionPlanResultFromSignature,
     type TransactionPlanResult,
     type TransactionPlanResultContext,
 } from './transaction-plan-result';
 
+/**
+ * Executes a transaction plan and returns the execution results.
+ *
+ * This function traverses the transaction plan tree, executing each transaction
+ * message and collecting results that mirror the structure of the original plan.
+ *
+ * @typeParam TContext - The type of the context object that may be passed along with successful results.
+ * @param transactionPlan - The transaction plan to execute.
+ * @param config - Optional configuration object that can include an `AbortSignal` to cancel execution.
+ * @return A promise that resolves to the execution results.
+ *
+ * @see {@link TransactionPlan}
+ * @see {@link TransactionPlanResult}
+ * @see {@link createTransactionPlanExecutor}
+ */
 export type TransactionPlanExecutor<TContext extends TransactionPlanResultContext = TransactionPlanResultContext> = (
     transactionPlan: TransactionPlan,
     config?: { abortSignal?: AbortSignal },
@@ -63,12 +80,22 @@ export type TransactionPlanExecutorConfig = {
  * - If the `abortSignal` is triggered, the executor will immediately stop processing the plan and
  * return a `TransactionPlanResult` with the status set to `canceled`.
  *
+ * @param config - Configuration object containing the transaction message executor function.
+ * @return A {@link TransactionPlanExecutor} function that can execute transaction plans.
+ *
+ * @throws {@link SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN}
+ *   if any transaction in the plan fails to execute. The error context contains a
+ *   `transactionPlanResult` property with the partial results up to the point of failure.
+ * @throws {@link SOLANA_ERROR__INSTRUCTION_PLANS__NON_DIVISIBLE_TRANSACTION_PLANS_NOT_SUPPORTED}
+ *   if the transaction plan contains non-divisible sequential plans, which are not
+ *   supported by this executor.
+ *
  * @example
  * ```ts
  * const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
  *
  * const transactionPlanExecutor = createTransactionPlanExecutor({
- *   executeTransactionMessage: (message) => {
+ *   executeTransactionMessage: async (message) => {
  *     const transaction = await signTransactionMessageWithSigners(message);
  *     await sendAndConfirmTransaction(transaction, { commitment: 'confirmed' });
  *     return { transaction };
@@ -76,7 +103,7 @@ export type TransactionPlanExecutorConfig = {
  * });
  * ```
  *
- * @see {@link TransactionPlannerConfig}
+ * @see {@link TransactionPlanExecutorConfig}
  */
 export function createTransactionPlanExecutor(config: TransactionPlanExecutorConfig): TransactionPlanExecutor {
     return async (plan, { abortSignal } = {}): Promise<TransactionPlanResult> => {
@@ -221,5 +248,63 @@ function assertDivisibleSequentialPlansOnly(transactionPlan: TransactionPlan): v
         case 'single':
         default:
             return;
+    }
+}
+
+/**
+ * Wraps a transaction plan execution promise to return a
+ * {@link TransactionPlanResult} even on execution failure.
+ *
+ * When a transaction plan executor throws a
+ * {@link SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN}
+ * error, this helper catches it and returns the `TransactionPlanResult`
+ * from the error context instead of throwing.
+ *
+ * This allows us to handle the result of an execution in a single unified way
+ * instead of using try/catch and examine the `TransactionPlanResult` in both
+ * success and failure cases.
+ *
+ * Any other errors are re-thrown as normal.
+ *
+ * @param promise - A promise returned by a transaction plan executor.
+ * @return A promise that resolves to the transaction plan result, even if some transactions failed.
+ *
+ * @example
+ * Handling failures using a single result object:
+ * ```ts
+ * const result = await passthroughFailedTransactionPlanExecution(
+ *   transactionPlanExecutor(transactionPlan)
+ * );
+ *
+ * const summary = summarizeTransactionPlanResult(result);
+ * if (summary.successful) {
+ *   console.log('All transactions executed successfully');
+ * } else {
+ *   console.log(`${summary.successfulTransactions.length} succeeded`);
+ *   console.log(`${summary.failedTransactions.length} failed`);
+ *   console.log(`${summary.canceledTransactions.length} canceled`);
+ * }
+ * ```
+ *
+ * @see {@link TransactionPlanResult}
+ * @see {@link createTransactionPlanExecutor}
+ * @see {@link summarizeTransactionPlanResult}
+ */
+export async function passthroughFailedTransactionPlanExecution(
+    promise: Promise<SingleTransactionPlanResult>,
+): Promise<SingleTransactionPlanResult>;
+export async function passthroughFailedTransactionPlanExecution(
+    promise: Promise<TransactionPlanResult>,
+): Promise<TransactionPlanResult>;
+export async function passthroughFailedTransactionPlanExecution(
+    promise: Promise<TransactionPlanResult>,
+): Promise<TransactionPlanResult> {
+    try {
+        return await promise;
+    } catch (error) {
+        if (isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)) {
+            return error.context.transactionPlanResult as TransactionPlanResult;
+        }
+        throw error;
     }
 }


### PR DESCRIPTION
#### Problem

When executing a transaction plan, if any transaction fails, the executor throws a `SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN` error which contains the failed `TransactionPlanResult` in its error context. This means developers must use try/catch to handle `TransactionPlanResults` in both success and failure cases.

#### Summary of Changes

This PR adds a `passthroughFailedTransactionPlanExecution` helper function that wraps a transaction plan execution promise and returns the `TransactionPlanResult` regardless of whether execution succeeded or failed.

#### Example Usage

```ts
// Before: duplicated result handling logic
let result: TransactionPlanResult;
try {
    result = await transactionPlanExecutor(transactionPlan);
    // handle successful execution result...
} catch (error) {
    if (isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)) {
        result = error.context.transactionPlanResult;
        // handle failed execution result...
    }
    throw error;
}

// After: unified result handling
const result = await passthroughFailedTransactionPlanExecution(transactionPlanExecutor(transactionPlan));

// handle execution result regardless of success or failure. For instance:
const summary = summarizeTransactionPlanResult(result);
if (summary.successful) {
    console.log('All transactions executed successfully');
} else {
    console.log(`${summary.successfulTransactions.length} succeeded`);
    console.log(`${summary.failedTransactions.length} failed`);
    console.log(`${summary.canceledTransactions.length} canceled`);
}
```
