### PR TITLE
Add `parseInstructionOrTransactionPlanInput` helper

### DIFF
--- a/.changeset/fluffy-shrimps-jump.md
+++ b/.changeset/fluffy-shrimps-jump.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Add `parseInstructionOrTransactionPlanInput` helper that converts flexible inputs (instruction plan input or transaction plan input) into an `InstructionPlan` or `TransactionPlan`

--- a/packages/instruction-plans/src/__tests__/instruction-plan-input-test.ts
+++ b/packages/instruction-plans/src/__tests__/instruction-plan-input-test.ts
@@ -6,6 +6,7 @@ import { Instruction } from '@solana/instructions';
 import {
     parallelInstructionPlan,
     parallelTransactionPlan,
+    parseInstructionOrTransactionPlanInput,
     parseInstructionPlanInput,
     parseTransactionPlanInput,
     sequentialInstructionPlan,
@@ -161,6 +162,151 @@ describe('parseTransactionPlanInput', () => {
         expect(parseTransactionPlanInput([sequentialTransactionPlan([createMessage('B')])])).toBeFrozenObject();
         expect(
             parseTransactionPlanInput([createMessage('A'), sequentialTransactionPlan([createMessage('B')])]),
+        ).toBeFrozenObject();
+    });
+});
+
+describe('parseInstructionOrTransactionPlanInput', () => {
+    it('returns an empty SequentialTransactionPlan from an empty array', () => {
+        // Because if we're trying to parse nothing, might as well avoid the planning phase.
+        const plan = parseInstructionOrTransactionPlanInput([]);
+        expect(plan).toStrictEqual(sequentialTransactionPlan([]));
+    });
+    it('returns an InstructionPlan from a single instruction', () => {
+        const plan = parseInstructionOrTransactionPlanInput(createInstruction('A'));
+        expect(plan).toStrictEqual(singleInstructionPlan(createInstruction('A')));
+    });
+    it('returns a provided InstructionPlan as-is', () => {
+        const input = sequentialInstructionPlan([
+            createInstruction('A'),
+            parallelInstructionPlan([createInstruction('B'), createInstruction('C')]),
+        ]);
+        const plan = parseInstructionOrTransactionPlanInput(input);
+        expect(plan).toBe(input);
+    });
+    it('returns a SingleInstructionPlan from an array of only one Instruction', () => {
+        const plan = parseInstructionOrTransactionPlanInput([createInstruction('A')]);
+        expect(plan).toStrictEqual(singleInstructionPlan(createInstruction('A')));
+    });
+    it('returns a provided InstructionPlan as-is when it is the only item in the provided array', () => {
+        const input = sequentialInstructionPlan([
+            createInstruction('A'),
+            parallelInstructionPlan([createInstruction('B'), createInstruction('C')]),
+        ]);
+        const plan = parseInstructionOrTransactionPlanInput([input]);
+        expect(plan).toBe(input);
+    });
+    it('returns a SequentialInstructionPlan from an array of instructions', () => {
+        const plan = parseInstructionOrTransactionPlanInput([createInstruction('A'), createInstruction('B')]);
+        expect(plan).toStrictEqual(sequentialInstructionPlan([createInstruction('A'), createInstruction('B')]));
+    });
+    it('returns a SequentialInstructionPlan from an array of InstructionPlans', () => {
+        const plan = parseInstructionOrTransactionPlanInput([
+            sequentialInstructionPlan([createInstruction('A'), createInstruction('B')]),
+            parallelInstructionPlan([createInstruction('C'), createInstruction('D')]),
+        ]);
+        expect(plan).toStrictEqual(
+            sequentialInstructionPlan([
+                sequentialInstructionPlan([createInstruction('A'), createInstruction('B')]),
+                parallelInstructionPlan([createInstruction('C'), createInstruction('D')]),
+            ]),
+        );
+    });
+    it('returns a SequentialInstructionPlan from a mixed array of InstructionPlans and Instructions', () => {
+        const plan = parseInstructionOrTransactionPlanInput([
+            createInstruction('A'),
+            sequentialInstructionPlan([createInstruction('B'), createInstruction('C')]),
+            createInstruction('D'),
+            parallelInstructionPlan([createInstruction('E'), createInstruction('F')]),
+        ]);
+        expect(plan).toStrictEqual(
+            sequentialInstructionPlan([
+                createInstruction('A'),
+                sequentialInstructionPlan([createInstruction('B'), createInstruction('C')]),
+                createInstruction('D'),
+                parallelInstructionPlan([createInstruction('E'), createInstruction('F')]),
+            ]),
+        );
+    });
+    it('returns an TransactionPlan from a single message', () => {
+        const plan = parseInstructionOrTransactionPlanInput(createMessage('A'));
+        expect(plan).toStrictEqual(singleTransactionPlan(createMessage('A')));
+    });
+    it('returns a provided TransactionPlan as-is', () => {
+        const input = sequentialTransactionPlan([
+            createMessage('A'),
+            parallelTransactionPlan([createMessage('B'), createMessage('C')]),
+        ]);
+        const plan = parseInstructionOrTransactionPlanInput(input);
+        expect(plan).toBe(input);
+    });
+    it('returns a SingleTransactionPlan from an array of only one TransactionMessage', () => {
+        const plan = parseInstructionOrTransactionPlanInput([createMessage('A')]);
+        expect(plan).toStrictEqual(singleTransactionPlan(createMessage('A')));
+    });
+    it('returns a provided TransactionPlan as-is when it is the only item in the provided array', () => {
+        const input = sequentialTransactionPlan([
+            createMessage('A'),
+            parallelTransactionPlan([createMessage('B'), createMessage('C')]),
+        ]);
+        const plan = parseInstructionOrTransactionPlanInput([input]);
+        expect(plan).toBe(input);
+    });
+    it('returns a SequentialTransactionPlan from an array of messages', () => {
+        const plan = parseInstructionOrTransactionPlanInput([createMessage('A'), createMessage('B')]);
+        expect(plan).toStrictEqual(sequentialTransactionPlan([createMessage('A'), createMessage('B')]));
+    });
+    it('returns a SequentialTransactionPlan from an array of TransactionPlans', () => {
+        const plan = parseInstructionOrTransactionPlanInput([
+            sequentialTransactionPlan([createMessage('A'), createMessage('B')]),
+            parallelTransactionPlan([createMessage('C'), createMessage('D')]),
+        ]);
+        expect(plan).toStrictEqual(
+            sequentialTransactionPlan([
+                sequentialTransactionPlan([createMessage('A'), createMessage('B')]),
+                parallelTransactionPlan([createMessage('C'), createMessage('D')]),
+            ]),
+        );
+    });
+    it('returns a SequentialTransactionPlan from a mixed array of TransactionPlans and TransactionMessages', () => {
+        const plan = parseInstructionOrTransactionPlanInput([
+            createMessage('A'),
+            sequentialTransactionPlan([createMessage('B'), createMessage('C')]),
+            createMessage('D'),
+            parallelTransactionPlan([createMessage('E'), createMessage('F')]),
+        ]);
+        expect(plan).toStrictEqual(
+            sequentialTransactionPlan([
+                createMessage('A'),
+                sequentialTransactionPlan([createMessage('B'), createMessage('C')]),
+                createMessage('D'),
+                parallelTransactionPlan([createMessage('E'), createMessage('F')]),
+            ]),
+        );
+    });
+    it('returns frozen objects', () => {
+        expect(parseInstructionOrTransactionPlanInput([])).toBeFrozenObject();
+        expect(parseInstructionOrTransactionPlanInput(createInstruction('A'))).toBeFrozenObject();
+        expect(
+            parseInstructionOrTransactionPlanInput(sequentialInstructionPlan([createInstruction('A')])),
+        ).toBeFrozenObject();
+        expect(parseInstructionOrTransactionPlanInput(createMessage('A'))).toBeFrozenObject();
+        expect(
+            parseInstructionOrTransactionPlanInput(sequentialTransactionPlan([createMessage('A')])),
+        ).toBeFrozenObject();
+        expect(parseInstructionOrTransactionPlanInput([createInstruction('A')])).toBeFrozenObject();
+        expect(parseInstructionOrTransactionPlanInput([createMessage('A')])).toBeFrozenObject();
+        expect(
+            parseInstructionOrTransactionPlanInput([
+                createInstruction('A'),
+                sequentialInstructionPlan([createInstruction('B')]),
+            ]),
+        ).toBeFrozenObject();
+        expect(
+            parseInstructionOrTransactionPlanInput([
+                createMessage('A'),
+                sequentialTransactionPlan([createMessage('B')]),
+            ]),
         ).toBeFrozenObject();
     });
 });

--- a/packages/instruction-plans/src/__typetests__/instruction-plan-input-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/instruction-plan-input-typetest.ts
@@ -1,7 +1,13 @@
 import type { Instruction } from '@solana/instructions';
 import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
 
-import { InstructionPlan, parseInstructionPlanInput, parseTransactionPlanInput, TransactionPlan } from '../index';
+import {
+    InstructionPlan,
+    parseInstructionOrTransactionPlanInput,
+    parseInstructionPlanInput,
+    parseTransactionPlanInput,
+    TransactionPlan,
+} from '../index';
 
 const instructionPlanA = null as unknown as InstructionPlan & { id: 'A' };
 const instructionPlanB = null as unknown as InstructionPlan & { id: 'B' };
@@ -95,5 +101,92 @@ const messageB = null as unknown as TransactionMessage & TransactionMessageWithF
     {
         const plan = parseTransactionPlanInput([]);
         plan satisfies TransactionPlan;
+    }
+}
+
+// [DESCRIBE] parseInstructionOrTransactionPlanInput
+{
+    // It parses a single Instruction.
+    {
+        const plan = parseInstructionOrTransactionPlanInput(instructionA);
+        plan satisfies InstructionPlan | TransactionPlan;
+    }
+
+    // It parses a single TransactionMessage & TransactionMessageWithFeePayer.
+    {
+        const plan = parseInstructionOrTransactionPlanInput(messageA);
+        plan satisfies InstructionPlan | TransactionPlan;
+    }
+
+    // It requires a fee payer for transaction messages.
+    {
+        const messageWithoutFeePayer = null as unknown as TransactionMessage;
+        // @ts-expect-error Missing fee payer.
+        parseInstructionOrTransactionPlanInput(messageWithoutFeePayer);
+    }
+
+    // It parses an InstructionPlan.
+    {
+        const plan = parseInstructionOrTransactionPlanInput(instructionPlanA);
+        plan satisfies InstructionPlan | TransactionPlan;
+    }
+
+    // It parses a TransactionPlan.
+    {
+        const plan = parseInstructionOrTransactionPlanInput(transactionPlanA);
+        plan satisfies InstructionPlan | TransactionPlan;
+    }
+
+    // It parses an array of Instructions.
+    {
+        const plan = parseInstructionOrTransactionPlanInput([instructionA, instructionB]);
+        plan satisfies InstructionPlan | TransactionPlan;
+    }
+
+    // It parses an array of TransactionMessages.
+    {
+        const plan = parseInstructionOrTransactionPlanInput([messageA, messageB]);
+        plan satisfies InstructionPlan | TransactionPlan;
+    }
+
+    // It parses an array of InstructionPlans.
+    {
+        const plan = parseInstructionOrTransactionPlanInput([instructionPlanA, instructionPlanB]);
+        plan satisfies InstructionPlan | TransactionPlan;
+    }
+
+    // It parses an array of mixed Instructions and InstructionPlans.
+    {
+        const plan = parseInstructionOrTransactionPlanInput([
+            instructionA,
+            instructionPlanA,
+            instructionB,
+            instructionPlanB,
+        ]);
+        plan satisfies InstructionPlan | TransactionPlan;
+    }
+
+    // It parses an array of TransactionPlans.
+    {
+        const plan = parseInstructionOrTransactionPlanInput([transactionPlanA, transactionPlanB]);
+        plan satisfies InstructionPlan | TransactionPlan;
+    }
+
+    // It parses an array of mixed TransactionMessages and TransactionPlans.
+    {
+        const plan = parseInstructionOrTransactionPlanInput([messageA, transactionPlanA, messageB, transactionPlanB]);
+        plan satisfies InstructionPlan | TransactionPlan;
+    }
+
+    // It parses an empty array.
+    {
+        const plan = parseInstructionOrTransactionPlanInput([]);
+        plan satisfies InstructionPlan | TransactionPlan;
+    }
+
+    // It does not parse arrays mixing Instruction and TransactionMessage inputs.
+    {
+        // @ts-expect-error Mixed instruction and transaction inputs are not supported.
+        parseInstructionOrTransactionPlanInput([instructionA, messageA]);
     }
 }

--- a/packages/instruction-plans/src/instruction-plan-input.ts
+++ b/packages/instruction-plans/src/instruction-plan-input.ts
@@ -194,3 +194,65 @@ export function parseTransactionPlanInput(input: TransactionPlanInput): Transact
     }
     return isTransactionPlan(input) ? input : singleTransactionPlan(input as SingleTransactionPlan['message']);
 }
+
+/**
+ * Parses an {@link InstructionPlanInput} or {@link TransactionPlanInput} and
+ * returns the appropriate plan type.
+ *
+ * This function automatically detects whether the input represents instructions
+ * or transactions and delegates to the appropriate parser:
+ * - If the input is a transaction message or transaction plan, it delegates
+ *   to {@link parseTransactionPlanInput}.
+ * - Otherwise, it delegates to {@link parseInstructionPlanInput}.
+ *
+ * @param input - The input to parse, which can be either an instruction-based
+ *   or transaction-based input.
+ * @returns The parsed plan, either an {@link InstructionPlan} or a {@link TransactionPlan}.
+ *
+ * @example
+ * Parsing an instruction input.
+ * ```ts
+ * const plan = parseInstructionOrTransactionPlanInput(myInstruction);
+ * // Returns an InstructionPlan
+ * ```
+ *
+ * @example
+ * Parsing a transaction message input.
+ * ```ts
+ * const plan = parseInstructionOrTransactionPlanInput(myTransactionMessage);
+ * // Returns a TransactionPlan
+ * ```
+ *
+ * @see {@link parseInstructionPlanInput}
+ * @see {@link parseTransactionPlanInput}
+ * @see {@link InstructionPlanInput}
+ * @see {@link TransactionPlanInput}
+ */
+export function parseInstructionOrTransactionPlanInput(
+    input: InstructionPlanInput | TransactionPlanInput,
+): InstructionPlan | TransactionPlan {
+    if (Array.isArray(input) && input.length === 0) {
+        return parseTransactionPlanInput(input);
+    }
+    if (Array.isArray(input) && isTransactionPlanInput(input[0])) {
+        return parseTransactionPlanInput(input as TransactionPlanInput);
+    }
+    if (isTransactionPlanInput(input)) {
+        return parseTransactionPlanInput(input as TransactionPlanInput);
+    }
+    return parseInstructionPlanInput(input as InstructionPlanInput);
+}
+
+function isTransactionPlanInput(value: unknown): value is SingleTransactionPlan['message'] | TransactionPlan {
+    return isTransactionPlan(value) || isTransactionMessage(value);
+}
+
+function isTransactionMessage(value: unknown): value is SingleTransactionPlan['message'] {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        'instructions' in value &&
+        Array.isArray(value.instructions) &&
+        'version' in value
+    );
+}


### PR DESCRIPTION
#### Problem

It may be that some helper functions accept any `InstructionPlanInput` _or_ `TransactionPlanInput`. This could be used for instance to plan and/or execute transactions based on the provided input. It would be nice to have a parsing function that converts `InstructionPlanInput | TransactionPlanInput` into `InstructionPlan | TransactionPlan` (since the latter now has a `planType` discriminator).

#### Summary of Changes

This PR offers a new `parseInstructionOrTransactionPlanInput` function that does just that.