### PR TITLE
Add `planType` to distinguish between `InstructionPlan`, `TransactionPlan` and `TransactionPlanResult`

### DIFF
--- a/.changeset/little-paws-trade.md
+++ b/.changeset/little-paws-trade.md
@@ -1,0 +1,29 @@
+---
+'@solana/instruction-plans': major
+---
+
+Add a new `planType` property to all `InstructionPlan`, `TransactionPlan`, and `TransactionPlanResult` types to distinguish them from each other at runtime. This property is a string literal with the value `'instructionPlan'`, `'transactionPlan'`, or `'transactionPlanResult'` respectively. It also adds new type guard functions that make use of that new property: `isInstructionPlan`, `isTransactionPlan`, and `isTransactionPlanResult`.
+
+**BREAKING CHANGES**
+
+**`InstructionPlan`, `TransactionPlan`, and `TransactionPlanResult` type guards updated.** All factories have been updated to add the new `planType` property but any custom instantiation of these types must be updated to include it as well.
+
+```diff
+  const myInstructionPlan: InstructionPlan = {
+    kind: 'parallel',
+    plans: [/* ... */],
++   planType: 'instructionPlan',
+  };
+
+  const myTransactionPlan: TransactionPlan = {
+    kind: 'parallel',
+    plans: [/* ... */],
++   planType: 'transactionPlan',
+  };
+
+  const myTransactionPlanResult: TransactionPlanResult = {
+    kind: 'parallel',
+    plans: [/* ... */],
++   planType: 'transactionPlanResult',
+  };
+```

--- a/packages/instruction-plans/src/__tests__/__setup__.ts
+++ b/packages/instruction-plans/src/__tests__/__setup__.ts
@@ -42,6 +42,7 @@ export function createSingleInstructionAtATimeMessagePackerInstructionPlan(
             };
         },
         kind: 'messagePacker',
+        planType: 'instructionPlan',
     });
 }
 
@@ -139,5 +140,6 @@ export function createMessagePackerInstructionPlan(
             };
         },
         kind: 'messagePacker',
+        planType: 'instructionPlan',
     });
 }

--- a/packages/instruction-plans/src/__typetests__/instruction-plan-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/instruction-plan-typetest.ts
@@ -11,6 +11,7 @@ import {
     getMessagePackerInstructionPlanFromInstructions,
     getReallocMessagePackerInstructionPlan,
     InstructionPlan,
+    isInstructionPlan,
     isMessagePackerInstructionPlan,
     isNonDivisibleSequentialInstructionPlan,
     isParallelInstructionPlan,
@@ -244,5 +245,16 @@ const instructionC = null as unknown as Instruction & { id: 'C' };
         const plan = null as unknown as InstructionPlan;
         assertIsParallelInstructionPlan(plan);
         plan satisfies ParallelInstructionPlan;
+    }
+}
+
+// [DESCRIBE] isInstructionPlan
+{
+    // It narrows to any InstructionPlan.
+    {
+        const plan = null as unknown;
+        if (isInstructionPlan(plan)) {
+            plan satisfies InstructionPlan;
+        }
     }
 }

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
@@ -24,6 +24,7 @@ import {
     isSingleTransactionPlanResult,
     isSuccessfulSingleTransactionPlanResult,
     isSuccessfulTransactionPlanResult,
+    isTransactionPlanResult,
     nonDivisibleSequentialTransactionPlanResult,
     ParallelTransactionPlanResult,
     parallelTransactionPlanResult,
@@ -522,5 +523,16 @@ type CustomContext = { customData: string };
         assertIsSuccessfulTransactionPlanResult(plan);
         plan satisfies SuccessfulSingleTransactionPlanResult;
         plan satisfies SuccessfulTransactionPlanResult;
+    }
+}
+
+// [DESCRIBE] isTransactionPlanResult
+{
+    // It narrows to any TransactionPlanResult.
+    {
+        const plan = null as unknown;
+        if (isTransactionPlanResult(plan)) {
+            plan satisfies TransactionPlanResult;
+        }
     }
 }

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-typetest.ts
@@ -10,6 +10,7 @@ import {
     isParallelTransactionPlan,
     isSequentialTransactionPlan,
     isSingleTransactionPlan,
+    isTransactionPlan,
     nonDivisibleSequentialTransactionPlan,
     ParallelTransactionPlan,
     parallelTransactionPlan,
@@ -182,5 +183,16 @@ const messageC = null as unknown as TransactionMessage & TransactionMessageWithF
         const plan = null as unknown as TransactionPlan;
         assertIsParallelTransactionPlan(plan);
         plan satisfies ParallelTransactionPlan;
+    }
+}
+
+// [DESCRIBE] isTransactionPlan
+{
+    // It narrows to any TransactionPlan.
+    {
+        const plan = null as unknown;
+        if (isTransactionPlan(plan)) {
+            plan satisfies TransactionPlan;
+        }
     }
 }

--- a/packages/instruction-plans/src/instruction-plan.ts
+++ b/packages/instruction-plans/src/instruction-plan.ts
@@ -92,6 +92,7 @@ export type InstructionPlan =
 export type SequentialInstructionPlan = Readonly<{
     divisible: boolean;
     kind: 'sequential';
+    planType: 'instructionPlan';
     plans: InstructionPlan[];
 }>;
 
@@ -126,6 +127,7 @@ export type SequentialInstructionPlan = Readonly<{
  */
 export type ParallelInstructionPlan = Readonly<{
     kind: 'parallel';
+    planType: 'instructionPlan';
     plans: InstructionPlan[];
 }>;
 
@@ -147,6 +149,7 @@ export type ParallelInstructionPlan = Readonly<{
 export type SingleInstructionPlan<TInstruction extends Instruction = Instruction> = Readonly<{
     instruction: TInstruction;
     kind: 'single';
+    planType: 'instructionPlan';
 }>;
 
 /**
@@ -206,6 +209,7 @@ export type SingleInstructionPlan<TInstruction extends Instruction = Instruction
 export type MessagePackerInstructionPlan = Readonly<{
     getMessagePacker: () => MessagePacker;
     kind: 'messagePacker';
+    planType: 'instructionPlan';
 }>;
 
 /**
@@ -276,6 +280,7 @@ export type MessagePacker = Readonly<{
 export function parallelInstructionPlan(plans: (Instruction | InstructionPlan)[]): ParallelInstructionPlan {
     return Object.freeze({
         kind: 'parallel',
+        planType: 'instructionPlan',
         plans: parseSingleInstructionPlans(plans),
     });
 }
@@ -307,6 +312,7 @@ export function sequentialInstructionPlan(
     return Object.freeze({
         divisible: true,
         kind: 'sequential',
+        planType: 'instructionPlan',
         plans: parseSingleInstructionPlans(plans),
     });
 }
@@ -338,6 +344,7 @@ export function nonDivisibleSequentialInstructionPlan(
     return Object.freeze({
         divisible: false,
         kind: 'sequential',
+        planType: 'instructionPlan',
         plans: parseSingleInstructionPlans(plans),
     });
 }
@@ -353,11 +360,46 @@ export function nonDivisibleSequentialInstructionPlan(
  * @see {@link SingleInstructionPlan}
  */
 export function singleInstructionPlan(instruction: Instruction): SingleInstructionPlan {
-    return Object.freeze({ instruction, kind: 'single' });
+    return Object.freeze({ instruction, kind: 'single', planType: 'instructionPlan' });
 }
 
 function parseSingleInstructionPlans(plans: (Instruction | InstructionPlan)[]): InstructionPlan[] {
     return plans.map(plan => ('kind' in plan ? plan : singleInstructionPlan(plan)));
+}
+
+/**
+ * Checks if the given value is an {@link InstructionPlan}.
+ *
+ * This type guard checks the `planType` property to determine if the value
+ * is an instruction plan. This is useful when you have a value that could be
+ * an {@link InstructionPlan}, {@link TransactionPlan}, or {@link TransactionPlanResult}
+ * and need to narrow the type.
+ *
+ * @param value - The value to check.
+ * @return `true` if the value is an instruction plan, `false` otherwise.
+ *
+ * @example
+ * ```ts
+ * function processItem(item: InstructionPlan | TransactionPlan | TransactionPlanResult) {
+ *   if (isInstructionPlan(item)) {
+ *     // item is narrowed to InstructionPlan
+ *     console.log(item.kind);
+ *   }
+ * }
+ * ```
+ *
+ * @see {@link InstructionPlan}
+ * @see {@link isTransactionPlan}
+ * @see {@link isTransactionPlanResult}
+ */
+export function isInstructionPlan(value: unknown): value is InstructionPlan {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'planType' in value &&
+        typeof value.planType === 'string' &&
+        value.planType === 'instructionPlan'
+    );
 }
 
 /**
@@ -915,6 +957,7 @@ export function getLinearMessagePackerInstructionPlan({
             });
         },
         kind: 'messagePacker',
+        planType: 'instructionPlan',
     });
 }
 
@@ -984,6 +1027,7 @@ export function getMessagePackerInstructionPlanFromInstructions<TInstruction ext
             });
         },
         kind: 'messagePacker',
+        planType: 'instructionPlan',
     });
 }
 

--- a/packages/instruction-plans/src/transaction-plan-result.ts
+++ b/packages/instruction-plans/src/transaction-plan-result.ts
@@ -170,6 +170,7 @@ export type SequentialTransactionPlanResult<
 > = Readonly<{
     divisible: boolean;
     kind: 'sequential';
+    planType: 'transactionPlanResult';
     plans: TransactionPlanResult<TContext, TTransactionMessage, TSingle>[];
 }>;
 
@@ -206,6 +207,7 @@ export type ParallelTransactionPlanResult<
     >,
 > = Readonly<{
     kind: 'parallel';
+    planType: 'transactionPlanResult';
     plans: TransactionPlanResult<TContext, TTransactionMessage, TSingle>[];
 }>;
 
@@ -301,6 +303,7 @@ export type SuccessfulSingleTransactionPlanResult<
 > = {
     context: Readonly<SuccessfulBaseTransactionPlanResultContext & TContext>;
     kind: 'single';
+    planType: 'transactionPlanResult';
     plannedMessage: TTransactionMessage;
     status: 'successful';
 };
@@ -345,6 +348,7 @@ export type FailedSingleTransactionPlanResult<
     context: Readonly<BaseTransactionPlanResultContext & TContext>;
     error: Error;
     kind: 'single';
+    planType: 'transactionPlanResult';
     plannedMessage: TTransactionMessage;
     status: 'failed';
 };
@@ -384,6 +388,7 @@ export type CanceledSingleTransactionPlanResult<
 > = {
     context: Readonly<BaseTransactionPlanResultContext & TContext>;
     kind: 'single';
+    planType: 'transactionPlanResult';
     plannedMessage: TTransactionMessage;
     status: 'canceled';
 };
@@ -412,7 +417,7 @@ export type CanceledSingleTransactionPlanResult<
 export function sequentialTransactionPlanResult<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
 >(plans: TransactionPlanResult<TContext>[]): SequentialTransactionPlanResult<TContext> & { divisible: true } {
-    return Object.freeze({ divisible: true, kind: 'sequential', plans });
+    return Object.freeze({ divisible: true, kind: 'sequential', planType: 'transactionPlanResult', plans });
 }
 
 /**
@@ -439,7 +444,7 @@ export function sequentialTransactionPlanResult<
 export function nonDivisibleSequentialTransactionPlanResult<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
 >(plans: TransactionPlanResult<TContext>[]): SequentialTransactionPlanResult<TContext> & { divisible: false } {
-    return Object.freeze({ divisible: false, kind: 'sequential', plans });
+    return Object.freeze({ divisible: false, kind: 'sequential', planType: 'transactionPlanResult', plans });
 }
 
 /**
@@ -465,7 +470,7 @@ export function nonDivisibleSequentialTransactionPlanResult<
 export function parallelTransactionPlanResult<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
 >(plans: TransactionPlanResult<TContext>[]): ParallelTransactionPlanResult<TContext> {
-    return Object.freeze({ kind: 'parallel', plans });
+    return Object.freeze({ kind: 'parallel', planType: 'transactionPlanResult', plans });
 }
 
 /**
@@ -505,6 +510,7 @@ export function successfulSingleTransactionPlanResultFromTransaction<
     return Object.freeze({
         context: Object.freeze({ ...((context ?? {}) as TContext), signature, transaction }),
         kind: 'single',
+        planType: 'transactionPlanResult',
         plannedMessage,
         status: 'successful',
     });
@@ -544,6 +550,7 @@ export function successfulSingleTransactionPlanResult<
     return Object.freeze({
         context: Object.freeze({ ...context }),
         kind: 'single',
+        planType: 'transactionPlanResult',
         plannedMessage,
         status: 'successful',
     });
@@ -588,6 +595,7 @@ export function failedSingleTransactionPlanResult<
         context: Object.freeze({ ...((context ?? {}) as TContext) }),
         error,
         kind: 'single',
+        planType: 'transactionPlanResult',
         plannedMessage,
         status: 'failed',
     });
@@ -622,9 +630,45 @@ export function canceledSingleTransactionPlanResult<
     return Object.freeze({
         context: Object.freeze({ ...((context ?? {}) as TContext) }),
         kind: 'single',
+        planType: 'transactionPlanResult',
         plannedMessage,
         status: 'canceled',
     });
+}
+
+/**
+ * Checks if the given value is a {@link TransactionPlanResult}.
+ *
+ * This type guard checks the `planType` property to determine if the value
+ * is a transaction plan result. This is useful when you have a value that could be
+ * an {@link InstructionPlan}, {@link TransactionPlan}, or {@link TransactionPlanResult}
+ * and need to narrow the type.
+ *
+ * @param value - The value to check.
+ * @return `true` if the value is a transaction plan result, `false` otherwise.
+ *
+ * @example
+ * ```ts
+ * function processItem(item: InstructionPlan | TransactionPlan | TransactionPlanResult) {
+ *   if (isTransactionPlanResult(item)) {
+ *     // item is narrowed to TransactionPlanResult
+ *     console.log(item.kind);
+ *   }
+ * }
+ * ```
+ *
+ * @see {@link TransactionPlanResult}
+ * @see {@link isInstructionPlan}
+ * @see {@link isTransactionPlan}
+ */
+export function isTransactionPlanResult(value: unknown): value is TransactionPlanResult {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'planType' in value &&
+        typeof value.planType === 'string' &&
+        value.planType === 'transactionPlanResult'
+    );
 }
 
 /**

--- a/packages/instruction-plans/src/transaction-planner.ts
+++ b/packages/instruction-plans/src/transaction-planner.ts
@@ -203,6 +203,7 @@ async function traverseSequential(
     return {
         divisible: instructionPlan.divisible,
         kind: 'sequential',
+        planType: 'transactionPlan',
         plans: transactionPlans,
     };
 }
@@ -239,7 +240,7 @@ async function traverseParallel(
     if (transactionPlans.length === 0) {
         return null;
     }
-    return { kind: 'parallel', plans: transactionPlans };
+    return { kind: 'parallel', planType: 'transactionPlan', plans: transactionPlans };
 }
 
 async function traverseSingle(
@@ -253,7 +254,7 @@ async function traverseSingle(
         return null;
     }
     const message = await createNewMessage(context, predicate);
-    return { kind: 'single', message };
+    return { kind: 'single', message, planType: 'transactionPlan' };
 }
 
 async function traverseMessagePacker(
@@ -268,7 +269,7 @@ async function traverseMessagePacker(
         const candidate = await selectAndMutateCandidate(context, candidates, messagePacker.packMessageToCapacity);
         if (!candidate) {
             const message = await createNewMessage(context, messagePacker.packMessageToCapacity);
-            const newPlan: MutableSingleTransactionPlan = { kind: 'single', message };
+            const newPlan: MutableSingleTransactionPlan = { kind: 'single', message, planType: 'transactionPlan' };
             transactionPlans.push(newPlan);
         }
     }
@@ -280,11 +281,12 @@ async function traverseMessagePacker(
         return null;
     }
     if (context.parent?.kind === 'parallel') {
-        return { kind: 'parallel', plans: transactionPlans };
+        return { kind: 'parallel', planType: 'transactionPlan', plans: transactionPlans };
     }
     return {
         divisible: context.parent?.kind === 'sequential' ? context.parent.divisible : true,
         kind: 'sequential',
+        planType: 'transactionPlan',
         plans: transactionPlans,
     };
 }


### PR DESCRIPTION
#### Problem

There is currently now way to distinguish between `InstructionPlan`, `TransactionPlan` and `TransactionPlanResult` types without inspecting the whole tree structure recursively and identifying the types of their leaves.

#### Summary of Changes

This PR adds a new `planType` property to all `InstructionPlan`, `TransactionPlan`, and `TransactionPlanResult` types to distinguish them from each other at runtime. This property is a string literal with the value `'instructionPlan'`, `'transactionPlan'`, or `'transactionPlanResult'` respectively.

This PR also adds new type guard functions that make use of that new property: `isInstructionPlan`, `isTransactionPlan`, and `isTransactionPlanResult`.

This means a function can now request an argument such as `InstructionPlan | TransactionPlan` and distinguish between them to tackle them differently. This will be useful in our instruction plan Kit Plugins as it will allow consumers to also pass `TransactionPlans` and skip the planning phase.

#### Alternatives

I went with `planType` for the discriminator because we already have `kind` to distinguish between the different kinds of plans inside a tree structure. Do let me know if `{ planType, kind }` is clear enough as a "discriminator pair".

Alternatively, instead of `{ planType, kind }` we could have a different `kind` name depending on the type of plan. For instance, `instructionPlanKind`, `transactionPlanKind` and `transactionPlanResultKind`. The property key would then be used to distinguish the plan types and the value to distinguish between the different structures inside that plan type.