### PR TITLE
Allow preview-docs to partially run on dependabot PRs

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -21,7 +21,6 @@ env:
 
 jobs:
   preview-docs:
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
@@ -42,6 +41,7 @@ jobs:
         run: pnpm install -g vercel
 
       - name: Deploy to Vercel
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         shell: bash
         id: vercel_deploy
         env:
@@ -64,6 +64,7 @@ jobs:
           echo "preview_url=$DEPLOY_URL" >> $GITHUB_OUTPUT
 
       - name: Comment on PR with Preview URL
+        if: steps.vercel_deploy.outcome == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
#### Problem

- Dependabot broke CI by merging a change to the docs/ dependencies that didn't update its lockfile: https://github.com/anza-xyz/kit/pull/1261
- The preview-docs CI job did not run on this branch because of a `if` check that stops dependabot PRs running the job
- It then broke CI when that job ran on main/subsequent non-dependabot PRs

#### Summary of Changes

Move the condition, so that only the deploy to Vercel is blocked for dependabot. This is necessary because they don't have access to the Vercel secrets. Dependabot PRs will now run the job, and verify the docs dependencies install

Note that the deploy job is still doing a lot that could be nice to test, like the `vercel build`. But all of that uses the Vercel token which dependabot PRs don't have access to. We might later want to split that job and see what we can test without the secret.