### PR TITLE
Update instruction plans documentation guide

### DIFF
--- a/docs/content/docs/concepts/instruction-plans.mdx
+++ b/docs/content/docs/concepts/instruction-plans.mdx
@@ -177,7 +177,7 @@ const instructionPlan = getReallocMessagePackerInstructionPlan({
 Whilst these helpers are fairly situational, you can create any custom message packer as long as you implement the following interfaces.
 
 ```ts twoslash
-import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/kit';
+import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/kit';
 // ---cut-before---
 type MessagePackerInstructionPlan = {
     getMessagePacker: () => MessagePacker;
@@ -187,8 +187,8 @@ type MessagePackerInstructionPlan = {
 type MessagePacker = {
     done: () => boolean;
     packMessageToCapacity: (
-        transactionMessage: BaseTransactionMessage & TransactionMessageWithFeePayer,
-    ) => BaseTransactionMessage & TransactionMessageWithFeePayer;
+        transactionMessage: TransactionMessage & TransactionMessageWithFeePayer,
+    ) => TransactionMessage & TransactionMessageWithFeePayer;
 };
 ```
 
@@ -326,12 +326,12 @@ import {
     singleTransactionPlan,
     sequentialTransactionPlan,
     parallelTransactionPlan,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/kit';
-const messageA = {} as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer;
-const messageB = {} as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer;
-const messageC = {} as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer;
+const messageA = {} as unknown as TransactionMessage & TransactionMessageWithFeePayer;
+const messageB = {} as unknown as TransactionMessage & TransactionMessageWithFeePayer;
+const messageC = {} as unknown as TransactionMessage & TransactionMessageWithFeePayer;
 // ---cut-before---
 const transactionPlan = parallelTransactionPlan([
     sequentialTransactionPlan([singleTransactionPlan(messageA), singleTransactionPlan(messageB)]),
@@ -373,7 +373,13 @@ const transactionPlanResult = await transactionPlanExecutor(transactionPlan, { a
 
 To spin up a transaction plan executor, you may use the `createTransactionPlanExecutor` helper. This helper requires an `executeTransactionMessage` function that tells us how each transaction message should be executed when encountered during the execution process.
 
-This function accepts a transaction message and must return an object containing the successfully executed transaction, along with an optional context object that can be used to pass additional information about the execution.
+The `executeTransactionMessage` callback receives the following arguments:
+
+- **`context`**: A mutable object for storing data during execution — see the [next section](#the-execution-context) for details.
+- **`message`**: The transaction message to execute.
+- **`config`**: An optional configuration object that may include an `abortSignal`.
+
+The callback must return either a `Signature` or a full `Transaction` object directly.
 
 For instance, in the example below we create a new executor such that each transaction message will be assigned the latest blockhash lifetime before being signed and sent to the network using the provided RPC client.
 
@@ -389,7 +395,7 @@ import {
     signTransactionMessageWithSigners,
     assertIsSendableTransaction,
     assertIsTransactionWithBlockhashLifetime,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/kit';
 const rpc = {} as unknown as Rpc<SolanaRpcApi>;
@@ -398,21 +404,107 @@ const rpcSubscriptions = {} as unknown as RpcSubscriptions<SolanaRpcSubscription
 const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
 
 const transactionPlanExecutor = createTransactionPlanExecutor({
-    executeTransactionMessage: async (
-        message: BaseTransactionMessage & TransactionMessageWithFeePayer,
-    ) => {
+    executeTransactionMessage: async (context, message) => {
         const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
         const messageWithBlockhash = setTransactionMessageLifetimeUsingBlockhash(
             latestBlockhash,
             message,
         );
+        context.message = messageWithBlockhash;
         const transaction = await signTransactionMessageWithSigners(messageWithBlockhash);
+        context.transaction = transaction;
         assertIsSendableTransaction(transaction);
         assertIsTransactionWithBlockhashLifetime(transaction);
         await sendAndConfirmTransaction(transaction, { commitment: 'confirmed' });
-        return { transaction };
+        return transaction;
     },
 });
+```
+
+### The execution context
+
+The `context` object passed to the `executeTransactionMessage` callback is a mutable object that you can populate incrementally as execution progresses. This context is preserved in the resulting `SingleTransactionPlanResult` regardless of the outcome — successful, failed, or canceled.
+
+This is particularly useful for debugging failures or building recovery plans. If an error is thrown at any point in the callback, any attributes you've already saved to the context will still be available in the `FailedSingleTransactionPlanResult`.
+
+The context object supports three optional base properties that have semantic meaning:
+
+- **`message`**: The transaction message after any modifications (e.g., after setting a lifetime).
+- **`transaction`**: The signed transaction ready to be sent.
+- **`signature`**: The transaction signature. Note that this is automatically populated when you set the `transaction` property on the context and/or return a `Transaction`.
+
+You can also add any custom properties you need:
+
+```ts twoslash
+import {
+    createTransactionPlanExecutor,
+    setTransactionMessageLifetimeUsingBlockhash,
+    signTransactionMessageWithSigners,
+    sendAndConfirmTransactionFactory,
+    assertIsSendableTransaction,
+    assertIsTransactionWithBlockhashLifetime,
+    Rpc,
+    SolanaRpcApi,
+    RpcSubscriptions,
+    SolanaRpcSubscriptionsApi,
+} from '@solana/kit';
+const rpc = {} as unknown as Rpc<SolanaRpcApi>;
+const rpcSubscriptions = {} as unknown as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions });
+// ---cut-before---
+const transactionPlanExecutor = createTransactionPlanExecutor({
+    executeTransactionMessage: async (context, message) => {
+        // Store the start time (custom context).
+        context.startedAt = Date.now();
+
+        const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+        const messageWithBlockhash = setTransactionMessageLifetimeUsingBlockhash(
+            latestBlockhash,
+            message,
+        );
+
+        // Store the message about to be signed.
+        context.message = messageWithBlockhash;
+
+        const transaction = await signTransactionMessageWithSigners(messageWithBlockhash);
+
+        // Store the transaction about to be sent.
+        context.transaction = transaction;
+
+        assertIsSendableTransaction(transaction);
+        assertIsTransactionWithBlockhashLifetime(transaction);
+        await sendAndConfirmTransaction(transaction, { commitment: 'confirmed' });
+
+        // Store the confirmation time (custom context).
+        context.confirmedAt = Date.now();
+
+        return transaction;
+    },
+});
+```
+
+When accessing the context from a result, you can retrieve both the base properties and your custom properties:
+
+```ts twoslash
+import {
+    SingleTransactionPlanResult,
+    isSuccessfulSingleTransactionPlanResult,
+    isFailedSingleTransactionPlanResult,
+} from '@solana/kit';
+const result = {} as unknown as SingleTransactionPlanResult<{ startedAt: number }>;
+// ---cut-before---
+if (isSuccessfulSingleTransactionPlanResult(result)) {
+    console.log(result.context.signature); // Always available for successful results.
+    console.log(result.context.transaction); // Available if you stored it.
+    console.log(result.context.startedAt); // Custom context property.
+}
+
+if (isFailedSingleTransactionPlanResult(result)) {
+    console.log(result.error); // The error that caused the failure.
+    console.log(result.context.message); // Available if stored before the failure.
+    console.log(result.context.transaction); // Available if stored before the failure.
+    console.log(result.context.startedAt); // Custom context property.
+}
 ```
 
 Check out the [Recipes section](#recipes) at this end of this guide for ideas of what can be achieved with this API.
@@ -423,30 +515,34 @@ When you execute a transaction plan, you get back a `TransactionPlanResult` that
 
 Each transaction message in your plan can have one of three execution outcomes:
 
-- **Successful** - The transaction was sent and confirmed. You get the original transaction message, the executed `Transaction` object and any context data.
-- **Failed** - The transaction encountered an error. You get the original transaction message and the error that caused the failure.
-- **Canceled** - The transaction was skipped because an earlier transaction failed or the operation was aborted. You only get the original transaction message.
+- **Successful** - The transaction was sent and confirmed. You get the original planned message, a context object containing the signature (and optionally the transaction), plus any custom context data.
+- **Failed** - The transaction encountered an error. You get the original planned message, the error that caused the failure, and a context object with any data accumulated before the failure.
+- **Canceled** - The transaction was skipped because an earlier transaction failed or the operation was aborted. You get the original planned message with any context data accumulated before cancellation.
 
 The result structure mirrors your transaction plan structure:
 
-- Single transaction messages become `SingleTransactionPlanResult` with the original message plus execution status
+- Single transaction messages become `SingleTransactionPlanResult` with the original `plannedMessage` plus execution status
 - Sequential plans become `SequentialTransactionPlanResult` containing child results
 - Parallel plans become `ParallelTransactionPlanResult` containing child results
+
+Each `SingleTransactionPlanResult` has a `status` property that is a string literal (`'successful'`, `'failed'`, or `'canceled'`), and properties like `context`, `error` live at the top level of each variant.
 
 ```ts twoslash
 import {
     parallelTransactionPlan,
     singleTransactionPlan,
     parallelTransactionPlanResult,
-    successfulSingleTransactionPlanResult,
+    successfulSingleTransactionPlanResultFromTransaction,
     failedSingleTransactionPlanResult,
+    isSuccessfulSingleTransactionPlanResult,
+    isFailedSingleTransactionPlanResult,
     SolanaError,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
     Transaction,
 } from '@solana/kit';
-const messageA = {} as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer;
-const messageB = {} as unknown as BaseTransactionMessage & TransactionMessageWithFeePayer;
+const messageA = {} as unknown as TransactionMessage & TransactionMessageWithFeePayer;
+const messageB = {} as unknown as TransactionMessage & TransactionMessageWithFeePayer;
 const transactionA = {} as unknown as Transaction;
 const error = {} as unknown as SolanaError;
 // ---cut-before---
@@ -458,9 +554,22 @@ const plan = parallelTransactionPlan([
 
 // Your result may look like this:
 const result = parallelTransactionPlanResult([
-    successfulSingleTransactionPlanResult(messageA, transactionA),
+    successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA),
     failedSingleTransactionPlanResult(messageB, error),
 ]);
+
+// Access the signature from a successful result:
+if (isSuccessfulSingleTransactionPlanResult(result.plans[0])) {
+    console.log(result.plans[0].context.signature);
+    console.log(result.plans[0].context.transaction); // If available
+}
+
+// Access the error from a failed result:
+if (isFailedSingleTransactionPlanResult(result.plans[1])) {
+    console.log(result.plans[1].error);
+    console.log(result.plans[1].context.signature); // If available
+    console.log(result.plans[1].context.transaction); // If available
+}
 ```
 
 ### Failed transaction executions
@@ -582,7 +691,7 @@ import {
     signTransactionMessageWithSigners,
     assertIsSendableTransaction,
     assertIsTransactionWithBlockhashLifetime,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/kit';
 const rpc = {} as unknown as Rpc<SolanaRpcApi>;
@@ -600,20 +709,21 @@ const estimateCULimit = estimateComputeUnitLimitFactory({ rpc });
 const estimateAndSetCULimit = estimateAndUpdateProvisoryComputeUnitLimitFactory(estimateCULimit);
 
 const transactionPlanExecutor = createTransactionPlanExecutor({
-    executeTransactionMessage: async (
-        message: BaseTransactionMessage & TransactionMessageWithFeePayer,
-    ) => {
+    executeTransactionMessage: async (context, message) => {
         const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
         const messageWithBlockhash = setTransactionMessageLifetimeUsingBlockhash(
             latestBlockhash,
             message,
         );
+        context.message = messageWithBlockhash;
         const estimatedMessage = await estimateAndSetCULimit(messageWithBlockhash); // [!code ++]
+        context.message = estimatedMessage; // [!code ++]
         const transaction = await signTransactionMessageWithSigners(estimatedMessage);
+        context.transaction = transaction;
         assertIsSendableTransaction(transaction);
         assertIsTransactionWithBlockhashLifetime(transaction);
         await sendAndConfirmTransaction(transaction, { commitment: 'confirmed' });
-        return { transaction };
+        return transaction;
     },
 });
 ```
@@ -667,7 +777,7 @@ import {
     SolanaRpcSubscriptionsApi,
     signTransactionMessageWithSigners,
     assertIsSendableTransaction,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
     assertIsTransactionWithDurableNonceLifetime,
 } from '@solana/kit';
@@ -687,15 +797,15 @@ const sendAndConfirmDurableNonceTransaction = sendAndConfirmDurableNonceTransact
 });
 
 const transactionPlanExecutor = createTransactionPlanExecutor({
-    executeTransactionMessage: async (
-        message: BaseTransactionMessage & TransactionMessageWithFeePayer,
-    ) => {
+    executeTransactionMessage: async (context, message) => {
         assertIsTransactionMessageWithDurableNonceLifetime(message); // [!code ++]
+        context.message = message;
         const transaction = await signTransactionMessageWithSigners(message);
+        context.transaction = transaction;
         assertIsSendableTransaction(transaction);
         assertIsTransactionWithDurableNonceLifetime(transaction);
         await sendAndConfirmDurableNonceTransaction(transaction, { commitment: 'confirmed' }); // [!code ++]
-        return { transaction };
+        return transaction;
     },
 });
 ```

--- a/docs/content/docs/getting-started/build-transaction.mdx
+++ b/docs/content/docs/getting-started/build-transaction.mdx
@@ -230,7 +230,7 @@ import {
     SolanaRpcSubscriptionsApi,
     TransactionSigner,
     MessageSigner,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/kit';
 import { getCreateAccountInstruction } from '@solana-program/system';
@@ -241,8 +241,7 @@ type Client = {
     wallet: TransactionSigner & MessageSigner;
 };
 const client = {} as Client;
-const transactionMessage = null as unknown as BaseTransactionMessage &
-    TransactionMessageWithFeePayer;
+const transactionMessage = null as unknown as TransactionMessage & TransactionMessageWithFeePayer;
 // ---cut-before---
 import { appendTransactionMessageInstruction } from '@solana/kit';
 import {
@@ -271,7 +270,7 @@ First, let's create a new `estimateAndSetComputeUnitLimitFactory` function that 
 import {
     // ...
     appendTransactionMessageInstruction,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/kit';
 import {
@@ -283,7 +282,7 @@ function estimateAndSetComputeUnitLimitFactory(
     ...params: Parameters<typeof estimateComputeUnitLimitFactory>
 ) {
     const estimateComputeUnitLimit = estimateComputeUnitLimitFactory(...params);
-    return async <T extends BaseTransactionMessage & TransactionMessageWithFeePayer>(
+    return async <T extends TransactionMessage & TransactionMessageWithFeePayer>(
         transactionMessage: T,
     ) => {
         const computeUnitsEstimate = await estimateComputeUnitLimit(transactionMessage);
@@ -299,7 +298,7 @@ Next, let's use the return type of that function to provide a new `estimateAndSe
 
 ```ts twoslash title="src/client.ts"
 import {
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
     Rpc,
     SolanaRpcApi,
@@ -311,7 +310,7 @@ import {
 import { estimateComputeUnitLimitFactory } from '@solana-program/compute-budget';
 const estimateAndSetComputeUnitLimitFactory = {} as unknown as (
     ...params: Parameters<typeof estimateComputeUnitLimitFactory>
-) => <T extends BaseTransactionMessage & TransactionMessageWithFeePayer>(
+) => <T extends TransactionMessage & TransactionMessageWithFeePayer>(
     transactionMessage: T,
 ) => Promise<T>;
 const rpc = {} as Rpc<SolanaRpcApi>;
@@ -356,13 +355,13 @@ import {
     SolanaRpcSubscriptionsApi,
     TransactionSigner,
     MessageSigner,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/kit';
 import { getCreateAccountInstruction } from '@solana-program/system';
 import { getInitializeMintInstruction } from '@solana-program/token';
 const estimateAndSetComputeUnitLimitFactory = {} as unknown as () => <
-    T extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+    T extends TransactionMessage & TransactionMessageWithFeePayer,
 >(
     transactionMessage: T,
 ) => Promise<T>;
@@ -401,9 +400,8 @@ const transactionMessage = await pipe(
 Our transaction message is now fully configured and ready to be signed. Since we have been providing signer objects every step of the way, our transaction message already knows how to sign itself. All that is left to do is call `signTransactionMessageWithSigners`. This helper function will extract and deduplicate all the signers from the transaction message and use them to sign the message. As the message is signed, it is compiled into a new `Transaction` type that contains the compiled message and all of its signatures.
 
 ```ts twoslash
-import { BaseTransactionMessage, TransactionMessageWithFeePayer } from '@solana/kit';
-const transactionMessage = null as unknown as BaseTransactionMessage &
-    TransactionMessageWithFeePayer;
+import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/kit';
+const transactionMessage = null as unknown as TransactionMessage & TransactionMessageWithFeePayer;
 // ---cut-before---
 import { signTransactionMessageWithSigners } from '@solana/kit';
 
@@ -418,12 +416,11 @@ Fortunately for us, there is a helper function called `assertIsSendableTransacti
 
 ```ts twoslash
 import {
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
     signTransactionMessageWithSigners,
 } from '@solana/kit';
-const transactionMessage = null as unknown as BaseTransactionMessage &
-    TransactionMessageWithFeePayer;
+const transactionMessage = null as unknown as TransactionMessage & TransactionMessageWithFeePayer;
 // ---cut-before---
 import { assertIsSendableTransaction, SendableTransaction } from '@solana/kit';
 
@@ -446,11 +443,11 @@ import {
     SolanaRpcSubscriptionsApi,
     TransactionSigner,
     MessageSigner,
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
 } from '@solana/kit';
 const estimateAndSetComputeUnitLimitFactory = {} as unknown as () => <
-    T extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+    T extends TransactionMessage & TransactionMessageWithFeePayer,
 >(
     transactionMessage: T,
 ) => Promise<T>;

--- a/docs/content/docs/getting-started/fetch-account.mdx
+++ b/docs/content/docs/getting-started/fetch-account.mdx
@@ -208,7 +208,7 @@ Since some of its data is optional, we'll use the `unwrapOption` helper to conve
 ```ts twoslash title="src/index.ts"
 // @filename: client.ts
 import {
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
     MessageSigner,
     Rpc,
@@ -219,7 +219,7 @@ import {
     sendAndConfirmTransactionFactory,
 } from '@solana/kit';
 const estimateAndSetComputeUnitLimitFactory = {} as unknown as () => <
-    T extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+    T extends TransactionMessage & TransactionMessageWithFeePayer,
 >(
     transactionMessage: T,
 ) => Promise<T>;

--- a/docs/content/docs/getting-started/send-transaction.mdx
+++ b/docs/content/docs/getting-started/send-transaction.mdx
@@ -130,7 +130,7 @@ With all that new knowledge in hand, let's update our `Client` object to include
 
 ```ts twoslash title="src/client.ts"
 import {
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
     MessageSigner,
     Rpc,
@@ -143,7 +143,7 @@ const rpc = null as unknown as Rpc<SolanaRpcApi>;
 const rpcSubscriptions = null as unknown as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
 const wallet = null as unknown as TransactionSigner & MessageSigner;
 const estimateAndSetComputeUnitLimitFactory = {} as unknown as () => <
-    T extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+    T extends TransactionMessage & TransactionMessageWithFeePayer,
 >(
     transactionMessage: T,
 ) => Promise<T>;
@@ -200,7 +200,7 @@ And with that, our `createMint` function is complete!
 ```ts twoslash title="src/create-mint.ts"
 // @filename: client.ts
 import {
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
     MessageSigner,
     Rpc,
@@ -211,7 +211,7 @@ import {
     sendAndConfirmTransactionFactory,
 } from '@solana/kit';
 const estimateAndSetComputeUnitLimitFactory = {} as unknown as () => <
-    T extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+    T extends TransactionMessage & TransactionMessageWithFeePayer,
 >(
     transactionMessage: T,
 ) => Promise<T>;
@@ -298,7 +298,7 @@ Finally, let's update our main `tutorial` function to execute the `createMint` f
 ```ts twoslash title="src/index.ts"
 // @filename: client.ts
 import {
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithFeePayer,
     MessageSigner,
     Rpc,
@@ -309,7 +309,7 @@ import {
     sendAndConfirmTransactionFactory,
 } from '@solana/kit';
 const estimateAndSetComputeUnitLimitFactory = {} as unknown as () => <
-    T extends BaseTransactionMessage & TransactionMessageWithFeePayer,
+    T extends TransactionMessage & TransactionMessageWithFeePayer,
 >(
     transactionMessage: T,
 ) => Promise<T>;

--- a/docs/content/docs/upgrade-guide.mdx
+++ b/docs/content/docs/upgrade-guide.mdx
@@ -364,11 +364,11 @@ transaction.sign([payer, authority]);
 import { compileTransaction, generateKeyPair, signTransaction } from '@solana/kit';
 // ---cut-start---
 import {
-    BaseTransactionMessage,
+    TransactionMessage,
     TransactionMessageWithBlockhashLifetime,
     TransactionMessageWithFeePayer,
 } from '@solana/kit';
-const transactionMessage = null as unknown as BaseTransactionMessage &
+const transactionMessage = null as unknown as TransactionMessage &
     TransactionMessageWithFeePayer &
     TransactionMessageWithBlockhashLifetime;
 // ---cut-end---

--- a/docs/package.json
+++ b/docs/package.json
@@ -24,16 +24,16 @@
         "twoslash": "^0.3.1"
     },
     "devDependencies": {
-        "@solana-program/address-lookup-table": "^0.7.0",
-        "@solana-program/compute-budget": "^0.8.0",
-        "@solana-program/memo": "^0.7.0",
-        "@solana-program/system": "^0.7.0",
-        "@solana-program/token": "^0.5.1",
-        "@solana/compat": "5.1.1-canary-20251216194212",
-        "@solana/kit": "5.1.1-canary-20251216194212",
-        "@solana/react": "5.1.1-canary-20251216194212",
+        "@solana-program/address-lookup-table": "^0.10.0",
+        "@solana-program/compute-budget": "^0.12.0",
+        "@solana-program/memo": "^0.10.0",
+        "@solana-program/system": "^0.10.0",
+        "@solana-program/token": "^0.9.0",
+        "@solana/compat": "6.0.0-canary-20260203172420",
+        "@solana/kit": "6.0.0-canary-20260203172420",
+        "@solana/react": "6.0.0-canary-20260203172420",
         "@solana/web3.js": "^1.98.2",
-        "@solana/webcrypto-ed25519-polyfill": "5.1.1-canary-20251216194212",
+        "@solana/webcrypto-ed25519-polyfill": "6.0.0-canary-20260203172420",
         "@tailwindcss/postcss": "^4.1.4",
         "@types/mdx": "^2.0.13",
         "@types/node": "22.13.8",
@@ -43,8 +43,8 @@
         "eslint-config-next": "^16.0.10",
         "postcss": "^8.5.3",
         "tailwindcss": "^4.1.4",
-        "typescript": "^5.8.3",
-        "vercel": "^50.1.0"
+        "typescript": "^5.9.3",
+        "vercel": "^50.9.6"
     },
     "pnpm": {
         "overrides": {

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -48,35 +48,35 @@ importers:
         version: 0.3.1(typescript@5.9.3)
     devDependencies:
       '@solana-program/address-lookup-table':
-        specifier: ^0.7.0
-        version: 0.7.0(@solana/kit@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+        specifier: ^0.10.0
+        version: 0.10.0(@solana/kit@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana-program/compute-budget':
-        specifier: ^0.8.0
-        version: 0.8.0(@solana/kit@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+        specifier: ^0.12.0
+        version: 0.12.0(@solana/kit@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana-program/memo':
-        specifier: ^0.7.0
-        version: 0.7.0(@solana/kit@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+        specifier: ^0.10.0
+        version: 0.10.0(@solana/kit@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana-program/system':
-        specifier: ^0.7.0
-        version: 0.7.0(@solana/kit@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+        specifier: ^0.10.0
+        version: 0.10.0(@solana/kit@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana-program/token':
-        specifier: ^0.5.1
-        version: 0.5.1(@solana/kit@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
+        specifier: ^0.9.0
+        version: 0.9.0(@solana/kit@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
       '@solana/compat':
-        specifier: 5.1.1-canary-20251216194212
-        version: 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+        specifier: 6.0.0-canary-20260203172420
+        version: 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/kit':
-        specifier: 5.1.1-canary-20251216194212
-        version: 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+        specifier: 6.0.0-canary-20260203172420
+        version: 6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/react':
-        specifier: 5.1.1-canary-20251216194212
-        version: 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)
+        specifier: 6.0.0-canary-20260203172420
+        version: 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)
       '@solana/web3.js':
         specifier: ^1.98.2
         version: 1.98.2(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@solana/webcrypto-ed25519-polyfill':
-        specifier: 5.1.1-canary-20251216194212
-        version: 5.1.1-canary-20251216194212(typescript@5.9.3)
+        specifier: 6.0.0-canary-20260203172420
+        version: 6.0.0-canary-20260203172420(typescript@5.9.3)
       '@tailwindcss/postcss':
         specifier: ^4.1.4
         version: 4.1.4
@@ -105,11 +105,11 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4
       typescript:
-        specifier: ^5.8.3
+        specifier: ^5.9.3
         version: 5.9.3
       vercel:
-        specifier: ^50.1.0
-        version: 50.1.0(typescript@5.9.3)
+        specifier: ^50.9.6
+        version: 50.9.6(typescript@5.9.3)
 
 packages:
 
@@ -215,6 +215,9 @@ packages:
   '@emnapi/core@1.6.0':
     resolution: {integrity: sha512-zq/ay+9fNIJJtJiZxdTnXS20PllcYMX3OE23ESc4HK/bdYu3cOWYVhsOhVnXALfU/uqJIxn5NBPd9z4v+SfoSg==}
 
+  '@emnapi/core@1.8.1':
+    resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
   '@emnapi/runtime@1.5.0':
     resolution: {integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==}
 
@@ -223,12 +226,6 @@ packages:
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
-
-  '@esbuild/aix-ppc64@0.23.1':
-    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
 
   '@esbuild/aix-ppc64@0.25.3':
     resolution: {integrity: sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==}
@@ -242,12 +239,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.23.1':
-    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
   '@esbuild/android-arm64@0.25.3':
     resolution: {integrity: sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==}
     engines: {node: '>=18'}
@@ -258,12 +249,6 @@ packages:
     resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm@0.23.1':
-    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.3':
@@ -278,12 +263,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.23.1':
-    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
   '@esbuild/android-x64@0.25.3':
     resolution: {integrity: sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==}
     engines: {node: '>=18'}
@@ -296,12 +275,6 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.23.1':
-    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.25.3':
     resolution: {integrity: sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==}
     engines: {node: '>=18'}
@@ -312,12 +285,6 @@ packages:
     resolution: {integrity: sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.23.1':
-    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.3':
@@ -332,12 +299,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.23.1':
-    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.25.3':
     resolution: {integrity: sha512-EJiyS70BYybOBpJth3M0KLOus0n+RRMKTYzhYhFeMwp7e/RaajXvP+BWlmEXNk6uk+KAu46j/kaQzr6au+JcIw==}
     engines: {node: '>=18'}
@@ -348,12 +309,6 @@ packages:
     resolution: {integrity: sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.23.1':
-    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.3':
@@ -368,12 +323,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.23.1':
-    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.25.3':
     resolution: {integrity: sha512-xCUgnNYhRD5bb1C1nqrDV1PfkwgbswTTBRbAd8aH5PhYzikdf/ddtsYyMXFfGSsb/6t6QaPSzxtbfAZr9uox4A==}
     engines: {node: '>=18'}
@@ -384,12 +333,6 @@ packages:
     resolution: {integrity: sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.23.1':
-    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.3':
@@ -404,12 +347,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.23.1':
-    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.25.3':
     resolution: {integrity: sha512-yplPOpczHOO4jTYKmuYuANI3WhvIPSVANGcNUeMlxH4twz/TeXuzEP41tGKNGWJjuMhotpGabeFYGAOU2ummBw==}
     engines: {node: '>=18'}
@@ -420,12 +357,6 @@ packages:
     resolution: {integrity: sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.23.1':
-    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.3':
@@ -440,12 +371,6 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.23.1':
-    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.25.3':
     resolution: {integrity: sha512-eRAOV2ODpu6P5divMEMa26RRqb2yUoYsuQQOuFUexUoQndm4MdpXXDBbUoKIc0iPa4aCO7gIhtnYomkn2x+bag==}
     engines: {node: '>=18'}
@@ -456,12 +381,6 @@ packages:
     resolution: {integrity: sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==}
     engines: {node: '>=18'}
     cpu: [mips64el]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.23.1':
-    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.3':
@@ -476,12 +395,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.23.1':
-    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.25.3':
     resolution: {integrity: sha512-LDDODcFzNtECTrUUbVCs6j9/bDVqy7DDRsuIXJg6so+mFksgwG7ZVnTruYi5V+z3eE5y+BJZw7VvUadkbfg7QA==}
     engines: {node: '>=18'}
@@ -494,12 +407,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.23.1':
-    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
   '@esbuild/linux-s390x@0.25.3':
     resolution: {integrity: sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==}
     engines: {node: '>=18'}
@@ -510,12 +417,6 @@ packages:
     resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
     engines: {node: '>=18'}
     cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-x64@0.23.1':
-    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.3':
@@ -542,12 +443,6 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.23.1':
-    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.25.3':
     resolution: {integrity: sha512-i5Hm68HXHdgv8wkrt+10Bc50zM0/eonPb/a/OFVfB6Qvpiirco5gBA5bz7S2SHuU+Y4LWn/zehzNX14Sp4r27g==}
     engines: {node: '>=18'}
@@ -560,12 +455,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.23.1':
-    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
   '@esbuild/openbsd-arm64@0.25.3':
     resolution: {integrity: sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==}
     engines: {node: '>=18'}
@@ -576,12 +465,6 @@ packages:
     resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-x64@0.23.1':
-    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.3':
@@ -602,12 +485,6 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.23.1':
-    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.25.3':
     resolution: {integrity: sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==}
     engines: {node: '>=18'}
@@ -619,12 +496,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
-
-  '@esbuild/win32-arm64@0.23.1':
-    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
 
   '@esbuild/win32-arm64@0.25.3':
     resolution: {integrity: sha512-YWcow8peiHpNBiIXHwaswPnAXLsLVygFwCB3A7Bh5jRkIBFWHGmNQ48AlX4xDvQNoMZlPYzjVOQDYEzWCqufMQ==}
@@ -638,12 +509,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.23.1':
-    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.25.3':
     resolution: {integrity: sha512-qspTZOIGoXVS4DpNqUYUs9UxVb04khS1Degaw/MnfMe7goQ3lTfQ13Vw4qY/Nj0979BGvMRpAYbs/BAxEvU8ew==}
     engines: {node: '>=18'}
@@ -654,12 +519,6 @@ packages:
     resolution: {integrity: sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.23.1':
-    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
-    engines: {node: '>=18'}
-    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.3':
@@ -936,8 +795,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.7':
     resolution: {integrity: sha512-5yximcFK5FNompXfJFoWanu5l8v1hNGqNHh9du1xETp9HWk/B/PzvchX55WYOPaIeNglG8++68AAiauBAtbnzw==}
 
-  '@napi-rs/wasm-runtime@1.0.7':
-    resolution: {integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==}
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
   '@next/env@16.1.6':
     resolution: {integrity: sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==}
@@ -1024,19 +883,36 @@ packages:
     resolution: {integrity: sha512-qtSrqCqRU93SjEBedz987tvWao1YQSELjBhGkHYGVP7Dg0lBWP6d+uZEIt5gxTAYio/YWWlhivmRABvRfPLmnQ==}
     engines: {node: '>= 16.0.0'}
 
-  '@oxc-project/runtime@0.82.3':
-    resolution: {integrity: sha512-LNh5GlJvYHAnMurO+EyA8jJwN1rki7l3PSHuosDh2I7h00T6/u9rCkUjg/SvPmT1CZzvhuW0y+gf7jcqUy/Usg==}
-    engines: {node: '>=6.9.0'}
+  '@oxc-project/types@0.110.0':
+    resolution: {integrity: sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==}
 
-  '@oxc-project/types@0.82.3':
-    resolution: {integrity: sha512-6nCUxBnGX0c6qfZW5MaF6/fmu5dHJDMiMPaioKHKs5mi5+8/FHQ7WGjgQIz1zxpmceMYfdIXkOaLYE+ejbuOtA==}
+  '@oxc-transform/binding-android-arm-eabi@0.111.0':
+    resolution: {integrity: sha512-NdFLicvorfHYu0g2ftjVJaH7+Dz27AQUNJOq8t/ofRUoWmczOodgUCHx8C1M1htCN4ZmhS/FzfSy6yd/UngJGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
 
-  '@oxc-project/types@0.99.0':
-    resolution: {integrity: sha512-LLDEhXB7g1m5J+woRSgfKsFPS3LhR9xRhTeIoEBm5WrkwMxn6eZ0Ld0c0K5eHB57ChZX6I3uSmmLjZ8pcjlRcw==}
+  '@oxc-transform/binding-android-arm64@0.111.0':
+    resolution: {integrity: sha512-J2v9ajarD2FYlhHtjbgZUFsS2Kvi27pPxDWLGCy7i8tO60xBoozX9/ktSgbiE/QsxKaUhfv4zVKppKWUo71PmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform/binding-darwin-arm64@0.111.0':
+    resolution: {integrity: sha512-2UYmExxpXzmiHTldhNlosWqG9Nc4US51K0GB9RLcGlTE23WO33vVo1NVAKwxPE+KYuhffwDnRYTovTMUjzwvZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
 
   '@oxc-transform/binding-darwin-arm64@0.53.0':
     resolution: {integrity: sha512-QG1djnqQ+EywamRwFMRYogmbF4aL+Fmw/tDKuZ4cpWpOBPaxgTNryfYS1WwCARlZLmLzDEZr0YkYSQ7Rmjyf1Q==}
     cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform/binding-darwin-x64@0.111.0':
+    resolution: {integrity: sha512-c4YRwfLV8Pj/ToiTCbndZaHxM2BD4W3bltr/fjXZcGypEK+U2RZFDL7tIZYT/tyneAC9hCORZKDaKhLLNuzPtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@oxc-transform/binding-darwin-x64@0.53.0':
@@ -1044,8 +920,38 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@oxc-transform/binding-freebsd-x64@0.111.0':
+    resolution: {integrity: sha512-prvf32IcEuLnLZbNVomFosBu0CaZpyj3YsZ6epbOgJy8iJjfLsXBb+PrkO/NBKzjuJoJa2+u7jFKRE0KT7gSOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.111.0':
+    resolution: {integrity: sha512-+se3579Wp7VOk8TnTZCpT+obTAyzOw2b/UuoM0+51LtbzCSfjKxd4A+o7zRl7GyPrPZvx57KdbMOC9rWB1xNrw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.111.0':
+    resolution: {integrity: sha512-8faC99pStqaSDPK/vBgaagAHUeL0LcIzfeSjSiDTtvPGc3AwZIeqC1tx3CP15a6tWXjdgS/IUw4IjfD5HweBlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.111.0':
+    resolution: {integrity: sha512-HtfQv8j796gzI5WR/RaP6IMwFpiL0vYeDrUA1hYhlPzTHKYan/B+NlhJkKOI1v24yAl/yEnFmb0pxIxLNqBqBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@oxc-transform/binding-linux-arm64-gnu@0.53.0':
     resolution: {integrity: sha512-BgY+h7bQsGP6lsQe4s7stz6SpbfijhiZGx/lPoTYn9wkLonqBVk2bGkPkyZvzd3Sr8aw2taOE6ycb146scyniQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-musl@0.111.0':
+    resolution: {integrity: sha512-ARyfcMCIxVLDgLf6FQ8Oo1/TFySpnquV+vuSb4SFQZfYDqgMklzwv0NYXxWD0aB6enElyMDs6pQJBzusEKCkOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
@@ -1054,8 +960,44 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@oxc-transform/binding-linux-ppc64-gnu@0.111.0':
+    resolution: {integrity: sha512-PKpVRrSvBNK3tv9vwxn7Fay+QWZmprPGlEqJcseBJllQc5mFMD4Q/w44chu5iR9ZLsDeSHzmNWrgMLo4J0sP2A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.111.0':
+    resolution: {integrity: sha512-9bUml6rMgk+8GF5rvNMweFspkzSiCjqpV6HduwiUyexqfGKrmjq9IZOxxvnzkE2RGdQzP507NNDoVNYIoGQYuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.111.0':
+    resolution: {integrity: sha512-tzGCohGxaeH6KRJjfYZd4mHCoGjCai6N+zZi1Oj+tSDMAAdyvs1dRzYb8PNUGnybCg3Te4M0jLPzWZaSmnKraQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.111.0':
+    resolution: {integrity: sha512-sRG1KIfZ0ML9ToEygm5aM/5GJeBA05uHlgW3M0Rx/DNWMJhuahLmqWuB02aWSmijndLfEKXLLXIWhvWupRG8lg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-gnu@0.111.0':
+    resolution: {integrity: sha512-T0Kmvk+OdlUdABdXlDIf3MQReMzFfC75NEI9x8jxy5pKooACEFg0k0V8gyR3gq4DzbDCfucqFQDWNvSgIopAbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
   '@oxc-transform/binding-linux-x64-gnu@0.53.0':
     resolution: {integrity: sha512-iWFm/ZNEYF5IKN3/gcYaMJUI1yc5iJ2vQ9fVxYAFT6GglnBqXXxqwazlL5QkiAwDOzVwDUctAIZWgxse1vTm2A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-musl@0.111.0':
+    resolution: {integrity: sha512-EgoutsP3YfqzN8a9vpc9+XLr0bmBl0dA3uOMiP77+exATCPxJBkJErGmQkqk6RtTp5XqX6q6mB45qWQyKk6+pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
@@ -1064,9 +1006,38 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@oxc-transform/binding-openharmony-arm64@0.111.0':
+    resolution: {integrity: sha512-d8J+ejc0j5WODbVwR/QxFaI65YMwvG0W53vcVCHwa6ja1QI5lpe7sislrefG2EFYgnY47voMRzlXab5d4gEcDw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform/binding-wasm32-wasi@0.111.0':
+    resolution: {integrity: sha512-HtyIZO8IwuZgXkyb56rysLz1OLbfLhEu8A3BeuyJXzUseAj96yuxgGt3cu3QYX9AXb9pfRfA3c/fvlhsDugyTQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.111.0':
+    resolution: {integrity: sha512-YeP80Riptc0MkVVBnzbmoFuHVLUq278+MbwNo9sTLALmzTIJxJqN029xRZbG+Bun7aLsoZhmRnm3J5JZ1NcP5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@oxc-transform/binding-win32-arm64-msvc@0.53.0':
     resolution: {integrity: sha512-Afh37KNowRgdDtV6EL4IxWBv/l5/XLctXADOCAvYNUsiUwQ2vNKiNwx+k8QzMZW59G5JEIN8yroMd/qnQSpdJw==}
     cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.111.0':
+    resolution: {integrity: sha512-A6ztCXpoSHt6PbvGAFqB0MLOcGG7ZJrrPXY1iB0zfOB1atLgI8oNePGxPl03XSbwpiTsFJ1oo8rj9DXcBzgT9g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-x64-msvc@0.111.0':
+    resolution: {integrity: sha512-QddKW4kBH0Wof6Y65eYCNHM4iOGmCTWLLcNYY1FGswhzmTYOUVXajNROR+iCXAOFnOF0ldtsR79SyqgyHH1Bgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [win32]
 
   '@oxc-transform/binding-win32-x64-msvc@0.53.0':
@@ -1915,164 +1886,85 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.35':
-    resolution: {integrity: sha512-zVTg0544Ib1ldJSWwjy8URWYHlLFJ98rLnj+2FIj5fRs4KqGKP4VgH/pVUbXNGxeLFjItie6NSK1Un7nJixneQ==}
-    cpu: [arm64]
-    os: [android]
-
-  '@rolldown/binding-android-arm64@1.0.0-beta.52':
-    resolution: {integrity: sha512-MBGIgysimZPqTDcLXI+i9VveijkP5C3EAncEogXhqfax6YXj1Tr2LY3DVuEOMIjWfMPMhtQSPup4fSTAmgjqIw==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-He6ZoCfv5D7dlRbrhNBkuMVIHd0GDnjJwbICE1OWpG7G3S2gmJ+eXkcNLJjzjNDpeI2aRy56ou39AJM9AD8YFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.35':
-    resolution: {integrity: sha512-WPy0qx22CABTKDldEExfpYHWHulRoPo+m/YpyxP+6ODUPTQexWl8Wp12fn1CVP0xi0rOBj7ugs6+kKMAJW56wQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.52':
-    resolution: {integrity: sha512-MmKeoLnKu1d9j6r19K8B+prJnIZ7u+zQ+zGQ3YHXGnr41rzE3eqQLovlkvoZnRoxDGPA4ps0pGiwXy6YE3lJyg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-YzJdn08kSOXnj85ghHauH2iHpOJ6eSmstdRTLyaziDcUxe9SyQJgGyx/5jDIhDvtOcNvMm2Ju7m19+S/Rm1jFg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.35':
-    resolution: {integrity: sha512-3k1TabJafF/GgNubXMkfp93d5p30SfIMOmQ5gm1tFwO+baMxxVPwDs3FDvSl+feCWwXxBA+bzemgkaDlInmp1Q==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.0.0-beta.52':
-    resolution: {integrity: sha512-qpHedvQBmIjT8zdnjN3nWPR2qjQyJttbXniCEKKdHeAbZG9HyNPBUzQF7AZZGwmS9coQKL+hWg9FhWzh2dZ2IA==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.1':
+    resolution: {integrity: sha512-cIvAbqM+ZVV6lBSKSBtlNqH5iCiW933t1q8j0H66B3sjbe8AxIRetVqfGgcHcJtMzBIkIALlL9fcDrElWLJQcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.35':
-    resolution: {integrity: sha512-GAiapN5YyIocnBVNEiOxMfWO9NqIeEKKWohj1sPLGc61P+9N1meXOOCiAPbLU+adXq0grtbYySid+Or7f2q+Mg==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.52':
-    resolution: {integrity: sha512-dDp7WbPapj/NVW0LSiH/CLwMhmLwwKb3R7mh2kWX+QW85X1DGVnIEyKh9PmNJjB/+suG1dJygdtdNPVXK1hylg==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
+    resolution: {integrity: sha512-rVt+B1B/qmKwCl1XD02wKfgh3vQPXRXdB/TicV2w6g7RVAM1+cZcpigwhLarqiVCxDObFZ7UgXCxPC7tpDoRog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.35':
-    resolution: {integrity: sha512-okPKKIE73qkUMvq7dxDyzD0VIysdV4AirHqjf8tGTjuNoddUAl3WAtMYbuZCEKJwUyI67UINKO1peFVlYEb+8w==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.52':
-    resolution: {integrity: sha512-9e4l6vy5qNSliDPqNfR6CkBOAx6PH7iDV4OJiEJzajajGrVy8gc/IKKJUsoE52G8ud8MX6r3PMl97NfwgOzB7g==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
+    resolution: {integrity: sha512-69YKwJJBOFprQa1GktPgbuBOfnn+EGxu8sBJ1TjPER+zhSpYeaU4N07uqmyBiksOLGXsMegymuecLobfz03h8Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.35':
-    resolution: {integrity: sha512-Nky8Q2cxyKVkEETntrvcmlzNir5khQbDfX3PflHPbZY7XVZalllRqw7+MW5vn+jTsk5BfKVeLsvrF4344IU55g==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.52':
-    resolution: {integrity: sha512-V48oDR84feRU2KRuzpALp594Uqlx27+zFsT6+BgTcXOtu7dWy350J1G28ydoCwKB+oxwsRPx2e7aeQnmd3YJbQ==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
+    resolution: {integrity: sha512-9JDhHUf3WcLfnViFWm+TyorqUtnSAHaCzlSNmMOq824prVuuzDOK91K0Hl8DUcEb9M5x2O+d2/jmBMsetRIn3g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.35':
-    resolution: {integrity: sha512-8aHpWVSfZl3Dy2VNFG9ywmlCPAJx45g0z+qdOeqmYceY7PBAT4QGzii9ig1hPb1pY8K45TXH44UzQwr2fx352Q==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.52':
-    resolution: {integrity: sha512-ENLmSQCWqSA/+YN45V2FqTIemg7QspaiTjlm327eUAMeOLdqmSOVVyrQexJGNTQ5M8sDYCgVAig2Kk01Ggmqaw==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
+    resolution: {integrity: sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.35':
-    resolution: {integrity: sha512-1r1Ac/vTcm1q4kRiX/NB6qtorF95PhjdCxKH3Z5pb+bWMDZnmcz18fzFlT/3C6Qpj/ZqUF+EUrG4QEDXtVXGgg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.52':
-    resolution: {integrity: sha512-klahlb2EIFltSUubn/VLjuc3qxp1E7th8ukayPfdkcKvvYcQ5rJztgx8JsJSuAKVzKtNTqUGOhy4On71BuyV8g==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
+    resolution: {integrity: sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.35':
-    resolution: {integrity: sha512-AFl1LnuhUBDfX2j+cE6DlVGROv4qG7GCPDhR1kJqi2+OuXGDkeEjqRvRQOFErhKz1ckkP/YakvN7JheLJ2PKHQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.52':
-    resolution: {integrity: sha512-UuA+JqQIgqtkgGN2c/AQ5wi8M6mJHrahz/wciENPTeI6zEIbbLGoth5XN+sQe2pJDejEVofN9aOAp0kaazwnVg==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
+    resolution: {integrity: sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-beta.35':
-    resolution: {integrity: sha512-Tuwb8vPs+TVJlHhyLik+nwln/burvIgaPDgg6wjNZ23F1ttjZi0w0rQSZfAgsX4jaUbylwCETXQmTp3w6vcJMw==}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-beta.52':
-    resolution: {integrity: sha512-1BNQW8u4ro8bsN1+tgKENJiqmvc+WfuaUhXzMImOVSMw28pkBKdfZtX2qJPADV3terx+vNJtlsgSGeb3+W6Jiw==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-PuGZVS2xNJyLADeh2F04b+Cz4NwvpglbtWACgrDOa5YDTEHKwmiTDjoD5eZ9/ptXtcpeFrMqD2H4Zn33KAh1Eg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.35':
-    resolution: {integrity: sha512-rG0OozgqNUYcpu50MpICMlJflexRVtQfjlN9QYf6hoel46VvY0FbKGwBKoeUp2K5D4i8lV04DpEMfTZlzRjeiA==}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1':
+    resolution: {integrity: sha512-2mOxY562ihHlz9lEXuaGEIDCZ1vI+zyFdtsoa3M62xsEunDXQE+DVPO4S4x5MPK9tKulG/aFcA/IH5eVN257Cw==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.52':
-    resolution: {integrity: sha512-K/p7clhCqJOQpXGykrFaBX2Dp9AUVIDHGc+PtFGBwg7V+mvBTv/tsm3LC3aUmH02H2y3gz4y+nUTQ0MLpofEEg==}
-    engines: {node: '>=14.0.0'}
-    cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.35':
-    resolution: {integrity: sha512-WeOfAZrycFo9+ZqTDp3YDCAOLolymtKGwImrr9n+OW0lpwI2UKyKXbAwGXRhydAYbfrNmuqWyfyoAnLh3X9Hjg==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.52':
-    resolution: {integrity: sha512-a4EkXBtnYYsKipjS7QOhEBM4bU5IlR9N1hU+JcVEVeuTiaslIyhWVKsvf7K2YkQHyVAJ+7/A9BtrGqORFcTgng==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
+    resolution: {integrity: sha512-oQVOP5cfAWZwRD0Q3nGn/cA9FW3KhMMuQ0NIndALAe6obqjLhqYVYDiGGRGrxvnjJsVbpLwR14gIUYnpIcHR1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.35':
-    resolution: {integrity: sha512-XkLT7ikKGiUDvLh7qtJHRukbyyP1BIrD1xb7A+w4PjIiOKeOH8NqZ+PBaO4plT7JJnLxx+j9g/3B7iylR1nTFQ==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.52':
-    resolution: {integrity: sha512-5ZXcYyd4GxPA6QfbGrNcQjmjbuLGvfz6728pZMsQvGHI+06LT06M6TPtXvFvLgXtexc+OqvFe1yAIXJU1gob/w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.35':
-    resolution: {integrity: sha512-rftASFKVzjbcQHTCYHaBIDrnQFzbeV50tm4hVugG3tPjd435RHZC2pbeGV5IPdKEqyJSuurM/GfbV3kLQ3LY/A==}
-    cpu: [x64]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.52':
-    resolution: {integrity: sha512-tzpnRQXJrSzb8Z9sm97UD3cY0toKOImx+xRKsDLX4zHaAlRXWh7jbaKBePJXEN7gNw7Nm03PBNwphdtA8KSUYQ==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
+    resolution: {integrity: sha512-Ydsxxx++FNOuov3wCBPaYjZrEvKOOGq3k+BF4BPridhg2pENfitSRD2TEuQ8i33bp5VptuNdC9IzxRKU031z5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-beta.35':
-    resolution: {integrity: sha512-slYrCpoxJUqzFDDNlvrOYRazQUNRvWPjXA17dAOISY3rDMxX6k8K4cj2H+hEYMHF81HO3uNd5rHVigAWRM5dSg==}
-
-  '@rolldown/pluginutils@1.0.0-beta.52':
-    resolution: {integrity: sha512-/L0htLJZbaZFL1g9OHOblTxbCYIGefErJjtYOwgl9ZqNx27P3L0SDfjhhHIss32gu5NWgnxuT2a2Hnnv6QGHKA==}
+  '@rolldown/pluginutils@1.0.0-rc.1':
+    resolution: {integrity: sha512-UTBjtTxVOhodhzFVp/ayITaTETRHPUPYZPXQe0WU0wOgxghMojXxYjOiPOauKIYNWJAWS2fd7gJgGQK8GU8vDA==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -2121,48 +2013,57 @@ packages:
   '@sinclair/typebox@0.25.24':
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
 
-  '@solana-program/address-lookup-table@0.7.0':
-    resolution: {integrity: sha512-dzCeIO5LtiK3bIg0AwO+TPeGURjSG2BKt0c4FRx7105AgLy7uzTktpUzUj6NXAK9SzbirI8HyvHUvw1uvL8O9A==}
+  '@solana-program/address-lookup-table@0.10.0':
+    resolution: {integrity: sha512-lcp+IYwoFBODhg8vXsh5vpxweLxpSKqjAu8P1LyqQxgk2yqwYmJGA79YKa+lZvsQjP/c0rzIZYWIGxFMMes2zA==}
     peerDependencies:
-      '@solana/kit': ^2.1.0
+      '@solana/kit': ^5.0
 
-  '@solana-program/compute-budget@0.8.0':
-    resolution: {integrity: sha512-qPKxdxaEsFxebZ4K5RPuy7VQIm/tfJLa1+Nlt3KNA8EYQkz9Xm8htdoEaXVrer9kpgzzp9R3I3Bh6omwCM06tQ==}
+  '@solana-program/compute-budget@0.12.0':
+    resolution: {integrity: sha512-ysHNVfctUyuY9+mHzJqt97en9ly2quR4n1pvJMQjYf4olwoCqB7+E9b+XZmlj91lFQuAs5z48aw5qDekg78DbQ==}
     peerDependencies:
-      '@solana/kit': ^2.1.0
+      '@solana/kit': ^5.0
 
-  '@solana-program/memo@0.7.0':
-    resolution: {integrity: sha512-3T9iUjWSYtN/5S5jzJuasD2yQfVfFAQ9yTwIE25+P9peWqz4oarn6ZQvRj/FLcBqaMLtSqLhU1hN2cyVBS6hyg==}
+  '@solana-program/memo@0.10.0':
+    resolution: {integrity: sha512-1FvQFenL3lzl5SpxhWV4QJCOLU/nvAOXGXjKjS7dprvG+0u971xoanApN7bM/a4NFZolp6S+lP2xVl6vTVIxbg==}
     peerDependencies:
-      '@solana/kit': ^2.1.0
+      '@solana/kit': ^5.0
 
-  '@solana-program/system@0.7.0':
-    resolution: {integrity: sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==}
+  '@solana-program/system@0.10.0':
+    resolution: {integrity: sha512-Go+LOEZmqmNlfr+Gjy5ZWAdY5HbYzk2RBewD9QinEU/bBSzpFfzqDRT55JjFRBGJUvMgf3C2vfXEGT4i8DSI4g==}
     peerDependencies:
-      '@solana/kit': ^2.1.0
+      '@solana/kit': ^5.0
 
-  '@solana-program/token@0.5.1':
-    resolution: {integrity: sha512-bJvynW5q9SFuVOZ5vqGVkmaPGA0MCC+m9jgJj1nk5m20I389/ms69ASnhWGoOPNcie7S9OwBX0gTj2fiyWpfag==}
+  '@solana-program/token@0.9.0':
+    resolution: {integrity: sha512-vnZxndd4ED4Fc56sw93cWZ2djEeeOFxtaPS8SPf5+a+JZjKA/EnKqzbE1y04FuMhIVrLERQ8uR8H2h72eZzlsA==}
     peerDependencies:
-      '@solana/kit': ^2.1.0
+      '@solana/kit': ^5.0
 
-  '@solana/accounts@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-8Qrt+FoN/+5Pbhgt8qtkUhInzM6ubYRzJ9+dCbaCplRsHnUw0QiK42/vHV/ol+wL+SLORTnLh4visgTd/t/Ufw==}
+  '@solana/accounts@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-wxvOJfmxmjhayMT/KRniD14LVt0iR8LEaB8M5wXedOf5Wq7gU2mcp0Ch3+ZfTLHdTy5mCJQ+0wjsG3fuJJ11Mg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/addresses@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-VEG/0PXlcUXtafB4FmDZ06np5QnPnBsE42eEZYaQa5TfY2zfN5fgMNfPT6H9VppGb04duLo8miYCEeBXXJYLkA==}
+  '@solana/addresses@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-J7UIfVlcq4cSxKfgUKRpKs8VDzk+HiE5o0zlzp+umw2FrGaCokf84epxSnq7clLe5DR9MBiICel8ocDWFEn+7Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/assertions@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-jJqSFGhkYkUPjBrGenPZLEWpzYBOa1lepuBcWdsRlDBQ+aOavXw7wcQ2MDeRKxUftlG0BYHRC4KBQHxdrNCB2w==}
+  '@solana/assertions@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-+seOafmZMPCEuX6UNLADIRLLo2U4/s39rk49LYgsSzebpG2pU0qfACpfNU7B11nZ15PzRWImu2TiBnd9/i6YNQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/buffer-layout@4.0.1':
     resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
@@ -2174,17 +2075,23 @@ packages:
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-core@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-PE+ryrJ59tZ7jSTfPYj9V975Bb3TYNHnOVYr4NGWWMfxJXkLcYDrL7dLOokQl49VoFqWEXf0YPmz4fzTf2P0uQ==}
+  '@solana/codecs-core@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-WwfePqO5jFGzO55Z4rPNJC3W/8Y+ydC/XTvkcOtrgJhjp5sFLy36n6AYWUe2cWsaN/qRFlx2LclGMFBmPpt6+Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/codecs-data-structures@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-mUpPyGVg4Ta+D8+lNO+g9puwKhYL+F4QRL8O8EhlpafZmx/Ag+tX49doG4XuJ9cBpZ1DntRayHZDM/HzosKRMg==}
+  '@solana/codecs-data-structures@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-29FuNJe/TsHkVal2Do+TjZdU//JqQgUqIAHky1fuepl4r+eUz4k5xk1XHe7w23vgsUugo5RYp7EICQORKjIT0w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/codecs-numbers@2.1.0':
     resolution: {integrity: sha512-XMu4yw5iCgQnMKsxSWPPOrGgtaohmupN3eyAtYv3K3C/MJEc5V90h74k5B1GUCiHvcrdUDO9RclNjD9lgbjFag==}
@@ -2192,33 +2099,44 @@ packages:
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/codecs-numbers@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-ZlaLAYPHqHNPGST1OIP8FKqqkGIAVQhu3alVCMLLme0hzv6Jsy8brXDPMaPStViDaMM9o/GdBSuKKgekq3Vcmw==}
+  '@solana/codecs-numbers@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-NflRDYfAH/Knzhtd+/pQlf9dUTFMmlPioAi3BcgOiYm+l5MC/gd3bNWrPowhKTrE8PWxiEgdHezSTUxNiE3K/A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/codecs-strings@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-hR9ZwT1OI2+FKjYd8tVTxF4vVkD5BD1p9CI/b0jYgfSXPyaXTlUIH0fE8fUcJIhJhIVnulPUNsS/casDvINYGA==}
+  '@solana/codecs-strings@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-bGxTwlVi++uN/7shoU7jwZ8e4VQBzZPyAvmTPuf46mLmZpqli0r3AqRcjDe1qnX76bWKqbLv+8QFmOC+2KpoqQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       fastestsmallesttextencoderdecoder: ^1.0.22
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
     peerDependenciesMeta:
       fastestsmallesttextencoderdecoder:
         optional: true
+      typescript:
+        optional: true
 
-  '@solana/codecs@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-OBA94A1Wkdfd/WZ/LhfupR9ay2yXsjNf3p9NcBqVqMKAUQn20rAMWaZAsOytWDXkSZZFU3RyUPaypdxVqbs9Jg==}
+  '@solana/codecs@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-X93IhknSlFB4WvzGJYMqydgrbz6ntg+xYGmTEGYkTC/A6WvNMQuQ8fAbohi3B/H4Z89IhTITpjHL0GkNWKGtGw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/compat@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-PlwxDSJ+G1wyVzGAvgo99H/ta5yMGVpPfOertAnXQfhooW+Gy4surAo6ERMe1kY4Hs850pRJcizKPtDsQqWMpw==}
+  '@solana/compat@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-TL835akkf7U9tbn8g4w6hzeuflkmbgFNRT9cfbFX4GXkTUHffksNe4rAmN+Wl2Av0NRE7YdciT69JhURGmVN1g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/errors@2.1.0':
     resolution: {integrity: sha512-l+GxAv0Ar4d3c3PlZdA9G++wFYZREEbbRyAFP8+n8HSg0vudCuzogh/13io6hYuUhG/9Ve8ARZNamhV7UScKNw==}
@@ -2227,81 +2145,126 @@ packages:
     peerDependencies:
       typescript: '>=5'
 
-  '@solana/errors@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-Y3moNfd9XO+63oROdtHEHifSFSNqw3HG7cTBPfcY9IJWwzO2GbIpJqQDPDih/oLH+X9Gz6Q10eRjP9B5OIKNDg==}
+  '@solana/errors@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-oVRIQ7mNjCQPIzIS2ehj9ljWcF3xhVdzo/8tsi7/v/6vdZZwK/jrZT6XNSatHFNOk+00ZREle3p7LSI1wFq0mQ==}
     engines: {node: '>=20.18.0'}
     hasBin: true
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/fast-stable-stringify@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-Wi1olS+9BVt7T47zemqxMGQthZ8HdA9U4/GKsuPEHPm8AuDN1jdS1mCSYpTXeyC/LsxAB2lhSeqC9ZTJ+lfORA==}
+  '@solana/fast-stable-stringify@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-weeNmxlLy1w2QqJeyYfyLqLN5ddUf/k9mjj1NTeXNHTIlehn/5NVryZ3q1Rvx+/311fh+6VE0xnWtCEJje3YXg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/functional@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-W85ShKCSEfr63U4Ne0Q0T4MbimkMKAniDcWZGSr9RWuB8tn5WVJEg091WwUZSUcFHBptgrtqSfavsKivxvh0Bg==}
+  '@solana/functional@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-PcCJLeQooEE9nQpv+yqGqmNWUD7vLGrnQfcaFZAkY8w4TgGtPB5wiZXiZPwPe8DQseeHnUHyHB5D4OWpQk9Myw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/instruction-plans@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-UiD2n++6A9LnvvFHyp042w6dKlAIMpfKdREqX6O52PLvtm7K2PD5axTRjPnte+JO6HIaJU06DtW6DnvlfMMU0g==}
+  '@solana/instruction-plans@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-ZfKbvm0Zdb0Bp1nOZkekd7OcgttbnZMtubL0ZqafbS4CrplvUMr2v8nZdrTOa86LpXYyxee11cALosKVG1khEA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/instructions@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-7kvyFupUpEPv40Xz8AJbI959M/3fVMI1/pPxUhi80i5553lLPsSIUSUaB1hk8cxLUxwdEe3PX1VoviakBWZxog==}
+  '@solana/instructions@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-+S2paeRQAKyjLXMOHkfM9aEl8QZKCTmVr2anr4qeoGRdro4UksXkr62xjon+pwPEZpRKXg9lXdmXcciGSX6f5A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/keys@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-mYGMg7LzHK409aSrWDwYO0LVElNUBy2kaDdt10FbnepdR7ACw+J3lWThnDIjyKNjVXCE3p77HrrKonWDEBg45w==}
+  '@solana/keys@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-XanIISTToCEVrk/uAN9eGok0mVF8IQ7eOmKyIeIR/wz7CTJ5D7bJX1N9lDYopaE0UQgDcA2uG4+hDSlg5QKVRg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/kit@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-XhJFLTd0TIBSTYZhYG8W/JWmgiJRM1WcebvQI/IXTAq0bnIY+CnCLUSKFZuRjw51E9/WypXeOA0clfbJdQJoTw==}
+  '@solana/kit@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-PPqj7eIsFO8XFLOXweb4N9XmgodlZ5bhTFspxwkuLQ89lBdcMAnfWcpaQIwj0X2qfxYkXb0Ct1PTFHB1kMyDJg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/nominal-types@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-krXIQNrZ40S0MQtNB3LYm//McVJSNDwItb+b6EyUS+MpFHkMemdJkirH21hO8irHYWRpLfmindJjwjqf6+l2Rw==}
+  '@solana/nominal-types@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-5BBvFu/BTpNIoWnag5P4qhkSJ4nCj0uFSdh3kJl3ZuPPY6lRqPt1KZ5lgH5znR7PweZ/8QtbUoebs641HY5KOg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/offchain-messages@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-JiKAANvFP++TXaTcApbzXKd0JT2J+MN3RtLYP7mpKHErtdZVSyi2x6pOCHI7cWWFimIk8jDxiObWc5n1w6wKuQ==}
+  '@solana/offchain-messages@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-hx6tF2YclrVDyNqyRTwlyS1LmgC6jSLtmoAOqrhSIi8A6opSmnBov/aioZgzjMHvbkMcX7wzCSUaoyUyZSvGjg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/options@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-JlazGO1IecxCPpkh/6pgmoYUjec/HjcYtRexBV/Klrx82Ng5yn9aM1xovcIh5ET2m+NVr8dKHxwVL7WUgsXMnw==}
+  '@solana/options@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-g8GCljcRuhcDZHL+/nq0HFIhgmwqptnL9NJzr+iXQFc/eU98/KEncgOGrKwaBVvTRWqKv88bpUw3Q0xV9sjJSA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/programs@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-4W19N2CnDU56sdFipgXgDvvBDjyezyix0N25wBN/vRh6mWPSumUAVSHSrL/DzKsfrdpVvJVHMfW69feGH6US7w==}
+  '@solana/plugin-core@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-ZjicFsySLS1ueMY76UeJHQiMIa/5BPDC//MeP/jsAZPDbiwTYhlgp5kEoBnmg/5CJW/6WgJj5bbzqmA3wxtB0Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/promises@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-ZiUpNQpUTyaxV+YC1zru8o+H9LarQYFPiPhsHpMNfF+A5M96PDI4mKF19RAtnwAEpmifu1nvsL4DA+3Wg598Lw==}
+  '@solana/programs@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-W6ooZ0ixcvj4f3gMOUQkc3RUcFoRgcXZeS4Vhun5w7Eab0ZKgU6zfxjCxd3DMI6qfKD2dzIlQJu9HW5c7fvTKQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/react@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-7atPxo4ItFjePH5ps4U+VzIFnyMwcBFD3ptxU89RlO2Iux/daG32UzcMqxZlp5EBe75m9DMk4fMDUr4QKNiaVg==}
+  '@solana/promises@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-sHM4Uh5y0NnQWvH5TaXZh6gWJCXbPtF/+9ZoN8cRqvRorSVMitwYQxJnH7ijDZYJOkx6b6WMAy9i+Cyvixt1Hw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/react@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-B3dFBQ3qDE0NSZZ6XoBklDkOcgr9iZSOUo0JCADAmd5bhQ2RPIpmj9uQWCZ2jiuvtVpmTbMoWrnaY0LiB3Je7Q==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
       react: '>=18'
@@ -2309,117 +2272,167 @@ packages:
       react:
         optional: true
 
-  '@solana/rpc-api@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-ffdNwmqKusgUuugvDT02YAOLjp1u3Gdq0ZN4buq6bLqyGB2dI2xsPgODEc1i+bqE8krJ21YoOVu7RcMi1c2HPQ==}
+  '@solana/rpc-api@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-nN5ADON8OFrmyJfA5vaFT+kLJFvAHRLsdODcu4OOPlgbyFh3Ede1BlehVc3f80m4vjucjfyd/qJZGAkYDmUuSQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-parsed-types@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-SSyldRCrf5ROvhd0/ljpxCreZpUbCuVHO1J5ObN/rw/JAOzFXZ31kPeWTlq03Nv8NtgkQtiYU+9RNquoPZYfKg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-spec-types@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-tzPMAfj46p3DU57ZbEgu9RpmVLcPKdlj28pYFahmo3TPaArLozHMlKrqQvohdsE5nSFJaQs5uvbBOzzQse7Rvg==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-spec@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-XMlM8lvdauguuXGZ+UrunBsSMXGkeOHIPhXPa0KODyObgexiveEugQs7vuov/rKAXxdZsbtEIZSCppOe2HHKDQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-subscriptions-api@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-h1B9inb1Np42L/5l06fYwSVdrLhJyPFYNs695vzhNwOIpjcSvyD7WoIUIfYNBKoqk/rxzGk1GWx7XbejsqjMMQ==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-
-  '@solana/rpc-subscriptions-channel-websocket@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-HNfEFG7eApdX+o8EfYRMOlgnbjEoOvoqWYBTrPAjZve15G1g7PxzakK4j4NCgKWUyWsTtv58pqS4EtnWz6piNw==}
-    engines: {node: '>=20.18.0'}
-    peerDependencies:
-      typescript: '>=5.3.3'
-      ws: ^8.18.0
+      typescript: ^5.0.0
     peerDependenciesMeta:
-      ws:
+      typescript:
         optional: true
 
-  '@solana/rpc-subscriptions-spec@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-rFKLyM84k0+AxMA9Raw1/cE6fRG17srrAMR+dir+QOhMeJ5dClr8sQ38/g9hDWv+oWQh340HoK+stZXsS9I9kw==}
+  '@solana/rpc-parsed-types@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-Qngl9hLoMbMFfkA4WFYHhM6+xqUm2aCI1RuBlaqwMtCHWbINAtpXL+kq1efD5zIMTRUDKMV1N29eGAaoprZb4g==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/rpc-subscriptions@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-9raHWyfoaA2oOerGt1i8wunx69RhnWimlClcF6Hg4EqJzpTzF9ZRXbe+drlXKQPPa1jx4qHgyYowtmkvDy5/TA==}
+  '@solana/rpc-spec-types@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-8gBLJnLFe0XIFcZsg30SiTntQicSH1nK4f9GOJY8tSLNfII8rAsDgmazPy+kwFzq9qQ+mM257QAsh/PGvjjJ9A==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/rpc-transformers@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-Gc/eR9N3c1qRe+0mG/QsBSb/VZO8qnag7JgHy4ySxumLJd7EdY6hFeGFmYkRciU7zbikQIMK1Kz9jtqCSk6tNg==}
+  '@solana/rpc-spec@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-1kzIIEtJriSYWMEZlDWpjvXyl017Fo3xUQCosBGHU1Y+OYLZmMk1Hc9KqFx4SMGx1Zq7tK2a7IeUC5bRjqHmOQ==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/rpc-transport-http@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-9uF93b4KADxtVlWJxdd++N1aq1kbYBywSpAAnN8cX8vtSqVPnL2T3z1WY5gOMrF0PQRWj26i1l/03GnzJN69Yw==}
+  '@solana/rpc-subscriptions-api@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-9zmi0CGVB8LRuMPefyT6ttixOUJJHjPOoqnn6IRNRkRh2YKMxnyCGTnU85gdQ+Wcmhu1Y4FhcnxGnLAJ0xwmsg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/rpc-types@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-fsj1e7OLxAMlpRNyJtVKUORXYyRzVXjmI13HGAi7x57s1qUD+pBVyRgC6+70Wzy0sQujcYwxk86616r3YX3rPA==}
+  '@solana/rpc-subscriptions-channel-websocket@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-XE2n4TZ9jGsrur/Ve5N3vAU+rLdTKrQNxEx2BBGqXAT5E//1GYkJYLNYJrbBAuSvcRHRj77lEog6UjllqNnQRg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/rpc@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-z+3IfMT0gEZa4uw+lPbIgsjDg1ULtaBkglfahyNTON1aCVBXg7pyPEkzOIc/Wkka0f6yPayIt6Z8pJ9onyFjxw==}
+  '@solana/rpc-subscriptions-spec@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-3pAitth5yhdoZEIRBqPZ7gndRkbOCTRdJ/WVLTh0+e/0VEa5wagY+argGiHg5JeKD6Jal1VM3ce7VT4i/pqlbw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/signers@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-b2PsSXimgot7ZvEGGqSEo7PAf0odIVH+h5Li5f9qGkqhlPS5iMlONaobCVypA89yec2JCcLaizcdZa8it0y/LA==}
+  '@solana/rpc-subscriptions@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-3ApfNsbYzOg9VPdRhVJ9Dw9SV6ipVeSi9QMhdalEWbGoAjuKjTbBru6m24T3MW+rsIR55uxQK9z5PqeNjnxCUg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/subscribable@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-36be1s3IkIKR3Us5fyOiNLcUUvXxOWpD/G66CPNEUlUysoTvwPNwcO735bRYjZg4WLom6uszS6z3orTNOc8hTw==}
+  '@solana/rpc-transformers@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-076vaEojidV4Ge+SYt1CxC6EpIbrXDQP422gHG8BJRwa5H1QAtASe3tTrKqRL8uLKfxrBuTGHNdstBmhanEbsw==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/sysvars@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-OwIAO8lQ4aTXSPxljS44hQckn3YX+EfNsyVtDgLm+eymvHqX2LKNf4YzE1VIVHtgLt1PVBCbve3gZed8qXXmxQ==}
+  '@solana/rpc-transport-http@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-YASreVbw6WDe9FETWTyeA4itpkcVOhNz1ZdI27h/guq43oN0q630PrIKtoqFMrJXw41/aZDHnbgmVpgtEkQHCA==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/transaction-confirmation@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-qdGHV7t+P5D+Cw1VfoURwd263CHXFgF9fNga8UFg0/0w6iNbSf89kiDzWuu6Brdqyj7Ma8US5faBEMGfyVNR/w==}
+  '@solana/rpc-types@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-ZgUEl7sRlz+184bE/bx11SCfsYORMajwJ+36AMP6u1pTTNnJkChYCQQxt5BSDCfgmuV8JsuyGC1C+t2tmEdEJg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/transaction-messages@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-Okhn+U/JXl8aW+daWPPrPvkIdZ0w+XQ1zHfQ9AO+0hKlG+bFM28UNeTn+xpQ2+fo+Tjr7p7hhwZRCNWPgIINsA==}
+  '@solana/rpc@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-gPasH9CyBQzXsdqFGGfsga1+MEkukAxG1MnGC5qqsRDvbkTHkRfLW0Bg2MNQ2Pz25d7ArjQFo1siCnMEGND6jg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
-  '@solana/transactions@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-h+n7SR6BoH3fEayUjUwQDLND3cMBZO6Jkn96+WkigP+sPGdfyIosG1l5U9tsrnWzlNBvr50pNkPfsnoSwrt4qA==}
+  '@solana/signers@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-TiLhEcNse+0ppO7HjbJcSh5u8BmwHu6p367ZeJhVYWwxznXGaiInp+HpeKIL7uxD7eHP2ecd0hRONkXt2l9n4w==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/subscribable@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-fiVJdrJjfeVT+0AiTFsmBznTItdoWzNAILdCQQngLBb5om4tMAKNML1ciCsAfaDURjNQaMFcifqCsLysGQK95Q==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/sysvars@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-CbdaKbQ37VZGu2dzZPwsIO53JHnceTSHwKRBGnUbl0m9xqCFATBY+UYaTMYYNsxYhSQZywX21ae4CgLOu+fgDQ==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-confirmation@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-5QTtUS9QR6YluAuW+m6bLCh85P2oa+aJSBJ0Q0Q9BniuXKhUhwUfdiA7xh8JZXkGxDKB5VNqNuS03vDdTuipbw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transaction-messages@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-LUHyOvQyY/RA+JrdLwbsbfm64b4JaLzS4bv0KBbst+tuaV1ZCgqLiU3XKMivHpAL2h1AojPL2GxPcYokuJCtTw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@solana/transactions@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-qw5YaUk2J7tKAJG5lV5sC6PmzMVxZJ16kzpb0741f09Q0ApM/Gi1gwcamnlg7okb9KKfgAM2umG6G1MkpKUptw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@solana/wallet-standard-features@1.3.0':
     resolution: {integrity: sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==}
@@ -2428,11 +2441,14 @@ packages:
   '@solana/web3.js@1.98.2':
     resolution: {integrity: sha512-BqVwEG+TaG2yCkBMbD3C4hdpustR4FpuUFRPUmqRZYYlPI9Hg4XMWxHWOWRzHE9Lkc9NDjzXFX7lDXSgzC7R1A==}
 
-  '@solana/webcrypto-ed25519-polyfill@5.1.1-canary-20251216194212':
-    resolution: {integrity: sha512-5yeIfF6LXqSzSlsIgaIh+2+zKLF0OMLO5WnrNbu50/RdoTI9vuRCh1gURaVO/I7szVKH7EVNaHxqEmjhBJTmpQ==}
+  '@solana/webcrypto-ed25519-polyfill@6.0.0-canary-20260203172420':
+    resolution: {integrity: sha512-plI7+8o/o8EfcQGekDV0n/AnEDZKSCeMQW74KFVsVmGIyAYC7RFAdJxFQi/vhaUVZlxJs3DMZoNXagRrNEPJqg==}
     engines: {node: '>=20.18.0'}
     peerDependencies:
-      typescript: '>=5.3.3'
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
@@ -2592,11 +2608,11 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@16.18.11':
-    resolution: {integrity: sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==}
-
   '@types/node@18.19.123':
     resolution: {integrity: sha512-K7DIaHnh0mzVxreCR9qwgNxp3MH9dltPNIEddW9MYUlcKAzm+3grKNSTe2vCJHI1FaLpvpL5JGJrz1UZDKYvDg==}
+
+  '@types/node@20.11.0':
+    resolution: {integrity: sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==}
 
   '@types/node@22.13.8':
     resolution: {integrity: sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==}
@@ -2772,97 +2788,109 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vercel/backends@0.0.17':
-    resolution: {integrity: sha512-T1wTYvBbOuSStMM3GO2YK39YOZaCsT8GpkSOP0+3Ya9MO7qkOsOTIkzIzMY4SRO1e1CiVqqlbkGgwsGirgc6mA==}
+  '@vercel/backends@0.0.24':
+    resolution: {integrity: sha512-Rs8hGZ/PMBskdajlxmb71VHB4arX1grMO0HaRwtNb2cY2wPbscNXXTdVGBGkoIQyAg5c9CtaeiIcGDFCjgdApA==}
 
   '@vercel/blob@1.0.2':
     resolution: {integrity: sha512-Im/KeFH4oPx7UsM+QiteimnE07bIUD7JK6CBafI9Z0jRFogaialTBMiZj8EKk/30ctUYsrpIIyP9iIY1YxWnUQ==}
     engines: {node: '>=16.14'}
 
-  '@vercel/build-utils@13.2.3':
-    resolution: {integrity: sha512-SmXSNXfRh7E3wKR50IV3bGHw9iE5bw6D08LYvJdkQv1SjUgYVuIf2P5ceUPjzA2dqrKol0dxMvYb28dNHxmj5w==}
+  '@vercel/build-utils@13.2.16':
+    resolution: {integrity: sha512-5i6q9xXhDaZ75bQ/VMMCyeXtRY1HTJXj47ch3BEN42BgNdvFoDSL0eQVMzi80yRjyTvJ1bzGpn1A1K5aswLZVQ==}
 
-  '@vercel/cervel@0.0.7':
-    resolution: {integrity: sha512-x4AeBr6tiRO1QDK1T4DINtczdsedhPLnpOiwTuBUqhAs681Whf23elUrv2ibOXYeGQIWMcy1MlFh7wzac7E9RA==}
+  '@vercel/cervel@0.0.11':
+    resolution: {integrity: sha512-3AH3jAcKR5GaVr5XZ4j4xkG+axhgZ4adbHig9439vzQN/pT4It97iONKENgbCQtBaG3rvsDJAd+Qjfhf0loi/Q==}
     hasBin: true
     peerDependencies:
       typescript: ^4.0.0 || ^5.0.0
 
-  '@vercel/detect-agent@1.0.0':
-    resolution: {integrity: sha512-AIPgNkmtFcDgPCl+xvTT1ga90OL7OTX2RKM4zu0PMpwBthPfN2DpdHy10n3bh8K+CA22GDU0/ncjzprZsrk0sw==}
+  '@vercel/detect-agent@1.1.0':
+    resolution: {integrity: sha512-Zfq6FbIcYl9gaAmVu6ROsqUiCNwpEj3Ljz/tMX5fl12Z95OFOxzf7vlO03WE5JBU/ri1tBDFHnW41dihMINOPQ==}
     engines: {node: '>=14'}
 
-  '@vercel/elysia@0.1.14':
-    resolution: {integrity: sha512-k5ztT5vlN/4J2VKzSQJKSOpefIP2yNzLIrNsdQOIcp6pCdelDjIfnj3UBWJ3pDPmYC8ODCJVRc+NngjLiv3OHQ==}
+  '@vercel/elysia@0.1.27':
+    resolution: {integrity: sha512-vMXA3WRTTyHjuueDLymZQ2btb0zN8LZlwCtG4oEFCePcP6zdPFht8BLXNfVetEGz26TYZSoLKdZxVo4CgV9MLg==}
 
   '@vercel/error-utils@2.0.3':
     resolution: {integrity: sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==}
 
-  '@vercel/express@0.1.20':
-    resolution: {integrity: sha512-B9jLqeFW3gCkpoqUjW4jILRRozB2gTqiHxVX+GefLFXP4TyOy3v2xvJkFt1rrxem0JDy2zltaJVpZ3qJ6lIo1Q==}
+  '@vercel/express@0.1.35':
+    resolution: {integrity: sha512-lviPeaL9NQDreXezoqV0V72ww1q239xHHJb2l0aoRQZiZ69wXC/jGqXYY4bi3RjYPz90jMODjFYKI+hwJnSvxw==}
 
-  '@vercel/fastify@0.1.17':
-    resolution: {integrity: sha512-CsGPVRWv/e4ImP7RXfdCku0AvqKr0gFam5/tYHwJVPPVgnpE8Gi0YvP/xszLTlYPGtfs3ZO8xnLB3zf0gIq64w==}
+  '@vercel/fastify@0.1.30':
+    resolution: {integrity: sha512-34Pz8TYJtsaIo6TYb91lFBfPJtQASJVq8Xa8S63UgWyscJuy1kO4keWiPizfWs6rXLmozSbeXW9e+6z7PvOGWw==}
 
-  '@vercel/fun@1.2.0':
-    resolution: {integrity: sha512-WSmS9qe2R+5roucDEwYB3atKhs9sUbkHV3laJGEUoqz25O83jLE/jqg/B/3yTunB0av1xqiCIBFFVKnXsqSc8w==}
+  '@vercel/fun@1.2.1':
+    resolution: {integrity: sha512-p0IuyxKAnaV9P7xApKBDYXdPheErVyoi68tt2l8i2g20n26FgZ7IQoDsFfmTg/ClllxhdOnaArNAFu2XBmfCxw==}
     engines: {node: '>= 18'}
 
   '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
     resolution: {integrity: sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==}
 
-  '@vercel/gatsby-plugin-vercel-builder@2.0.113':
-    resolution: {integrity: sha512-z+/TIgEIwyyXhh48dnad5LjBGA8KObH4DCSHoGG/NRHPA6jLIBatflINhpX4wnmiJ0zJOBQhu0XR1ddI1Jw4Bw==}
+  '@vercel/gatsby-plugin-vercel-builder@2.0.127':
+    resolution: {integrity: sha512-Y4zoxkAc6vn+MkdG78Wbm5B7zXHbAKZitfVpia6oCbfhu4hDIUmqMmQJeGLZmTSB00V0eOEIBWd39/AvrTDI2Q==}
 
-  '@vercel/go@3.2.4':
-    resolution: {integrity: sha512-160JJuGJmBsu391lhiICFNZ4k5e3h7IUvnfXAzC1/W3ImpgDNWbR+pDcasZ1hs6xxtMzhHkO8CB94wZCgWibDA==}
+  '@vercel/go@3.3.4':
+    resolution: {integrity: sha512-PAa7XYZk+ZuE3pWuPJU32fdDl3YH9+f9iYkd/yFhhRgHsd0PqCB5HQ+EHUKsso+BHlYo145GV6cPLh+HE+UI1A==}
 
-  '@vercel/h3@0.1.23':
-    resolution: {integrity: sha512-d+7Jw7OrHNSIoLOjqA8CFi/men6cZ+BRMqZI+EB/5gNMnqN7due3xybOek6kFLQ5EuQn5IN60aUNOzAbz8M5Vg==}
+  '@vercel/h3@0.1.36':
+    resolution: {integrity: sha512-Uh/LtmWDgq6tpqB9pmpqgjntdFmGrmzSQggPzs/x6zKlzDMWxvItnB1D+1SD/vKTcImmFwOlCOOcNgFr/ZynCA==}
 
-  '@vercel/hono@0.2.17':
-    resolution: {integrity: sha512-aW9wX5mcC3JnKehvD6AhmHMhSJgg0U7CncN1WjhI40qqB8A/vJAlnGfW5Fph1ogl0CRz614qmoYuIMO8ycOHGQ==}
+  '@vercel/hono@0.2.30':
+    resolution: {integrity: sha512-w7Ctqw8P/MP0trBnAxiK7vm6Zm0L8JLlYdTXhaCjaMH8Q7+/bFsYXApyccJ//cMIJ9oRTSDmxy37ibUh9kzMzA==}
 
-  '@vercel/hydrogen@1.3.3':
-    resolution: {integrity: sha512-SCyAtjLCEvKbXgac/u42AVNcIE0/GdNe1dvTP/SV6qSUPo/5od9jlry+U55OdlUr9LRqCopehTrN5SxnmrderQ==}
+  '@vercel/hydrogen@1.3.5':
+    resolution: {integrity: sha512-7EE6yVKcCnjMb1io9y069GkLyGyIzRbW3Krm3Q7EEfJ3P46h9xe9v/O5UhBoPrwtqDUHxmDngZp9YyfgY8IITA==}
 
-  '@vercel/introspection@0.0.7':
-    resolution: {integrity: sha512-8JjxYqUsdxHaExbUANvGftAJeRTxVGYwTmaV9KcOA+C3SVvYSUertnQeTgKiau0Fc2cHmxh9e0poLxs2N3gZ2A==}
+  '@vercel/introspection@0.0.10':
+    resolution: {integrity: sha512-saUF0T9NpN24HXo0xt3qrgrfg6hGnqosQeHXSPTuLprhBL58DONS+So7jfa8eNi+1vW8CHJVV8USfQ5OeCT25A==}
 
-  '@vercel/nestjs@0.2.18':
-    resolution: {integrity: sha512-3Jvgx/2XxBvB/P/YE/6/Xzt5LjPg9AmiTMVka+ht+iPkFWQrPC1ClbKvUj/fJgquG3Y9s58lDgHSEOUCzYQl9g==}
+  '@vercel/koa@0.1.10':
+    resolution: {integrity: sha512-3vvz3o9kc9wzIh4wHuHkfAFFdZN0Ga+NwNeN3iKSxwt6RhjjyxfFY1d8LONUXNjh7m+Val0AM9g/Ij5o7Xaizg==}
 
-  '@vercel/next@4.15.9':
-    resolution: {integrity: sha512-L1bQTxyCnGhWXafQ5xGgOvhAfGZbh5AVro0yOvAHf5Y3plGktR/psudEbbKyEeCszttVHWgdGwKYiVu+0nO40g==}
+  '@vercel/nestjs@0.2.31':
+    resolution: {integrity: sha512-OGcUy8rrGKnrQO/izSfwEG01wcJBQCv2IXR1jTlPjAd6ijEfss9qBPGC/Rmp6yaYeg8IFZl9J0479gyZ+l3qUA==}
+
+  '@vercel/next@4.15.20':
+    resolution: {integrity: sha512-qJGLmhUGw7Iv1FYIDn0C4xmCOKQIKK8pigo8insAUkE+z3k1Hg4DbU3EpOfi8npztA/zzCRgcHfAWdB2X77X+A==}
 
   '@vercel/nft@1.1.1':
     resolution: {integrity: sha512-mKMGa7CEUcXU75474kOeqHbtvK1kAcu4wiahhmlUenB5JbTQB8wVlDI8CyHR3rpGo0qlzoRWqcDzI41FUoBJCA==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@vercel/node@5.5.15':
-    resolution: {integrity: sha512-qAuPvkBONsfp3aQktYGxJsuJh+5pzs6GsR7oywIBEXlAfDB7XXAW/D1ECb8OP/pZyprUHi85o94a3bg6fIxJXg==}
+  '@vercel/nft@1.3.0':
+    resolution: {integrity: sha512-i4EYGkCsIjzu4vorDUbqglZc5eFtQI2syHb++9ZUDm6TU4edVywGpVnYDein35x9sevONOn9/UabfQXuNXtuzQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
-  '@vercel/python@6.1.4':
-    resolution: {integrity: sha512-rAaQtNxQuiXTQJQRSp8HblyEn8OfrF8ShVnR21WgUk/MisYVbBHS9vSbma50JuNx4UsWjA5CEzGNLW2PQkxlHQ==}
+  '@vercel/node@5.5.28':
+    resolution: {integrity: sha512-zuhUKqFdeoTz+o6S5zyKKXERrxbJpFmbt5qMrsg7t2pfxJZSAR6xg+HRSJd710uJnKpmi4h89hp/TIu1CuvAUQ==}
 
-  '@vercel/redwood@2.4.6':
-    resolution: {integrity: sha512-lJgRENm7yZHvSMiGTFXd/x1Asz6MTFACfJHHMDThNL2hESvpbrOpp27t/NfNMCrV7TUEedHOE1fNIogy704S0Q==}
+  '@vercel/python@6.4.2':
+    resolution: {integrity: sha512-sFQZnhAXA3PNKfSgbnpy/eL3wybsp/Et03VvB+mgLmAus9ENSmMu7Kqr6gb2CT2PHMa+Bz8mhlRuAiuu2PRKtA==}
 
-  '@vercel/remix-builder@5.5.6':
-    resolution: {integrity: sha512-7NG5OCyM3Hki1GYjLMv3LTusRR1oXNriW9Ux58kvmTmcXQFXAUzth1V3FuZRuxyn+f70io7AN2TRDAAwaAlfIA==}
+  '@vercel/redwood@2.4.9':
+    resolution: {integrity: sha512-U7bYIuWfMEFMIcKKbX7lTT8pFNjig9Q3vLeCYRYQUrKVP8xLoUBXSEfW3ijtWJBUV8GmbZCDI30A16uUfNhN+g==}
 
-  '@vercel/ruby@2.2.3':
-    resolution: {integrity: sha512-hYg9ZVKPJ/O5r5PNA1xaBqFlIDM/U0u+DOHw3ZZypJ7L4vz6WJq1IVybHtxuiae4Nr6eajMWh360shc7cLuDlQ==}
+  '@vercel/remix-builder@5.5.9':
+    resolution: {integrity: sha512-uVscM3Hx+2AqCnwUpksIZG2ADC3+mPnjyKtsvjHUWEgnxVgADp5MStSoVuQT6AKWwSEnBtxMfNi13I20MwUeeg==}
 
-  '@vercel/rust@1.0.4':
-    resolution: {integrity: sha512-G0uO7+j0c/r1vlumlC6KgBfAq9/eip43C96fxnhoN6aeesChrFh8dTeU6Qh9E26AGzHYBENjkpw0Qk4/FbI1ww==}
+  '@vercel/ruby@2.2.5':
+    resolution: {integrity: sha512-DeSHZDEU1BvxzomHeBDsFyZ9VL2U/rUC15Ce4Asaw6LadYPyQ9HEvREJC7Vz4f2iHHD0iamJG9znaC3/UgvQDg==}
 
-  '@vercel/static-build@2.8.14':
-    resolution: {integrity: sha512-hCV74EgUJjNBl5UIQ93RhpQjP+QMNltT86hC2OgGHCZZms6fVQfaO4aaidWmBVr1LqVuSbY/V2MnS/zflpsVcQ==}
+  '@vercel/rust@1.0.5':
+    resolution: {integrity: sha512-Y03g59nv1uT6Da+PvB/50WqJSHlaFZ9MSkG00R82dUcTySslMbQdOeaXymZtabrmU8zQYhWDb1/CwBki8sWnaQ==}
+
+  '@vercel/static-build@2.8.28':
+    resolution: {integrity: sha512-NAyZZ8AXGHdcKelbA8zYoZ76abgv1Uf3axuwgHtvnfHmkJtao3KAJWm4NhLLy05jo4I1iFmIjEslU3k0CFECew==}
 
   '@vercel/static-config@3.1.2':
     resolution: {integrity: sha512-2d+TXr6K30w86a+WbMbGm2W91O0UzO5VeemZYBBUJbCjk/5FLLGIi8aV6RS2+WmaRvtcqNTn2pUA7nCOK3bGcQ==}
+
+  '@wallet-standard/app@1.1.0':
+    resolution: {integrity: sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==}
+    engines: {node: '>=16'}
 
   '@wallet-standard/base@1.1.0':
     resolution: {integrity: sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==}
@@ -2873,8 +2901,23 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  '@wallet-standard/experimental-features@0.2.0':
+    resolution: {integrity: sha512-B6fBLgouurN3IAoqhh8/1Mm33IAWIErQXVyvMcyBJM+elOD6zkNDUjew5QMG19qCbJ+ZiZUZmdOUC5PxxWw69w==}
+    engines: {node: '>=16'}
+
   '@wallet-standard/features@1.1.0':
     resolution: {integrity: sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==}
+    engines: {node: '>=16'}
+
+  '@wallet-standard/react-core@1.0.1':
+    resolution: {integrity: sha512-g+vZaLlAGlYMwZEoKsmjjI5qz1D8P3FF1aqiI3WLooWOVk55Nszbpk01QCbIFdIMF0UDhxia2FU667TCv509iw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  '@wallet-standard/react@1.0.1':
+    resolution: {integrity: sha512-StpPv234R94MmJCCUZurQvQSsX6Xe1eOd2lNgwVonvSVdPqCNVS/haVpdrBMx0wX1Ut24X77qyBLP7SGxK5OUg==}
     engines: {node: '>=16'}
 
   '@wallet-standard/ui-compare@1.0.1':
@@ -2979,10 +3022,6 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
-
-  ansis@4.2.0:
-    resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
-    engines: {node: '>=14'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -3245,8 +3284,8 @@ packages:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
 
-  commander@14.0.2:
-    resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
   commander@2.20.3:
@@ -3474,136 +3513,6 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
-
-  esbuild-android-64@0.14.47:
-    resolution: {integrity: sha512-R13Bd9+tqLVFndncMHssZrPWe6/0Kpv2/dt4aA69soX4PRxlzsVpCvoJeFE8sOEoeVEiBkI0myjlkDodXlHa0g==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-
-  esbuild-android-arm64@0.14.47:
-    resolution: {integrity: sha512-OkwOjj7ts4lBp/TL6hdd8HftIzOy/pdtbrNA4+0oVWgGG64HrdVzAF5gxtJufAPOsEjkyh1oIYvKAUinKKQRSQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-
-  esbuild-darwin-64@0.14.47:
-    resolution: {integrity: sha512-R6oaW0y5/u6Eccti/TS6c/2c1xYTb1izwK3gajJwi4vIfNs1s8B1dQzI1UiC9T61YovOQVuePDcfqHLT3mUZJA==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-
-  esbuild-darwin-arm64@0.14.47:
-    resolution: {integrity: sha512-seCmearlQyvdvM/noz1L9+qblC5vcBrhUaOoLEDDoLInF/VQ9IkobGiLlyTPYP5dW1YD4LXhtBgOyevoIHGGnw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-
-  esbuild-freebsd-64@0.14.47:
-    resolution: {integrity: sha512-ZH8K2Q8/Ux5kXXvQMDsJcxvkIwut69KVrYQhza/ptkW50DC089bCVrJZZ3sKzIoOx+YPTrmsZvqeZERjyYrlvQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-
-  esbuild-freebsd-arm64@0.14.47:
-    resolution: {integrity: sha512-ZJMQAJQsIOhn3XTm7MPQfCzEu5b9STNC+s90zMWe2afy9EwnHV7Ov7ohEMv2lyWlc2pjqLW8QJnz2r0KZmeAEQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-
-  esbuild-linux-32@0.14.47:
-    resolution: {integrity: sha512-FxZOCKoEDPRYvq300lsWCTv1kcHgiiZfNrPtEhFAiqD7QZaXrad8LxyJ8fXGcWzIFzRiYZVtB3ttvITBvAFhKw==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-
-  esbuild-linux-64@0.14.47:
-    resolution: {integrity: sha512-nFNOk9vWVfvWYF9YNYksZptgQAdstnDCMtR6m42l5Wfugbzu11VpMCY9XrD4yFxvPo9zmzcoUL/88y0lfJZJJw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-
-  esbuild-linux-arm64@0.14.47:
-    resolution: {integrity: sha512-ywfme6HVrhWcevzmsufjd4iT3PxTfCX9HOdxA7Hd+/ZM23Y9nXeb+vG6AyA6jgq/JovkcqRHcL9XwRNpWG6XRw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-
-  esbuild-linux-arm@0.14.47:
-    resolution: {integrity: sha512-ZGE1Bqg/gPRXrBpgpvH81tQHpiaGxa8c9Rx/XOylkIl2ypLuOcawXEAo8ls+5DFCcRGt/o3sV+PzpAFZobOsmA==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-
-  esbuild-linux-mips64le@0.14.47:
-    resolution: {integrity: sha512-mg3D8YndZ1LvUiEdDYR3OsmeyAew4MA/dvaEJxvyygahWmpv1SlEEnhEZlhPokjsUMfRagzsEF/d/2XF+kTQGg==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-
-  esbuild-linux-ppc64le@0.14.47:
-    resolution: {integrity: sha512-WER+f3+szmnZiWoK6AsrTKGoJoErG2LlauSmk73LEZFQ/iWC+KhhDsOkn1xBUpzXWsxN9THmQFltLoaFEH8F8w==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-
-  esbuild-linux-riscv64@0.14.47:
-    resolution: {integrity: sha512-1fI6bP3A3rvI9BsaaXbMoaOjLE3lVkJtLxsgLHqlBhLlBVY7UqffWBvkrX/9zfPhhVMd9ZRFiaqXnB1T7BsL2g==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-
-  esbuild-linux-s390x@0.14.47:
-    resolution: {integrity: sha512-eZrWzy0xFAhki1CWRGnhsHVz7IlSKX6yT2tj2Eg8lhAwlRE5E96Hsb0M1mPSE1dHGpt1QVwwVivXIAacF/G6mw==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-
-  esbuild-netbsd-64@0.14.47:
-    resolution: {integrity: sha512-Qjdjr+KQQVH5Q2Q1r6HBYswFTToPpss3gqCiSw2Fpq/ua8+eXSQyAMG+UvULPqXceOwpnPo4smyZyHdlkcPppQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-
-  esbuild-openbsd-64@0.14.47:
-    resolution: {integrity: sha512-QpgN8ofL7B9z8g5zZqJE+eFvD1LehRlxr25PBkjyyasakm4599iroUpaj96rdqRlO2ShuyqwJdr+oNqWwTUmQw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-
-  esbuild-sunos-64@0.14.47:
-    resolution: {integrity: sha512-uOeSgLUwukLioAJOiGYm3kNl+1wJjgJA8R671GYgcPgCx7QR73zfvYqXFFcIO93/nBdIbt5hd8RItqbbf3HtAQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-
-  esbuild-windows-32@0.14.47:
-    resolution: {integrity: sha512-H0fWsLTp2WBfKLBgwYT4OTfFly4Im/8B5f3ojDv1Kx//kiubVY0IQunP2Koc/fr/0wI7hj3IiBDbSrmKlrNgLQ==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-
-  esbuild-windows-64@0.14.47:
-    resolution: {integrity: sha512-/Pk5jIEH34T68r8PweKRi77W49KwanZ8X6lr3vDAtOlH5EumPE4pBHqkCUdELanvsT14yMXLQ/C/8XPi1pAtkQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-
-  esbuild-windows-arm64@0.14.47:
-    resolution: {integrity: sha512-HFSW2lnp62fl86/qPQlqw6asIwCnEsEoNIL1h2uVMgakddf+vUuMcCbtUY1i8sst7KkgHrVKCJQB33YhhOweCQ==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-
-  esbuild@0.14.47:
-    resolution: {integrity: sha512-wI4ZiIfFxpkuxB8ju4MHrGwGLyp1+awEHAHVpx6w7a+1pmYIq8T9FGEVVwFo0iFierDoMj++Xq69GXWYn2EiwA==}
-    engines: {node: '>=12'}
-    hasBin: true
-
-  esbuild@0.23.1:
-    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   esbuild@0.25.3:
     resolution: {integrity: sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==}
@@ -4114,10 +4023,6 @@ packages:
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
-  http-errors@1.4.0:
-    resolution: {integrity: sha512-oLjPqve1tuOl5aRhv8GK5eHpqP1C9fb+Ol+XTLjKfLltE44zdDbEdjPSbU7Ch5rSNsVFqZn97SrMmZLdu1/YMw==}
-    engines: {node: '>= 0.6'}
-
   http-errors@1.7.3:
     resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
     engines: {node: '>= 0.6'}
@@ -4171,9 +4076,6 @@ packages:
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
-  inherits@2.0.1:
-    resolution: {integrity: sha512-8nWq2nLTAwd02jTqJExUYFSD/fKq6VH9Y/oG2accc/kdI0V98Bag8d5a4gi3XHz73rDWa2PvTtvcWYquKqSENA==}
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -4326,9 +4228,6 @@ packages:
   is-what@4.1.16:
     resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
     engines: {node: '>=12.13'}
-
-  isarray@0.0.1:
-    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
 
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
@@ -4823,6 +4722,9 @@ packages:
       sass:
         optional: true
 
+  nf3@0.3.6:
+    resolution: {integrity: sha512-/XRUUILTAyuy1XunyVQuqGp8aEmZ2TfRTn8Rji+FA4xqv20qzL4jV7Reqbuey2XucKgPeRVcEYGScmJM0UnB6Q==}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -4944,6 +4846,10 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  oxc-transform@0.111.0:
+    resolution: {integrity: sha512-oa5KKSDNLHZGaiqIGAbCWXeN9IJUAz9MElWcQX90epDxdKc9Hrt/BsLj3K4gDqfAYa5dwdH+ZCFJG9hR74fiGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   oxc-transform@0.53.0:
     resolution: {integrity: sha512-ovYJDZfHNLyXlkJBT0HTNHDPHp4JlyG+NePCLrGRT4c1xXOPZ1TWy8xu2shOuLo6n6fiMbpqZha3Ne7C8H7OJA==}
 
@@ -4988,10 +4894,6 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-match@1.2.4:
-    resolution: {integrity: sha512-UWlehEdqu36jmh4h5CWJ7tARp1OEVKGHKm6+dg9qMq5RKUTV5WJrGgaZ3dN2m7WFAXDbjlHzvJvL/IUpy84Ktw==}
-    deprecated: This package is archived and no longer maintained. For support, visit https://github.com/expressjs/express/discussions
-
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -4999,11 +4901,12 @@ packages:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
 
-  path-to-regexp@1.9.0:
-    resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
-
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
@@ -5249,6 +5152,10 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
+
   resolve@1.22.10:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
@@ -5271,12 +5178,8 @@ packages:
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
-  rolldown@1.0.0-beta.35:
-    resolution: {integrity: sha512-gJATyqcsJe0Cs8RMFO8XgFjfTc0lK1jcSvirDQDSIfsJE+vt53QH/Ob+OBSJsXb98YtZXHfP/bHpELpPwCprow==}
-    hasBin: true
-
-  rolldown@1.0.0-beta.52:
-    resolution: {integrity: sha512-Hbnpljue+JhMJrlOjQ1ixp9me7sUec7OjFvS+A1Qm8k8Xyxmw3ZhxFu7LlSXW1s9AX3POE9W9o2oqCEeR5uDmg==}
+  rolldown@1.0.0-rc.1:
+    resolution: {integrity: sha512-M3AeZjYE6UclblEf531Hch0WfVC/NOL43Cc+WdF3J50kk5/fvouHhDumSGTh0oRjbZ8C4faaVr5r6Nx1xMqDGg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5518,10 +5421,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   tar@7.5.1:
     resolution: {integrity: sha512-nlGpxf+hv0v7GkWBK2V9spgactGOp0qvfWRxUMjqHyzrt3SgwE48DIv/FhqPHJYLHpgW1opq3nERbz5Anq7n1g==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   text-encoding-utf-8@1.0.2:
     resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
@@ -5604,8 +5509,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  tsx@4.19.2:
-    resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
 
@@ -5671,8 +5576,8 @@ packages:
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
-  undici-types@7.16.0:
-    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+  undici-types@7.20.0:
+    resolution: {integrity: sha512-PZDAAlMkNw5ZzN/ebfyrwzrMWfIf7Jbn9iM/I6SF456OKrb2wnfqVowaxEY/cMAM8MjFu1zhdpJyA0L+rTYwNw==}
 
   undici@5.28.4:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
@@ -5789,8 +5694,8 @@ packages:
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
-  vercel@50.1.0:
-    resolution: {integrity: sha512-a1SouUAEaB5hNW1lg8eGnC2vDWyHF81qLmzacCo5nN5wZ9wBxAMG6KNQc+7cUekkcybinyPQ1qt8nbLsc0ogFw==}
+  vercel@50.9.6:
+    resolution: {integrity: sha512-eQI81w54KvPyizQnarQLf1wqxFL9gWYzqlS271er23ZJzNs/2tHVc+mikpXCu5V+Y4f1OSIaC5eNrzoV/hsthg==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -5861,6 +5766,18 @@ packages:
 
   ws@8.18.1:
     resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -6059,6 +5976,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.8.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.5.0':
     dependencies:
       tslib: 2.8.1
@@ -6074,16 +5997,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@esbuild/aix-ppc64@0.23.1':
-    optional: true
-
   '@esbuild/aix-ppc64@0.25.3':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.0':
-    optional: true
-
-  '@esbuild/android-arm64@0.23.1':
     optional: true
 
   '@esbuild/android-arm64@0.25.3':
@@ -6092,16 +6009,10 @@ snapshots:
   '@esbuild/android-arm64@0.27.0':
     optional: true
 
-  '@esbuild/android-arm@0.23.1':
-    optional: true
-
   '@esbuild/android-arm@0.25.3':
     optional: true
 
   '@esbuild/android-arm@0.27.0':
-    optional: true
-
-  '@esbuild/android-x64@0.23.1':
     optional: true
 
   '@esbuild/android-x64@0.25.3':
@@ -6110,16 +6021,10 @@ snapshots:
   '@esbuild/android-x64@0.27.0':
     optional: true
 
-  '@esbuild/darwin-arm64@0.23.1':
-    optional: true
-
   '@esbuild/darwin-arm64@0.25.3':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.0':
-    optional: true
-
-  '@esbuild/darwin-x64@0.23.1':
     optional: true
 
   '@esbuild/darwin-x64@0.25.3':
@@ -6128,16 +6033,10 @@ snapshots:
   '@esbuild/darwin-x64@0.27.0':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.23.1':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.25.3':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.0':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.23.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.3':
@@ -6146,16 +6045,10 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.0':
     optional: true
 
-  '@esbuild/linux-arm64@0.23.1':
-    optional: true
-
   '@esbuild/linux-arm64@0.25.3':
     optional: true
 
   '@esbuild/linux-arm64@0.27.0':
-    optional: true
-
-  '@esbuild/linux-arm@0.23.1':
     optional: true
 
   '@esbuild/linux-arm@0.25.3':
@@ -6164,16 +6057,10 @@ snapshots:
   '@esbuild/linux-arm@0.27.0':
     optional: true
 
-  '@esbuild/linux-ia32@0.23.1':
-    optional: true
-
   '@esbuild/linux-ia32@0.25.3':
     optional: true
 
   '@esbuild/linux-ia32@0.27.0':
-    optional: true
-
-  '@esbuild/linux-loong64@0.23.1':
     optional: true
 
   '@esbuild/linux-loong64@0.25.3':
@@ -6182,16 +6069,10 @@ snapshots:
   '@esbuild/linux-loong64@0.27.0':
     optional: true
 
-  '@esbuild/linux-mips64el@0.23.1':
-    optional: true
-
   '@esbuild/linux-mips64el@0.25.3':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.0':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.23.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.3':
@@ -6200,25 +6081,16 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.0':
     optional: true
 
-  '@esbuild/linux-riscv64@0.23.1':
-    optional: true
-
   '@esbuild/linux-riscv64@0.25.3':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.0':
     optional: true
 
-  '@esbuild/linux-s390x@0.23.1':
-    optional: true
-
   '@esbuild/linux-s390x@0.25.3':
     optional: true
 
   '@esbuild/linux-s390x@0.27.0':
-    optional: true
-
-  '@esbuild/linux-x64@0.23.1':
     optional: true
 
   '@esbuild/linux-x64@0.25.3':
@@ -6233,25 +6105,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.0':
     optional: true
 
-  '@esbuild/netbsd-x64@0.23.1':
-    optional: true
-
   '@esbuild/netbsd-x64@0.25.3':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.0':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.23.1':
-    optional: true
-
   '@esbuild/openbsd-arm64@0.25.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.0':
-    optional: true
-
-  '@esbuild/openbsd-x64@0.23.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.3':
@@ -6263,16 +6126,10 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.23.1':
-    optional: true
-
   '@esbuild/sunos-x64@0.25.3':
     optional: true
 
   '@esbuild/sunos-x64@0.27.0':
-    optional: true
-
-  '@esbuild/win32-arm64@0.23.1':
     optional: true
 
   '@esbuild/win32-arm64@0.25.3':
@@ -6281,16 +6138,10 @@ snapshots:
   '@esbuild/win32-arm64@0.27.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.23.1':
-    optional: true
-
   '@esbuild/win32-ia32@0.25.3':
     optional: true
 
   '@esbuild/win32-ia32@0.27.0':
-    optional: true
-
-  '@esbuild/win32-x64@0.23.1':
     optional: true
 
   '@esbuild/win32-x64@0.25.3':
@@ -6644,9 +6495,9 @@ snapshots:
       '@tybys/wasm-util': 0.9.0
     optional: true
 
-  '@napi-rs/wasm-runtime@1.0.7':
+  '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
-      '@emnapi/core': 1.6.0
+      '@emnapi/core': 1.8.1
       '@emnapi/runtime': 1.7.1
       '@tybys/wasm-util': 0.10.1
     optional: true
@@ -6705,31 +6556,89 @@ snapshots:
 
   '@orama/orama@3.1.6': {}
 
-  '@oxc-project/runtime@0.82.3': {}
+  '@oxc-project/types@0.110.0': {}
 
-  '@oxc-project/types@0.82.3': {}
+  '@oxc-transform/binding-android-arm-eabi@0.111.0':
+    optional: true
 
-  '@oxc-project/types@0.99.0': {}
+  '@oxc-transform/binding-android-arm64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-arm64@0.111.0':
+    optional: true
 
   '@oxc-transform/binding-darwin-arm64@0.53.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-x64@0.111.0':
     optional: true
 
   '@oxc-transform/binding-darwin-x64@0.53.0':
     optional: true
 
+  '@oxc-transform/binding-freebsd-x64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.111.0':
+    optional: true
+
   '@oxc-transform/binding-linux-arm64-gnu@0.53.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-musl@0.111.0':
     optional: true
 
   '@oxc-transform/binding-linux-arm64-musl@0.53.0':
     optional: true
 
+  '@oxc-transform/binding-linux-ppc64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-gnu@0.111.0':
+    optional: true
+
   '@oxc-transform/binding-linux-x64-gnu@0.53.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-musl@0.111.0':
     optional: true
 
   '@oxc-transform/binding-linux-x64-musl@0.53.0':
     optional: true
 
+  '@oxc-transform/binding-openharmony-arm64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-wasm32-wasi@0.111.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.111.0':
+    optional: true
+
   '@oxc-transform/binding-win32-arm64-msvc@0.53.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-x64-msvc@0.111.0':
     optional: true
 
   '@oxc-transform/binding-win32-x64-msvc@0.53.0':
@@ -7524,97 +7433,48 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.35':
+  '@rolldown/binding-android-arm64@1.0.0-rc.1':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.0.0-beta.52':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.35':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.1':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-beta.52':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.35':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-beta.52':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.35':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-beta.52':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.35':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.52':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.35':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.52':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.35':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.52':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.35':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.52':
-    optional: true
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.35':
-    optional: true
-
-  '@rolldown/binding-linux-x64-musl@1.0.0-beta.52':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-beta.35':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.0.0-beta.52':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.35':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.0.7
+      '@napi-rs/wasm-runtime': 1.1.1
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-beta.52':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.0.7
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.35':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.52':
-    optional: true
-
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.35':
-    optional: true
-
-  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.52':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.35':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.52':
-    optional: true
-
-  '@rolldown/pluginutils@1.0.0-beta.35': {}
-
-  '@rolldown/pluginutils@1.0.0-beta.52': {}
+  '@rolldown/pluginutils@1.0.0-rc.1': {}
 
   '@rollup/pluginutils@5.3.0':
     dependencies:
@@ -7682,52 +7542,55 @@ snapshots:
 
   '@sinclair/typebox@0.25.24': {}
 
-  '@solana-program/address-lookup-table@0.7.0(@solana/kit@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/address-lookup-table@0.10.0(@solana/kit@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/kit': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/kit': 6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana-program/compute-budget@0.8.0(@solana/kit@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/compute-budget@0.12.0(@solana/kit@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/kit': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/kit': 6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana-program/memo@0.7.0(@solana/kit@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/memo@0.10.0(@solana/kit@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/kit': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/kit': 6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana-program/system@0.7.0(@solana/kit@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/system@0.10.0(@solana/kit@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/kit': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/kit': 6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana-program/token@0.5.1(@solana/kit@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)))':
+  '@solana-program/token@0.9.0(@solana/kit@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))':
     dependencies:
-      '@solana/kit': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/kit': 6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
-  '@solana/accounts@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/accounts@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-strings': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-spec': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-types': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-strings': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-spec': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-types': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/addresses@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/addresses@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/assertions': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-strings': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/nominal-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
+      '@solana/assertions': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-strings': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/nominal-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/assertions@5.1.1-canary-20251216194212(typescript@5.9.3)':
+  '@solana/assertions@6.0.0-canary-20260203172420(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/buffer-layout@4.0.1':
@@ -7739,16 +7602,18 @@ snapshots:
       '@solana/errors': 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@solana/codecs-core@5.1.1-canary-20251216194212(typescript@5.9.3)':
+  '@solana/codecs-core@6.0.0-canary-20260203172420(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-data-structures@5.1.1-canary-20251216194212(typescript@5.9.3)':
+  '@solana/codecs-data-structures@6.0.0-canary-20260203172420(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
   '@solana/codecs-numbers@2.1.0(typescript@5.9.3)':
@@ -7757,40 +7622,43 @@ snapshots:
       '@solana/errors': 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@solana/codecs-numbers@5.1.1-canary-20251216194212(typescript@5.9.3)':
+  '@solana/codecs-numbers@6.0.0-canary-20260203172420(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/codecs-strings@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/codecs-strings@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      typescript: 5.9.3
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
     optionalDependencies:
       fastestsmallesttextencoderdecoder: 1.0.22
+      typescript: 5.9.3
 
-  '@solana/codecs@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/codecs@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-strings': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/options': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-strings': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/options': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/compat@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/compat@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/instructions': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/keys': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transactions': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/instructions': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/keys': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -7801,339 +7669,376 @@ snapshots:
       commander: 13.1.0
       typescript: 5.9.3
 
-  '@solana/errors@5.1.1-canary-20251216194212(typescript@5.9.3)':
+  '@solana/errors@6.0.0-canary-20260203172420(typescript@5.9.3)':
     dependencies:
       chalk: 5.6.2
-      commander: 14.0.2
+      commander: 14.0.3
+    optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/fast-stable-stringify@5.1.1-canary-20251216194212(typescript@5.9.3)':
-    dependencies:
+  '@solana/fast-stable-stringify@6.0.0-canary-20260203172420(typescript@5.9.3)':
+    optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/functional@5.1.1-canary-20251216194212(typescript@5.9.3)':
-    dependencies:
+  '@solana/functional@6.0.0-canary-20260203172420(typescript@5.9.3)':
+    optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/instruction-plans@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/instruction-plans@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/instructions': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/keys': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/promises': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/transaction-messages': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transactions': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/instructions@5.1.1-canary-20251216194212(typescript@5.9.3)':
-    dependencies:
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      typescript: 5.9.3
-
-  '@solana/keys@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
-    dependencies:
-      '@solana/assertions': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-strings': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/nominal-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/instructions': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/keys': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/promises': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/transaction-messages': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+  '@solana/instructions@6.0.0-canary-20260203172420(typescript@5.9.3)':
     dependencies:
-      '@solana/accounts': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/functional': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/instruction-plans': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/instructions': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/keys': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/offchain-messages': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/programs': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-parsed-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-types': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/signers': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/sysvars': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-confirmation': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/transaction-messages': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transactions': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
-  '@solana/nominal-types@5.1.1-canary-20251216194212(typescript@5.9.3)':
-    dependencies:
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/offchain-messages@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/keys@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-strings': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/keys': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/nominal-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
+      '@solana/assertions': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-strings': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/nominal-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/options@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/kit@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-strings': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
+      '@solana/accounts': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/functional': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/instruction-plans': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/instructions': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/keys': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/offchain-messages': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/plugin-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/programs': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-api': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/rpc-types': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/signers': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/sysvars': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-confirmation': 6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/transaction-messages': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/nominal-types@6.0.0-canary-20260203172420(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/offchain-messages@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-strings': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/keys': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/nominal-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/programs@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/options@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-strings': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/promises@5.1.1-canary-20251216194212(typescript@5.9.3)':
-    dependencies:
+  '@solana/plugin-core@6.0.0-canary-20260203172420(typescript@5.9.3)':
+    optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/react@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.1)(typescript@5.9.3)':
+  '@solana/programs@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/keys': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/promises': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/signers': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-messages': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transactions': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/promises@6.0.0-canary-20260203172420(typescript@5.9.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/react@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/keys': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/promises': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/signers': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/wallet-standard-features': 1.3.0
       '@wallet-standard/base': 1.1.0
       '@wallet-standard/errors': 0.1.1
+      '@wallet-standard/react': 1.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@wallet-standard/ui': 1.0.1
       '@wallet-standard/ui-registry': 1.0.1
     optionalDependencies:
       react: 19.2.1
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
+      - react-dom
       - typescript
 
-  '@solana/rpc-api@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/rpc-api@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-strings': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/keys': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-parsed-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-spec': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-transformers': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-types': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-messages': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transactions': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc-parsed-types@5.1.1-canary-20251216194212(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
-
-  '@solana/rpc-spec-types@5.1.1-canary-20251216194212(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
-
-  '@solana/rpc-spec@5.1.1-canary-20251216194212(typescript@5.9.3)':
-    dependencies:
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      typescript: 5.9.3
-
-  '@solana/rpc-subscriptions-api@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
-    dependencies:
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/keys': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-transformers': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-types': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-messages': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transactions': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/rpc-subscriptions-channel-websocket@5.1.1-canary-20251216194212(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/functional': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-subscriptions-spec': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/subscribable': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      typescript: 5.9.3
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-strings': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/keys': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-parsed-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-spec': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
     optionalDependencies:
-      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-
-  '@solana/rpc-subscriptions-spec@5.1.1-canary-20251216194212(typescript@5.9.3)':
-    dependencies:
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/promises': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/subscribable': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      typescript: 5.9.3
-
-  '@solana/rpc-subscriptions@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/fast-stable-stringify': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/functional': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/promises': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-subscriptions-api': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 5.1.1-canary-20251216194212(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-subscriptions-spec': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-transformers': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-types': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/subscribable': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
-  '@solana/rpc-transformers@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
-    dependencies:
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/functional': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/nominal-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-types': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-transport-http@5.1.1-canary-20251216194212(typescript@5.9.3)':
-    dependencies:
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-spec': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
+  '@solana/rpc-parsed-types@6.0.0-canary-20260203172420(typescript@5.9.3)':
+    optionalDependencies:
       typescript: 5.9.3
-      undici-types: 7.16.0
 
-  '@solana/rpc-types@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
-    dependencies:
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-strings': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/nominal-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
+  '@solana/rpc-spec-types@6.0.0-canary-20260203172420(typescript@5.9.3)':
+    optionalDependencies:
       typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/rpc-spec@6.0.0-canary-20260203172420(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/fast-stable-stringify': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/functional': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-api': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-spec': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-spec-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-transformers': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-transport-http': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-types': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-subscriptions-api@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/keys': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/signers@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/rpc-subscriptions-channel-websocket@6.0.0-canary-20260203172420(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/instructions': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/keys': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/nominal-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/offchain-messages': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-messages': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transactions': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/functional': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-subscriptions-spec': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/subscribable': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      ws: 8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@solana/rpc-subscriptions-spec@6.0.0-canary-20260203172420(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/promises': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/subscribable': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/rpc-subscriptions@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/functional': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/promises': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-subscriptions-api': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions-channel-websocket': 6.0.0-canary-20260203172420(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/rpc-subscriptions-spec': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-types': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/subscribable': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/rpc-transformers@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/functional': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/nominal-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-types': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/subscribable@5.1.1-canary-20251216194212(typescript@5.9.3)':
+  '@solana/rpc-transport-http@6.0.0-canary-20260203172420(typescript@5.9.3)':
     dependencies:
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-spec': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      undici-types: 7.20.0
+    optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/sysvars@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/rpc-types@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/accounts': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-types': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-
-  '@solana/transaction-confirmation@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs-strings': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/keys': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/promises': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@solana/rpc-types': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-messages': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transactions': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - fastestsmallesttextencoderdecoder
-      - ws
-
-  '@solana/transaction-messages@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
-    dependencies:
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/functional': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/instructions': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/nominal-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-types': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-strings': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/nominal-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transactions@5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+  '@solana/rpc@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
     dependencies:
-      '@solana/addresses': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/codecs-core': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-data-structures': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-numbers': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/codecs-strings': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/errors': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/functional': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/instructions': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/keys': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/nominal-types': 5.1.1-canary-20251216194212(typescript@5.9.3)
-      '@solana/rpc-types': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-messages': 5.1.1-canary-20251216194212(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/fast-stable-stringify': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/functional': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-api': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-spec': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-spec-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-transformers': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-transport-http': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-types': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/signers@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/instructions': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/keys': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/nominal-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/offchain-messages': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/subscribable@6.0.0-canary-20260203172420(typescript@5.9.3)':
+    dependencies:
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
+  '@solana/sysvars@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/accounts': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-types': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transaction-confirmation@6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-strings': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/keys': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/promises': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/rpc-subscriptions': 6.0.0-canary-20260203172420(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/rpc-types': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transactions': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - fastestsmallesttextencoderdecoder
+      - utf-8-validate
+
+  '@solana/transaction-messages@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/functional': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/instructions': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/nominal-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-types': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+
+  '@solana/transactions@6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)':
+    dependencies:
+      '@solana/addresses': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/codecs-core': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-data-structures': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-numbers': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/codecs-strings': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/errors': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/functional': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/instructions': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/keys': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/nominal-types': 6.0.0-canary-20260203172420(typescript@5.9.3)
+      '@solana/rpc-types': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/transaction-messages': 6.0.0-canary-20260203172420(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+    optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
@@ -8166,9 +8071,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@solana/webcrypto-ed25519-polyfill@5.1.1-canary-20251216194212(typescript@5.9.3)':
+  '@solana/webcrypto-ed25519-polyfill@6.0.0-canary-20260203172420(typescript@5.9.3)':
     dependencies:
       '@noble/ed25519': 3.0.0
+    optionalDependencies:
       typescript: 5.9.3
 
   '@standard-schema/spec@1.0.0': {}
@@ -8313,9 +8219,11 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@16.18.11': {}
-
   '@types/node@18.19.123':
+    dependencies:
+      undici-types: 5.26.5
+
+  '@types/node@20.11.0':
     dependencies:
       undici-types: 5.26.5
 
@@ -8496,14 +8404,11 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.3.2':
     optional: true
 
-  '@vercel/backends@0.0.17(typescript@5.9.3)':
+  '@vercel/backends@0.0.24(typescript@5.9.3)':
     dependencies:
-      '@vercel/cervel': 0.0.7(typescript@5.9.3)
-      '@vercel/introspection': 0.0.7
-      '@vercel/nft': 1.1.1
-      '@vercel/static-config': 3.1.2
+      '@vercel/cervel': 0.0.11(typescript@5.9.3)
+      '@vercel/introspection': 0.0.10
       fs-extra: 11.1.0
-      rolldown: 1.0.0-beta.35
     transitivePeerDependencies:
       - encoding
       - rollup
@@ -8518,21 +8423,30 @@ snapshots:
       throttleit: 2.1.0
       undici: 5.29.0
 
-  '@vercel/build-utils@13.2.3': {}
+  '@vercel/build-utils@13.2.16': {}
 
-  '@vercel/cervel@0.0.7(typescript@5.9.3)':
+  '@vercel/cervel@0.0.11(typescript@5.9.3)':
     dependencies:
+      '@vercel/build-utils': 13.2.16
+      '@vercel/nft': 1.3.0
       execa: 3.2.0
-      rolldown: 1.0.0-beta.52
+      nf3: 0.3.6
+      oxc-transform: 0.111.0
+      resolve.exports: 2.0.3
+      rolldown: 1.0.0-rc.1
       srvx: 0.8.9
-      tsx: 4.19.2
+      tsx: 4.21.0
       typescript: 5.9.3
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
 
-  '@vercel/detect-agent@1.0.0': {}
+  '@vercel/detect-agent@1.1.0': {}
 
-  '@vercel/elysia@0.1.14':
+  '@vercel/elysia@0.1.27':
     dependencies:
-      '@vercel/node': 5.5.15
+      '@vercel/node': 5.5.28
       '@vercel/static-config': 3.1.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -8543,15 +8457,14 @@ snapshots:
 
   '@vercel/error-utils@2.0.3': {}
 
-  '@vercel/express@0.1.20(typescript@5.9.3)':
+  '@vercel/express@0.1.35(typescript@5.9.3)':
     dependencies:
-      '@vercel/cervel': 0.0.7(typescript@5.9.3)
+      '@vercel/cervel': 0.0.11(typescript@5.9.3)
       '@vercel/nft': 1.1.1
-      '@vercel/node': 5.5.15
+      '@vercel/node': 5.5.28
       '@vercel/static-config': 3.1.2
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
-      rolldown: 1.0.0-beta.35
       ts-morph: 12.0.0
       zod: 3.22.4
     transitivePeerDependencies:
@@ -8562,9 +8475,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@vercel/fastify@0.1.17':
+  '@vercel/fastify@0.1.30':
     dependencies:
-      '@vercel/node': 5.5.15
+      '@vercel/node': 5.5.28
       '@vercel/static-config': 3.1.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -8573,7 +8486,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/fun@1.2.0':
+  '@vercel/fun@1.2.1':
     dependencies:
       '@tootallnate/once': 2.0.0
       async-listen: 1.2.0
@@ -8582,7 +8495,7 @@ snapshots:
       micro: 9.3.5-canary.3
       ms: 2.1.1
       node-fetch: 2.6.7
-      path-match: 1.2.4
+      path-to-regexp: 8.2.0
       promisepipe: 3.0.0
       semver: 7.5.4
       stat-mode: 0.3.0
@@ -8601,19 +8514,19 @@ snapshots:
     dependencies:
       web-vitals: 0.2.4
 
-  '@vercel/gatsby-plugin-vercel-builder@2.0.113':
+  '@vercel/gatsby-plugin-vercel-builder@2.0.127':
     dependencies:
       '@sinclair/typebox': 0.25.24
-      '@vercel/build-utils': 13.2.3
-      esbuild: 0.14.47
+      '@vercel/build-utils': 13.2.16
+      esbuild: 0.27.0
       etag: 1.8.1
       fs-extra: 11.1.0
 
-  '@vercel/go@3.2.4': {}
+  '@vercel/go@3.3.4': {}
 
-  '@vercel/h3@0.1.23':
+  '@vercel/h3@0.1.36':
     dependencies:
-      '@vercel/node': 5.5.15
+      '@vercel/node': 5.5.28
       '@vercel/static-config': 3.1.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -8622,14 +8535,13 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/hono@0.2.17':
+  '@vercel/hono@0.2.30':
     dependencies:
       '@vercel/nft': 1.1.1
-      '@vercel/node': 5.5.15
+      '@vercel/node': 5.5.28
       '@vercel/static-config': 3.1.2
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
-      rolldown: 1.0.0-beta.35
       ts-morph: 12.0.0
       zod: 3.22.4
     transitivePeerDependencies:
@@ -8639,19 +8551,19 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/hydrogen@1.3.3':
+  '@vercel/hydrogen@1.3.5':
     dependencies:
       '@vercel/static-config': 3.1.2
       ts-morph: 12.0.0
 
-  '@vercel/introspection@0.0.7':
+  '@vercel/introspection@0.0.10':
     dependencies:
       path-to-regexp: 8.3.0
       zod: 3.22.4
 
-  '@vercel/nestjs@0.2.18':
+  '@vercel/koa@0.1.10':
     dependencies:
-      '@vercel/node': 5.5.15
+      '@vercel/node': 5.5.28
       '@vercel/static-config': 3.1.2
     transitivePeerDependencies:
       - '@swc/core'
@@ -8660,7 +8572,18 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/next@4.15.9':
+  '@vercel/nestjs@0.2.31':
+    dependencies:
+      '@vercel/node': 5.5.28
+      '@vercel/static-config': 3.1.2
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@swc/wasm'
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/next@4.15.20':
     dependencies:
       '@vercel/nft': 1.1.1
     transitivePeerDependencies:
@@ -8687,13 +8610,32 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/node@5.5.15':
+  '@vercel/nft@1.3.0':
+    dependencies:
+      '@mapbox/node-pre-gyp': 2.0.0
+      '@rollup/pluginutils': 5.3.0
+      acorn: 8.14.1
+      acorn-import-attributes: 1.9.5(acorn@8.14.1)
+      async-sema: 3.1.1
+      bindings: 1.5.0
+      estree-walker: 2.0.2
+      glob: 13.0.0
+      graceful-fs: 4.2.11
+      node-gyp-build: 4.8.4
+      picomatch: 4.0.3
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/node@5.5.28':
     dependencies:
       '@edge-runtime/node-utils': 2.3.0
       '@edge-runtime/primitives': 4.1.0
       '@edge-runtime/vm': 3.2.0
-      '@types/node': 16.18.11
-      '@vercel/build-utils': 13.2.3
+      '@types/node': 20.11.0
+      '@vercel/build-utils': 13.2.16
       '@vercel/error-utils': 2.0.3
       '@vercel/nft': 1.1.1
       '@vercel/static-config': 3.1.2
@@ -8701,14 +8643,14 @@ snapshots:
       cjs-module-lexer: 1.2.3
       edge-runtime: 2.5.9
       es-module-lexer: 1.4.1
-      esbuild: 0.14.47
+      esbuild: 0.27.0
       etag: 1.8.1
       mime-types: 2.1.35
       node-fetch: 2.6.9
       path-to-regexp: 6.3.0
       path-to-regexp-updated: path-to-regexp@6.3.0
       ts-morph: 12.0.0
-      ts-node: 10.9.1(@types/node@16.18.11)(typescript@4.9.5)
+      ts-node: 10.9.1(@types/node@20.11.0)(typescript@4.9.5)
       typescript: 4.9.5
       typescript5: typescript@5.9.3
       undici: 5.28.4
@@ -8719,9 +8661,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/python@6.1.4': {}
+  '@vercel/python@6.4.2': {}
 
-  '@vercel/redwood@2.4.6':
+  '@vercel/redwood@2.4.9':
     dependencies:
       '@vercel/nft': 1.1.1
       '@vercel/static-config': 3.1.2
@@ -8732,7 +8674,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/remix-builder@5.5.6':
+  '@vercel/remix-builder@5.5.9':
     dependencies:
       '@vercel/error-utils': 2.0.3
       '@vercel/nft': 1.1.1
@@ -8745,17 +8687,17 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/ruby@2.2.3': {}
+  '@vercel/ruby@2.2.5': {}
 
-  '@vercel/rust@1.0.4':
+  '@vercel/rust@1.0.5':
     dependencies:
       '@iarna/toml': 2.2.5
       execa: 5.1.1
 
-  '@vercel/static-build@2.8.14':
+  '@vercel/static-build@2.8.28':
     dependencies:
       '@vercel/gatsby-plugin-vercel-analytics': 1.0.11
-      '@vercel/gatsby-plugin-vercel-builder': 2.0.113
+      '@vercel/gatsby-plugin-vercel-builder': 2.0.127
       '@vercel/static-config': 3.1.2
       ts-morph: 12.0.0
 
@@ -8765,6 +8707,10 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
+  '@wallet-standard/app@1.1.0':
+    dependencies:
+      '@wallet-standard/base': 1.1.0
+
   '@wallet-standard/base@1.1.0': {}
 
   '@wallet-standard/errors@0.1.1':
@@ -8772,9 +8718,32 @@ snapshots:
       chalk: 5.6.2
       commander: 13.1.0
 
+  '@wallet-standard/experimental-features@0.2.0':
+    dependencies:
+      '@wallet-standard/base': 1.1.0
+
   '@wallet-standard/features@1.1.0':
     dependencies:
       '@wallet-standard/base': 1.1.0
+
+  '@wallet-standard/react-core@1.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@wallet-standard/app': 1.1.0
+      '@wallet-standard/base': 1.1.0
+      '@wallet-standard/errors': 0.1.1
+      '@wallet-standard/experimental-features': 0.2.0
+      '@wallet-standard/features': 1.1.0
+      '@wallet-standard/ui': 1.0.1
+      '@wallet-standard/ui-registry': 1.0.1
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+
+  '@wallet-standard/react@1.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      '@wallet-standard/react-core': 1.0.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@wallet-standard/ui-compare@1.0.1':
     dependencies:
@@ -8895,8 +8864,6 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-
-  ansis@4.2.0: {}
 
   any-promise@1.3.0: {}
 
@@ -9165,7 +9132,7 @@ snapshots:
 
   commander@13.1.0: {}
 
-  commander@14.0.2: {}
+  commander@14.0.3: {}
 
   commander@2.20.3: {}
 
@@ -9488,116 +9455,6 @@ snapshots:
       acorn: 8.14.1
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.2
-
-  esbuild-android-64@0.14.47:
-    optional: true
-
-  esbuild-android-arm64@0.14.47:
-    optional: true
-
-  esbuild-darwin-64@0.14.47:
-    optional: true
-
-  esbuild-darwin-arm64@0.14.47:
-    optional: true
-
-  esbuild-freebsd-64@0.14.47:
-    optional: true
-
-  esbuild-freebsd-arm64@0.14.47:
-    optional: true
-
-  esbuild-linux-32@0.14.47:
-    optional: true
-
-  esbuild-linux-64@0.14.47:
-    optional: true
-
-  esbuild-linux-arm64@0.14.47:
-    optional: true
-
-  esbuild-linux-arm@0.14.47:
-    optional: true
-
-  esbuild-linux-mips64le@0.14.47:
-    optional: true
-
-  esbuild-linux-ppc64le@0.14.47:
-    optional: true
-
-  esbuild-linux-riscv64@0.14.47:
-    optional: true
-
-  esbuild-linux-s390x@0.14.47:
-    optional: true
-
-  esbuild-netbsd-64@0.14.47:
-    optional: true
-
-  esbuild-openbsd-64@0.14.47:
-    optional: true
-
-  esbuild-sunos-64@0.14.47:
-    optional: true
-
-  esbuild-windows-32@0.14.47:
-    optional: true
-
-  esbuild-windows-64@0.14.47:
-    optional: true
-
-  esbuild-windows-arm64@0.14.47:
-    optional: true
-
-  esbuild@0.14.47:
-    optionalDependencies:
-      esbuild-android-64: 0.14.47
-      esbuild-android-arm64: 0.14.47
-      esbuild-darwin-64: 0.14.47
-      esbuild-darwin-arm64: 0.14.47
-      esbuild-freebsd-64: 0.14.47
-      esbuild-freebsd-arm64: 0.14.47
-      esbuild-linux-32: 0.14.47
-      esbuild-linux-64: 0.14.47
-      esbuild-linux-arm: 0.14.47
-      esbuild-linux-arm64: 0.14.47
-      esbuild-linux-mips64le: 0.14.47
-      esbuild-linux-ppc64le: 0.14.47
-      esbuild-linux-riscv64: 0.14.47
-      esbuild-linux-s390x: 0.14.47
-      esbuild-netbsd-64: 0.14.47
-      esbuild-openbsd-64: 0.14.47
-      esbuild-sunos-64: 0.14.47
-      esbuild-windows-32: 0.14.47
-      esbuild-windows-64: 0.14.47
-      esbuild-windows-arm64: 0.14.47
-
-  esbuild@0.23.1:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.23.1
-      '@esbuild/android-arm': 0.23.1
-      '@esbuild/android-arm64': 0.23.1
-      '@esbuild/android-x64': 0.23.1
-      '@esbuild/darwin-arm64': 0.23.1
-      '@esbuild/darwin-x64': 0.23.1
-      '@esbuild/freebsd-arm64': 0.23.1
-      '@esbuild/freebsd-x64': 0.23.1
-      '@esbuild/linux-arm': 0.23.1
-      '@esbuild/linux-arm64': 0.23.1
-      '@esbuild/linux-ia32': 0.23.1
-      '@esbuild/linux-loong64': 0.23.1
-      '@esbuild/linux-mips64el': 0.23.1
-      '@esbuild/linux-ppc64': 0.23.1
-      '@esbuild/linux-riscv64': 0.23.1
-      '@esbuild/linux-s390x': 0.23.1
-      '@esbuild/linux-x64': 0.23.1
-      '@esbuild/netbsd-x64': 0.23.1
-      '@esbuild/openbsd-arm64': 0.23.1
-      '@esbuild/openbsd-x64': 0.23.1
-      '@esbuild/sunos-x64': 0.23.1
-      '@esbuild/win32-arm64': 0.23.1
-      '@esbuild/win32-ia32': 0.23.1
-      '@esbuild/win32-x64': 0.23.1
 
   esbuild@0.25.3:
     optionalDependencies:
@@ -10399,11 +10256,6 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  http-errors@1.4.0:
-    dependencies:
-      inherits: 2.0.1
-      statuses: 1.5.0
-
   http-errors@1.7.3:
     dependencies:
       depd: 1.1.2
@@ -10452,8 +10304,6 @@ snapshots:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
-
-  inherits@2.0.1: {}
 
   inherits@2.0.4: {}
 
@@ -10600,8 +10450,6 @@ snapshots:
       get-intrinsic: 1.3.0
 
   is-what@4.1.16: {}
-
-  isarray@0.0.1: {}
 
   isarray@2.0.5: {}
 
@@ -11323,6 +11171,8 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  nf3@0.3.6: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@2.6.7:
@@ -11445,6 +11295,29 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  oxc-transform@0.111.0:
+    optionalDependencies:
+      '@oxc-transform/binding-android-arm-eabi': 0.111.0
+      '@oxc-transform/binding-android-arm64': 0.111.0
+      '@oxc-transform/binding-darwin-arm64': 0.111.0
+      '@oxc-transform/binding-darwin-x64': 0.111.0
+      '@oxc-transform/binding-freebsd-x64': 0.111.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.111.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.111.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.111.0
+      '@oxc-transform/binding-linux-ppc64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-riscv64-musl': 0.111.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.111.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-x64-musl': 0.111.0
+      '@oxc-transform/binding-openharmony-arm64': 0.111.0
+      '@oxc-transform/binding-wasm32-wasi': 0.111.0
+      '@oxc-transform/binding-win32-arm64-msvc': 0.111.0
+      '@oxc-transform/binding-win32-ia32-msvc': 0.111.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.111.0
+
   oxc-transform@0.53.0:
     optionalDependencies:
       '@oxc-transform/binding-darwin-arm64': 0.53.0
@@ -11494,11 +11367,6 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-match@1.2.4:
-    dependencies:
-      http-errors: 1.4.0
-      path-to-regexp: 1.9.0
-
   path-parse@1.0.7: {}
 
   path-scurry@2.0.1:
@@ -11506,11 +11374,9 @@ snapshots:
       lru-cache: 11.1.0
       minipass: 7.1.2
 
-  path-to-regexp@1.9.0:
-    dependencies:
-      isarray: 0.0.1
-
   path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.2.0: {}
 
   path-to-regexp@8.3.0: {}
 
@@ -11819,6 +11685,8 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  resolve.exports@2.0.3: {}
+
   resolve@1.22.10:
     dependencies:
       is-core-module: 2.16.1
@@ -11839,47 +11707,24 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rolldown@1.0.0-beta.35:
+  rolldown@1.0.0-rc.1:
     dependencies:
-      '@oxc-project/runtime': 0.82.3
-      '@oxc-project/types': 0.82.3
-      '@rolldown/pluginutils': 1.0.0-beta.35
-      ansis: 4.2.0
+      '@oxc-project/types': 0.110.0
+      '@rolldown/pluginutils': 1.0.0-rc.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-beta.35
-      '@rolldown/binding-darwin-arm64': 1.0.0-beta.35
-      '@rolldown/binding-darwin-x64': 1.0.0-beta.35
-      '@rolldown/binding-freebsd-x64': 1.0.0-beta.35
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.35
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.35
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.35
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.35
-      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.35
-      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.35
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.35
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.35
-      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.35
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.35
-
-  rolldown@1.0.0-beta.52:
-    dependencies:
-      '@oxc-project/types': 0.99.0
-      '@rolldown/pluginutils': 1.0.0-beta.52
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-beta.52
-      '@rolldown/binding-darwin-arm64': 1.0.0-beta.52
-      '@rolldown/binding-darwin-x64': 1.0.0-beta.52
-      '@rolldown/binding-freebsd-x64': 1.0.0-beta.52
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.52
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.52
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.52
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.52
-      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.52
-      '@rolldown/binding-openharmony-arm64': 1.0.0-beta.52
-      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.52
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.52
-      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.52
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.52
+      '@rolldown/binding-android-arm64': 1.0.0-rc.1
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.1
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.1
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.1
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.1
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.1
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.1
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.1
 
   rpc-websockets@9.1.1:
     dependencies:
@@ -12242,14 +12087,14 @@ snapshots:
       '@ts-morph/common': 0.11.1
       code-block-writer: 10.1.1
 
-  ts-node@10.9.1(@types/node@16.18.11)(typescript@4.9.5):
+  ts-node@10.9.1(@types/node@20.11.0)(typescript@4.9.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 16.18.11
+      '@types/node': 20.11.0
       acorn: 8.14.1
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -12271,9 +12116,9 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsx@4.19.2:
+  tsx@4.21.0:
     dependencies:
-      esbuild: 0.23.1
+      esbuild: 0.27.0
       get-tsconfig: 4.10.0
     optionalDependencies:
       fsevents: 2.3.3
@@ -12355,7 +12200,7 @@ snapshots:
 
   undici-types@6.20.0: {}
 
-  undici-types@7.16.0: {}
+  undici-types@7.20.0: {}
 
   undici@5.28.4:
     dependencies:
@@ -12483,29 +12328,30 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  vercel@50.1.0(typescript@5.9.3):
+  vercel@50.9.6(typescript@5.9.3):
     dependencies:
-      '@vercel/backends': 0.0.17(typescript@5.9.3)
+      '@vercel/backends': 0.0.24(typescript@5.9.3)
       '@vercel/blob': 1.0.2
-      '@vercel/build-utils': 13.2.3
-      '@vercel/detect-agent': 1.0.0
-      '@vercel/elysia': 0.1.14
-      '@vercel/express': 0.1.20(typescript@5.9.3)
-      '@vercel/fastify': 0.1.17
-      '@vercel/fun': 1.2.0
-      '@vercel/go': 3.2.4
-      '@vercel/h3': 0.1.23
-      '@vercel/hono': 0.2.17
-      '@vercel/hydrogen': 1.3.3
-      '@vercel/nestjs': 0.2.18
-      '@vercel/next': 4.15.9
-      '@vercel/node': 5.5.15
-      '@vercel/python': 6.1.4
-      '@vercel/redwood': 2.4.6
-      '@vercel/remix-builder': 5.5.6
-      '@vercel/ruby': 2.2.3
-      '@vercel/rust': 1.0.4
-      '@vercel/static-build': 2.8.14
+      '@vercel/build-utils': 13.2.16
+      '@vercel/detect-agent': 1.1.0
+      '@vercel/elysia': 0.1.27
+      '@vercel/express': 0.1.35(typescript@5.9.3)
+      '@vercel/fastify': 0.1.30
+      '@vercel/fun': 1.2.1
+      '@vercel/go': 3.3.4
+      '@vercel/h3': 0.1.36
+      '@vercel/hono': 0.2.30
+      '@vercel/hydrogen': 1.3.5
+      '@vercel/koa': 0.1.10
+      '@vercel/nestjs': 0.2.31
+      '@vercel/next': 4.15.20
+      '@vercel/node': 5.5.28
+      '@vercel/python': 6.4.2
+      '@vercel/redwood': 2.4.9
+      '@vercel/remix-builder': 5.5.9
+      '@vercel/ruby': 2.2.5
+      '@vercel/rust': 1.0.5
+      '@vercel/static-build': 2.8.28
       chokidar: 4.0.0
       esbuild: 0.27.0
       form-data: 4.0.4
@@ -12601,6 +12447,11 @@ snapshots:
       utf-8-validate: 5.0.10
 
   ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
+
+  ws@8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10


### PR DESCRIPTION
This PR updates the instruction plan documentation guide based on the changes introduced in this PR stack.

~Note that we'll need to bump the documentation dependencies using the latest canary versions (once the rest of the stack is merged) before CI can pass here. Until then, I'll leave this PR as a draft.~

It also:
- Bumps the Kit dependencies to the latest canary.
- Bumps program clients to their latest versions.
- Replaces the removed `BaseTransactionMessage` with `TransactionMessage`.