### PR TITLE
Make canary snapshot build use cache + concurrency

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -93,8 +93,8 @@ jobs:
         id: start-test-validator
         uses: ./.github/workflows/actions/setup-validator
 
-      - name: Run Build Step (force)
-        run: pnpm turbo build --force=true
+      - name: Run Build Step
+        run: pnpm build
 
       - name: Publish Canary Releases
         run: |


### PR DESCRIPTION
#### Problem

The publish-packages workflow is really slow: https://github.com/anza-xyz/kit/actions/runs/21639102099 (31 minutes)

The slow job is `[build-and-publish-snapshots-to-npm](https://github.com/anza-xyz/kit/actions/runs/21639102099/job/62376635824#logs)`. This gets us a canary version published, which is very useful.

`build-and-publish-to-npm` is faster, but in practice is a no-op on most builds because it's only responsible for publishing when we merge a changesets PR, ie when we publish a new version for real. 

Snapshot is slow because:

- It uses `--force`, ie it won't use turborepo caching
- It uses `pnpm turbo build`, while the other job uses `pnpm build`. This means it runs with the default concurrency, rather than the oddly specific 95.84% concurrency that `pnpm build` defaults to.

#### Summary of Changes

- Now uses `pnpm build` so it has the same concurrency as the rest of the CI builds
- I've removed `--force` for the canary packages. It seems overkill, and not using force reflects what we do in PRs. If something fails with `--force` (ie there's a turborepo caching issue) then we will still catch it with `build-and-publish-to-npm`. It's ok to publish a broken canary in the worst case, and better to get a canary faster when we want one.

We could choose not to remove `--force` and would still (I think) get most of the speed up, as it should run as fast as `build-and-publish-to-npm` (about 10 minutes). But without `--force` it should be very fast as anything merged from a PR will have everything cached.
