### PR TITLE
Reshape successful `SingleTransactionPlanResult` factories

### DIFF
--- a/.changeset/lazy-baths-rule.md
+++ b/.changeset/lazy-baths-rule.md
@@ -1,0 +1,26 @@
+---
+'@solana/instruction-plans': major
+---
+
+Reshape the successful `SingleTransactionPlanResult` factory functions. The `successfulSingleTransactionPlanResult` helper now accepts a context object (which must include a `signature` property) instead of a separate `signature` argument. A new `successfulSingleTransactionPlanResultFromTransaction` helper is introduced for the common case of creating a successful result from a full `Transaction` object.
+
+**BREAKING CHANGES**
+
+**`successfulSingleTransactionPlanResult` renamed to `successfulSingleTransactionPlanResultFromTransaction`.** If you were creating a successful result from a `Transaction`, update the function name.
+
+```diff
+- successfulSingleTransactionPlanResult(message, transaction)
++ successfulSingleTransactionPlanResultFromTransaction(message, transaction)
+```
+
+**`successfulSingleTransactionPlanResultFromSignature` renamed to `successfulSingleTransactionPlanResult` with a new signature.** The `signature` is no longer a separate argument — it must be included in the `context` object.
+
+```diff
+- successfulSingleTransactionPlanResultFromSignature(message, signature)
++ successfulSingleTransactionPlanResult(message, { signature })
+```
+
+```diff
+- successfulSingleTransactionPlanResultFromSignature(message, signature, context)
++ successfulSingleTransactionPlanResult(message, { ...context, signature })
+```

--- a/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
@@ -19,7 +19,7 @@ import {
     sequentialTransactionPlan,
     sequentialTransactionPlanResult,
     singleTransactionPlan,
-    successfulSingleTransactionPlanResult,
+    successfulSingleTransactionPlanResultFromTransaction,
     TransactionPlanResult,
 } from '../index';
 import { createMessage, createTransaction, FOREVER_PROMISE } from './__setup__';
@@ -60,7 +60,9 @@ describe('createTransactionPlanExecutor', () => {
             const executor = createTransactionPlanExecutor({ executeTransactionMessage });
 
             const promise = executor(singleTransactionPlan(messageA));
-            await expect(promise).resolves.toStrictEqual(successfulSingleTransactionPlanResult(messageA, transactionA));
+            await expect(promise).resolves.toStrictEqual(
+                successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA),
+            );
             expect(executeTransactionMessage).toHaveBeenNthCalledWith(1, messageA, { abortSignal: undefined });
         });
 
@@ -88,7 +90,7 @@ describe('createTransactionPlanExecutor', () => {
 
             const promise = executor(singleTransactionPlan(messageA));
             await expect(promise).resolves.toStrictEqual(
-                successfulSingleTransactionPlanResult(messageA, transactionA, { custom: 'context' }),
+                successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA, { custom: 'context' }),
             );
         });
 
@@ -192,8 +194,8 @@ describe('createTransactionPlanExecutor', () => {
             const promise = executor(sequentialTransactionPlan([messageA, messageB]));
             await expect(promise).resolves.toStrictEqual(
                 sequentialTransactionPlanResult([
-                    successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
-                    successfulSingleTransactionPlanResult(messageB, createTransaction('B')),
+                    successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
+                    successfulSingleTransactionPlanResultFromTransaction(messageB, createTransaction('B')),
                 ]),
             );
 
@@ -258,8 +260,12 @@ describe('createTransactionPlanExecutor', () => {
             const promise = executor(sequentialTransactionPlan([messageA, messageB]));
             await expect(promise).resolves.toStrictEqual(
                 sequentialTransactionPlanResult([
-                    successfulSingleTransactionPlanResult(messageA, createTransaction('A'), { custom: 'context' }),
-                    successfulSingleTransactionPlanResult(messageB, createTransaction('B'), { custom: 'context' }),
+                    successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A'), {
+                        custom: 'context',
+                    }),
+                    successfulSingleTransactionPlanResultFromTransaction(messageB, createTransaction('B'), {
+                        custom: 'context',
+                    }),
                 ]),
             );
         });
@@ -278,7 +284,7 @@ describe('createTransactionPlanExecutor', () => {
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
                     transactionPlanResult: sequentialTransactionPlanResult([
-                        successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
+                        successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
                         failedSingleTransactionPlanResult(messageB, cause),
                     ]),
                 }),
@@ -343,7 +349,7 @@ describe('createTransactionPlanExecutor', () => {
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
                     transactionPlanResult: sequentialTransactionPlanResult([
-                        successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
+                        successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
                         failedSingleTransactionPlanResult(messageB, cause),
                         canceledSingleTransactionPlanResult(messageC),
                     ]),
@@ -404,8 +410,8 @@ describe('createTransactionPlanExecutor', () => {
             const promise = executor(parallelTransactionPlan([messageA, messageB]));
             await expect(promise).resolves.toStrictEqual(
                 parallelTransactionPlanResult([
-                    successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
-                    successfulSingleTransactionPlanResult(messageB, createTransaction('B')),
+                    successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
+                    successfulSingleTransactionPlanResultFromTransaction(messageB, createTransaction('B')),
                 ]),
             );
 
@@ -443,8 +449,12 @@ describe('createTransactionPlanExecutor', () => {
             const promise = executor(parallelTransactionPlan([messageA, messageB]));
             await expect(promise).resolves.toStrictEqual(
                 parallelTransactionPlanResult([
-                    successfulSingleTransactionPlanResult(messageA, createTransaction('A'), { custom: 'context' }),
-                    successfulSingleTransactionPlanResult(messageB, createTransaction('B'), { custom: 'context' }),
+                    successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A'), {
+                        custom: 'context',
+                    }),
+                    successfulSingleTransactionPlanResultFromTransaction(messageB, createTransaction('B'), {
+                        custom: 'context',
+                    }),
                 ]),
             );
         });
@@ -467,9 +477,9 @@ describe('createTransactionPlanExecutor', () => {
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
                     transactionPlanResult: parallelTransactionPlanResult([
-                        successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
+                        successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
                         failedSingleTransactionPlanResult(messageB, cause),
-                        successfulSingleTransactionPlanResult(messageC, createTransaction('C')),
+                        successfulSingleTransactionPlanResultFromTransaction(messageC, createTransaction('C')),
                     ]),
                 }),
             );
@@ -500,9 +510,9 @@ describe('createTransactionPlanExecutor', () => {
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
                     transactionPlanResult: parallelTransactionPlanResult([
-                        successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
+                        successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
                         failedSingleTransactionPlanResult(messageB, cause),
-                        successfulSingleTransactionPlanResult(messageC, createTransaction('C')),
+                        successfulSingleTransactionPlanResultFromTransaction(messageC, createTransaction('C')),
                     ]),
                 }),
             );
@@ -569,17 +579,17 @@ describe('createTransactionPlanExecutor', () => {
             await expect(promise).resolves.toStrictEqual(
                 parallelTransactionPlanResult([
                     sequentialTransactionPlanResult([
-                        successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
+                        successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
                         parallelTransactionPlanResult([
-                            successfulSingleTransactionPlanResult(messageB, createTransaction('B')),
-                            successfulSingleTransactionPlanResult(messageC, createTransaction('C')),
+                            successfulSingleTransactionPlanResultFromTransaction(messageB, createTransaction('B')),
+                            successfulSingleTransactionPlanResultFromTransaction(messageC, createTransaction('C')),
                         ]),
-                        successfulSingleTransactionPlanResult(messageD, createTransaction('D')),
+                        successfulSingleTransactionPlanResultFromTransaction(messageD, createTransaction('D')),
                     ]),
-                    successfulSingleTransactionPlanResult(messageE, createTransaction('E')),
+                    successfulSingleTransactionPlanResultFromTransaction(messageE, createTransaction('E')),
                     sequentialTransactionPlanResult([
-                        successfulSingleTransactionPlanResult(messageF, createTransaction('F')),
-                        successfulSingleTransactionPlanResult(messageG, createTransaction('G')),
+                        successfulSingleTransactionPlanResultFromTransaction(messageF, createTransaction('F')),
+                        successfulSingleTransactionPlanResultFromTransaction(messageG, createTransaction('G')),
                     ]),
                 ]),
             );
@@ -617,17 +627,17 @@ describe('createTransactionPlanExecutor', () => {
                     cause,
                     transactionPlanResult: parallelTransactionPlanResult([
                         sequentialTransactionPlanResult([
-                            successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
+                            successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
                             parallelTransactionPlanResult([
-                                successfulSingleTransactionPlanResult(messageB, createTransaction('B')),
+                                successfulSingleTransactionPlanResultFromTransaction(messageB, createTransaction('B')),
                                 failedSingleTransactionPlanResult(messageC, cause),
                             ]),
                             canceledSingleTransactionPlanResult(messageD),
                         ]),
-                        successfulSingleTransactionPlanResult(messageE, createTransaction('E')),
+                        successfulSingleTransactionPlanResultFromTransaction(messageE, createTransaction('E')),
                         sequentialTransactionPlanResult([
-                            successfulSingleTransactionPlanResult(messageF, createTransaction('F')),
-                            successfulSingleTransactionPlanResult(messageG, createTransaction('G')),
+                            successfulSingleTransactionPlanResultFromTransaction(messageF, createTransaction('F')),
+                            successfulSingleTransactionPlanResultFromTransaction(messageG, createTransaction('G')),
                         ]),
                     ]),
                 }),
@@ -672,17 +682,17 @@ describe('createTransactionPlanExecutor', () => {
                     cause,
                     transactionPlanResult: parallelTransactionPlanResult([
                         sequentialTransactionPlanResult([
-                            successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
+                            successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
                             parallelTransactionPlanResult([
-                                successfulSingleTransactionPlanResult(messageB, createTransaction('B')),
+                                successfulSingleTransactionPlanResultFromTransaction(messageB, createTransaction('B')),
                                 failedSingleTransactionPlanResult(messageC, cause),
                             ]),
                             canceledSingleTransactionPlanResult(messageD),
                         ]),
-                        successfulSingleTransactionPlanResult(messageE, createTransaction('E')),
+                        successfulSingleTransactionPlanResultFromTransaction(messageE, createTransaction('E')),
                         sequentialTransactionPlanResult([
-                            successfulSingleTransactionPlanResult(messageF, createTransaction('F')),
-                            successfulSingleTransactionPlanResult(messageG, createTransaction('G')),
+                            successfulSingleTransactionPlanResultFromTransaction(messageF, createTransaction('F')),
+                            successfulSingleTransactionPlanResultFromTransaction(messageG, createTransaction('G')),
                         ]),
                     ]),
                 }),
@@ -742,7 +752,7 @@ describe('createTransactionPlanExecutor', () => {
 describe('passthroughFailedTransactionPlanExecution', () => {
     it('returns the resolved result as-is', async () => {
         expect.assertions(1);
-        const result = successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A'));
+        const result = successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A'));
         const promise = Promise.resolve(result);
         await expect(passthroughFailedTransactionPlanExecution(promise)).resolves.toBe(result);
     });

--- a/packages/instruction-plans/src/__tests__/transaction-plan-result-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-result-test.ts
@@ -35,17 +35,17 @@ import {
     parallelTransactionPlanResult,
     sequentialTransactionPlanResult,
     successfulSingleTransactionPlanResult,
-    successfulSingleTransactionPlanResultFromSignature,
+    successfulSingleTransactionPlanResultFromTransaction,
     summarizeTransactionPlanResult,
     transformTransactionPlanResult,
 } from '../index';
 import { createMessage, createTransaction } from './__setup__';
 
-describe('successfulSingleTransactionPlanResult', () => {
+describe('successfulSingleTransactionPlanResultFromTransaction', () => {
     it('creates SingleTransactionPlanResult objects with successful status', () => {
         const messageA = createMessage('A');
         const transactionA = createTransaction('A');
-        const result = successfulSingleTransactionPlanResult(messageA, transactionA);
+        const result = successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA);
         expect(result).toEqual({
             context: { signature: 'A', transaction: transactionA },
             kind: 'single',
@@ -57,7 +57,7 @@ describe('successfulSingleTransactionPlanResult', () => {
         const messageA = createMessage('A');
         const transactionA = createTransaction('A');
         const context = { foo: 'bar' };
-        const result = successfulSingleTransactionPlanResult(messageA, transactionA, context);
+        const result = successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA, context);
         expect(result).toEqual({
             context: { ...context, signature: 'A', transaction: transactionA },
             kind: 'single',
@@ -68,22 +68,22 @@ describe('successfulSingleTransactionPlanResult', () => {
     it('freezes created SingleTransactionPlanResult objects', () => {
         const messageA = createMessage('A');
         const transactionA = createTransaction('A');
-        const result = successfulSingleTransactionPlanResult(messageA, transactionA);
+        const result = successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA);
         expect(result).toBeFrozenObject();
     });
     it('freezes the status object of created SingleTransactionPlanResult objects', () => {
         const messageA = createMessage('A');
         const transactionA = createTransaction('A');
-        const result = successfulSingleTransactionPlanResult(messageA, transactionA);
+        const result = successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA);
         expect(result.status).toBeFrozenObject();
     });
 });
 
-describe('successfulSingleTransactionPlanResultFromSignature', () => {
+describe('successfulSingleTransactionPlanResult', () => {
     it('creates SingleTransactionPlanResult objects with successful status', () => {
         const messageA = createMessage('A');
         const signature = 'A' as Signature;
-        const result = successfulSingleTransactionPlanResultFromSignature(messageA, signature);
+        const result = successfulSingleTransactionPlanResult(messageA, { signature });
         expect(result).toEqual({
             context: { signature: 'A' },
             kind: 'single',
@@ -95,7 +95,7 @@ describe('successfulSingleTransactionPlanResultFromSignature', () => {
         const messageA = createMessage('A');
         const signature = 'A' as Signature;
         const context = { foo: 'bar' };
-        const result = successfulSingleTransactionPlanResultFromSignature(messageA, signature, context);
+        const result = successfulSingleTransactionPlanResult(messageA, { ...context, signature });
         expect(result).toEqual({
             context: { ...context, signature: 'A' },
             kind: 'single',
@@ -106,13 +106,13 @@ describe('successfulSingleTransactionPlanResultFromSignature', () => {
     it('freezes created SingleTransactionPlanResult objects', () => {
         const messageA = createMessage('A');
         const signature = 'A' as Signature;
-        const result = successfulSingleTransactionPlanResultFromSignature(messageA, signature);
+        const result = successfulSingleTransactionPlanResult(messageA, { signature });
         expect(result).toBeFrozenObject();
     });
     it('freezes the status object of created SingleTransactionPlanResult objects', () => {
         const messageA = createMessage('A');
         const signature = 'A' as Signature;
-        const result = successfulSingleTransactionPlanResultFromSignature(messageA, signature);
+        const result = successfulSingleTransactionPlanResult(messageA, { signature });
         expect(result.status).toBeFrozenObject();
     });
 });
@@ -262,12 +262,12 @@ describe('isSingleTransactionPlanResult', () => {
     it('returns true for any SingleTransactionPlanResult', () => {
         expect(
             isSingleTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toBe(true);
         expect(
             isSingleTransactionPlanResult(
-                successfulSingleTransactionPlanResultFromSignature(createMessage('A'), 'A' as Signature),
+                successfulSingleTransactionPlanResult(createMessage('A'), { signature: 'A' as Signature }),
             ),
         ).toBe(true);
         expect(
@@ -291,12 +291,12 @@ describe('assertIsSingleTransactionPlanResult', () => {
     it('does nothing for any SingleTransactionPlanResult', () => {
         expect(() =>
             assertIsSingleTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).not.toThrow();
         expect(() =>
             assertIsSingleTransactionPlanResult(
-                successfulSingleTransactionPlanResultFromSignature(createMessage('A'), 'A' as Signature),
+                successfulSingleTransactionPlanResult(createMessage('A'), { signature: 'A' as Signature }),
             ),
         ).not.toThrow();
         expect(() =>
@@ -328,12 +328,12 @@ describe('isSuccessfulSingleTransactionPlanResult', () => {
     it('returns true for successful SingleTransactionPlanResult', () => {
         expect(
             isSuccessfulSingleTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toBe(true);
         expect(
             isSuccessfulSingleTransactionPlanResult(
-                successfulSingleTransactionPlanResultFromSignature(createMessage('A'), 'A' as Signature),
+                successfulSingleTransactionPlanResult(createMessage('A'), { signature: 'A' as Signature }),
             ),
         ).toBe(true);
     });
@@ -359,12 +359,12 @@ describe('assertIsSuccessfulSingleTransactionPlanResult', () => {
     it('does nothing for successful SingleTransactionPlanResult', () => {
         expect(() =>
             assertIsSuccessfulSingleTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).not.toThrow();
         expect(() =>
             assertIsSuccessfulSingleTransactionPlanResult(
-                successfulSingleTransactionPlanResultFromSignature(createMessage('A'), 'A' as Signature),
+                successfulSingleTransactionPlanResult(createMessage('A'), { signature: 'A' as Signature }),
             ),
         ).not.toThrow();
     });
@@ -406,7 +406,7 @@ describe('isFailedSingleTransactionPlanResult', () => {
     it('returns false for other plans', () => {
         expect(
             isFailedSingleTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toBe(false);
         expect(isFailedSingleTransactionPlanResult(canceledSingleTransactionPlanResult(createMessage('A')))).toBe(
@@ -432,7 +432,7 @@ describe('assertIsFailedSingleTransactionPlanResult', () => {
     it('throws for other plans', () => {
         expect(() =>
             assertIsFailedSingleTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toThrow('Unexpected transaction plan result. Expected failed single plan, got successful single plan.');
         expect(() =>
@@ -459,7 +459,7 @@ describe('isCanceledSingleTransactionPlanResult', () => {
     it('returns false for other plans', () => {
         expect(
             isCanceledSingleTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toBe(false);
         expect(
@@ -485,7 +485,7 @@ describe('assertIsCanceledSingleTransactionPlanResult', () => {
     it('throws for other plans', () => {
         expect(() =>
             assertIsCanceledSingleTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toThrow('Unexpected transaction plan result. Expected canceled single plan, got successful single plan.');
         expect(() =>
@@ -516,7 +516,7 @@ describe('isSequentialTransactionPlanResult', () => {
     it('returns false for other plans', () => {
         expect(
             isSequentialTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toBe(false);
         expect(
@@ -542,7 +542,7 @@ describe('assertIsSequentialTransactionPlanResult', () => {
     it('throws for other plans', () => {
         expect(() =>
             assertIsSequentialTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toThrow('Unexpected transaction plan result. Expected sequential plan, got single plan.');
         expect(() =>
@@ -571,7 +571,7 @@ describe('isNonDivisibleSequentialTransactionPlanResult', () => {
     it('returns false for other plans', () => {
         expect(
             isNonDivisibleSequentialTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toBe(false);
         expect(
@@ -599,7 +599,7 @@ describe('assertIsNonDivisibleSequentialTransactionPlanResult', () => {
     it('throws for other plans', () => {
         expect(() =>
             assertIsNonDivisibleSequentialTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toThrow('Unexpected transaction plan result. Expected non-divisible sequential plan, got single plan.');
         expect(() =>
@@ -631,7 +631,7 @@ describe('isParallelTransactionPlanResult', () => {
     it('returns false for other plans', () => {
         expect(
             isParallelTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toBe(false);
         expect(
@@ -655,7 +655,7 @@ describe('assertIsParallelTransactionPlanResult', () => {
     it('throws for other plans', () => {
         expect(() =>
             assertIsParallelTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toThrow('Unexpected transaction plan result. Expected parallel plan, got single plan.');
         expect(() =>
@@ -682,16 +682,16 @@ describe('isSuccessfulTransactionPlanResult', () => {
     it('returns true for a single successful result', () => {
         expect(
             isSuccessfulTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).toBe(true);
     });
     it('returns true for nested results that are all successful', () => {
         const result = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             sequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
-                successfulSingleTransactionPlanResult(createMessage('C'), createTransaction('C')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('C'), createTransaction('C')),
             ]),
         ]);
         expect(isSuccessfulTransactionPlanResult(result)).toBe(true);
@@ -704,7 +704,7 @@ describe('isSuccessfulTransactionPlanResult', () => {
     });
     it('returns false when any single result is failed', () => {
         const result = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             failedSingleTransactionPlanResult(
                 createMessage('B'),
                 new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE),
@@ -714,7 +714,7 @@ describe('isSuccessfulTransactionPlanResult', () => {
     });
     it('returns false when any single result is canceled', () => {
         const result = sequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             canceledSingleTransactionPlanResult(createMessage('B')),
         ]);
         expect(isSuccessfulTransactionPlanResult(result)).toBe(false);
@@ -736,7 +736,7 @@ describe('isSuccessfulTransactionPlanResult', () => {
         const result = parallelTransactionPlanResult([
             sequentialTransactionPlanResult([
                 parallelTransactionPlanResult([
-                    successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                    successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
                     failedSingleTransactionPlanResult(
                         createMessage('B'),
                         new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE),
@@ -752,16 +752,16 @@ describe('assertIsSuccessfulTransactionPlanResult', () => {
     it('does nothing for a single successful result', () => {
         expect(() =>
             assertIsSuccessfulTransactionPlanResult(
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ),
         ).not.toThrow();
     });
     it('does nothing for nested results that are all successful', () => {
         const result = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             sequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
-                successfulSingleTransactionPlanResult(createMessage('C'), createTransaction('C')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('C'), createTransaction('C')),
             ]),
         ]);
         expect(() => assertIsSuccessfulTransactionPlanResult(result)).not.toThrow();
@@ -774,7 +774,7 @@ describe('assertIsSuccessfulTransactionPlanResult', () => {
     });
     it('throws when any single result is failed', () => {
         const result = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             failedSingleTransactionPlanResult(
                 createMessage('B'),
                 new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE),
@@ -788,7 +788,7 @@ describe('assertIsSuccessfulTransactionPlanResult', () => {
     });
     it('throws when any single result is canceled', () => {
         const result = sequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             canceledSingleTransactionPlanResult(createMessage('B')),
         ]);
         expect(() => assertIsSuccessfulTransactionPlanResult(result)).toThrow(
@@ -918,7 +918,7 @@ describe('findTransactionPlanResult', () => {
         const error = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
         const failedResult = failedSingleTransactionPlanResult(messageB, error);
         const result = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
             failedResult,
         ]);
         const found = findTransactionPlanResult(
@@ -931,7 +931,7 @@ describe('findTransactionPlanResult', () => {
     it('finds a successful single transaction result', () => {
         const messageA = createMessage('A');
         const messageB = createMessage('B');
-        const successfulResult = successfulSingleTransactionPlanResult(messageA, createTransaction('A'));
+        const successfulResult = successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A'));
         const result = sequentialTransactionPlanResult([
             successfulResult,
             canceledSingleTransactionPlanResult(messageB),
@@ -963,7 +963,7 @@ describe('everyTransactionPlanResult', () => {
         expect(result).toBe(false);
     });
     it('matches successful single transaction plans', () => {
-        const plan = successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A'));
+        const plan = successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A'));
         // eslint-disable-next-line jest/no-conditional-in-test
         const result = everyTransactionPlanResult(plan, p => p.kind === 'single' && p.status === 'successful');
         expect(result).toBe(true);
@@ -1000,7 +1000,10 @@ describe('everyTransactionPlanResult', () => {
         expect(result).toBe(true);
     });
     it('matches complex transaction plans', () => {
-        const resultA = successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A'));
+        const resultA = successfulSingleTransactionPlanResultFromTransaction(
+            createMessage('A'),
+            createTransaction('A'),
+        );
         const resultB = failedSingleTransactionPlanResult(
             createMessage('B'),
             new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE),
@@ -1019,7 +1022,10 @@ describe('everyTransactionPlanResult', () => {
         expect(result).toBe(true);
     });
     it('returns false on complex transaction plans', () => {
-        const resultA = successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A'));
+        const resultA = successfulSingleTransactionPlanResultFromTransaction(
+            createMessage('A'),
+            createTransaction('A'),
+        );
         const resultB = failedSingleTransactionPlanResult(
             createMessage('B'),
             new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE),
@@ -1035,8 +1041,14 @@ describe('everyTransactionPlanResult', () => {
     });
     it('fails fast before evaluating children', () => {
         const predicate = jest.fn().mockReturnValueOnce(false);
-        const messageA = successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A'));
-        const messageB = successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B'));
+        const messageA = successfulSingleTransactionPlanResultFromTransaction(
+            createMessage('A'),
+            createTransaction('A'),
+        );
+        const messageB = successfulSingleTransactionPlanResultFromTransaction(
+            createMessage('B'),
+            createTransaction('B'),
+        );
         const plan = sequentialTransactionPlanResult([messageA, messageB]);
         const result = everyTransactionPlanResult(plan, predicate);
         expect(result).toBe(false);
@@ -1047,8 +1059,14 @@ describe('everyTransactionPlanResult', () => {
     });
     it('fails fast before evaluating siblings', () => {
         const predicate = jest.fn().mockReturnValueOnce(true).mockReturnValueOnce(false);
-        const messageA = successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A'));
-        const messageB = successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B'));
+        const messageA = successfulSingleTransactionPlanResultFromTransaction(
+            createMessage('A'),
+            createTransaction('A'),
+        );
+        const messageB = successfulSingleTransactionPlanResultFromTransaction(
+            createMessage('B'),
+            createTransaction('B'),
+        );
         const plan = sequentialTransactionPlanResult([messageA, messageB]);
         const result = everyTransactionPlanResult(plan, predicate);
         expect(result).toBe(false);
@@ -1061,13 +1079,13 @@ describe('everyTransactionPlanResult', () => {
 
 describe('transformTransactionPlanResult', () => {
     it('transforms successful single transaction plan results', () => {
-        const plan = successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A'));
+        const plan = successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A'));
         const transformedPlan = transformTransactionPlanResult(plan, p =>
             // eslint-disable-next-line jest/no-conditional-in-test
             p.kind === 'single' ? { ...p, plannedMessage: { ...p.plannedMessage, id: 'New A' } } : p,
         );
         expect(transformedPlan).toStrictEqual(
-            successfulSingleTransactionPlanResult(createMessage('New A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('New A'), createTransaction('A')),
         );
     });
     it('transforms failed single transaction plan results', () => {
@@ -1089,8 +1107,8 @@ describe('transformTransactionPlanResult', () => {
     });
     it('transforms sequential transaction plan results', () => {
         const plan = sequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
-            successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
         ]);
         const transformedPlan = transformTransactionPlanResult(plan, p =>
             // eslint-disable-next-line jest/no-conditional-in-test
@@ -1098,15 +1116,15 @@ describe('transformTransactionPlanResult', () => {
         );
         expect(transformedPlan).toStrictEqual(
             sequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ]),
         );
     });
     it('transforms non-divisible sequential transaction plan results', () => {
         const plan = nonDivisibleSequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
-            successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
         ]);
         const transformedPlan = transformTransactionPlanResult(plan, p =>
             // eslint-disable-next-line jest/no-conditional-in-test
@@ -1114,15 +1132,15 @@ describe('transformTransactionPlanResult', () => {
         );
         expect(transformedPlan).toStrictEqual(
             nonDivisibleSequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ]),
         );
     });
     it('transforms parallel transaction plan results', () => {
         const plan = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
-            successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
         ]);
         const transformedPlan = transformTransactionPlanResult(plan, p =>
             // eslint-disable-next-line jest/no-conditional-in-test
@@ -1130,18 +1148,18 @@ describe('transformTransactionPlanResult', () => {
         );
         expect(transformedPlan).toStrictEqual(
             parallelTransactionPlanResult([
-                successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             ]),
         );
     });
     it('transforms using a bottom-up approach', () => {
         // Given the following nested plans.
         const plan = sequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
             sequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
-                successfulSingleTransactionPlanResult(createMessage('C'), createTransaction('C')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('C'), createTransaction('C')),
             ]),
         ]);
 
@@ -1172,8 +1190,8 @@ describe('transformTransactionPlanResult', () => {
     });
     it('can be used to duplicate transaction results', () => {
         const plan = sequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
-            successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
         ]);
         const transformedPlan = transformTransactionPlanResult(plan, p =>
             // eslint-disable-next-line jest/no-conditional-in-test
@@ -1182,20 +1200,20 @@ describe('transformTransactionPlanResult', () => {
         expect(transformedPlan).toStrictEqual(
             sequentialTransactionPlanResult([
                 sequentialTransactionPlanResult([
-                    successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
-                    successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+                    successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
+                    successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
                 ]),
                 sequentialTransactionPlanResult([
-                    successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
-                    successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
+                    successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
+                    successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
                 ]),
             ]),
         );
     });
     it('can be used to remove parallelism', () => {
         const plan = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
-            successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
         ]);
         const transformedPlan = transformTransactionPlanResult(plan, p =>
             // eslint-disable-next-line jest/no-conditional-in-test
@@ -1203,22 +1221,22 @@ describe('transformTransactionPlanResult', () => {
         );
         expect(transformedPlan).toStrictEqual(
             sequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
-                successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
             ]),
         );
     });
     it('can be used to flatten nested transaction plan results', () => {
         const plan = sequentialTransactionPlanResult([
             sequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
-                successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
             ]),
             sequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(createMessage('C'), createTransaction('C')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('C'), createTransaction('C')),
                 sequentialTransactionPlanResult([
-                    successfulSingleTransactionPlanResult(createMessage('D'), createTransaction('D')),
-                    successfulSingleTransactionPlanResult(createMessage('E'), createTransaction('E')),
+                    successfulSingleTransactionPlanResultFromTransaction(createMessage('D'), createTransaction('D')),
+                    successfulSingleTransactionPlanResultFromTransaction(createMessage('E'), createTransaction('E')),
                 ]),
             ]),
         ]);
@@ -1233,16 +1251,16 @@ describe('transformTransactionPlanResult', () => {
         });
         expect(transformedPlan).toStrictEqual(
             sequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
-                successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B')),
-                successfulSingleTransactionPlanResult(createMessage('C'), createTransaction('C')),
-                successfulSingleTransactionPlanResult(createMessage('D'), createTransaction('D')),
-                successfulSingleTransactionPlanResult(createMessage('E'), createTransaction('E')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('C'), createTransaction('C')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('D'), createTransaction('D')),
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('E'), createTransaction('E')),
             ]),
         );
     });
     it('keeps transformed successful single transaction plan results frozen', () => {
-        const plan = successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A'));
+        const plan = successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A'));
         const transformedPlan = transformTransactionPlanResult(plan, p => ({ ...p }));
         expect(transformedPlan).toBeFrozenObject();
     });
@@ -1261,14 +1279,14 @@ describe('transformTransactionPlanResult', () => {
     });
     it('keeps transformed sequential transaction plan results frozen', () => {
         const plan = sequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
         ]);
         const transformedPlan = transformTransactionPlanResult(plan, p => ({ ...p }));
         expect(transformedPlan).toBeFrozenObject();
     });
     it('keeps transformed parallel transaction plan results frozen', () => {
         const plan = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
         ]);
         const transformedPlan = transformTransactionPlanResult(plan, p => ({ ...p }));
         expect(transformedPlan).toBeFrozenObject();
@@ -1276,9 +1294,9 @@ describe('transformTransactionPlanResult', () => {
 });
 
 describe('flattenTransactionPlanResult', () => {
-    const plan1 = successfulSingleTransactionPlanResult(createMessage('A'), createTransaction('A'));
-    const plan2 = successfulSingleTransactionPlanResult(createMessage('B'), createTransaction('B'));
-    const plan3 = successfulSingleTransactionPlanResult(createMessage('C'), createTransaction('C'));
+    const plan1 = successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A'));
+    const plan2 = successfulSingleTransactionPlanResultFromTransaction(createMessage('B'), createTransaction('B'));
+    const plan3 = successfulSingleTransactionPlanResultFromTransaction(createMessage('C'), createTransaction('C'));
 
     it('flattens a parallel transaction plan result', () => {
         const result = parallelTransactionPlanResult([plan1, plan2, plan3]);
@@ -1310,7 +1328,9 @@ describe('flattenTransactionPlanResult', () => {
 
 describe('summarizeTransactionPlanResult', () => {
     it('summarizes a single successful transaction', () => {
-        const result = successfulSingleTransactionPlanResultFromSignature(createMessage('A'), 'A' as Signature);
+        const result = successfulSingleTransactionPlanResult(createMessage('A'), {
+            signature: 'A' as Signature,
+        });
         const summary = summarizeTransactionPlanResult(result);
         expect(summary).toEqual({
             canceledTransactions: [],
@@ -1344,9 +1364,15 @@ describe('summarizeTransactionPlanResult', () => {
     });
 
     it('summarizes nested successful transactions', () => {
-        const planA = successfulSingleTransactionPlanResultFromSignature(createMessage('A'), 'A' as Signature);
-        const planB = successfulSingleTransactionPlanResultFromSignature(createMessage('B'), 'B' as Signature);
-        const planC = successfulSingleTransactionPlanResultFromSignature(createMessage('C'), 'C' as Signature);
+        const planA = successfulSingleTransactionPlanResult(createMessage('A'), {
+            signature: 'A' as Signature,
+        });
+        const planB = successfulSingleTransactionPlanResult(createMessage('B'), {
+            signature: 'B' as Signature,
+        });
+        const planC = successfulSingleTransactionPlanResult(createMessage('C'), {
+            signature: 'C' as Signature,
+        });
         const nestedResult = sequentialTransactionPlanResult([parallelTransactionPlanResult([planA, planB]), planC]);
 
         const summary = summarizeTransactionPlanResult(nestedResult);
@@ -1398,7 +1424,9 @@ describe('summarizeTransactionPlanResult', () => {
     });
 
     it('summarizes a mix of successful, failed, and canceled transactions', () => {
-        const planA = successfulSingleTransactionPlanResultFromSignature(createMessage('A'), 'A' as Signature);
+        const planA = successfulSingleTransactionPlanResult(createMessage('A'), {
+            signature: 'A' as Signature,
+        });
         const planB = failedSingleTransactionPlanResult(
             createMessage('B'),
             new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE),
@@ -1432,7 +1460,7 @@ describe('getFirstFailedSingleTransactionPlanResult', () => {
         const error = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
         const failedResult = failedSingleTransactionPlanResult(messageB, error);
         const parallelResult = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
             failedResult,
         ]);
 
@@ -1446,7 +1474,7 @@ describe('getFirstFailedSingleTransactionPlanResult', () => {
         const error = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
         const failedResult = failedSingleTransactionPlanResult(messageB, error);
         const sequentialResult = sequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
             failedResult,
         ]);
 
@@ -1462,9 +1490,9 @@ describe('getFirstFailedSingleTransactionPlanResult', () => {
         const failedResult = failedSingleTransactionPlanResult(messageC, error);
         const nestedResult = parallelTransactionPlanResult([
             sequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
+                successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
                 parallelTransactionPlanResult([
-                    successfulSingleTransactionPlanResult(messageB, createTransaction('B')),
+                    successfulSingleTransactionPlanResultFromTransaction(messageB, createTransaction('B')),
                     failedResult,
                 ]),
             ]),
@@ -1490,8 +1518,8 @@ describe('getFirstFailedSingleTransactionPlanResult', () => {
         const messageA = createMessage('A');
         const messageB = createMessage('B');
         const successfulResult = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
-            successfulSingleTransactionPlanResult(messageB, createTransaction('B')),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(messageB, createTransaction('B')),
         ]);
 
         expect(() => getFirstFailedSingleTransactionPlanResult(successfulResult)).toThrow(
@@ -1522,7 +1550,7 @@ describe('getFirstFailedSingleTransactionPlanResult', () => {
         const messageA = createMessage('A');
         const messageB = createMessage('B');
         const mixedResult = sequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, createTransaction('A')),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
             canceledSingleTransactionPlanResult(messageB),
         ]);
 
@@ -1537,7 +1565,7 @@ describe('getFirstFailedSingleTransactionPlanResult', () => {
 
     it('throws an error where context contains transactionPlanResult as non-enumerable', () => {
         const messageA = createMessage('A');
-        const successfulResult = successfulSingleTransactionPlanResult(messageA, createTransaction('A'));
+        const successfulResult = successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A'));
 
         let caughtError:
             | SolanaError<typeof SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_SINGLE_TRANSACTION_PLAN_RESULT_NOT_FOUND>

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
@@ -1,3 +1,4 @@
+import { Signature } from '@solana/keys';
 import type { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 import type { Transaction } from '@solana/transactions';
 
@@ -31,6 +32,7 @@ import {
     SingleTransactionPlanResult,
     SuccessfulSingleTransactionPlanResult,
     successfulSingleTransactionPlanResult,
+    successfulSingleTransactionPlanResultFromTransaction,
     SuccessfulTransactionPlanResult,
     TransactionPlanResult,
     TransactionPlanResultContext,
@@ -39,8 +41,8 @@ import {
 const messageA = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { id: 'A' };
 const messageB = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { id: 'B' };
 const messageC = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { id: 'C' };
-const transactionA = null as unknown as Transaction;
-const transactionB = null as unknown as Transaction;
+const transactionA = null as unknown as Transaction & { id: 'A' };
+const transactionB = null as unknown as Transaction & { id: 'B' };
 const error = null as unknown as Error;
 
 type CustomContext = { customData: string };
@@ -50,8 +52,8 @@ type CustomContext = { customData: string };
     // It satisfies ParallelTransactionPlanResult.
     {
         const result = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, transactionA),
-            successfulSingleTransactionPlanResult(messageB, transactionB),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA),
+            successfulSingleTransactionPlanResultFromTransaction(messageB, transactionB),
         ]);
         result satisfies ParallelTransactionPlanResult;
         result satisfies TransactionPlanResult;
@@ -60,8 +62,8 @@ type CustomContext = { customData: string };
     // It can work with custom context.
     {
         const result = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, transactionA, { customData: 'A' }),
-            successfulSingleTransactionPlanResult(messageB, transactionB, { customData: 'B' }),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA, { customData: 'A' }),
+            successfulSingleTransactionPlanResultFromTransaction(messageB, transactionB, { customData: 'B' }),
         ]);
         result satisfies ParallelTransactionPlanResult<CustomContext>;
         result satisfies TransactionPlanResult;
@@ -70,9 +72,9 @@ type CustomContext = { customData: string };
     // It can nest other result plans.
     {
         const result = parallelTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, transactionA),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA),
             parallelTransactionPlanResult([
-                successfulSingleTransactionPlanResult(messageB, transactionB),
+                successfulSingleTransactionPlanResultFromTransaction(messageB, transactionB),
                 canceledSingleTransactionPlanResult(messageC),
             ]),
         ]);
@@ -86,8 +88,8 @@ type CustomContext = { customData: string };
     // It satisfies a divisible SequentialTransactionPlanResult.
     {
         const result = sequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, transactionA),
-            successfulSingleTransactionPlanResult(messageB, transactionB),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA),
+            successfulSingleTransactionPlanResultFromTransaction(messageB, transactionB),
         ]);
         result satisfies SequentialTransactionPlanResult & { divisible: true };
         result satisfies TransactionPlanResult;
@@ -96,8 +98,8 @@ type CustomContext = { customData: string };
     // It can work with custom context.
     {
         const result = sequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, transactionA, { customData: 'A' }),
-            successfulSingleTransactionPlanResult(messageB, transactionB, { customData: 'B' }),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA, { customData: 'A' }),
+            successfulSingleTransactionPlanResultFromTransaction(messageB, transactionB, { customData: 'B' }),
         ]);
         result satisfies SequentialTransactionPlanResult<CustomContext> & { divisible: true };
         result satisfies TransactionPlanResult;
@@ -106,9 +108,9 @@ type CustomContext = { customData: string };
     // It can nest other result plans.
     {
         const result = sequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, transactionA),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA),
             sequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(messageB, transactionB),
+                successfulSingleTransactionPlanResultFromTransaction(messageB, transactionB),
                 canceledSingleTransactionPlanResult(messageC),
             ]),
         ]);
@@ -122,8 +124,8 @@ type CustomContext = { customData: string };
     // It satisfies a non-divisible SequentialTransactionPlanResult.
     {
         const result = nonDivisibleSequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, transactionA),
-            successfulSingleTransactionPlanResult(messageB, transactionB),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA),
+            successfulSingleTransactionPlanResultFromTransaction(messageB, transactionB),
         ]);
         result satisfies SequentialTransactionPlanResult & { divisible: false };
         result satisfies TransactionPlanResult;
@@ -132,8 +134,8 @@ type CustomContext = { customData: string };
     // It can work with custom context.
     {
         const result = nonDivisibleSequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, transactionA, { customData: 'A' }),
-            successfulSingleTransactionPlanResult(messageB, transactionB, { customData: 'B' }),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA, { customData: 'A' }),
+            successfulSingleTransactionPlanResultFromTransaction(messageB, transactionB, { customData: 'B' }),
         ]);
         result satisfies SequentialTransactionPlanResult<CustomContext> & { divisible: false };
         result satisfies TransactionPlanResult;
@@ -142,9 +144,9 @@ type CustomContext = { customData: string };
     // It can nest other result plans.
     {
         const result = nonDivisibleSequentialTransactionPlanResult([
-            successfulSingleTransactionPlanResult(messageA, transactionA),
+            successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA),
             nonDivisibleSequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(messageB, transactionB),
+                successfulSingleTransactionPlanResultFromTransaction(messageB, transactionB),
                 canceledSingleTransactionPlanResult(messageC),
             ]),
         ]);
@@ -153,19 +155,41 @@ type CustomContext = { customData: string };
     }
 }
 
-// [DESCRIBE] successfulSingleTransactionPlanResult
+// [DESCRIBE] successfulSingleTransactionPlanResultFromTransaction
 {
     // It satisfies SingleTransactionPlanResult with a successful status.
     {
-        const result = successfulSingleTransactionPlanResult(messageA, transactionA);
-        result satisfies SingleTransactionPlanResult<TransactionPlanResultContext, typeof messageA>;
+        const result = successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA);
+        result satisfies SuccessfulSingleTransactionPlanResult<TransactionPlanResultContext, typeof messageA>;
         result satisfies TransactionPlanResult;
     }
 
     // It can include a custom context.
     {
-        const result = successfulSingleTransactionPlanResult(messageA, transactionA, { customData: 'test' });
-        result satisfies SingleTransactionPlanResult<CustomContext, typeof messageA>;
+        const result = successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA, {
+            customData: 'test',
+        });
+        result satisfies SuccessfulSingleTransactionPlanResult<CustomContext, typeof messageA>;
+        result satisfies TransactionPlanResult;
+    }
+}
+
+// [DESCRIBE] successfulSingleTransactionPlanResult
+{
+    // It satisfies SingleTransactionPlanResult with a successful status.
+    {
+        const result = successfulSingleTransactionPlanResult(messageA, { signature: 'A' as Signature });
+        result satisfies SuccessfulSingleTransactionPlanResult<TransactionPlanResultContext, typeof messageA>;
+        result satisfies TransactionPlanResult;
+    }
+
+    // It can include a custom context.
+    {
+        const result = successfulSingleTransactionPlanResult(messageA, {
+            customData: 'test',
+            signature: 'A' as Signature,
+        });
+        result satisfies SuccessfulSingleTransactionPlanResult<CustomContext, typeof messageA>;
         result satisfies TransactionPlanResult;
     }
 }
@@ -175,7 +199,14 @@ type CustomContext = { customData: string };
     // It satisfies SingleTransactionPlanResult with a failed status.
     {
         const result = failedSingleTransactionPlanResult(messageA, error);
-        result satisfies SingleTransactionPlanResult<TransactionPlanResultContext, typeof messageA>;
+        result satisfies FailedSingleTransactionPlanResult<TransactionPlanResultContext, typeof messageA>;
+        result satisfies TransactionPlanResult;
+    }
+
+    // It can include a custom context.
+    {
+        const result = failedSingleTransactionPlanResult(messageA, error, { customData: 'test' });
+        result satisfies FailedSingleTransactionPlanResult<CustomContext, typeof messageA>;
         result satisfies TransactionPlanResult;
     }
 }
@@ -185,7 +216,14 @@ type CustomContext = { customData: string };
     // It satisfies SingleTransactionPlanResult with a canceled status.
     {
         const result = canceledSingleTransactionPlanResult(messageA);
-        result satisfies SingleTransactionPlanResult<TransactionPlanResultContext, typeof messageA>;
+        result satisfies CanceledSingleTransactionPlanResult<TransactionPlanResultContext, typeof messageA>;
+        result satisfies TransactionPlanResult;
+    }
+
+    // It can include a custom context.
+    {
+        const result = canceledSingleTransactionPlanResult(messageA, { customData: 'test' });
+        result satisfies CanceledSingleTransactionPlanResult<CustomContext, typeof messageA>;
         result satisfies TransactionPlanResult;
     }
 }
@@ -194,7 +232,7 @@ type CustomContext = { customData: string };
 {
     // It extracts single plan results from a simple plan result.
     {
-        const result = successfulSingleTransactionPlanResult(messageA, transactionA);
+        const result = successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA);
         const results = flattenTransactionPlanResult(result);
         results satisfies SingleTransactionPlanResult[];
     }
@@ -203,8 +241,8 @@ type CustomContext = { customData: string };
     {
         const result = parallelTransactionPlanResult([
             sequentialTransactionPlanResult([
-                successfulSingleTransactionPlanResult(messageA, transactionA),
-                successfulSingleTransactionPlanResult(messageB, transactionB),
+                successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA),
+                successfulSingleTransactionPlanResultFromTransaction(messageB, transactionB),
             ]),
         ]);
         const results = flattenTransactionPlanResult(result);

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -23,7 +23,7 @@ import {
     sequentialTransactionPlanResult,
     SingleTransactionPlanResult,
     successfulSingleTransactionPlanResult,
-    successfulSingleTransactionPlanResultFromSignature,
+    successfulSingleTransactionPlanResultFromTransaction,
     type TransactionPlanResult,
     type TransactionPlanResultContext,
 } from './transaction-plan-result';
@@ -203,13 +203,16 @@ async function traverseSingle(
             context.abortSignal,
         );
         if ('transaction' in result) {
-            return successfulSingleTransactionPlanResult(transactionPlan.message, result.transaction, result.context);
-        } else {
-            return successfulSingleTransactionPlanResultFromSignature(
+            return successfulSingleTransactionPlanResultFromTransaction(
                 transactionPlan.message,
-                result.signature,
+                result.transaction,
                 result.context,
             );
+        } else {
+            return successfulSingleTransactionPlanResult(transactionPlan.message, {
+                ...result.context,
+                signature: result.signature,
+            });
         }
     } catch (error) {
         context.canceled = true;


### PR DESCRIPTION
#### Problem

Since we've reshaped the `SuccessfulSingleTransactionPlanResult` type, its factories also need a small reshape.

#### Summary of Changes

- The `successfulSingleTransactionPlanResult` function is renamed to `successfulSingleTransactionPlanResultFromTransaction` since it uses a `transaction` object to derive the `signature` requirement.
- The `successfulSingleTransactionPlanResultFromSignature` function is renamed to `successfulSingleTransactionPlanResult` since it is the factory that is closest to the type itself. The signature must be provided as part of the `context` object instead of a separate argument.

Relates to https://github.com/anza-xyz/kit/issues/1273