### PR TITLE
RPC: Include index in getSignaturesForAddress response #1246

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 node_modules
 .pnp
 .pnp.js
+.pnpm-store/*
 
 # misc
 .DS_Store

--- a/packages/rpc-api/src/getSignaturesForAddress.ts
+++ b/packages/rpc-api/src/getSignaturesForAddress.ts
@@ -9,14 +9,14 @@ type GetSignaturesForAddressTransaction = Readonly<{
     confirmationStatus: Commitment | null;
     /** Error if transaction failed, null if transaction succeeded. */
     err: TransactionError | null;
+    /** Index of the transaction in the block */
+    index: number;
     /** Memo associated with the transaction, null if no memo is present */
     memo: string | null;
     /** transaction signature as base-58 encoded string */
     signature: Signature;
     /** The slot that contains the block with the transaction */
     slot: Slot;
-    /** Index of the transaction in the block */
-    index: number;
 }>;
 
 type GetSignaturesForAddressApiResponse = readonly GetSignaturesForAddressTransaction[];

--- a/packages/rpc-api/src/getSignaturesForAddress.ts
+++ b/packages/rpc-api/src/getSignaturesForAddress.ts
@@ -15,6 +15,8 @@ type GetSignaturesForAddressTransaction = Readonly<{
     signature: Signature;
     /** The slot that contains the block with the transaction */
     slot: Slot;
+    /** Index of the transaction in the block */
+    index: number;
 }>;
 
 type GetSignaturesForAddressApiResponse = readonly GetSignaturesForAddressTransaction[];

--- a/packages/rpc-api/src/index.ts
+++ b/packages/rpc-api/src/index.ts
@@ -304,6 +304,7 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
                 [KEYPATH_WILDCARD, 'account', ...c],
             ]),
             getRecentPerformanceSamples: [[KEYPATH_WILDCARD, 'samplePeriodSecs']],
+            getSignaturesForAddress: [[KEYPATH_WILDCARD, 'index']],
             getTokenAccountBalance: [
                 ['value', 'decimals'],
                 ['value', 'uiAmount'],


### PR DESCRIPTION
#### Problem [Refers to Issue #1246 ]
With https://github.com/anza-xyz/agave/pull/9683, to be included with Agave v4.0, getSignaturesForAddress will include the block index of each transaction returned. Kit should also include this new field.

#### Summary of Changes
- Add index field to GetSignaturesForAddressTransaction type
- Configure index as allowed numeric keypath to prevent bigint conversion