### PR TITLE
Add a typetest for TransactionMessageWithSigners

### DIFF
--- a/packages/kit/src/__typetests__/scenarios/transaction-signers-typetest.ts
+++ b/packages/kit/src/__typetests__/scenarios/transaction-signers-typetest.ts
@@ -1,0 +1,107 @@
+import { Address } from '@solana/addresses';
+import { pipe } from '@solana/functional';
+import { Instruction } from '@solana/instructions';
+import {
+    InstructionWithSigners,
+    setTransactionMessageFeePayerSigner,
+    TransactionMessageWithSigners,
+    TransactionSigner,
+} from '@solana/signers';
+import {
+    appendTransactionMessageInstructions,
+    createTransactionMessage,
+    setTransactionMessageFeePayer,
+    TransactionMessage,
+    TransactionMessageWithFeePayer,
+    TransactionVersion,
+} from '@solana/transaction-messages';
+
+// [DESCRIBE] TransactionMessageWithSigners type
+{
+    // It is satisfied by a transaction message from `createTransactionMessage`
+    {
+        const result = createTransactionMessage({ version: null as unknown as TransactionVersion });
+        result satisfies TransactionMessage & TransactionMessageWithSigners;
+    }
+
+    // It is satisfied after adding an address fee payer
+    {
+        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+            setTransactionMessageFeePayer(null as unknown as Address, m),
+        );
+        result satisfies TransactionMessage & TransactionMessageWithFeePayer;
+        result satisfies TransactionMessageWithSigners;
+        // @ts-expect-error FIXME
+        result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
+    }
+
+    // It is satisfied after adding a signer fee payer
+    {
+        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+            setTransactionMessageFeePayerSigner(null as unknown as TransactionSigner, m),
+        );
+        result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
+    }
+
+    // It is satisfied after appending instructions
+    {
+        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+            appendTransactionMessageInstructions(null as unknown as Instruction[], m),
+        );
+        result satisfies TransactionMessage & TransactionMessageWithSigners;
+    }
+
+    // It is satisfied after appending instructions with signers
+    {
+        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+            appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
+        );
+        result satisfies TransactionMessage & TransactionMessageWithSigners;
+    }
+
+    // It is satisfied after adding a fee payer and instructions
+    {
+        const result = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => setTransactionMessageFeePayer(null as unknown as Address, m),
+            m => appendTransactionMessageInstructions(null as unknown as Instruction[], m),
+        );
+        result satisfies TransactionMessage & TransactionMessageWithFeePayer;
+        result satisfies TransactionMessageWithSigners;
+        // @ts-expect-error FIXME
+        result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
+    }
+
+    // It is satisfied after adding a signer fee payer and instructions
+    {
+        const result = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => setTransactionMessageFeePayerSigner(null as unknown as TransactionSigner, m),
+            m => appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
+        );
+        result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
+    }
+
+    // It is satisfied after adding a fee payer and instructions with signers
+    {
+        const result = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => setTransactionMessageFeePayer(null as unknown as Address, m),
+            m => appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
+        );
+        result satisfies TransactionMessage & TransactionMessageWithFeePayer;
+        result satisfies TransactionMessageWithSigners;
+        // @ts-expect-error FIXME
+        result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
+    }
+
+    // It is satisfied after adding a signer fee payer and instructions with signers
+    {
+        const result = pipe(
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            m => setTransactionMessageFeePayerSigner(null as unknown as TransactionSigner, m),
+            m => appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
+        );
+        result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
+    }
+}


### PR DESCRIPTION
#### Problem

This is a similar issue with Kit v6 and a typescript limitation with more complex/branching `TransactionMessage` types.

In Kit 6, the type of `TransactionMessageWithSigners` does not intersect correctly with other `TransactionMessage` types:

```ts
{
    const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
        setTransactionMessageFeePayer(null as unknown as Address, m),
    );
    result satisfies TransactionMessage & TransactionMessageWithFeePayer;
    result satisfies TransactionMessageWithSigners;
    result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
}
```

#### Summary of Changes

Again this was not caught by our current testing. This PR adds a new scenario typetest in the Kit package, because it includes functions/types from both `transaction-messages` and `signers`. This demonstrates the current issue and serves as a regression test for future. 
