### PR TITLE
Improve the type of `TransactionMessageWithSigners`

### DIFF
--- a/.changeset/social-tires-lie.md
+++ b/.changeset/social-tires-lie.md
@@ -1,0 +1,7 @@
+---
+'@solana/transaction-messages': patch
+'@solana/signers': patch
+'@solana/kit': patch
+---
+
+Fix a bug in the type of `TransactionMessageWithSigners`

--- a/packages/kit/src/__typetests__/scenarios/transaction-signers-typetest.ts
+++ b/packages/kit/src/__typetests__/scenarios/transaction-signers-typetest.ts
@@ -29,9 +29,6 @@ import {
         const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
             setTransactionMessageFeePayer(null as unknown as Address, m),
         );
-        result satisfies TransactionMessage & TransactionMessageWithFeePayer;
-        result satisfies TransactionMessageWithSigners;
-        // @ts-expect-error FIXME
         result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
     }
 
@@ -66,9 +63,6 @@ import {
             m => setTransactionMessageFeePayer(null as unknown as Address, m),
             m => appendTransactionMessageInstructions(null as unknown as Instruction[], m),
         );
-        result satisfies TransactionMessage & TransactionMessageWithFeePayer;
-        result satisfies TransactionMessageWithSigners;
-        // @ts-expect-error FIXME
         result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
     }
 
@@ -89,9 +83,6 @@ import {
             m => setTransactionMessageFeePayer(null as unknown as Address, m),
             m => appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
         );
-        result satisfies TransactionMessage & TransactionMessageWithFeePayer;
-        result satisfies TransactionMessageWithSigners;
-        // @ts-expect-error FIXME
         result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
     }
 

--- a/packages/signers/src/account-signer-meta.ts
+++ b/packages/signers/src/account-signer-meta.ts
@@ -114,7 +114,9 @@ export type TransactionMessageWithSigners<
     TAddress extends string = string,
     TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
     TAccounts extends readonly AccountMetaWithSigner<TSigner>[] = readonly AccountMetaWithSigner<TSigner>[],
-> = Partial<TransactionMessageWithFeePayer<TAddress> | TransactionMessageWithFeePayerSigner<TAddress, TSigner>> &
+> = Partial<
+    Pick<TransactionMessageWithFeePayer<TAddress> | TransactionMessageWithFeePayerSigner<TAddress, TSigner>, 'feePayer'>
+> &
     Readonly<{ instructions: readonly (Instruction & InstructionWithSigners<TSigner, TAccounts>)[] }>;
 
 /**


### PR DESCRIPTION
#### Summary of Changes

This PR makes a similar change to the type of `TransactionMessageWithSigners` to the change made to the lifetime functions earlier in the stack.

It updates the typetest to remove all the `@ts-expect-error` lines and simplify assertions where the intersection now works as expected. 
