### PR TITLE
Add docs as a separate dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,24 @@ updates:
         patterns:
           - 'react'
           - 'react-dom'
+  - package-ecosystem: 'npm'
+    directory: '/docs'
+    schedule:
+      interval: daily
+      time: '01:00'
+      timezone: America/Los_Angeles
+    groups:
+      eslint:
+        patterns:
+          - 'eslint*'
+          - 'typescript'
+      solana:
+        patterns:
+          - '@solana/*'
+      solana-program-clients:
+        patterns:
+          - '@solana-program/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'


### PR DESCRIPTION
#### Problem

Dependabot currently doesn't work correctly for docs because `docs` is correctly ignored by the `/` pnpm workspace. This means that dependabot PRs that update docs dependencies fail as they don't update the appropriate lockfile.

#### Summary of Changes

Add a dependabot config for the `/docs` directory

- same schedule as /
- eslint group is different, as we use `eslint` and `eslint-next-config` rather than `@eslint/` and `@typescript-eslint/`
- added `solana` as a group with `@solana/*`. This will capture updates to Kit and web3js. I think this will make dependabot automatically update the kit dependencies which it currently doesn't, probably because they're in the root workspace
- keep the solana-program-client and react groups from root

This might take a little iteration but it's low risk and I think worth it to get one more thing automated properly 

Fixes: broken dependabot PRs hopefully