### PR TITLE
ci: use github app generated token for dependabot pipeline

### DIFF
--- a/.github/workflows/update-docs-lockfile.yml
+++ b/.github/workflows/update-docs-lockfile.yml
@@ -11,12 +11,30 @@ permissions:
 jobs:
   update-lockfile:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-      - name: Checkout PR branch
-        uses: actions/checkout@v4
+      - uses: actions/create-github-app-token@v2
+        id: app-token
         with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Set git config
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "github-actions"
+          git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf https://github.com/
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.pull_request.head.ref }}
+          persist-credentials: false
 
       - name: Install Dependencies
         uses: ./.github/workflows/actions/install-dependencies
@@ -31,8 +49,6 @@ jobs:
           if git diff --cached --quiet; then
             echo "No lockfile changes to commit"
           else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
             git commit -m "Update docs lockfile"
             git push
           fi


### PR DESCRIPTION
#### Problem

let's use github app generated token instead of PAT for dependabot's PR

#### Summary of Changes

update
