### PR TITLE
Add `parseTransactionPlanInput` helper

### DIFF
--- a/.changeset/strong-phones-happen.md
+++ b/.changeset/strong-phones-happen.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Add `parseTransactionPlanInput` helper that converts flexible inputs (single transaction message, transaction plan, or array) into an `TransactionPlan`

--- a/packages/instruction-plans/src/__typetests__/instruction-plan-input-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/instruction-plan-input-typetest.ts
@@ -1,11 +1,17 @@
 import type { Instruction } from '@solana/instructions';
+import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
-import { InstructionPlan, parseInstructionPlanInput } from '../index';
+import { InstructionPlan, parseInstructionPlanInput, parseTransactionPlanInput, TransactionPlan } from '../index';
 
 const instructionPlanA = null as unknown as InstructionPlan & { id: 'A' };
 const instructionPlanB = null as unknown as InstructionPlan & { id: 'B' };
 const instructionA = null as unknown as Instruction & { id: 'A' };
 const instructionB = null as unknown as Instruction & { id: 'B' };
+
+const transactionPlanA = null as unknown as TransactionPlan & { id: 'A' };
+const transactionPlanB = null as unknown as TransactionPlan & { id: 'B' };
+const messageA = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { id: 'A' };
+const messageB = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { id: 'B' };
 
 // [DESCRIBE] parseInstructionPlanInput
 {
@@ -43,5 +49,51 @@ const instructionB = null as unknown as Instruction & { id: 'B' };
     {
         const plan = parseInstructionPlanInput([]);
         plan satisfies InstructionPlan;
+    }
+}
+
+// [DESCRIBE] parseTransactionPlanInput
+{
+    // It parses a single TransactionMessage & TransactionMessageWithFeePayer.
+    {
+        const plan = parseTransactionPlanInput(messageA);
+        plan satisfies TransactionPlan;
+    }
+
+    // It requires a fee payer.
+    {
+        const messageWithoutFeePayer = null as unknown as TransactionMessage;
+        // @ts-expect-error Missing fee payer.
+        parseTransactionPlanInput(messageWithoutFeePayer);
+    }
+
+    // It parses an InstructionPlan.
+    {
+        const plan = parseTransactionPlanInput(transactionPlanA);
+        plan satisfies TransactionPlan;
+    }
+
+    // It parses an array of Instructions.
+    {
+        const plan = parseTransactionPlanInput([messageA, messageB]);
+        plan satisfies TransactionPlan;
+    }
+
+    // It parses an array of InstructionPlans.
+    {
+        const plan = parseTransactionPlanInput([transactionPlanA, transactionPlanB]);
+        plan satisfies TransactionPlan;
+    }
+
+    // It parses an array of mixed Instructions and InstructionPlans.
+    {
+        const plan = parseTransactionPlanInput([messageA, transactionPlanA, messageB, transactionPlanB]);
+        plan satisfies TransactionPlan;
+    }
+
+    // It parses an empty array.
+    {
+        const plan = parseTransactionPlanInput([]);
+        plan satisfies TransactionPlan;
     }
 }


### PR DESCRIPTION
#### Problem

Since we're going to add convenience methods to execute transaction plans, it would be nice to have a type that encompassed various input types that can easily be parsed into a `TransactionPlan`.

#### Summary of Changes

This PR adds an `TransactionPlanInput` type and a `parseTransactionPlanInput` function that converts any variation of an `TransactionPlanInput` into an `TransactionPlan`.