### PR TITLE
Refactor compressTransactionMessageUsingAddressLookupTables to not use BaseTransactionMessage

### DIFF
--- a/.changeset/clever-shirts-read.md
+++ b/.changeset/clever-shirts-read.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-messages': patch
+---
+
+Refactor compressTransactionMessageUsingAddressLookupTables to not use BaseTransactionMessage

--- a/packages/transaction-messages/src/__typetests__/compress-transaction-message-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/compress-transaction-message-typetest.ts
@@ -3,7 +3,7 @@ import { AccountLookupMeta, AccountMeta, AccountRole, Instruction } from '@solan
 import { TransactionMessageWithBlockhashLifetime } from '../blockhash';
 import { compressTransactionMessageUsingAddressLookupTables } from '../compress-transaction-message';
 import { TransactionMessageWithFeePayer } from '../fee-payer';
-import { BaseTransactionMessage, TransactionMessage } from '../transaction-message';
+import { TransactionMessage } from '../transaction-message';
 
 type v0TransactionMessage = TransactionMessage & { version: 0 };
 
@@ -53,7 +53,7 @@ const addressesByLookupTableAddress = null as unknown as AddressesByLookupTableA
             '1111',
             readonly [AccountMeta<'aaaa'> & { readonly role: AccountRole.WRITABLE }]
         >;
-        const message = null as unknown as BaseTransactionMessage<0, MyInstruction>;
+        const message = null as unknown as { readonly instructions: readonly MyInstruction[]; readonly version: 0 };
         const result = compressTransactionMessageUsingAddressLookupTables(message, addressesByLookupTableAddress);
         const accounts = result.instructions[0].accounts!;
         accounts[0] satisfies AccountLookupMeta<'aaaa'> | AccountMeta<'aaaa'>;

--- a/packages/transaction-messages/src/compress-transaction-message.ts
+++ b/packages/transaction-messages/src/compress-transaction-message.ts
@@ -2,7 +2,7 @@ import { Address } from '@solana/addresses';
 import { AccountLookupMeta, AccountMeta, AccountRole, Instruction, isSignerRole } from '@solana/instructions';
 
 import { AddressesByLookupTableAddress } from './addresses-by-lookup-table-address';
-import { BaseTransactionMessage, TransactionMessage } from './transaction-message';
+import { TransactionMessage } from './transaction-message';
 
 type Mutable<T> = {
     -readonly [P in keyof T]: T[P];
@@ -43,16 +43,13 @@ type WidenInstructionAccounts<TInstruction extends Instruction> =
           >
         : TInstruction;
 
-type ExtractAdditionalProps<T, U> = Omit<T, keyof U>;
-
-type WidenTransactionMessageInstructions<TTransactionMessage extends TransactionMessage> =
-    TTransactionMessage extends BaseTransactionMessage<infer TVersion, infer TInstruction>
-        ? BaseTransactionMessage<TVersion, WidenInstructionAccounts<TInstruction>> &
-              ExtractAdditionalProps<
-                  TTransactionMessage,
-                  BaseTransactionMessage<TVersion, WidenInstructionAccounts<TInstruction>>
-              >
-        : TTransactionMessage;
+type WidenTransactionMessageInstructions<TTransactionMessage extends TransactionMessage> = TTransactionMessage extends {
+    readonly instructions: readonly (infer TInstruction extends Instruction)[];
+}
+    ? Omit<TTransactionMessage, 'instructions'> & {
+          readonly instructions: readonly WidenInstructionAccounts<TInstruction>[];
+      }
+    : TTransactionMessage;
 
 /**
  * Given a transaction message and a mapping of lookup tables to the addresses stored in them, this


### PR DESCRIPTION
This PR refactors the `WidenTransactionMessageInstructions` type returned by `compressTransactionMessageUsingAddressLookupTables` to no longer use `BaseTransactionMessage`.

It also becomes much simpler, dropping the `ExtractAdditionalProps`.

Verified by typetests added in the previous PR. 