### PR TITLE
Simplify the canary publish job

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -99,11 +99,8 @@ jobs:
       - name: Publish Canary Releases
         run: |
           if [ -n "$(find .changeset -name '*.md')" ]; then
-            find packages/* -maxdepth 0 -type d -print0 | \
-              xargs -t0 -n 1 -I {} \
-                sh -c 'cd {} && pnpm pkg delete devDependencies'
             pnpm changeset version --snapshot canary
-            pnpm turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-1}
+            pnpm changeset:publish
           else
             echo "No changesets found, skipping canary publish"
           fi


### PR DESCRIPTION
#### Problem

The canary publish job is still painfully slow

The reason is that it does:

1. build, this is now fast, using turborepo + concurrency
2. surgically delete `devDependencies` from each package
3. `pnpm turbo publish-packages --concurrency=1`. In turbo `publish-packages` requires build steps to run first, sensibly. I think the problem is that deleting `devDependencies` busts the cache, so that nice fast build we just did is partly ignored. And we now have `concurrency=1` for a bunch of build jobs. 

#### Summary of Changes

- I've removed the manual delete of `devDependencies` which busts the build cache. We do this in `prepublishOnly` in every package, which is part of the `publish-packages` script for each package. The manual delete is only being done for canary, in the real publish job we rely on `publish-packages` to do it for us. We can do the same here.
  - I'm also not convinced we need to delete `devDependencies` at all before publishing, but that's a separate change/discussion
- I've changed `pnpm turbo publish-packages --concurrency=${TURBO_CONCURRENCY:-1}` to `pnpm changeset:publish`, which is implemented as the same:
https://github.com/anza-xyz/kit/blob/e5e8a2484e25263043ace9670cf1d87f8be473c3/package.json#L6
This again matches what we do in the real publish job. I think it makes sense to use the same publish script in case we change it in future. 

This means that the difference between the publish for canary and real are now:
- Real: uses changeset/action, runs `pnpm changeset:publish` to publish if a changeset Version Packages PR has been merged
- Canary:
  - Only runs if there are changesets, so we don't tag an unmodified version as canary
  - Uses `pnpm changeset version --snapshot canary` to change the versions before publishing
  - Then uses the same `pnpm changeset:publish` to publish these versions tagged `canary`

This should now make publishing canary builds fast, because `pnpm build` will use the cache + concurrency, and `turbo publish-packages` should use that build. 
