### PR TITLE
Add `parseInstructionPlanInput` helper

### DIFF
--- a/.changeset/slimy-jobs-attend.md
+++ b/.changeset/slimy-jobs-attend.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Add `parseInstructionPlanInput` helper that converts flexible inputs (single instruction, instruction plan, or array) into an `InstructionPlan`

--- a/packages/instruction-plans/src/__tests__/instruction-plan-input-test.ts
+++ b/packages/instruction-plans/src/__tests__/instruction-plan-input-test.ts
@@ -1,0 +1,88 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import { Address } from '@solana/addresses';
+import { Instruction } from '@solana/instructions';
+
+import {
+    parallelInstructionPlan,
+    parseInstructionPlanInput,
+    sequentialInstructionPlan,
+    singleInstructionPlan,
+} from '../index';
+
+function createInstruction<TId extends string>(id: TId): Instruction & { id: TId } {
+    return { id, programAddress: '11111111111111111111111111111111' as Address };
+}
+
+describe('parseInstructionPlanInput', () => {
+    it('returns an InstructionPlan from a single instruction', () => {
+        const plan = parseInstructionPlanInput(createInstruction('A'));
+        expect(plan).toStrictEqual(singleInstructionPlan(createInstruction('A')));
+    });
+    it('returns a provided InstructionPlan as-is', () => {
+        const input = sequentialInstructionPlan([
+            createInstruction('A'),
+            parallelInstructionPlan([createInstruction('B'), createInstruction('C')]),
+        ]);
+        const plan = parseInstructionPlanInput(input);
+        expect(plan).toBe(input);
+    });
+    it('returns an empty SequentialInstructionPlan from an empty array', () => {
+        const plan = parseInstructionPlanInput([]);
+        expect(plan).toStrictEqual(sequentialInstructionPlan([]));
+    });
+    it('returns a SingleInstructionPlan from an array of only one Instruction', () => {
+        const plan = parseInstructionPlanInput([createInstruction('A')]);
+        expect(plan).toStrictEqual(singleInstructionPlan(createInstruction('A')));
+    });
+    it('returns a provided InstructionPlan as-is when it is the only item in the provided array', () => {
+        const input = sequentialInstructionPlan([
+            createInstruction('A'),
+            parallelInstructionPlan([createInstruction('B'), createInstruction('C')]),
+        ]);
+        const plan = parseInstructionPlanInput([input]);
+        expect(plan).toBe(input);
+    });
+    it('returns a SequentialInstructionPlan from an array of instructions', () => {
+        const plan = parseInstructionPlanInput([createInstruction('A'), createInstruction('B')]);
+        expect(plan).toStrictEqual(sequentialInstructionPlan([createInstruction('A'), createInstruction('B')]));
+    });
+    it('returns a SequentialInstructionPlan from an array of InstructionPlans', () => {
+        const plan = parseInstructionPlanInput([
+            sequentialInstructionPlan([createInstruction('A'), createInstruction('B')]),
+            parallelInstructionPlan([createInstruction('C'), createInstruction('D')]),
+        ]);
+        expect(plan).toStrictEqual(
+            sequentialInstructionPlan([
+                sequentialInstructionPlan([createInstruction('A'), createInstruction('B')]),
+                parallelInstructionPlan([createInstruction('C'), createInstruction('D')]),
+            ]),
+        );
+    });
+    it('returns a SequentialInstructionPlan from a mixed array of InstructionPlans and Instructions', () => {
+        const plan = parseInstructionPlanInput([
+            createInstruction('A'),
+            sequentialInstructionPlan([createInstruction('B'), createInstruction('C')]),
+            createInstruction('D'),
+            parallelInstructionPlan([createInstruction('E'), createInstruction('F')]),
+        ]);
+        expect(plan).toStrictEqual(
+            sequentialInstructionPlan([
+                createInstruction('A'),
+                sequentialInstructionPlan([createInstruction('B'), createInstruction('C')]),
+                createInstruction('D'),
+                parallelInstructionPlan([createInstruction('E'), createInstruction('F')]),
+            ]),
+        );
+    });
+    it('returns frozen objects', () => {
+        expect(parseInstructionPlanInput(createInstruction('A'))).toBeFrozenObject();
+        expect(parseInstructionPlanInput(sequentialInstructionPlan([createInstruction('A')]))).toBeFrozenObject();
+        expect(parseInstructionPlanInput([])).toBeFrozenObject();
+        expect(parseInstructionPlanInput([createInstruction('A')])).toBeFrozenObject();
+        expect(parseInstructionPlanInput([sequentialInstructionPlan([createInstruction('B')])])).toBeFrozenObject();
+        expect(
+            parseInstructionPlanInput([createInstruction('A'), sequentialInstructionPlan([createInstruction('B')])]),
+        ).toBeFrozenObject();
+    });
+});

--- a/packages/instruction-plans/src/__typetests__/instruction-plan-input-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/instruction-plan-input-typetest.ts
@@ -1,0 +1,47 @@
+import type { Instruction } from '@solana/instructions';
+
+import { InstructionPlan, parseInstructionPlanInput } from '../index';
+
+const instructionPlanA = null as unknown as InstructionPlan & { id: 'A' };
+const instructionPlanB = null as unknown as InstructionPlan & { id: 'B' };
+const instructionA = null as unknown as Instruction & { id: 'A' };
+const instructionB = null as unknown as Instruction & { id: 'B' };
+
+// [DESCRIBE] parseInstructionPlanInput
+{
+    // It parses a single Instruction.
+    {
+        const plan = parseInstructionPlanInput(instructionA);
+        plan satisfies InstructionPlan;
+    }
+
+    // It parses an InstructionPlan.
+    {
+        const plan = parseInstructionPlanInput(instructionPlanA);
+        plan satisfies InstructionPlan;
+    }
+
+    // It parses an array of Instructions.
+    {
+        const plan = parseInstructionPlanInput([instructionA, instructionB]);
+        plan satisfies InstructionPlan;
+    }
+
+    // It parses an array of InstructionPlans.
+    {
+        const plan = parseInstructionPlanInput([instructionPlanA, instructionPlanB]);
+        plan satisfies InstructionPlan;
+    }
+
+    // It parses an array of mixed Instructions and InstructionPlans.
+    {
+        const plan = parseInstructionPlanInput([instructionA, instructionPlanA, instructionB, instructionPlanB]);
+        plan satisfies InstructionPlan;
+    }
+
+    // It parses an empty array.
+    {
+        const plan = parseInstructionPlanInput([]);
+        plan satisfies InstructionPlan;
+    }
+}

--- a/packages/instruction-plans/src/index.ts
+++ b/packages/instruction-plans/src/index.ts
@@ -52,6 +52,7 @@
  */
 export * from './append-instruction-plan';
 export * from './instruction-plan';
+export * from './instruction-plan-input';
 export * from './transaction-plan';
 export * from './transaction-plan-executor';
 export * from './transaction-plan-result';

--- a/packages/instruction-plans/src/instruction-plan-input.ts
+++ b/packages/instruction-plans/src/instruction-plan-input.ts
@@ -1,0 +1,97 @@
+import type { Instruction } from '@solana/instructions';
+
+import {
+    type InstructionPlan,
+    isInstructionPlan,
+    sequentialInstructionPlan,
+    singleInstructionPlan,
+} from './instruction-plan';
+
+/**
+ * A flexible input type that can be used to create an {@link InstructionPlan}.
+ *
+ * This type accepts:
+ * - A single {@link Instruction}.
+ * - An existing {@link InstructionPlan}.
+ * - An array of instructions and/or instruction plans.
+ *
+ * Use the {@link parseInstructionPlanInput} function to convert this input
+ * into a proper {@link InstructionPlan}.
+ *
+ * @example
+ * Using a single instruction.
+ * ```ts
+ * const input: InstructionPlanInput = myInstruction;
+ * ```
+ *
+ * @example
+ * Use as argument type in a function that will parse it into an InstructionPlan.
+ * ```ts
+ * function myFunction(input: InstructionPlanInput) {
+ *   const plan = parseInstructionPlanInput(input);
+ *   // Use the plan...
+ * }
+ * ```
+ *
+ * @see {@link parseInstructionPlanInput}
+ * @see {@link InstructionPlan}
+ */
+export type InstructionPlanInput = Instruction | InstructionPlan | readonly (Instruction | InstructionPlan)[];
+
+/**
+ * Parses an {@link InstructionPlanInput} and returns an {@link InstructionPlan}.
+ *
+ * This function handles the following input types:
+ * - A single {@link Instruction} is wrapped in a {@link SingleInstructionPlan}.
+ * - An existing {@link InstructionPlan} is returned as-is.
+ * - An array with a single element is unwrapped and parsed recursively.
+ * - An array with multiple elements is wrapped in a divisible {@link SequentialInstructionPlan}.
+ *
+ * @param input - The input to parse into an instruction plan.
+ * @return The parsed instruction plan.
+ *
+ * @example
+ * Parsing a single instruction.
+ * ```ts
+ * const plan = parseInstructionPlanInput(myInstruction);
+ * // Equivalent to: singleInstructionPlan(myInstruction)
+ * ```
+ *
+ * @example
+ * Parsing an array of instructions.
+ * ```ts
+ * const plan = parseInstructionPlanInput([instructionA, instructionB]);
+ * // Equivalent to: sequentialInstructionPlan([instructionA, instructionB])
+ * ```
+ *
+ * @example
+ * Parsing a mixed array with nested plans.
+ * ```ts
+ * const plan = parseInstructionPlanInput([
+ *   instructionA,
+ *   parallelInstructionPlan([instructionB, instructionC]),
+ * ]);
+ * // Returns a sequential plan containing:
+ * // - A single instruction plan for instructionA.
+ * // - The parallel plan for instructionB and instructionC.
+ * ```
+ *
+ * @example
+ * Single-element arrays are unwrapped.
+ * ```ts
+ * const plan = parseInstructionPlanInput([myInstruction]);
+ * // Equivalent to: singleInstructionPlan(myInstruction)
+ * ```
+ *
+ * @see {@link InstructionPlanInput}
+ * @see {@link InstructionPlan}
+ */
+export function parseInstructionPlanInput(input: InstructionPlanInput): InstructionPlan {
+    if (Array.isArray(input) && input.length === 1) {
+        return parseInstructionPlanInput(input[0]);
+    }
+    if (Array.isArray(input)) {
+        return sequentialInstructionPlan(input.map(parseInstructionPlanInput));
+    }
+    return isInstructionPlan(input) ? input : singleInstructionPlan(input as Instruction);
+}


### PR DESCRIPTION
#### Problem

Since we're going to add convenience methods to plan and execute instruction plans, it would be nice to have a type that encompassed various input types that can easily be parsed into an `InstructionPlan`.

#### Summary of Changes

This PR adds an `InstructionPlanInput` type and a `parseInstructionPlanInput` function that converts any variation of an `InstructionPlanInput` into an `InstructionPlan`.