### PR TITLE
Add a dependabot group for undici and undici-types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,10 @@ updates:
         patterns:
           - 'react'
           - 'react-dom'
+      undici:
+        patterns:
+          - 'undici'
+          - 'undici-types'
   - package-ecosystem: 'npm'
     directory: '/docs'
     schedule:
@@ -47,3 +51,7 @@ updates:
         patterns:
           - 'react'
           - 'react-dom'
+      undici:
+        patterns:
+          - 'undici'
+          - 'undici-types'


### PR DESCRIPTION
#### Problem

Failed dependabot PR: https://github.com/anza-xyz/kit/pull/1278

#### Summary of Changes

It looks like this is because of a type error caused by not also updating `undici-types`. This PR adds a new dependabot group for `undici` and `undici-types`.

Added to the root and docs, because both lockfiles include these packages. 

Fixes: another dependabot slowdown, hopefully! 