### PR TITLE
Fix issues in types of set lifetime functions

### DIFF
--- a/.changeset/wild-ends-argue.md
+++ b/.changeset/wild-ends-argue.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-messages': patch
+---
+
+Fix bugs in types of `setTransactionMessageLifetimeUsingBlockhash` and `setTransactionMessageLifetimeUsingDurableNonce`

--- a/packages/transaction-messages/src/__typetests__/scenarios/message-modifications-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/scenarios/message-modifications-typetest.ts
@@ -32,10 +32,8 @@ const instruction = null as unknown as Instruction;
 {
     // It sets the blockhash after `createTransactionMessage`
     {
-        const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
-            // @ts-expect-error FIXME
-            m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+            setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
         message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
     }
@@ -45,10 +43,8 @@ const instruction = null as unknown as Instruction;
         const message = pipe(
             createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageFeePayer(null as unknown as Address, m),
-            // @ts-expect-error FIXME
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
-        // @ts-expect-error FIXME
         message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime & TransactionMessageWithFeePayer;
     }
 
@@ -62,7 +58,6 @@ const instruction = null as unknown as Instruction;
 
         const messageWithBlockhash = setTransactionMessageLifetimeUsingBlockhash(
             blockhashLifetime,
-            // @ts-expect-error FIXME
             messageWithDurableNonce,
         );
         messageWithBlockhash satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
@@ -96,7 +91,6 @@ const instruction = null as unknown as Instruction;
             m => prependTransactionMessageInstruction(instruction, m),
             m => appendTransactionMessageInstructions([instruction], m),
             m => prependTransactionMessageInstructions([instruction], m),
-            // @ts-expect-error FIXME
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
         message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
@@ -106,7 +100,6 @@ const instruction = null as unknown as Instruction;
     {
         const message = pipe(
             createTransactionMessage({ version: null as unknown as TransactionVersion }),
-            // @ts-expect-error FIXME
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
@@ -141,7 +134,6 @@ const instruction = null as unknown as Instruction;
     {
         const messageWithBlockhash = pipe(
             createTransactionMessage({ version: null as unknown as TransactionVersion }),
-            // @ts-expect-error FIXME
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
         messageWithBlockhash satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
@@ -151,7 +143,7 @@ const instruction = null as unknown as Instruction;
             messageWithBlockhash,
         );
         messageWithDurableNonce satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
-        // FIXME should be @ts-expect-error It should strip the blockhash lifetime
+        // @ts-expect-error It should strip the blockhash lifetime
         messageWithDurableNonce satisfies TransactionMessageWithBlockhashLifetime;
     }
 
@@ -264,10 +256,8 @@ const instruction = null as unknown as Instruction;
 
     // It sets the fee payer after setting a blockhash lifetime
     {
-        const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
-            // @ts-expect-error FIXME
-            m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
+        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+            setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
         const newMessage = setTransactionMessageFeePayer(feePayer, message);
         newMessage satisfies TransactionMessage &
@@ -316,7 +306,6 @@ const instruction = null as unknown as Instruction;
     {
         const message = pipe(
             createTransactionMessage({ version: null as unknown as TransactionVersion }),
-            // @ts-expect-error FIXME
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
             m => appendTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstruction(instruction, m),

--- a/packages/transaction-messages/src/blockhash.ts
+++ b/packages/transaction-messages/src/blockhash.ts
@@ -115,7 +115,8 @@ export function assertIsTransactionMessageWithBlockhashLifetime(
  * ```
  */
 export function setTransactionMessageLifetimeUsingBlockhash<
-    TTransactionMessage extends Partial<TransactionMessageWithLifetime> & TransactionMessage,
+    TTransactionMessage extends Partial<Pick<TransactionMessageWithLifetime, 'lifetimeConstraint'>> &
+        TransactionMessage,
 >(
     blockhashLifetimeConstraint: BlockhashLifetimeConstraint,
     transactionMessage: TTransactionMessage,

--- a/packages/transaction-messages/src/durable-nonce.ts
+++ b/packages/transaction-messages/src/durable-nonce.ts
@@ -258,9 +258,11 @@ type SetTransactionMessageWithDurableNonceLifetime<
               ? TTransactionMessage
               : ExcludeTransactionMessageWithinSizeLimit<TTransactionMessage>,
           // 2. Remove the instructions array as we are going to replace it with a new one.
-          'instructions'
+          | 'instructions'
+          // 3. Remove the existing lifetime constraint as we are going to replace it with a new one.
+          | 'lifetimeConstraint'
       > & {
-          // 3. Replace or prepend the first instruction with the advance nonce account instruction.
+          // 4. Replace or prepend the first instruction with the advance nonce account instruction.
           readonly instructions: TTransactionMessage['instructions'] extends readonly [
               AdvanceNonceAccountInstruction,
               ...infer TTail extends readonly Instruction[],
@@ -270,7 +272,7 @@ type SetTransactionMessageWithDurableNonceLifetime<
                     AdvanceNonceAccountInstruction<TNonceAccountAddress, TNonceAuthorityAddress>,
                     ...TTransactionMessage['instructions'],
                 ];
-          // 4. Set the lifetime constraint to the nonce value.
+          // 5. Set the lifetime constraint to the nonce value.
           readonly lifetimeConstraint: NonceLifetimeConstraint<TNonceValue>;
       }
     : never;


### PR DESCRIPTION
#### Problem

Some of the tests in the previous PR that we would expect to work fail, because of issues with the typing of `setTransactionMessageLifetimeUsingBlockhash` and `setTransactionMessageLifetimeUsingDurableNonce`

#### Summary of Changes

- The type of the input for `setTransactionMessageLifetimeUsingBlockhash` is modified to only use the `lifetimeConstraint` of the `TransactionWithLifetime` function. This fixes a bug where passing known-empty transactions with an unknown version would fail, as identified by the new tests.
- `setTransactionMessageLifetimeUsingDurableNonce` now strips the existing `lifetimeConstraint` before attaching the new one. This fixes a bug where if we called it on a transaction with a blockhash, the resulting transaction message would satisfy both `TransactionMessageWithBlockhash` and `TransactionMessageWithDurableNonce`. 
- Remove all the `FIXME` errors in the new tests, these now work correctly. 