### PR TITLE
ci: add merge_queue to preview documentation

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -2,6 +2,7 @@ name: Preview Documentation
 
 on:
   pull_request:
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
#### Problem

we added `Build Documentation Preview` as a required status in ci but it will never be triggered in the merge queue if we don't update the pipeline.

#### Summary of Changes

add `merge_group:`