### PR TITLE
Add workflow to update docs lockfile when dependabot bumps docs/

### DIFF
--- a/.github/workflows/update-docs-lockfile.yml
+++ b/.github/workflows/update-docs-lockfile.yml
@@ -1,0 +1,38 @@
+name: Update Docs Lockfile
+
+on:
+  pull_request_target:
+    paths:
+      - 'docs/package.json'
+
+permissions:
+  contents: write
+
+jobs:
+  update-lockfile:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Install Dependencies
+        uses: ./.github/workflows/actions/install-dependencies
+
+      - name: Update Docs Lockfile
+        working-directory: ./docs/
+        run: pnpm install --ignore-workspace --no-frozen-lockfile --ignore-scripts
+
+      - name: Commit and Push
+        run: |
+          git add docs/pnpm-lock.yaml
+          if git diff --cached --quiet; then
+            echo "No lockfile changes to commit"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -m "Update docs lockfile"
+            git push
+          fi


### PR DESCRIPTION
#### Problem

Annoyingly, dependabot isn't clever enough to use `--ignore-workspace` in docs, and (AFAICT) can't be configured to do so. Here's an issue that might look familiar :) https://github.com/dependabot/dependabot-core/issues/13802 

This means that even though it now runs separately (which is probably still better), it still runs `pnpm install` and doesn't update any lockfile. And then its PRs fail

#### Summary of Changes

This PR adds a new workflow, which runs on dependabot PRs that update `docs/package.json`. It checks out the PR branch, runs `pnpm install --ignore-workspace --no-frozen-lockfile --ignore-scripts` and then commits docs/pnpm-lock.yaml if it has changed, and pushes it to that branch. This should mean that the branch ends up with a correct `pnpm-lock.yaml` and its CI passes.

#### Security

- This workflow runs with `pull_request_target`, because it needs to be able to push to the branch.
- It uses `--ignore-scripts` in the `pnpm install` command, so that a malicious version of an updated dependency cannot run a script with access to our CI environment 
