### PR TITLE
Remove the export of BaseTransactionMessage

### DIFF
--- a/.changeset/khaki-places-roll.md
+++ b/.changeset/khaki-places-roll.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-messages': major
+---
+
+Remove the export of BaseTransactionMessage, which was previously deprecated. Use TransactionMessage instead.

--- a/packages/transaction-messages/src/transaction-message.ts
+++ b/packages/transaction-messages/src/transaction-message.ts
@@ -1,10 +1,6 @@
 import { AccountMeta, Instruction } from '@solana/instructions';
 
-/**
- * @deprecated Use `TransactionMessage` instead.
- */
-// TODO(#1147) Stop exporting this in a future major version.
-export type BaseTransactionMessage<
+type BaseTransactionMessage<
     TVersion extends TransactionVersion = TransactionVersion,
     TInstruction extends Instruction = Instruction,
 > = Readonly<{


### PR DESCRIPTION
This PR removes the export of `BaseTransactionMessage`, so that it is only used as implementation detail for the definition of `TransactionMessage`. As it is no longer exported, I've removed the `@deprecated` tag. 