### PR TITLE
Stop using deprecated BaseTransactionMessage type in signers

### DIFF
--- a/packages/signers/README.md
+++ b/packages/signers/README.md
@@ -440,7 +440,7 @@ const myInstructionWithSigners: Instruction & InstructionWithSigners = {
 Composable type that allows `AccountSignerMetas` to be used inside all of the transaction message's account metas.
 
 ```ts
-const myTransactionMessageWithSigners: BaseTransactionMessage & TransactionMessageWithSigners = {
+const myTransactionMessageWithSigners: TransactionMessage & TransactionMessageWithSigners = {
     instructions: [
         myInstructionA as Instruction & InstructionWithSigners,
         myInstructionB as Instruction & InstructionWithSigners,

--- a/packages/signers/src/__tests__/add-signers-test.ts
+++ b/packages/signers/src/__tests__/add-signers-test.ts
@@ -3,7 +3,7 @@ import '@solana/test-matchers/toBeFrozenObject';
 import { Address } from '@solana/addresses';
 import { SOLANA_ERROR__SIGNER__ADDRESS_CANNOT_HAVE_MULTIPLE_SIGNERS, SolanaError } from '@solana/errors';
 import { AccountRole, Instruction } from '@solana/instructions';
-import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
 import { AccountSignerMeta, InstructionWithSigners } from '../account-signer-meta';
 import { addSignersToInstruction, addSignersToTransactionMessage } from '../add-signers';
@@ -170,7 +170,7 @@ describe('addSignersToTransactionMessage', () => {
             data: new Uint8Array([]),
             programAddress: '9999' as Address,
         };
-        const transaction: BaseTransactionMessage = {
+        const transaction: TransactionMessage = {
             instructions: [instructionA, instructionB],
             version: 0,
         };
@@ -193,7 +193,7 @@ describe('addSignersToTransactionMessage', () => {
 
     it('updates the fee payer if a matching signer is provided', () => {
         // Given a transaction with a fee payer address.
-        const transaction: BaseTransactionMessage & TransactionMessageWithFeePayer = {
+        const transaction: TransactionMessage & TransactionMessageWithFeePayer = {
             feePayer: { address: '1111' as Address },
             instructions: [],
             version: 0,
@@ -215,7 +215,7 @@ describe('addSignersToTransactionMessage', () => {
         const signerB = createMockTransactionModifyingSigner('1111' as Address);
 
         // And a transaction using fee payer signer A.
-        const transaction: BaseTransactionMessage & TransactionMessageWithFeePayerSigner = {
+        const transaction: TransactionMessage & TransactionMessageWithFeePayerSigner = {
             feePayer: signerA,
             instructions: [],
             version: 0,
@@ -230,7 +230,7 @@ describe('addSignersToTransactionMessage', () => {
 
     it('freezes the returned transaction', () => {
         // Given a one-instruction transaction with signer account metas.
-        const transaction: BaseTransactionMessage = {
+        const transaction: TransactionMessage = {
             instructions: [
                 {
                     accounts: [{ address: '1111' as Address, role: AccountRole.READONLY_SIGNER }],
@@ -253,7 +253,7 @@ describe('addSignersToTransactionMessage', () => {
 
     it('returns the transaction as-is if it has no instructions or fee payer to update', () => {
         // Given transaction with no instructions or fee payer.
-        const transaction: BaseTransactionMessage = { instructions: [], version: 0 };
+        const transaction: TransactionMessage = { instructions: [], version: 0 };
 
         // When we try to add signers to the transaction.
         const signer = createMockTransactionPartialSigner('1111' as Address);

--- a/packages/signers/src/__typetests__/add-signers-typetest.ts
+++ b/packages/signers/src/__typetests__/add-signers-typetest.ts
@@ -27,4 +27,19 @@ const message = null as unknown as TransactionMessage;
         const messageWithSigners = addSignersToTransactionMessage([aliceSigner, bobSigner], message);
         messageWithSigners satisfies TransactionMessageWithSigners;
     }
+
+    // It preserves the instruction type of the transaction message
+    {
+        type InstructionA = Instruction & { id: 'A' };
+        type InstructionB = Instruction & { id: 'B' };
+
+        const message = null as unknown as TransactionMessage & {
+            instructions: [InstructionA, InstructionB];
+        };
+
+        message.instructions satisfies [InstructionA, InstructionB];
+        const messageWithSigners = addSignersToTransactionMessage([aliceSigner, bobSigner], message);
+        messageWithSigners satisfies TransactionMessageWithSigners;
+        messageWithSigners.instructions satisfies [InstructionA, InstructionB];
+    }
 }

--- a/packages/signers/src/__typetests__/sign-transaction-typetest.ts
+++ b/packages/signers/src/__typetests__/sign-transaction-typetest.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { SignatureBytes } from '@solana/keys';
 import {
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithBlockhashLifetime,
     TransactionMessageWithDurableNonceLifetime,
     TransactionMessageWithFeePayer,
@@ -25,7 +25,7 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 
 {
     // [partiallySignTransactionMessageWithSigners]: returns a transaction with a lifetime when the input message has a blockhash lifetime
-    const transactionMessage = null as unknown as BaseTransactionMessage &
+    const transactionMessage = null as unknown as TransactionMessage &
         TransactionMessageWithBlockhashLifetime &
         TransactionMessageWithFeePayer &
         TransactionMessageWithSigners;
@@ -36,7 +36,7 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 
 {
     // [partiallySignTransactionMessageWithSigners]: returns a transaction with a lifetime when the input message has a durable nonce lifetime
-    const transactionMessage = null as unknown as BaseTransactionMessage &
+    const transactionMessage = null as unknown as TransactionMessage &
         TransactionMessageWithDurableNonceLifetime &
         TransactionMessageWithFeePayer &
         TransactionMessageWithSigners;
@@ -47,7 +47,7 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 
 {
     // [partiallySignTransactionMessageWithSigners]: returns a transaction with an unknown lifetime when the input message has an unknown lifetime
-    const transactionMessage = null as unknown as BaseTransactionMessage &
+    const transactionMessage = null as unknown as TransactionMessage &
         TransactionMessageWithFeePayer &
         TransactionMessageWithLifetime &
         TransactionMessageWithSigners;
@@ -58,7 +58,7 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 
 {
     // [partiallySignTransactionMessageWithSigners]: returns a transaction with a lifetime when the input message has no lifetime
-    const transactionMessage = null as unknown as BaseTransactionMessage &
+    const transactionMessage = null as unknown as TransactionMessage &
         TransactionMessageWithFeePayer &
         TransactionMessageWithSigners;
     partiallySignTransactionMessageWithSigners(transactionMessage) satisfies Promise<Readonly<Transaction>>;
@@ -69,7 +69,7 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 
 {
     // [partiallySignTransactionMessageWithSigners]: returns a transaction with a `TransactionWithinSizeLimit` flag
-    const transactionMessage = null as unknown as BaseTransactionMessage &
+    const transactionMessage = null as unknown as TransactionMessage &
         TransactionMessageWithFeePayer &
         TransactionMessageWithinSizeLimit &
         TransactionMessageWithLifetime &
@@ -81,7 +81,7 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 
 {
     // [signTransactionMessageWithSigners]: returns a fully signed transaction with a lifetime when the input message has a blockhash lifetime
-    const transactionMessage = null as unknown as BaseTransactionMessage &
+    const transactionMessage = null as unknown as TransactionMessage &
         TransactionMessageWithBlockhashLifetime &
         TransactionMessageWithFeePayer &
         TransactionMessageWithSigners;
@@ -92,7 +92,7 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 
 {
     // [signTransactionMessageWithSigners]: returns a fully signed transaction with a lifetime when the input message has a durable nonce lifetime
-    const transactionMessage = null as unknown as BaseTransactionMessage &
+    const transactionMessage = null as unknown as TransactionMessage &
         TransactionMessageWithDurableNonceLifetime &
         TransactionMessageWithFeePayer &
         TransactionMessageWithSigners;
@@ -103,7 +103,7 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 
 {
     // [signTransactionMessageWithSigners]: returns a fully signed transaction with an unknown lifetime when the input message has an unknown lifetime
-    const transactionMessage = null as unknown as BaseTransactionMessage &
+    const transactionMessage = null as unknown as TransactionMessage &
         TransactionMessageWithFeePayer &
         TransactionMessageWithLifetime &
         TransactionMessageWithSigners;
@@ -114,7 +114,7 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 
 {
     // [signTransactionMessageWithSigners]: returns a transaction with a lifetime when the input message has no lifetime
-    const transactionMessage = null as unknown as BaseTransactionMessage &
+    const transactionMessage = null as unknown as TransactionMessage &
         TransactionMessageWithFeePayer &
         TransactionMessageWithSigners;
     signTransactionMessageWithSigners(transactionMessage) satisfies Promise<Readonly<Transaction>>;
@@ -125,7 +125,7 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 
 {
     // [signTransactionMessageWithSigners]: returns a transaction with a `TransactionWithinSizeLimit` flag
-    const transactionMessage = null as unknown as BaseTransactionMessage &
+    const transactionMessage = null as unknown as TransactionMessage &
         TransactionMessageWithFeePayer &
         TransactionMessageWithinSizeLimit &
         TransactionMessageWithLifetime &
@@ -137,7 +137,7 @@ import { TransactionMessageWithSingleSendingSigner } from '../transaction-with-s
 
 {
     // [signAndSendTransactionMessageWithSigners]: returns a signature
-    const transactionMessage = null as unknown as BaseTransactionMessage &
+    const transactionMessage = null as unknown as TransactionMessage &
         TransactionMessageWithFeePayer &
         TransactionMessageWithLifetime &
         TransactionMessageWithSigners &

--- a/packages/signers/src/account-signer-meta.ts
+++ b/packages/signers/src/account-signer-meta.ts
@@ -1,9 +1,5 @@
 import { AccountLookupMeta, AccountMeta, AccountRole, Instruction } from '@solana/instructions';
-import {
-    BaseTransactionMessage,
-    TransactionMessageWithFeePayer,
-    TransactionVersion,
-} from '@solana/transaction-messages';
+import { TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
 import { deduplicateSigners } from './deduplicate-signers';
 import { TransactionMessageWithFeePayerSigner } from './fee-payer-signer';
@@ -88,7 +84,7 @@ export type InstructionWithSigners<
 > = Pick<Instruction<string, TAccounts>, 'accounts'>;
 
 /**
- * A {@link BaseTransactionMessage} type extension that accept {@link TransactionSigner | TransactionSigners}.
+ * A {@link TransactionMessage} type extension that accept {@link TransactionSigner | TransactionSigners}.
  *
  * Namely, it allows:
  * - a {@link TransactionSigner} to be used as the fee payer and
@@ -102,13 +98,13 @@ export type InstructionWithSigners<
  * @example
  * ```ts
  * import { Instruction } from '@solana/instructions';
- * import { BaseTransactionMessage } from '@solana/transaction-messages';
+ * import { TransactionMessage } from '@solana/transaction-messages';
  * import { generateKeyPairSigner, InstructionWithSigners, TransactionMessageWithSigners } from '@solana/signers';
  *
  * const signer = await generateKeyPairSigner();
  * const firstInstruction: Instruction = { ... };
  * const secondInstruction: InstructionWithSigners = { ... };
- * const transactionMessage: BaseTransactionMessage & TransactionMessageWithSigners = {
+ * const transactionMessage: TransactionMessage & TransactionMessageWithSigners = {
  *     feePayer: signer,
  *     instructions: [firstInstruction, secondInstruction],
  * }
@@ -119,10 +115,7 @@ export type TransactionMessageWithSigners<
     TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
     TAccounts extends readonly AccountMetaWithSigner<TSigner>[] = readonly AccountMetaWithSigner<TSigner>[],
 > = Partial<TransactionMessageWithFeePayer<TAddress> | TransactionMessageWithFeePayerSigner<TAddress, TSigner>> &
-    Pick<
-        BaseTransactionMessage<TransactionVersion, Instruction & InstructionWithSigners<TSigner, TAccounts>>,
-        'instructions'
-    >;
+    Readonly<{ instructions: readonly (Instruction & InstructionWithSigners<TSigner, TAccounts>)[] }>;
 
 /**
  * Extracts and deduplicates all {@link TransactionSigner | TransactionSigners} stored

--- a/packages/signers/src/sign-transaction.ts
+++ b/packages/signers/src/sign-transaction.ts
@@ -1,6 +1,6 @@
 import { SOLANA_ERROR__SIGNER__TRANSACTION_SENDING_SIGNER_MISSING, SolanaError } from '@solana/errors';
 import { SignatureBytes } from '@solana/keys';
-import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 import {
     assertIsFullySignedTransaction,
     compileTransaction,
@@ -63,7 +63,7 @@ import { assertIsTransactionMessageWithSingleSendingSigner } from './transaction
  * @see {@link signAndSendTransactionMessageWithSigners}
  */
 export async function partiallySignTransactionMessageWithSigners(
-    transactionMessage: BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners,
+    transactionMessage: TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners,
     config?: TransactionPartialSignerConfig,
 ): Promise<Transaction & TransactionWithinSizeLimit & TransactionWithLifetime> {
     const { partialSigners, modifyingSigners } = categorizeTransactionSigners(
@@ -104,7 +104,7 @@ export async function partiallySignTransactionMessageWithSigners(
  * @see {@link signAndSendTransactionMessageWithSigners}
  */
 export async function signTransactionMessageWithSigners(
-    transactionMessage: BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners,
+    transactionMessage: TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners,
     config?: TransactionPartialSignerConfig,
 ): Promise<SendableTransaction & Transaction & TransactionWithLifetime> {
     const signedTransaction = await partiallySignTransactionMessageWithSigners(transactionMessage, config);
@@ -161,7 +161,7 @@ export async function signTransactionMessageWithSigners(
  *
  */
 export async function signAndSendTransactionMessageWithSigners(
-    transaction: BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners,
+    transaction: TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners,
     config?: TransactionSendingSignerConfig,
 ): Promise<SignatureBytes> {
     assertIsTransactionMessageWithSingleSendingSigner(transaction);
@@ -268,7 +268,7 @@ function identifyTransactionModifyingSigners(
  * sequentially followed by the TransactionPartialSigners in parallel.
  */
 async function signModifyingAndPartialTransactionSigners(
-    transactionMessage: BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners,
+    transactionMessage: TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners,
     modifyingSigners: readonly TransactionModifyingSigner[] = [],
     partialSigners: readonly TransactionPartialSigner[] = [],
     config?: TransactionModifyingSignerConfig,

--- a/packages/signers/src/transaction-with-single-sending-signer.ts
+++ b/packages/signers/src/transaction-with-single-sending-signer.ts
@@ -4,7 +4,7 @@ import {
     SolanaError,
 } from '@solana/errors';
 import { Brand } from '@solana/nominal-types';
-import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
 import { getSignersFromTransactionMessage, TransactionMessageWithSigners } from './account-signer-meta';
 import { isTransactionModifyingSigner } from './transaction-modifying-signer';
@@ -64,7 +64,7 @@ export type TransactionMessageWithSingleSendingSigner = Brand<
  * @see {@link assertIsTransactionMessageWithSingleSendingSigner}
  */
 export function isTransactionMessageWithSingleSendingSigner<
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer,
 >(transaction: TTransactionMessage): transaction is TransactionMessageWithSingleSendingSigner & TTransactionMessage {
     try {
         assertIsTransactionMessageWithSingleSendingSigner(transaction);
@@ -97,7 +97,7 @@ export function isTransactionMessageWithSingleSendingSigner<
  * @see {@link isTransactionMessageWithSingleSendingSigner}
  */
 export function assertIsTransactionMessageWithSingleSendingSigner<
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer,
 >(
     transaction: TTransactionMessage,
 ): asserts transaction is TransactionMessageWithSingleSendingSigner & TTransactionMessage {


### PR DESCRIPTION
#### Summary of Changes

Part of a stack to remove `BaseTransactionMessage`, changeset at the top of the stack. 

This was a little fiddly because of the `TransactionMessageWithSigners` type needing to be updated.

In `addSignersToTransactionMessage`, typescript doesn't like the union of different possible instruction types, so I've unpacked that signature to just provide `Instruction[]`.

I've added a typetest to make sure the instruction type is preserved
