### PR TITLE
Refactor transaction-messages to stop using BaseTransactionMessage

### DIFF
--- a/.changeset/metal-rice-make.md
+++ b/.changeset/metal-rice-make.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-messages': patch
+---
+
+Refactor transaction-messages package to stop using BaseTransactionMessage

--- a/packages/transaction-messages/src/__tests__/fee-payer-test.ts
+++ b/packages/transaction-messages/src/__tests__/fee-payer-test.ts
@@ -3,7 +3,7 @@ import '@solana/test-matchers/toBeFrozenObject';
 import { Address } from '@solana/addresses';
 
 import { setTransactionMessageFeePayer, TransactionMessageWithFeePayer } from '../fee-payer';
-import { BaseTransactionMessage } from '../transaction-message';
+import { TransactionMessage } from '../transaction-message';
 
 const EXAMPLE_FEE_PAYER_A =
     '7mvYAxeCui21xYkAyQSjh6iBVZPpgVyt7PYv9km8V5mE' as Address<'7mvYAxeCui21xYkAyQSjh6iBVZPpgVyt7PYv9km8V5mE'>;
@@ -11,7 +11,7 @@ const EXAMPLE_FEE_PAYER_B =
     '5LHng8dLBxCYyR3jdDbobLiRQ6pR74pYtxKohY93RbZN' as Address<'5LHng8dLBxCYyR3jdDbobLiRQ6pR74pYtxKohY93RbZN'>;
 
 describe('setTransactionMessageFeePayer', () => {
-    let baseTx: BaseTransactionMessage;
+    let baseTx: TransactionMessage;
     beforeEach(() => {
         baseTx = {
             instructions: [],
@@ -23,7 +23,7 @@ describe('setTransactionMessageFeePayer', () => {
         expect(txWithFeePayerA).toHaveProperty('feePayer', { address: EXAMPLE_FEE_PAYER_A });
     });
     describe('given a transaction with a fee payer already set', () => {
-        let txWithFeePayerA: BaseTransactionMessage & TransactionMessageWithFeePayer;
+        let txWithFeePayerA: TransactionMessage & TransactionMessageWithFeePayer;
         beforeEach(() => {
             txWithFeePayerA = {
                 ...baseTx,
@@ -40,7 +40,7 @@ describe('setTransactionMessageFeePayer', () => {
         });
     });
     describe('given a transaction with a fee payer with extra properties set', () => {
-        let txWithFeePayerA: BaseTransactionMessage & {
+        let txWithFeePayerA: TransactionMessage & {
             readonly feePayer: Readonly<{ address: Address; extra: 'extra' }>;
         };
         beforeEach(() => {

--- a/packages/transaction-messages/src/__tests__/instructions-test.ts
+++ b/packages/transaction-messages/src/__tests__/instructions-test.ts
@@ -9,7 +9,7 @@ import {
     prependTransactionMessageInstruction,
     prependTransactionMessageInstructions,
 } from '../instructions';
-import { BaseTransactionMessage } from '../transaction-message';
+import { TransactionMessage } from '../transaction-message';
 
 const PROGRAM_A =
     'AALQD2dt1k43Acrkp4SvdhZaN4S115Ff2Bi7rHPti3sL' as Address<'AALQD2dt1k43Acrkp4SvdhZaN4S115Ff2Bi7rHPti3sL'>;
@@ -19,7 +19,7 @@ const PROGRAM_C =
     '6Bkt4j67rxzFF6s9DaMRyfitftRrGxe4oYHPRHuFChzi' as Address<'6Bkt4j67rxzFF6s9DaMRyfitftRrGxe4oYHPRHuFChzi'>;
 
 describe('Transaction instruction helpers', () => {
-    let baseTx: BaseTransactionMessage;
+    let baseTx: TransactionMessage;
     let exampleInstruction: Instruction<string>;
     let secondExampleInstruction: Instruction<string>;
     beforeEach(() => {

--- a/packages/transaction-messages/src/__typetests__/fee-payer-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/fee-payer-typetest.ts
@@ -3,7 +3,7 @@ import { Address } from '@solana/addresses';
 import { TransactionMessageWithBlockhashLifetime } from '../blockhash';
 import { TransactionMessageWithDurableNonceLifetime } from '../durable-nonce';
 import { setTransactionMessageFeePayer, TransactionMessageWithFeePayer } from '../fee-payer';
-import { BaseTransactionMessage, TransactionMessage } from '../transaction-message';
+import { TransactionMessage } from '../transaction-message';
 
 const mockFeePayer = 'mock' as Address<'mockFeePayer'>;
 const aliceAddress = 'alice' as Address<'alice'>;
@@ -16,17 +16,17 @@ type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
 {
     // It adds the fee payer to the new message
     {
-        const message = null as unknown as BaseTransactionMessage & { some: 1 };
+        const message = null as unknown as TransactionMessage & { some: 1 };
         const messageWithFeePayer = setTransactionMessageFeePayer(aliceAddress, message);
-        messageWithFeePayer satisfies BaseTransactionMessage & TransactionMessageWithFeePayer<'alice'> & { some: 1 };
+        messageWithFeePayer satisfies TransactionMessage & TransactionMessageWithFeePayer<'alice'> & { some: 1 };
     }
 
     // It *replaces* an existing fee payer with the new one
     {
-        const messageWithAliceFeePayer = null as unknown as BaseTransactionMessage &
+        const messageWithAliceFeePayer = null as unknown as TransactionMessage &
             TransactionMessageWithFeePayer<'alice'> & { some: 1 };
         const messageWithBobFeePayer = setTransactionMessageFeePayer(bobAddress, messageWithAliceFeePayer);
-        messageWithBobFeePayer satisfies BaseTransactionMessage & TransactionMessageWithFeePayer<'bob'> & { some: 1 };
+        messageWithBobFeePayer satisfies TransactionMessage & TransactionMessageWithFeePayer<'bob'> & { some: 1 };
         // @ts-expect-error Alice should no longer be a payer.
         messageWithBobFeePayer satisfies TransactionMessageWithFeePayer<'alice'>;
     }

--- a/packages/transaction-messages/src/__typetests__/instructions-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/instructions-typetest.ts
@@ -15,10 +15,10 @@ import {
     prependTransactionMessageInstruction,
     prependTransactionMessageInstructions,
 } from '../instructions';
-import { BaseTransactionMessage, TransactionMessage } from '../transaction-message';
+import { TransactionMessage } from '../transaction-message';
 import { TransactionMessageWithinSizeLimit } from '../transaction-message-size';
 
-type Instruction = BaseTransactionMessage['instructions'][number];
+type Instruction = TransactionMessage['instructions'][number];
 type InstructionA = Instruction & { identifier: 'A' };
 type InstructionB = Instruction & { identifier: 'B' };
 type InstructionC = Instruction & { identifier: 'C' };
@@ -29,9 +29,9 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
 {
     // It returns the same TransactionMessage type
     {
-        const message = null as unknown as BaseTransactionMessage & { some: 1 };
+        const message = null as unknown as TransactionMessage & { some: 1 };
         const newMessage = appendTransactionMessageInstruction(null as unknown as Instruction, message);
-        newMessage satisfies BaseTransactionMessage & { some: 1 };
+        newMessage satisfies TransactionMessage & { some: 1 };
     }
 
     // It concatenates the instruction types
@@ -47,7 +47,7 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
 
     // It adds instruction types to base transaction messages
     {
-        const message = null as unknown as BaseTransactionMessage;
+        const message = null as unknown as TransactionMessage;
         const newMessage = appendTransactionMessageInstruction(null as unknown as InstructionA, message);
         newMessage.instructions satisfies readonly [...Instruction[], InstructionA];
     }
@@ -63,9 +63,7 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
             m => appendTransactionMessageInstruction(null as unknown as InstructionA, m),
         );
 
-        message satisfies BaseTransactionMessage &
-            TransactionMessageWithBlockhashLifetime &
-            TransactionMessageWithFeePayer;
+        message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime & TransactionMessageWithFeePayer;
         message.instructions satisfies readonly [InstructionA];
     }
 
@@ -80,7 +78,7 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
             m => appendTransactionMessageInstruction(null as unknown as InstructionA, m),
         );
 
-        message satisfies BaseTransactionMessage &
+        message satisfies TransactionMessage &
             TransactionMessageWithDurableNonceLifetime &
             TransactionMessageWithFeePayer;
         message.instructions satisfies readonly [AdvanceNonceAccountInstruction, InstructionA];
@@ -88,7 +86,7 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
 
     // It removes the size limit type safety.
     {
-        const message = null as unknown as BaseTransactionMessage & TransactionMessageWithinSizeLimit;
+        const message = null as unknown as TransactionMessage & TransactionMessageWithinSizeLimit;
         const newMessage = appendTransactionMessageInstruction(null as unknown as Instruction, message);
         // @ts-expect-error Potentially no longer within size limit.
         newMessage satisfies TransactionMessageWithinSizeLimit;
@@ -110,9 +108,9 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
 {
     // It returns the same TransactionMessage type
     {
-        const message = null as unknown as BaseTransactionMessage & { some: 1 };
+        const message = null as unknown as TransactionMessage & { some: 1 };
         const newMessage = appendTransactionMessageInstructions(null as unknown as Instruction[], message);
-        newMessage satisfies BaseTransactionMessage & { some: 1 };
+        newMessage satisfies TransactionMessage & { some: 1 };
     }
 
     // It concatenates the instruction types
@@ -131,7 +129,7 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
 
     // It adds instruction types to base transaction messages
     {
-        const message = null as unknown as BaseTransactionMessage;
+        const message = null as unknown as TransactionMessage;
         const newMessage = appendTransactionMessageInstructions(
             [null as unknown as InstructionA, null as unknown as InstructionB],
             message,
@@ -141,7 +139,7 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
 
     // It removes the size limit type safety.
     {
-        const message = null as unknown as BaseTransactionMessage & TransactionMessageWithinSizeLimit;
+        const message = null as unknown as TransactionMessage & TransactionMessageWithinSizeLimit;
         const newMessage = appendTransactionMessageInstructions([null as unknown as Instruction], message);
         // @ts-expect-error Potentially no longer within size limit.
         newMessage satisfies TransactionMessageWithinSizeLimit;
@@ -163,27 +161,26 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
 {
     // It returns the same TransactionMessage type
     {
-        const message = null as unknown as BaseTransactionMessage & { some: 1 };
+        const message = null as unknown as TransactionMessage & { some: 1 };
         const newMessage = prependTransactionMessageInstruction(null as unknown as Instruction, message);
-        newMessage satisfies BaseTransactionMessage & { some: 1 };
+        newMessage satisfies TransactionMessage & { some: 1 };
     }
 
     // It strips the durable nonce transaction message type
     {
-        const message = null as unknown as BaseTransactionMessage &
+        const message = null as unknown as TransactionMessage &
             TransactionMessageWithDurableNonceLifetime & { some: 1 };
         const newMessage = prependTransactionMessageInstruction(null as unknown as Instruction, message);
-        newMessage satisfies BaseTransactionMessage & { some: 1 };
+        newMessage satisfies TransactionMessage & { some: 1 };
         // @ts-expect-error The durable nonce transaction message type should be stripped.
         newMessage satisfies TransactionMessageWithDurableNonceLifetime;
     }
 
     // It does not remove blockhash lifetimes.
     {
-        const message = null as unknown as BaseTransactionMessage &
-            TransactionMessageWithBlockhashLifetime & { some: 1 };
+        const message = null as unknown as TransactionMessage & TransactionMessageWithBlockhashLifetime & { some: 1 };
         const newMessage = prependTransactionMessageInstruction(null as unknown as Instruction, message);
-        newMessage satisfies BaseTransactionMessage & TransactionMessageWithBlockhashLifetime & { some: 1 };
+        newMessage satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime & { some: 1 };
     }
 
     // It concatenates the instruction types
@@ -199,7 +196,7 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
 
     // It adds instruction types to base transaction messages
     {
-        const message = null as unknown as BaseTransactionMessage;
+        const message = null as unknown as TransactionMessage;
         const newMessage = prependTransactionMessageInstruction(null as unknown as InstructionA, message);
         newMessage.instructions satisfies readonly [InstructionA, ...Instruction[]];
     }
@@ -215,9 +212,7 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
             m => prependTransactionMessageInstruction(null as unknown as InstructionA, m),
         );
 
-        message satisfies BaseTransactionMessage &
-            TransactionMessageWithBlockhashLifetime &
-            TransactionMessageWithFeePayer;
+        message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime & TransactionMessageWithFeePayer;
         message.instructions satisfies readonly [InstructionA];
     }
 
@@ -233,14 +228,14 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
         );
 
         message.instructions satisfies readonly [InstructionA, AdvanceNonceAccountInstruction];
-        message satisfies BaseTransactionMessage & TransactionMessageWithFeePayer;
+        message satisfies TransactionMessage & TransactionMessageWithFeePayer;
         // @ts-expect-error No longer a durable nonce lifetime.
         message satisfies TransactionMessageWithDurableNonceLifetime;
     }
 
     // It removes the size limit type safety.
     {
-        const message = null as unknown as BaseTransactionMessage & TransactionMessageWithinSizeLimit;
+        const message = null as unknown as TransactionMessage & TransactionMessageWithinSizeLimit;
         const newMessage = prependTransactionMessageInstruction(null as unknown as Instruction, message);
         // @ts-expect-error Potentially no longer within size limit.
         newMessage satisfies TransactionMessageWithinSizeLimit;
@@ -262,17 +257,17 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
 {
     // It returns the same TransactionMessage type
     {
-        const message = null as unknown as BaseTransactionMessage & { some: 1 };
+        const message = null as unknown as TransactionMessage & { some: 1 };
         const newMessage = prependTransactionMessageInstructions(null as unknown as Instruction[], message);
-        newMessage satisfies BaseTransactionMessage & { some: 1 };
+        newMessage satisfies TransactionMessage & { some: 1 };
     }
 
     // It strips the durable nonce transaction message type
     {
-        const message = null as unknown as BaseTransactionMessage &
+        const message = null as unknown as TransactionMessage &
             TransactionMessageWithDurableNonceLifetime & { some: 1 };
         const newMessage = prependTransactionMessageInstructions(null as unknown as Instruction[], message);
-        newMessage satisfies BaseTransactionMessage & { some: 1 };
+        newMessage satisfies TransactionMessage & { some: 1 };
         // @ts-expect-error The durable nonce transaction message type should be stripped.
         newMessage satisfies TransactionMessageWithDurableNonceLifetime;
     }
@@ -293,7 +288,7 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
 
     // It adds instruction types to base transaction messages
     {
-        const message = null as unknown as BaseTransactionMessage;
+        const message = null as unknown as TransactionMessage;
         const newMessage = prependTransactionMessageInstructions(
             [null as unknown as InstructionA, null as unknown as InstructionB],
             message,
@@ -303,7 +298,7 @@ type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legac
 
     // It removes the size limit type safety.
     {
-        const message = null as unknown as BaseTransactionMessage & TransactionMessageWithinSizeLimit;
+        const message = null as unknown as TransactionMessage & TransactionMessageWithinSizeLimit;
         const newMessage = prependTransactionMessageInstructions([null as unknown as Instruction], message);
         // @ts-expect-error Potentially no longer within size limit.
         newMessage satisfies TransactionMessageWithinSizeLimit;

--- a/packages/transaction-messages/src/compile/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/compile/__tests__/message-test.ts
@@ -3,7 +3,7 @@ import { Address } from '@solana/addresses';
 import { TransactionMessageWithBlockhashLifetime } from '../../blockhash';
 import { TransactionMessageWithFeePayer } from '../../fee-payer';
 import { TransactionMessageWithLifetime } from '../../lifetime';
-import { BaseTransactionMessage } from '../../transaction-message';
+import { TransactionMessage } from '../../transaction-message';
 import { getCompiledAddressTableLookups } from '../address-table-lookups';
 import { getCompiledMessageHeader } from '../header';
 import { getCompiledInstructions } from '../instructions';
@@ -21,7 +21,7 @@ const MOCK_LIFETIME_CONSTRAINT =
     'SOME_CONSTRAINT' as unknown as TransactionMessageWithBlockhashLifetime['lifetimeConstraint'];
 
 describe('compileTransactionMessage', () => {
-    let baseTx: BaseTransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime;
+    let baseTx: TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime;
     beforeEach(() => {
         baseTx = {
             feePayer: { address: 'abc' as Address<'abc'> },
@@ -50,7 +50,7 @@ describe('compileTransactionMessage', () => {
             });
         });
         it('sets `addressTableLookups` to the return value of `getCompiledAddressTableLookups`', () => {
-            const message = compileTransactionMessage(baseTx);
+            const message = compileTransactionMessage(baseTx as typeof baseTx & { version: 0 });
             expect(getCompiledAddressTableLookups).toHaveBeenCalled();
             expect(message.addressTableLookups).toBe(expectedAddressTableLookups);
         });

--- a/packages/transaction-messages/src/compile/message.ts
+++ b/packages/transaction-messages/src/compile/message.ts
@@ -1,6 +1,6 @@
 import { TransactionMessageWithFeePayer } from '../fee-payer';
 import { TransactionMessageWithLifetime } from '../lifetime';
-import { BaseTransactionMessage } from '../transaction-message';
+import { TransactionMessage } from '../transaction-message';
 import { getAddressMapFromInstructions, getOrderedAccountsFromAddressMap } from './accounts';
 import { getCompiledAddressTableLookups } from './address-table-lookups';
 import { getCompiledMessageHeader } from './header';
@@ -63,7 +63,7 @@ type VersionedCompiledTransactionMessage = BaseCompiledTransactionMessage &
  * @see {@link decompileTransactionMessage}
  */
 export function compileTransactionMessage<
-    TTransactionMessage extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer,
 >(transactionMessage: TTransactionMessage): CompiledTransactionMessageFromTransactionMessage<TTransactionMessage> {
     type ReturnType = CompiledTransactionMessageFromTransactionMessage<TTransactionMessage>;
 
@@ -86,17 +86,17 @@ export function compileTransactionMessage<
     } as ReturnType;
 }
 
-type CompiledTransactionMessageFromTransactionMessage<TTransactionMessage extends BaseTransactionMessage> =
+type CompiledTransactionMessageFromTransactionMessage<TTransactionMessage extends TransactionMessage> =
     ForwardTransactionMessageLifetime<ForwardTransactionMessageVersion<TTransactionMessage>, TTransactionMessage>;
 
-type ForwardTransactionMessageVersion<TTransactionMessage extends BaseTransactionMessage> =
+type ForwardTransactionMessageVersion<TTransactionMessage extends TransactionMessage> =
     TTransactionMessage extends Readonly<{ version: 'legacy' }>
         ? LegacyCompiledTransactionMessage
         : VersionedCompiledTransactionMessage;
 
 type ForwardTransactionMessageLifetime<
     TCompiledTransactionMessage extends CompiledTransactionMessage,
-    TTransactionMessage extends BaseTransactionMessage,
+    TTransactionMessage extends TransactionMessage,
 > = TTransactionMessage extends TransactionMessageWithLifetime
     ? CompiledTransactionMessageWithLifetime & TCompiledTransactionMessage
     : TCompiledTransactionMessage;

--- a/packages/transaction-messages/src/transaction-message-size.ts
+++ b/packages/transaction-messages/src/transaction-message-size.ts
@@ -1,6 +1,6 @@
 import type { NominalType } from '@solana/nominal-types';
 
-import type { BaseTransactionMessage } from './transaction-message';
+import type { TransactionMessage } from './transaction-message';
 
 /**
  * A type guard that checks if a transaction message is within the size limit
@@ -12,7 +12,7 @@ export type TransactionMessageWithinSizeLimit = NominalType<'transactionSize', '
  * Helper type that removes the `TransactionMessageWithinSizeLimit` flag
  * from a transaction message.
  */
-export type ExcludeTransactionMessageWithinSizeLimit<TTransactionMessage extends BaseTransactionMessage> = Omit<
+export type ExcludeTransactionMessageWithinSizeLimit<TTransactionMessage extends TransactionMessage> = Omit<
     TTransactionMessage,
     '__transactionSize:@solana/kit'
 >;


### PR DESCRIPTION
After the previous PR, the remaining uses of `BaseTransactionMessage` in the `transaction-messages` package are simple to change to `TransactionMessage`.

This PR changes the last of them so that we no longer use `BaseTransactionMessage` outside of the file where it's declared. 