### PR TITLE
Make dependabot group react and react-dom dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,7 @@ updates:
       solana-program-clients:
         patterns:
           - '@solana-program/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'


### PR DESCRIPTION
#### Problem

Dependabot opened separate PRs for [react](https://github.com/anza-xyz/kit/pull/1250) and [react-dom](https://github.com/anza-xyz/kit/pull/1251). Both fail because their versions have to match

#### Summary of Changes

Make dependabot update both packages together by adding a group to dependabot.yml
