### PR TITLE
Add `transform` helpers for instruction plan types

### DIFF
--- a/.changeset/metal-worms-lick.md
+++ b/.changeset/metal-worms-lick.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Add `transformInstructionPlan`, `transformTransactionPlan` and `transformTransactionPlanResult` helpers for bottom-up transformation of instruction plan trees.


### PR DESCRIPTION
#### Problem

Transforming nested type structures such as `InstructionPlans`, `TransactionPlans` and `TransactionPlanResults` can be cumbersome.

#### Summary of Changes

This PR adds three new helper functions `transformInstructionPlan`, `transactionTransactionPlan` and `transformTransactionPlanResult` that aim to make this process easier.

They accept their respective plan structure and a transform callback as a second argument that transform each plan within their trees recursively using a bottom-up approach. That is, the callback will be first applied to the leaves of the nested plan and will gradually go up until reaching the root plan. This also means that, any children of a given sequential or parallel plan inside the callback function has already been transformed.

Additionally, all transformed results are frozen to ensure immutability.

#### Usage examples

```ts
// Makes all sequential plans non-divisible.
const transformed = transformInstructionPlan(plan, (p) => {
  if (p.kind === 'sequential' && p.divisible) {
    return nonDivisibleSequentialInstructionPlan(p.plans);
  }
  return p;
});

// Updates the fee payer on all transaction messages.
const transformed = transformTransactionPlan(plan, (p) => {
  if (p.kind === 'single') {
    return singleTransactionPlan({ ...p.message, feePayer: newFeePayer });
  }
  return p;
});
```