### PR TITLE
Refactor instruction-plans to not use BaseTransactionMessage

### DIFF
--- a/packages/instruction-plans/src/__tests__/__setup__.ts
+++ b/packages/instruction-plans/src/__tests__/__setup__.ts
@@ -6,9 +6,9 @@ import type { Instruction } from '@solana/instructions';
 import { SignatureBytes } from '@solana/keys';
 import {
     appendTransactionMessageInstruction,
-    type BaseTransactionMessage,
     createTransactionMessage,
     setTransactionMessageFeePayer,
+    type TransactionMessage,
     type TransactionMessageWithFeePayer,
 } from '@solana/transaction-messages';
 import { getTransactionMessageSize, SignaturesMap, Transaction, TRANSACTION_SIZE_LIMIT } from '@solana/transactions';
@@ -23,7 +23,7 @@ export const FOREVER_PROMISE = new Promise(() => {
 
 export function createMessage<TId extends string>(
     id: TId,
-): BaseTransactionMessage & TransactionMessageWithFeePayer & { id: TId } {
+): TransactionMessage & TransactionMessageWithFeePayer & { id: TId } {
     return pipe(
         createTransactionMessage({ version: 0 }),
         m => setTransactionMessageFeePayer('E9Nykp3rSdza2moQutaJ3K3RSC8E5iFERX2SqLTsQfjJ' as Address, m),
@@ -57,7 +57,7 @@ export function instructionFactory(baseSeed?: string) {
 }
 
 export function transactionPercentFactory(
-    createTransactionMessage: () => BaseTransactionMessage & TransactionMessageWithFeePayer,
+    createTransactionMessage: () => TransactionMessage & TransactionMessageWithFeePayer,
 ) {
     const minimumTransactionSize = getTransactionMessageSize(createTransactionMessage());
     const remainingSize = TRANSACTION_SIZE_LIMIT - minimumTransactionSize - 1; /* For shortU16. */

--- a/packages/instruction-plans/src/__tests__/instruction-plan-test.ts
+++ b/packages/instruction-plans/src/__tests__/instruction-plan-test.ts
@@ -10,9 +10,9 @@ import { pipe } from '@solana/functional';
 import { Instruction } from '@solana/instructions';
 import {
     appendTransactionMessageInstruction,
-    BaseTransactionMessage,
     createTransactionMessage,
     setTransactionMessageFeePayer,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/transaction-messages';
 import { getTransactionMessageSize, TRANSACTION_SIZE_LIMIT } from '@solana/transactions';
@@ -201,7 +201,7 @@ describe('nonDivisibleSequentialInstructionPlan', () => {
 });
 
 describe('getLinearMessagePackerInstructionPlan', () => {
-    let message: BaseTransactionMessage & TransactionMessageWithFeePayer;
+    let message: TransactionMessage & TransactionMessageWithFeePayer;
     beforeEach(() => {
         message = pipe(createTransactionMessage({ version: 0 }), m =>
             setTransactionMessageFeePayer('E9Nykp3rSdza2moQutaJ3K3RSC8E5iFERX2SqLTsQfjJ' as Address, m),
@@ -263,7 +263,7 @@ describe('getLinearMessagePackerInstructionPlan', () => {
 });
 
 describe('getMessagePackerInstructionPlanFromInstructions', () => {
-    let message: BaseTransactionMessage & TransactionMessageWithFeePayer;
+    let message: TransactionMessage & TransactionMessageWithFeePayer;
     beforeEach(() => {
         message = pipe(createTransactionMessage({ version: 0 }), m =>
             setTransactionMessageFeePayer('E9Nykp3rSdza2moQutaJ3K3RSC8E5iFERX2SqLTsQfjJ' as Address, m),
@@ -307,7 +307,7 @@ describe('getMessagePackerInstructionPlanFromInstructions', () => {
 });
 
 describe('getReallocMessagePackerInstructionPlan', () => {
-    let message: BaseTransactionMessage & TransactionMessageWithFeePayer;
+    let message: TransactionMessage & TransactionMessageWithFeePayer;
     beforeEach(() => {
         message = pipe(createTransactionMessage({ version: 0 }), m =>
             setTransactionMessageFeePayer('E9Nykp3rSdza2moQutaJ3K3RSC8E5iFERX2SqLTsQfjJ' as Address, m),

--- a/packages/instruction-plans/src/__tests__/transaction-planner-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-planner-test.ts
@@ -4,7 +4,7 @@ import { SOLANA_ERROR__INSTRUCTION_PLANS__MESSAGE_CANNOT_ACCOMMODATE_PLAN, Solan
 import { Instruction } from '@solana/instructions';
 import {
     appendTransactionMessageInstructions,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/transaction-messages';
 import { getTransactionMessageSize, TRANSACTION_SIZE_LIMIT } from '@solana/transactions';
@@ -35,11 +35,11 @@ import {
     transactionPercentFactory,
 } from './__setup__';
 
-function createMockTransactionMessage(): BaseTransactionMessage & TransactionMessageWithFeePayer {
+function createMockTransactionMessage(): TransactionMessage & TransactionMessageWithFeePayer {
     return createMessage('mock-message');
 }
 
-function getHelpers(createTransactionMessage: () => BaseTransactionMessage & TransactionMessageWithFeePayer) {
+function getHelpers(createTransactionMessage: () => TransactionMessage & TransactionMessageWithFeePayer) {
     return {
         instruction: instructionFactory(),
         singleTransactionPlan: (instructions: Instruction[]) =>

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
@@ -1,4 +1,4 @@
-import type { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import type { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 import type { Transaction } from '@solana/transactions';
 
 import {
@@ -16,9 +16,9 @@ import {
     TransactionPlanResultContext,
 } from '../transaction-plan-result';
 
-const messageA = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer & { id: 'A' };
-const messageB = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer & { id: 'B' };
-const messageC = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer & { id: 'C' };
+const messageA = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { id: 'A' };
+const messageB = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { id: 'B' };
+const messageC = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { id: 'C' };
 const transactionA = null as unknown as Transaction;
 const transactionB = null as unknown as Transaction;
 const error = null as unknown as Error;

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-typetest.ts
@@ -1,4 +1,4 @@
-import type { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import type { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
 import {
     flattenTransactionPlan,
@@ -12,9 +12,9 @@ import {
     singleTransactionPlan,
 } from '../transaction-plan';
 
-const messageA = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer & { id: 'A' };
-const messageB = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer & { id: 'B' };
-const messageC = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer & { id: 'C' };
+const messageA = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { id: 'A' };
+const messageB = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { id: 'B' };
+const messageC = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { id: 'C' };
 
 // [DESCRIBE] parallelTransactionPlan
 {

--- a/packages/instruction-plans/src/__typetests__/transaction-planner-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-planner-typetest.ts
@@ -3,7 +3,7 @@
 import { Instruction } from '@solana/instructions';
 import {
     appendTransactionMessageInstruction,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/transaction-messages';
 
@@ -31,7 +31,7 @@ import { createTransactionPlanner, type TransactionPlanner } from '../transactio
                 typeof createTransactionPlanner
             >[0]['createTransactionMessage'],
             onTransactionMessageUpdated: message => {
-                message satisfies BaseTransactionMessage & TransactionMessageWithFeePayer;
+                message satisfies TransactionMessage & TransactionMessageWithFeePayer;
                 return message;
             },
         });

--- a/packages/instruction-plans/src/instruction-plan.ts
+++ b/packages/instruction-plans/src/instruction-plan.ts
@@ -6,7 +6,7 @@ import {
 import { Instruction } from '@solana/instructions';
 import {
     appendTransactionMessageInstruction,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/transaction-messages';
 import { getTransactionMessageSize, TRANSACTION_SIZE_LIMIT } from '@solana/transactions';
@@ -247,8 +247,8 @@ export type MessagePacker = Readonly<{
      *   if the message packer is already done and no more instructions can be packed.
      */
     packMessageToCapacity: (
-        transactionMessage: BaseTransactionMessage & TransactionMessageWithFeePayer,
-    ) => BaseTransactionMessage & TransactionMessageWithFeePayer;
+        transactionMessage: TransactionMessage & TransactionMessageWithFeePayer,
+    ) => TransactionMessage & TransactionMessageWithFeePayer;
 }>;
 
 /**
@@ -620,7 +620,7 @@ export function getLinearMessagePackerInstructionPlan({
             let offset = 0;
             return Object.freeze({
                 done: () => offset >= totalBytes,
-                packMessageToCapacity: (message: BaseTransactionMessage & TransactionMessageWithFeePayer) => {
+                packMessageToCapacity: (message: TransactionMessage & TransactionMessageWithFeePayer) => {
                     if (offset >= totalBytes) {
                         throw new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__MESSAGE_PACKER_ALREADY_COMPLETE);
                     }
@@ -689,7 +689,7 @@ export function getMessagePackerInstructionPlanFromInstructions<TInstruction ext
             let instructionIndex = 0;
             return Object.freeze({
                 done: () => instructionIndex >= instructions.length,
-                packMessageToCapacity: (message: BaseTransactionMessage & TransactionMessageWithFeePayer) => {
+                packMessageToCapacity: (message: TransactionMessage & TransactionMessageWithFeePayer) => {
                     if (instructionIndex >= instructions.length) {
                         throw new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__MESSAGE_PACKER_ALREADY_COMPLETE);
                     }

--- a/packages/instruction-plans/src/transaction-plan-result.ts
+++ b/packages/instruction-plans/src/transaction-plan-result.ts
@@ -3,7 +3,7 @@ import {
     SolanaError,
 } from '@solana/errors';
 import { Signature } from '@solana/keys';
-import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 import { getSignatureFromTransaction, Transaction } from '@solana/transactions';
 
 /**
@@ -152,7 +152,7 @@ export type ParallelTransactionPlanResult<
  */
 export type SingleTransactionPlanResult<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 > = Readonly<{
     kind: 'single';
@@ -282,7 +282,7 @@ export function parallelTransactionPlanResult<
  */
 export function successfulSingleTransactionPlanResult<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
     transactionMessage: TTransactionMessage,
@@ -327,7 +327,7 @@ export function successfulSingleTransactionPlanResult<
  */
 export function successfulSingleTransactionPlanResultFromSignature<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
     transactionMessage: TTransactionMessage,
@@ -369,7 +369,7 @@ export function successfulSingleTransactionPlanResultFromSignature<
  */
 export function failedSingleTransactionPlanResult<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(transactionMessage: TTransactionMessage, error: Error): SingleTransactionPlanResult<TContext, TTransactionMessage> {
     return Object.freeze({
@@ -399,7 +399,7 @@ export function failedSingleTransactionPlanResult<
  */
 export function canceledSingleTransactionPlanResult<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(transactionMessage: TTransactionMessage): SingleTransactionPlanResult<TContext, TTransactionMessage> {
     return Object.freeze({

--- a/packages/instruction-plans/src/transaction-plan.ts
+++ b/packages/instruction-plans/src/transaction-plan.ts
@@ -1,4 +1,4 @@
-import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
 /**
  * A set of transaction messages with constraints on how they can be executed.
@@ -128,7 +128,7 @@ export type ParallelTransactionPlan = Readonly<{
  * @see {@link singleTransactionPlan}
  */
 export type SingleTransactionPlan<
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 > = Readonly<{
     kind: 'single';
@@ -159,7 +159,7 @@ export type SingleTransactionPlan<
  * @see {@link ParallelTransactionPlan}
  */
 export function parallelTransactionPlan(
-    plans: (TransactionPlan | (BaseTransactionMessage & TransactionMessageWithFeePayer))[],
+    plans: (TransactionPlan | (TransactionMessage & TransactionMessageWithFeePayer))[],
 ): ParallelTransactionPlan {
     return Object.freeze({ kind: 'parallel', plans: parseSingleTransactionPlans(plans) });
 }
@@ -188,7 +188,7 @@ export function parallelTransactionPlan(
  * @see {@link SequentialTransactionPlan}
  */
 export function sequentialTransactionPlan(
-    plans: (TransactionPlan | (BaseTransactionMessage & TransactionMessageWithFeePayer))[],
+    plans: (TransactionPlan | (TransactionMessage & TransactionMessageWithFeePayer))[],
 ): SequentialTransactionPlan & { divisible: true } {
     return Object.freeze({ divisible: true, kind: 'sequential', plans: parseSingleTransactionPlans(plans) });
 }
@@ -217,7 +217,7 @@ export function sequentialTransactionPlan(
  * @see {@link SequentialTransactionPlan}
  */
 export function nonDivisibleSequentialTransactionPlan(
-    plans: (TransactionPlan | (BaseTransactionMessage & TransactionMessageWithFeePayer))[],
+    plans: (TransactionPlan | (TransactionMessage & TransactionMessageWithFeePayer))[],
 ): SequentialTransactionPlan & { divisible: false } {
     return Object.freeze({ divisible: false, kind: 'sequential', plans: parseSingleTransactionPlans(plans) });
 }
@@ -234,14 +234,14 @@ export function nonDivisibleSequentialTransactionPlan(
  * @see {@link SingleTransactionPlan}
  */
 export function singleTransactionPlan<
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer = BaseTransactionMessage &
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(transactionMessage: TTransactionMessage): SingleTransactionPlan<TTransactionMessage> {
     return Object.freeze({ kind: 'single', message: transactionMessage });
 }
 
 function parseSingleTransactionPlans(
-    plans: (TransactionPlan | (BaseTransactionMessage & TransactionMessageWithFeePayer))[],
+    plans: (TransactionPlan | (TransactionMessage & TransactionMessageWithFeePayer))[],
 ): TransactionPlan[] {
     return plans.map(plan => ('kind' in plan ? plan : singleTransactionPlan(plan)));
 }

--- a/packages/instruction-plans/src/transaction-planner.ts
+++ b/packages/instruction-plans/src/transaction-planner.ts
@@ -9,7 +9,7 @@ import {
 import { getAbortablePromise } from '@solana/promises';
 import {
     appendTransactionMessageInstructions,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/transaction-messages';
 import { getTransactionMessageSize, TRANSACTION_SIZE_LIMIT } from '@solana/transactions';
@@ -50,15 +50,15 @@ type Mutable<T> = { -readonly [P in keyof T]: T[P] };
 type CreateTransactionMessage = (config?: {
     abortSignal?: AbortSignal;
 }) =>
-    | Promise<BaseTransactionMessage & TransactionMessageWithFeePayer>
-    | (BaseTransactionMessage & TransactionMessageWithFeePayer);
+    | Promise<TransactionMessage & TransactionMessageWithFeePayer>
+    | (TransactionMessage & TransactionMessageWithFeePayer);
 
 type OnTransactionMessageUpdated = (
-    transactionMessage: BaseTransactionMessage & TransactionMessageWithFeePayer,
+    transactionMessage: TransactionMessage & TransactionMessageWithFeePayer,
     config?: { abortSignal?: AbortSignal },
 ) =>
-    | Promise<BaseTransactionMessage & TransactionMessageWithFeePayer>
-    | (BaseTransactionMessage & TransactionMessageWithFeePayer);
+    | Promise<TransactionMessage & TransactionMessageWithFeePayer>
+    | (TransactionMessage & TransactionMessageWithFeePayer);
 
 /**
  * Configuration object for creating a new transaction planner.
@@ -246,7 +246,7 @@ async function traverseSingle(
     instructionPlan: SingleInstructionPlan,
     context: TraverseContext,
 ): Promise<MutableTransactionPlan | null> {
-    const predicate = (message: BaseTransactionMessage & TransactionMessageWithFeePayer) =>
+    const predicate = (message: TransactionMessage & TransactionMessageWithFeePayer) =>
         appendTransactionMessageInstructions([instructionPlan.instruction], message);
     const candidate = await selectAndMutateCandidate(context, context.parentCandidates, predicate);
     if (candidate) {
@@ -307,8 +307,8 @@ async function selectAndMutateCandidate(
     context: Pick<TraverseContext, 'abortSignal' | 'onTransactionMessageUpdated'>,
     candidates: MutableSingleTransactionPlan[],
     predicate: (
-        message: BaseTransactionMessage & TransactionMessageWithFeePayer,
-    ) => BaseTransactionMessage & TransactionMessageWithFeePayer,
+        message: TransactionMessage & TransactionMessageWithFeePayer,
+    ) => TransactionMessage & TransactionMessageWithFeePayer,
 ): Promise<MutableSingleTransactionPlan | null> {
     for (const candidate of candidates) {
         try {
@@ -338,9 +338,9 @@ async function selectAndMutateCandidate(
 async function createNewMessage(
     context: Pick<TraverseContext, 'abortSignal' | 'createTransactionMessage' | 'onTransactionMessageUpdated'>,
     predicate: (
-        message: BaseTransactionMessage & TransactionMessageWithFeePayer,
-    ) => BaseTransactionMessage & TransactionMessageWithFeePayer,
-): Promise<BaseTransactionMessage & TransactionMessageWithFeePayer> {
+        message: TransactionMessage & TransactionMessageWithFeePayer,
+    ) => TransactionMessage & TransactionMessageWithFeePayer,
+): Promise<TransactionMessage & TransactionMessageWithFeePayer> {
     const newMessage = await getAbortablePromise(
         Promise.resolve(context.createTransactionMessage({ abortSignal: context.abortSignal })),
         context.abortSignal,
@@ -381,9 +381,9 @@ function freezeTransactionPlan(plan: MutableTransactionPlan): TransactionPlan {
 
 function fitEntirePlanInsideMessage(
     instructionPlan: InstructionPlan,
-    message: BaseTransactionMessage & TransactionMessageWithFeePayer,
-): BaseTransactionMessage & TransactionMessageWithFeePayer {
-    let newMessage: BaseTransactionMessage & TransactionMessageWithFeePayer = message;
+    message: TransactionMessage & TransactionMessageWithFeePayer,
+): TransactionMessage & TransactionMessageWithFeePayer {
+    let newMessage: TransactionMessage & TransactionMessageWithFeePayer = message;
 
     const kind = instructionPlan.kind;
     switch (kind) {


### PR DESCRIPTION
#### Problem

We deprecated `BaseTransactionMessage` a while ago, let's clean up instruction-plans while we're here

#### Summary of Changes

Just type name changes. All code stays compatible 
