### PR TITLE
Stop using deprecated BaseTransactionMessage type in transactions

### DIFF
--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -25,7 +25,7 @@ Given a `TransactionMessage`, this function returns a `Transaction` object. This
 
 Whether a transaction message is ready to be compiled or not is enforced for you at the type level. In order to be signable, a transaction message must:
 
-- have a version and a list of zero or more instructions (ie. conform to `BaseTransactionMessage`)
+- have a version and a list of zero or more instructions (ie. conform to `TransactionMessage`)
 - have a fee payer set (ie. conform to `TransactionMessageWithFeePayer`)
 - have a lifetime specified (ie. conform to `TransactionMessageWithBlockhashLifetime | TransactionMessageWithDurableNonceLifetime`)
 

--- a/packages/transactions/src/__typetests__/transaction-message-size-typetest.ts
+++ b/packages/transactions/src/__typetests__/transaction-message-size-typetest.ts
@@ -1,5 +1,5 @@
 import {
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
     TransactionMessageWithinSizeLimit,
 } from '@solana/transaction-messages';
@@ -13,9 +13,9 @@ import {
 {
     // It narrows the type of the transaction message to include the `TransactionMessageWithinSizeLimit` flag.
     {
-        const transactionMessage = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer;
+        const transactionMessage = null as unknown as TransactionMessage & TransactionMessageWithFeePayer;
         if (isTransactionMessageWithinSizeLimit(transactionMessage)) {
-            transactionMessage satisfies BaseTransactionMessage &
+            transactionMessage satisfies TransactionMessage &
                 TransactionMessageWithFeePayer &
                 TransactionMessageWithinSizeLimit;
         }
@@ -23,10 +23,9 @@ import {
 
     // It keeps any extra properties from the transaction message.
     {
-        const transactionMessage = null as unknown as BaseTransactionMessage &
-            TransactionMessageWithFeePayer & { some: 1 };
+        const transactionMessage = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { some: 1 };
         if (isTransactionMessageWithinSizeLimit(transactionMessage)) {
-            transactionMessage satisfies BaseTransactionMessage & TransactionMessageWithFeePayer & { some: 1 };
+            transactionMessage satisfies TransactionMessage & TransactionMessageWithFeePayer & { some: 1 };
         }
     }
 }
@@ -35,18 +34,17 @@ import {
 {
     // It narrows the type of the transaction message to include the `TransactionMessageWithinSizeLimit` flag.
     {
-        const transactionMessage = null as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer;
+        const transactionMessage = null as unknown as TransactionMessage & TransactionMessageWithFeePayer;
         assertIsTransactionMessageWithinSizeLimit(transactionMessage);
-        transactionMessage satisfies BaseTransactionMessage &
+        transactionMessage satisfies TransactionMessage &
             TransactionMessageWithFeePayer &
             TransactionMessageWithinSizeLimit;
     }
 
     // It keeps any extra properties from the transaction message.
     {
-        const transactionMessage = null as unknown as BaseTransactionMessage &
-            TransactionMessageWithFeePayer & { some: 1 };
+        const transactionMessage = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { some: 1 };
         assertIsTransactionMessageWithinSizeLimit(transactionMessage);
-        transactionMessage satisfies BaseTransactionMessage & TransactionMessageWithFeePayer & { some: 1 };
+        transactionMessage satisfies TransactionMessage & TransactionMessageWithFeePayer & { some: 1 };
     }
 }

--- a/packages/transactions/src/__typetests__/transaction-size-typetest.ts
+++ b/packages/transactions/src/__typetests__/transaction-size-typetest.ts
@@ -1,4 +1,4 @@
-import type { BaseTransactionMessage, TransactionMessageWithinSizeLimit } from '@solana/transaction-messages';
+import type { TransactionMessage, TransactionMessageWithinSizeLimit } from '@solana/transaction-messages';
 
 import { Transaction } from '../transaction';
 import {
@@ -50,7 +50,7 @@ import {
     {
         type Result = SetTransactionWithinSizeLimitFromTransactionMessage<
             Transaction,
-            BaseTransactionMessage & TransactionMessageWithinSizeLimit
+            TransactionMessage & TransactionMessageWithinSizeLimit
         >;
         null as unknown as Result satisfies Transaction & TransactionWithinSizeLimit;
     }
@@ -59,7 +59,7 @@ import {
     {
         type Result = SetTransactionWithinSizeLimitFromTransactionMessage<
             Transaction & { _from_transaction: 1 },
-            BaseTransactionMessage & TransactionMessageWithinSizeLimit & { _from_transaction_message: 1 }
+            TransactionMessage & TransactionMessageWithinSizeLimit & { _from_transaction_message: 1 }
         >;
         null as unknown as Result satisfies { _from_transaction: 1 };
         // @ts-expect-error Does not keep extra properties from transaction messages.
@@ -70,7 +70,7 @@ import {
     {
         type Result = SetTransactionWithinSizeLimitFromTransactionMessage<
             Transaction & { some: 1 },
-            BaseTransactionMessage
+            TransactionMessage
         >;
         null as unknown as Result satisfies Transaction & { some: 1 };
     }

--- a/packages/transactions/src/transaction-message-size.ts
+++ b/packages/transactions/src/transaction-message-size.ts
@@ -1,6 +1,6 @@
 import { SOLANA_ERROR__TRANSACTION__EXCEEDS_SIZE_LIMIT, SolanaError } from '@solana/errors';
 import type {
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
     TransactionMessageWithinSizeLimit,
 } from '@solana/transaction-messages';
@@ -17,7 +17,7 @@ import { getTransactionSize, TRANSACTION_SIZE_LIMIT } from './transaction-size';
  * ```
  */
 export function getTransactionMessageSize(
-    transactionMessage: BaseTransactionMessage & TransactionMessageWithFeePayer,
+    transactionMessage: TransactionMessage & TransactionMessageWithFeePayer,
 ): number {
     return getTransactionSize(compileTransaction(transactionMessage));
 }
@@ -36,7 +36,7 @@ export function getTransactionMessageSize(
  * ```
  */
 export function isTransactionMessageWithinSizeLimit<
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer,
 >(
     transactionMessage: TTransactionMessage,
 ): transactionMessage is TransactionMessageWithinSizeLimit & TTransactionMessage {
@@ -59,7 +59,7 @@ export function isTransactionMessageWithinSizeLimit<
  * ```
  */
 export function assertIsTransactionMessageWithinSizeLimit<
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer,
 >(
     transactionMessage: TTransactionMessage,
 ): asserts transactionMessage is TransactionMessageWithinSizeLimit & TTransactionMessage {

--- a/packages/transactions/src/transaction-size.ts
+++ b/packages/transactions/src/transaction-size.ts
@@ -1,6 +1,6 @@
 import { SOLANA_ERROR__TRANSACTION__EXCEEDS_SIZE_LIMIT, SolanaError } from '@solana/errors';
 import type { NominalType } from '@solana/nominal-types';
-import type { BaseTransactionMessage, TransactionMessageWithinSizeLimit } from '@solana/transaction-messages';
+import type { TransactionMessage, TransactionMessageWithinSizeLimit } from '@solana/transaction-messages';
 
 import { getTransactionEncoder } from './codecs';
 import { Transaction } from './transaction';
@@ -49,7 +49,7 @@ export type TransactionWithinSizeLimit = NominalType<'transactionSize', 'withinL
  */
 export type SetTransactionWithinSizeLimitFromTransactionMessage<
     TTransaction extends Transaction,
-    TTransactionMessage extends BaseTransactionMessage,
+    TTransactionMessage extends TransactionMessage,
 > = TTransactionMessage extends TransactionMessageWithinSizeLimit
     ? TransactionWithinSizeLimit & TTransaction
     : TTransaction;

--- a/packages/transactions/src/transaction.ts
+++ b/packages/transactions/src/transaction.ts
@@ -2,7 +2,7 @@ import type { Address } from '@solana/addresses';
 import type { ReadonlyUint8Array } from '@solana/codecs-core';
 import type { SignatureBytes } from '@solana/keys';
 import type { Brand, EncodedString } from '@solana/nominal-types';
-import type { BaseTransactionMessage } from '@solana/transaction-messages';
+import type { TransactionMessage } from '@solana/transaction-messages';
 
 import type { SetTransactionLifetimeFromTransactionMessage } from './lifetime';
 import type { SetTransactionWithinSizeLimitFromTransactionMessage } from './transaction-size';
@@ -25,9 +25,9 @@ export type Transaction = Readonly<{
 
 /**
  * Helper type that creates a `Transaction` type as narrow as possible
- * from the provided `BaseTransactionMessage` type.
+ * from the provided `TransactionMessage` type.
  */
-export type TransactionFromTransactionMessage<TTransactionMessage extends BaseTransactionMessage> =
+export type TransactionFromTransactionMessage<TTransactionMessage extends TransactionMessage> =
     SetTransactionWithinSizeLimitFromTransactionMessage<
         SetTransactionLifetimeFromTransactionMessage<Transaction, TTransactionMessage>,
         TTransactionMessage


### PR DESCRIPTION
#### Summary of Changes

Part of a stack to remove `BaseTransactionMessage`, changeset at the top of the stack. 

Trivial change, just change uses of `BaseTransactionMessage` to use `TransactionMessage`

