### PR TITLE
Remove deprecated function `getAllSingleTransactionPlans`

### DIFF
--- a/.changeset/thick-spoons-wink.md
+++ b/.changeset/thick-spoons-wink.md
@@ -1,0 +1,14 @@
+---
+'@solana/instruction-plans': major
+---
+
+Remove deprecated function `getAllSingleTransactionPlans`
+
+**BREAKING CHANGES**
+
+**`getAllSingleTransactionPlans` removed.** Use `flattenTransactionPlan` instead.
+
+```diff
+- const singlePlans = getAllSingleTransactionPlans(transactionPlan);
++ const singlePlans = flattenTransactionPlan(transactionPlan);
+```

--- a/packages/instruction-plans/src/__tests__/transaction-plan-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-test.ts
@@ -8,7 +8,6 @@ import {
     everyTransactionPlan,
     findTransactionPlan,
     flattenTransactionPlan,
-    getAllSingleTransactionPlans,
     isNonDivisibleSequentialTransactionPlan,
     isParallelTransactionPlan,
     isSequentialTransactionPlan,
@@ -283,49 +282,6 @@ describe('assertIsParallelTransactionPlan', () => {
         expect(() => assertIsParallelTransactionPlan(nonDivisibleSequentialTransactionPlan([]))).toThrow(
             'Unexpected transaction plan. Expected parallel plan, got sequential plan.',
         );
-    });
-});
-
-describe('getAllSingleTransactionPlans', () => {
-    it('returns the single transaction plan when given a SingleTransactionPlan', () => {
-        const messageA = createMessage('A');
-        const plan = singleTransactionPlan(messageA);
-        const result = getAllSingleTransactionPlans(plan);
-        expect(result).toEqual([plan]);
-    });
-    it('returns all single transaction plans from a ParallelTransactionPlan', () => {
-        const messageA = createMessage('A');
-        const messageB = createMessage('B');
-        const plan = parallelTransactionPlan([messageA, messageB]);
-        const result = getAllSingleTransactionPlans(plan);
-        expect(result).toEqual([singleTransactionPlan(messageA), singleTransactionPlan(messageB)]);
-    });
-    it('returns all single transaction plans from a SequentialTransactionPlan', () => {
-        const messageA = createMessage('A');
-        const messageB = createMessage('B');
-        const plan = sequentialTransactionPlan([messageA, messageB]);
-        const result = getAllSingleTransactionPlans(plan);
-        expect(result).toEqual([singleTransactionPlan(messageA), singleTransactionPlan(messageB)]);
-    });
-    it('returns all single transaction plans from a complex nested structure', () => {
-        const messageA = createMessage('A');
-        const messageB = createMessage('B');
-        const messageC = createMessage('C');
-        const messageD = createMessage('D');
-        const messageE = createMessage('E');
-        const plan = parallelTransactionPlan([
-            sequentialTransactionPlan([messageA, messageB]),
-            nonDivisibleSequentialTransactionPlan([messageC, messageD]),
-            messageE,
-        ]);
-        const result = getAllSingleTransactionPlans(plan);
-        expect(result).toEqual([
-            singleTransactionPlan(messageA),
-            singleTransactionPlan(messageB),
-            singleTransactionPlan(messageC),
-            singleTransactionPlan(messageD),
-            singleTransactionPlan(messageE),
-        ]);
     });
 });
 

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-typetest.ts
@@ -6,7 +6,6 @@ import {
     assertIsSequentialTransactionPlan,
     assertIsSingleTransactionPlan,
     flattenTransactionPlan,
-    getAllSingleTransactionPlans,
     isNonDivisibleSequentialTransactionPlan,
     isParallelTransactionPlan,
     isSequentialTransactionPlan,
@@ -79,26 +78,6 @@ const messageC = null as unknown as TransactionMessage & TransactionMessageWithF
     {
         const plan = singleTransactionPlan(messageA);
         plan satisfies SingleTransactionPlan;
-    }
-}
-
-// [DESCRIBE] getAllSingleTransactionPlans
-{
-    // It extracts single transaction plans from a simple plan.
-    {
-        const plan = singleTransactionPlan(messageA);
-        const singlePlans = getAllSingleTransactionPlans(plan);
-        singlePlans satisfies SingleTransactionPlan[];
-    }
-
-    // It extracts single transaction plans from a nested plan.
-    {
-        const plan = parallelTransactionPlan([
-            sequentialTransactionPlan([messageA, messageB]),
-            nonDivisibleSequentialTransactionPlan([messageC]),
-        ]);
-        const singlePlans = getAllSingleTransactionPlans(plan);
-        singlePlans satisfies SingleTransactionPlan[];
     }
 }
 

--- a/packages/instruction-plans/src/transaction-plan.ts
+++ b/packages/instruction-plans/src/transaction-plan.ts
@@ -458,11 +458,6 @@ export function assertIsParallelTransactionPlan(plan: TransactionPlan): asserts 
 }
 
 /**
- * @deprecated Use {@link flattenTransactionPlan} instead.
- */
-export const getAllSingleTransactionPlans = flattenTransactionPlan;
-
-/**
  * Retrieves all individual {@link SingleTransactionPlan} instances from a transaction plan tree.
  *
  * This function recursively traverses any nested structure of transaction plans and extracts


### PR DESCRIPTION
This `getAllSingleTransactionPlans` function was deprecated in version `5.5.0` in favour of the new `flattenTransactionPlan` (consistent with the other `flattenX` helpers).

This PR removes the deprecated `getAllSingleTransactionPlans` function as we are about to publish Kit v6.