### PR TITLE
Reshape single `TransactionPlanResults`

### DIFF
--- a/.changeset/thin-maps-guess.md
+++ b/.changeset/thin-maps-guess.md
@@ -1,0 +1,59 @@
+---
+'@solana/instruction-plans': major
+---
+
+Reshape `SingleTransactionPlanResult` from a single object type with a `status` discriminated union into three distinct types: `SuccessfulSingleTransactionPlanResult`, `FailedSingleTransactionPlanResult`, and `CanceledSingleTransactionPlanResult`. This flattens the result structure so that `status` is now a string literal (`'successful'`, `'failed'`, or `'canceled'`) and properties like `context`, `error`, and `signature` live at the top level of each variant.
+
+Other changes include:
+
+- Rename the `message` property to `plannedMessage` on all single transaction plan result types. This makes it clearer that this original planned message from the `TransactionPlan`, not the final message that was sent to the network.
+- Move the `context` object from inside the `status` field to the top level of each result variant. All variants now carry a `context` — not just successful ones.
+- Expand `TransactionPlanResultContext` to optionally include `message`, `signature`, and `transaction` properties.
+- Remove the now-unused `TransactionPlanResultStatus` type.
+- `failedSingleTransactionPlanResult` and `canceledSingleTransactionPlanResult` now accept an optional `context` parameter.
+
+**BREAKING CHANGES**
+
+**Accessing the status kind.** Replace `result.status.kind` with `result.status`.
+
+```diff
+- if (result.status.kind === 'successful') { /* ... */ }
++ if (result.status === 'successful') { /* ... */ }
+```
+
+**Accessing the signature.** The signature has moved from `result.status.signature` to `result.context.signature`.
+
+```diff
+- const sig = result.status.signature;
++ const sig = result.context.signature;
+```
+
+**Accessing the transaction.** The transaction has moved from `result.status.transaction` to `result.context.transaction`.
+
+```diff
+- const tx = result.status.transaction;
++ const tx = result.context.transaction;
+```
+
+**Accessing the error.** The error has moved from `result.status.error` to `result.error`.
+
+```diff
+- const err = result.status.error;
++ const err = result.error;
+```
+
+**Accessing the context.** The context has moved from `result.status.context` to `result.context`.
+
+```diff
+- const ctx = result.status.context;
++ const ctx = result.context;
+```
+
+**Accessing the message.** The `message` property has been renamed to `plannedMessage`.
+
+```diff
+- const msg = result.message;
++ const msg = result.plannedMessage;
+```
+
+**`TransactionPlanResultStatus` removed.** Code that references this type must be updated to use the individual result variant types (`SuccessfulSingleTransactionPlanResult`, `FailedSingleTransactionPlanResult`, `CanceledSingleTransactionPlanResult`) or the `SingleTransactionPlanResult` union directly.

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -34,7 +34,7 @@ import {
  * This function traverses the transaction plan tree, executing each transaction
  * message and collecting results that mirror the structure of the original plan.
  *
- * @typeParam TContext - The type of the context object that may be passed along with successful results.
+ * @typeParam TContext - The type of the context object that may be passed along with results.
  * @param transactionPlan - The transaction plan to execute.
  * @param config - Optional configuration object that can include an `AbortSignal` to cancel execution.
  * @return A promise that resolves to the execution results.
@@ -219,7 +219,7 @@ async function traverseSingle(
 
 function findErrorFromTransactionPlanResult(result: TransactionPlanResult): Error | undefined {
     if (result.kind === 'single') {
-        return result.status.kind === 'failed' ? result.status.error : undefined;
+        return result.status === 'failed' ? result.error : undefined;
     }
     for (const plan of result.plans) {
         const error = findErrorFromTransactionPlanResult(plan);


### PR DESCRIPTION
#### Problem

Only successful transaction plan results can carry additional context (e.g. the transaction signature). When a transaction fails or is canceled, there is no way to retrieve the signature or other contextual data that was accumulated during execution. This makes debugging and logging difficult — for instance, a failed transaction may still have a signature if it was sent but not confirmed, yet the current API provides no way to access it.

Additionally, the `TransactionPlanExecutor` may progressively build up state during execution — fetching a blockhash, estimating compute units, signing the transaction — and any of these steps could fail. Ideally, the most recent state (the latest message, the signed transaction, the signature) should remain accessible on the result regardless of the outcome.

#### Summary of Changes

- Reshape `SingleTransactionPlanResult` from a single object type with a `status` discriminated union into three distinct types: `SuccessfulSingleTransactionPlanResult`, `FailedSingleTransactionPlanResult`, and `CanceledSingleTransactionPlanResult`. The `status` field is now a string literal (`'successful'`, `'failed'`, or `'canceled'`) and properties like `context`, `error`, and `signature` live at the top level of each variant.
- Rename the `message` property to `plannedMessage` on all single transaction plan result types to clarify that this is the original planned message from the `TransactionPlan`, not the final message sent to the network.
- Move the `context` object from inside the `status` field to the top level of each result variant. All variants now carry a `context` — not just successful ones.
- Expand `TransactionPlanResultContext` to optionally include `message`, `signature`, and `transaction` properties.
- Remove the now-unused `TransactionPlanResultStatus` type.
- `failedSingleTransactionPlanResult` and `canceledSingleTransactionPlanResult` now accept an optional `context` parameter.

Relates to https://github.com/anza-xyz/kit/issues/1273