### PR TITLE
Add typetests that use combinations of transaction message functions

### DIFF
--- a/packages/transaction-messages/src/__typetests__/scenarios/message-modifications-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/scenarios/message-modifications-typetest.ts
@@ -1,0 +1,391 @@
+import { Address } from '@solana/addresses';
+import { pipe } from '@solana/functional';
+import { Instruction } from '@solana/instructions';
+
+import {
+    appendTransactionMessageInstruction,
+    appendTransactionMessageInstructions,
+    decompileTransactionMessage,
+    prependTransactionMessageInstruction,
+    prependTransactionMessageInstructions,
+} from '../..';
+import { setTransactionMessageLifetimeUsingBlockhash, TransactionMessageWithBlockhashLifetime } from '../../blockhash';
+import { compressTransactionMessageUsingAddressLookupTables } from '../../compress-transaction-message';
+import { createTransactionMessage } from '../../create-transaction-message';
+import {
+    setTransactionMessageLifetimeUsingDurableNonce,
+    TransactionMessageWithDurableNonceLifetime,
+} from '../../durable-nonce';
+import { setTransactionMessageFeePayer, TransactionMessageWithFeePayer } from '../../fee-payer';
+import { TransactionMessage, TransactionVersion } from '../../transaction-message';
+
+const blockhashLifetime = null as unknown as Parameters<typeof setTransactionMessageLifetimeUsingBlockhash>[0];
+const durableNonceLifetime = null as unknown as Parameters<typeof setTransactionMessageLifetimeUsingDurableNonce>[0];
+const addressesByLookupTableAddress = null as unknown as Parameters<
+    typeof compressTransactionMessageUsingAddressLookupTables
+>[1];
+const compiledTransactionMessage = null as unknown as Parameters<typeof decompileTransactionMessage>[0];
+const feePayer = null as unknown as Address;
+const instruction = null as unknown as Instruction;
+
+// [DESCRIBE] setTransactionMessageLifetimeUsingBlockhash
+{
+    // It sets the blockhash after `createTransactionMessage`
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            // @ts-expect-error FIXME
+            m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+        );
+        message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
+    }
+
+    // It sets the blockhash after other transformations
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => setTransactionMessageFeePayer(null as unknown as Address, m),
+            // @ts-expect-error FIXME
+            m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+        );
+        // @ts-expect-error FIXME
+        message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime & TransactionMessageWithFeePayer;
+    }
+
+    // It sets the blockhash after a durable nonce lifetime
+    {
+        const messageWithDurableNonce = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
+        );
+        messageWithDurableNonce satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+
+        const messageWithBlockhash = setTransactionMessageLifetimeUsingBlockhash(
+            blockhashLifetime,
+            // @ts-expect-error FIXME
+            messageWithDurableNonce,
+        );
+        messageWithBlockhash satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
+        // @ts-expect-error It should strip the durable nonce lifetime
+        messageWithBlockhash satisfies TransactionMessageWithDurableNonceLifetime;
+    }
+
+    // It sets the blockhash after compressing a transaction message
+    {
+        const message = pipe(
+            createTransactionMessage({ version: 0 }), // only supported for v0
+            m => compressTransactionMessageUsingAddressLookupTables(m, addressesByLookupTableAddress),
+        );
+        const messageWithBlockhash = setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, message);
+        messageWithBlockhash satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
+    }
+
+    // It sets the blockhash after decompiling a message
+    {
+        const message = pipe(decompileTransactionMessage(compiledTransactionMessage), m =>
+            setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+        );
+        message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
+    }
+
+    // It sets the blockhash with instructions
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => appendTransactionMessageInstruction(instruction, m),
+            m => prependTransactionMessageInstruction(instruction, m),
+            m => appendTransactionMessageInstructions([instruction], m),
+            m => prependTransactionMessageInstructions([instruction], m),
+            // @ts-expect-error FIXME
+            m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+        );
+        message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
+    }
+
+    // It sets the blockhash multiple times
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            // @ts-expect-error FIXME
+            m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+            m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+            m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+        );
+        message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
+    }
+}
+
+// [DESCRIBE] setTransactionMessageLifetimeUsingDurableNonce
+{
+    // It sets the durable nonce after `createTransactionMessage`
+    {
+        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+            setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
+        );
+        message satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+    }
+
+    // It sets the durable nonce after other transformations
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => setTransactionMessageFeePayer(null as unknown as Address, m),
+            m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
+        );
+        message satisfies TransactionMessage &
+            TransactionMessageWithDurableNonceLifetime &
+            TransactionMessageWithFeePayer;
+    }
+
+    // It sets the durable nonce after a blockhash lifetime
+    {
+        const messageWithBlockhash = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            // @ts-expect-error FIXME
+            m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+        );
+        messageWithBlockhash satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
+
+        const messageWithDurableNonce = setTransactionMessageLifetimeUsingDurableNonce(
+            durableNonceLifetime,
+            messageWithBlockhash,
+        );
+        messageWithDurableNonce satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+        // FIXME should be @ts-expect-error It should strip the blockhash lifetime
+        messageWithDurableNonce satisfies TransactionMessageWithBlockhashLifetime;
+    }
+
+    // It sets the durable nonce after compressing a transaction message
+    {
+        const message = pipe(
+            createTransactionMessage({ version: 0 }), // only supported for v0
+            m => compressTransactionMessageUsingAddressLookupTables(m, addressesByLookupTableAddress),
+        );
+        const messageWithDurableNonce = setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, message);
+        messageWithDurableNonce satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+    }
+
+    // It sets the durable nonce after decompiling a message
+    {
+        const message = pipe(decompileTransactionMessage(compiledTransactionMessage), m =>
+            setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
+        );
+        message satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+    }
+
+    // It sets the durable nonce with instructions
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => appendTransactionMessageInstruction(instruction, m),
+            m => prependTransactionMessageInstruction(instruction, m),
+            m => appendTransactionMessageInstructions([instruction], m),
+            m => prependTransactionMessageInstructions([instruction], m),
+            m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
+        );
+        message satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+    }
+
+    // It sets the durable nonce multiple times
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
+            m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
+            m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
+        );
+        message satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+    }
+}
+
+// [DESCRIBE] compressTransactionMessageUsingAddressLookupTables
+{
+    // It compresses after `createTransactionMessage`
+    {
+        const message = createTransactionMessage({ version: 0 }); // only supported for v0
+        const compressedMessage = compressTransactionMessageUsingAddressLookupTables(
+            message,
+            addressesByLookupTableAddress,
+        );
+        compressedMessage satisfies TransactionMessage & { version: 0 };
+    }
+
+    // It cannot be used with legacy messages from `createTransactionMessage`
+    {
+        const message = createTransactionMessage({ version: 'legacy' });
+        compressTransactionMessageUsingAddressLookupTables(
+            // @ts-expect-error Only v0 messages are accepted.
+            message,
+            addressesByLookupTableAddress,
+        );
+    }
+
+    // It compresses after other transformations
+    {
+        const message = pipe(
+            createTransactionMessage({ version: 0 }), // only supported for v0
+            m => setTransactionMessageFeePayer(null as unknown as Address, m),
+            m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+            m => appendTransactionMessageInstruction(instruction, m),
+            m => prependTransactionMessageInstruction(instruction, m),
+            m => appendTransactionMessageInstructions([instruction], m),
+            m => prependTransactionMessageInstructions([instruction], m),
+        );
+        const compressedMessage = compressTransactionMessageUsingAddressLookupTables(
+            message,
+            addressesByLookupTableAddress,
+        );
+        compressedMessage satisfies TransactionMessage & { version: 0 };
+        compressedMessage satisfies TransactionMessageWithBlockhashLifetime;
+        compressedMessage satisfies TransactionMessageWithFeePayer;
+    }
+
+    // It compresses after decompiling a message
+    {
+        const message = decompileTransactionMessage(compiledTransactionMessage);
+        if (message.version === 0) {
+            const compressedMessage = compressTransactionMessageUsingAddressLookupTables(
+                message,
+                addressesByLookupTableAddress,
+            );
+            compressedMessage satisfies TransactionMessage & { version: 0 };
+        }
+    }
+}
+
+// [DESCRIBE] setTransactionMessageFeePayer
+{
+    // It sets the fee payer after `createTransactionMessage`
+    {
+        const message = createTransactionMessage({ version: null as unknown as TransactionVersion });
+        const newMessage = setTransactionMessageFeePayer(feePayer, message);
+        newMessage satisfies TransactionMessage & TransactionMessageWithFeePayer;
+    }
+
+    // It sets the fee payer after setting a blockhash lifetime
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            // @ts-expect-error FIXME
+            m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+        );
+        const newMessage = setTransactionMessageFeePayer(feePayer, message);
+        newMessage satisfies TransactionMessage &
+            TransactionMessageWithBlockhashLifetime &
+            TransactionMessageWithFeePayer;
+    }
+
+    // It sets the fee payer after setting a durable nonce lifetime
+    {
+        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+            setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
+        );
+        const newMessage = setTransactionMessageFeePayer(feePayer, message);
+        newMessage satisfies TransactionMessage &
+            TransactionMessageWithDurableNonceLifetime &
+            TransactionMessageWithFeePayer;
+    }
+
+    // It sets the fee payer multiple times
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => setTransactionMessageFeePayer(feePayer, m),
+            m => setTransactionMessageFeePayer(feePayer, m),
+            m => setTransactionMessageFeePayer(feePayer, m),
+        );
+        message satisfies TransactionMessage & TransactionMessageWithFeePayer;
+    }
+}
+
+// [DESCRIBE] instructions functions
+{
+    // It can call instruction functions after `createTransactionMessage`
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => appendTransactionMessageInstruction(instruction, m),
+            m => prependTransactionMessageInstruction(instruction, m),
+            m => appendTransactionMessageInstructions([instruction], m),
+            m => prependTransactionMessageInstructions([instruction], m),
+        );
+        message satisfies TransactionMessage;
+    }
+
+    // It can call instruction functions after setting a blockhash lifetime
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            // @ts-expect-error FIXME
+            m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+            m => appendTransactionMessageInstruction(instruction, m),
+            m => prependTransactionMessageInstruction(instruction, m),
+            m => appendTransactionMessageInstructions([instruction], m),
+            m => prependTransactionMessageInstructions([instruction], m),
+        );
+        message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
+    }
+
+    // It can call append instruction functions after setting a durable nonce lifetime
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
+            m => appendTransactionMessageInstruction(instruction, m),
+            m => appendTransactionMessageInstructions([instruction], m),
+        );
+        message satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
+    }
+
+    // It can call prepend instruction functions after setting a durable nonce lifetime, but
+    // the durable nonce lifetime is stripped because the first instruction must be the AdvanceNonceAccount instruction
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
+            m => prependTransactionMessageInstruction(instruction, m),
+            m => prependTransactionMessageInstructions([instruction], m),
+        );
+        message satisfies TransactionMessage;
+        // @ts-expect-error It should strip the durable nonce lifetime
+        message satisfies TransactionMessageWithDurableNonceLifetime;
+    }
+
+    // It can call instruction functions after setting a fee payer
+    {
+        const message = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => setTransactionMessageFeePayer(feePayer, m),
+            m => appendTransactionMessageInstruction(instruction, m),
+            m => prependTransactionMessageInstruction(instruction, m),
+            m => appendTransactionMessageInstructions([instruction], m),
+            m => prependTransactionMessageInstructions([instruction], m),
+        );
+        message satisfies TransactionMessage & TransactionMessageWithFeePayer;
+    }
+
+    // It can call instruction functions after compressing a transaction message
+    {
+        const message = pipe(
+            createTransactionMessage({ version: 0 }), // only supported for v0
+            m => compressTransactionMessageUsingAddressLookupTables(m, addressesByLookupTableAddress),
+            m => appendTransactionMessageInstruction(instruction, m),
+            m => prependTransactionMessageInstruction(instruction, m),
+            m => appendTransactionMessageInstructions([instruction], m),
+            m => prependTransactionMessageInstructions([instruction], m),
+        );
+        message satisfies TransactionMessage & { version: 0 };
+    }
+
+    // It can call instruction functions after decompiling a message
+    {
+        const message = pipe(
+            decompileTransactionMessage(compiledTransactionMessage),
+            m => appendTransactionMessageInstruction(instruction, m),
+            m => prependTransactionMessageInstruction(instruction, m),
+            m => appendTransactionMessageInstructions([instruction], m),
+            m => prependTransactionMessageInstructions([instruction], m),
+        );
+        message satisfies TransactionMessage;
+    }
+}


### PR DESCRIPTION
#### Problem

I found a bug in the types of our set lifetime functions, exposed by the change from `BaseTransactionMessage` to `TransactionMessage`.

With Kit v6, code like this has a type error:

```ts
const message = pipe(
  createTransactionMessage({ version: (config.transactionVersion) }),
  (m) => setTransactionMessageLifetimeUsingBlockhash(lifetime, m)
)
```

The root cause is the typing of `setTransactionMessageLifetimeUsingBlockhash`. But this escaped our notice because:

- Our `examples/` do not use a configurable transaction version, they use `{ version: 0 }`. This does not trigger the issue
- Our typetests for `setTransactionMessageLifetimeUsingBlockhash` start from a `null as unknown as TransactionMessage`. This does not capture the complexity of the type of `createTransactionMessage(null as unknown as TransactionVersion)` which is effectively how the above code is typed.

#### Summary of Changes

This PR adds `__typetests__/scenarios/message-modifications-typetest.ts` for the transaction-messages package. This is somewhat similar to the `__typetests__/scenarios/transaction-message-decompile-modify-typetest.ts` in the Kit package, except it is only concerned with combinations of functions from `transaction-messages`.

This new test file contains many combinations of functions that modify transaction-messages that we expect to work together.

For the sake of documentation, this PR only adds these tests and does not fix them yet. Therefore there are a number of `@ts-expect-error FIXME` comments, addressed in the following PR.

These tests, like all our typetests, will also function as protection against future regressions. 