### PR TITLE
Use the same commitment for latest blockhash and sendTransaction in test

### DIFF
--- a/packages/rpc-api/src/__tests__/send-transaction-test.ts
+++ b/packages/rpc-api/src/__tests__/send-transaction-test.ts
@@ -108,7 +108,7 @@ describe('sendTransaction', () => {
                 expect.assertions(1);
                 const [secretKey, { value: latestBlockhash }] = await Promise.all([
                     getSecretKey(MOCK_PRIVATE_KEY_BYTES),
-                    rpc.getLatestBlockhash({ commitment: 'processed' }).send(),
+                    rpc.getLatestBlockhash({ commitment }).send(),
                 ]);
                 const message = getMockTransactionMessage({
                     blockhash: latestBlockhash.blockhash,


### PR DESCRIPTION
#### Problem

I noticed multiple CI failures ([example1](https://github.com/anza-xyz/kit/actions/runs/21352900084/job/61453514646?pr=1242), [example2](https://github.com/anza-xyz/kit/actions/runs/21356963906/job/61467792003?pr=1243)) with the same failures in `rpc-api` tests:

```ts
Summary of all failing tests
FAIL src/__tests__/send-transaction-test.ts
  ● sendTransaction › when called with `confirmed` preflight commitment › returns the transaction signature

    expect(received).resolves.toEqual()

    Received promise rejected instead of resolved
    Rejected to value: [SolanaError: Transaction simulation failed]

      129 |                     )
      130 |                     .send();
    > 131 |                 await expect(resultPromise).resolves.toEqual(getBase58Decoder().decode(signature));
          |                       ^
      132 |             });
      133 |         });
      134 |     });

      at expect (../../node_modules/.pnpm/expect@30.2.0/node_modules/expect/build/index.js:2116:15)
      at Object.expect (src/__tests__/send-transaction-test.ts:131:23)
```

A hypothesis is that this is caused by these tests hardcoding `commitment: 'processed'` in the call to `getLatestBlockhash`, and then using the desired commitment (in this case `confirmed`) as the`preflightCommitment` in the call to `sendTransaction`.

This would be a race condition and more likely to fail in CI/a full build than when running just these tests as there will be more activity on the test validator.

#### Summary of Changes

Change the tests to use the desired commitment for both calls. This matches what we do in simulate-transaction-test:

https://github.com/anza-xyz/kit/blob/7e0377b41caed78f81b3fe8272efbc9d4af0464a/packages/rpc-api/src/__tests__/simulate-transaction-test.ts#L145-L168

Fixes: CI (🤞)