### PR TITLE
ci: add merge_group to pull_request Github Actions

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -2,6 +2,7 @@ name: Pull requests
 
 on:
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
#### Problem

we want to use required status checks. however, the merge queue will block the PR if the check is not triggered.

context: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

#### Summary of Changes

add `merge_group`
