### PR TITLE
Add instruction input resolution to `program-client-core`

### DIFF
--- a/packages/program-client-core/package.json
+++ b/packages/program-client-core/package.json
@@ -55,7 +55,9 @@
         "test:treeshakability:browser": "agadoo dist/index.browser.mjs",
         "test:treeshakability:native": "agadoo dist/index.native.mjs",
         "test:treeshakability:node": "agadoo dist/index.node.mjs",
-        "test:typecheck": "tsc --noEmit"
+        "test:typecheck": "tsc --noEmit",
+        "test:unit:browser": "NODE_OPTIONS=\"--no-experimental-webstorage\" TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ../../node_modules/@solana/test-config/jest-unit.config.browser.js --rootDir . --silent",
+        "test:unit:node": "NODE_OPTIONS=\"--no-experimental-webstorage\" TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ../../node_modules/@solana/test-config/jest-unit.config.node.js --rootDir . --silent"
     },
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "license": "MIT",
@@ -70,6 +72,12 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
+    "dependencies": {
+        "@solana/addresses": "workspace:*",
+        "@solana/errors": "workspace:*",
+        "@solana/instructions": "workspace:*",
+        "@solana/signers": "workspace:*"
+    },
     "peerDependencies": {
         "typescript": "^5.0.0"
     },

--- a/packages/program-client-core/src/__tests__/instruction-input-resolution-test.ts
+++ b/packages/program-client-core/src/__tests__/instruction-input-resolution-test.ts
@@ -1,0 +1,206 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import { type Address, address, ProgramDerivedAddressBump } from '@solana/addresses';
+import {
+    SOLANA_ERROR__PROGRAM_CLIENTS__RESOLVED_INSTRUCTION_INPUT_MUST_BE_NON_NULL,
+    SOLANA_ERROR__PROGRAM_CLIENTS__UNEXPECTED_RESOLVED_INSTRUCTION_INPUT_TYPE,
+    SolanaError,
+} from '@solana/errors';
+import { AccountRole } from '@solana/instructions';
+
+import {
+    getAccountMetaFactory,
+    getAddressFromResolvedInstructionAccount,
+    getNonNullResolvedInstructionInput,
+    getResolvedInstructionAccountAsProgramDerivedAddress,
+    getResolvedInstructionAccountAsTransactionSigner,
+} from '../instruction-input-resolution';
+
+const mockAddress = address('FiRHXPUxuo42VfWp3vvPVb5he5zvhvMw6DzNigN7nEpe');
+const mockPda = [mockAddress, 255 as ProgramDerivedAddressBump] as const;
+const mockSigner = {
+    address: mockAddress,
+    signTransactions: () => Promise.resolve([]),
+};
+
+describe('getNonNullResolvedInstructionInput', () => {
+    it('returns the value as-is when it is not null or undefined', () => {
+        expect(getNonNullResolvedInstructionInput('test', 'hello')).toBe('hello');
+        expect(getNonNullResolvedInstructionInput('test', 42)).toBe(42);
+        expect(getNonNullResolvedInstructionInput('test', mockAddress)).toBe(mockAddress);
+    });
+
+    it('throws when the value is null or undefined', () => {
+        expect(() => getNonNullResolvedInstructionInput('myInput', null)).toThrow(
+            new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__RESOLVED_INSTRUCTION_INPUT_MUST_BE_NON_NULL, {
+                inputName: 'myInput',
+            }),
+        );
+        expect(() => getNonNullResolvedInstructionInput('myInput', undefined)).toThrow(
+            new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__RESOLVED_INSTRUCTION_INPUT_MUST_BE_NON_NULL, {
+                inputName: 'myInput',
+            }),
+        );
+    });
+});
+
+describe('getAddressFromResolvedInstructionAccount', () => {
+    it('returns the address when given an Address', () => {
+        expect(getAddressFromResolvedInstructionAccount('test', mockAddress)).toBe(mockAddress);
+    });
+
+    it('extracts the address from a ProgramDerivedAddress', () => {
+        expect(getAddressFromResolvedInstructionAccount('test', mockPda)).toBe(mockAddress);
+    });
+
+    it('extracts the address from a TransactionSigner', () => {
+        expect(getAddressFromResolvedInstructionAccount('test', mockSigner)).toBe(mockAddress);
+    });
+
+    it('throws when the value is null or undefined', () => {
+        expect(() => getAddressFromResolvedInstructionAccount('myInput', null)).toThrow(
+            new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__RESOLVED_INSTRUCTION_INPUT_MUST_BE_NON_NULL, {
+                inputName: 'myInput',
+            }),
+        );
+        expect(() => getAddressFromResolvedInstructionAccount('myInput', undefined)).toThrow(
+            new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__RESOLVED_INSTRUCTION_INPUT_MUST_BE_NON_NULL, {
+                inputName: 'myInput',
+            }),
+        );
+    });
+});
+
+describe('getResolvedInstructionAccountAsProgramDerivedAddress', () => {
+    it('returns the PDA when given a ProgramDerivedAddress', () => {
+        expect(getResolvedInstructionAccountAsProgramDerivedAddress('test', mockPda)).toBe(mockPda);
+    });
+
+    it('throws when the value is not a PDA', () => {
+        expect(() => getResolvedInstructionAccountAsProgramDerivedAddress('myInput', mockAddress)).toThrow(
+            new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNEXPECTED_RESOLVED_INSTRUCTION_INPUT_TYPE, {
+                expectedType: 'ProgramDerivedAddress',
+                inputName: 'myInput',
+            }),
+        );
+        expect(() => getResolvedInstructionAccountAsProgramDerivedAddress('myInput', mockSigner)).toThrow(
+            new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNEXPECTED_RESOLVED_INSTRUCTION_INPUT_TYPE, {
+                expectedType: 'ProgramDerivedAddress',
+                inputName: 'myInput',
+            }),
+        );
+    });
+
+    it('throws when the value is null or undefined', () => {
+        expect(() => getResolvedInstructionAccountAsProgramDerivedAddress('myInput', null)).toThrow(
+            new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNEXPECTED_RESOLVED_INSTRUCTION_INPUT_TYPE, {
+                expectedType: 'ProgramDerivedAddress',
+                inputName: 'myInput',
+            }),
+        );
+        expect(() => getResolvedInstructionAccountAsProgramDerivedAddress('myInput', undefined)).toThrow(
+            new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNEXPECTED_RESOLVED_INSTRUCTION_INPUT_TYPE, {
+                expectedType: 'ProgramDerivedAddress',
+                inputName: 'myInput',
+            }),
+        );
+    });
+});
+
+describe('getResolvedInstructionAccountAsTransactionSigner', () => {
+    it('returns the signer when given a TransactionSigner', () => {
+        expect(getResolvedInstructionAccountAsTransactionSigner('test', mockSigner)).toBe(mockSigner);
+    });
+
+    it('throws when the value is not a TransactionSigner', () => {
+        expect(() => getResolvedInstructionAccountAsTransactionSigner('myInput', mockAddress)).toThrow(
+            new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNEXPECTED_RESOLVED_INSTRUCTION_INPUT_TYPE, {
+                expectedType: 'TransactionSigner',
+                inputName: 'myInput',
+            }),
+        );
+        expect(() => getResolvedInstructionAccountAsTransactionSigner('myInput', mockPda)).toThrow(
+            new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNEXPECTED_RESOLVED_INSTRUCTION_INPUT_TYPE, {
+                expectedType: 'TransactionSigner',
+                inputName: 'myInput',
+            }),
+        );
+    });
+
+    it('throws when the value is null or undefined', () => {
+        expect(() => getResolvedInstructionAccountAsTransactionSigner('myInput', null)).toThrow(
+            new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNEXPECTED_RESOLVED_INSTRUCTION_INPUT_TYPE, {
+                expectedType: 'TransactionSigner',
+                inputName: 'myInput',
+            }),
+        );
+        expect(() => getResolvedInstructionAccountAsTransactionSigner('myInput', undefined)).toThrow(
+            new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNEXPECTED_RESOLVED_INSTRUCTION_INPUT_TYPE, {
+                expectedType: 'TransactionSigner',
+                inputName: 'myInput',
+            }),
+        );
+    });
+});
+
+describe('getAccountMetaFactory', () => {
+    it('creates account meta for an Address with the correct role', () => {
+        const toAccountMeta = getAccountMetaFactory(mockAddress, 'programId');
+
+        const readonlyMeta = toAccountMeta('test', { isWritable: false, value: mockAddress });
+        expect(readonlyMeta).toEqual({ address: mockAddress, role: AccountRole.READONLY });
+
+        const writableMeta = toAccountMeta('test', { isWritable: true, value: mockAddress });
+        expect(writableMeta).toEqual({ address: mockAddress, role: AccountRole.WRITABLE });
+    });
+
+    it('creates account meta for a TransactionSigner with the signer role', () => {
+        const toAccountMeta = getAccountMetaFactory(mockAddress, 'programId');
+
+        const readonlySignerMeta = toAccountMeta('test', { isWritable: false, value: mockSigner });
+        expect(readonlySignerMeta).toEqual({
+            address: mockAddress,
+            role: AccountRole.READONLY_SIGNER,
+            signer: mockSigner,
+        });
+
+        const writableSignerMeta = toAccountMeta('test', { isWritable: true, value: mockSigner });
+        expect(writableSignerMeta).toEqual({
+            address: mockAddress,
+            role: AccountRole.WRITABLE_SIGNER,
+            signer: mockSigner,
+        });
+    });
+
+    it('extracts the address from a PDA', () => {
+        const toAccountMeta = getAccountMetaFactory(mockAddress, 'programId');
+        const meta = toAccountMeta('test', { isWritable: false, value: mockPda });
+        expect(meta).toEqual({ address: mockAddress, role: AccountRole.READONLY });
+    });
+
+    it('returns undefined for null accounts with omitted strategy', () => {
+        const toAccountMeta = getAccountMetaFactory(mockAddress, 'omitted');
+        const meta = toAccountMeta('test', { isWritable: false, value: null });
+        expect(meta).toBeUndefined();
+    });
+
+    it('returns program address for null accounts with programId strategy', () => {
+        const programAddress = address('11111111111111111111111111111111') as Address;
+        const toAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+        const meta = toAccountMeta('test', { isWritable: false, value: null });
+        expect(meta).toEqual({ address: programAddress, role: AccountRole.READONLY });
+    });
+
+    it('freezes the returned meta object', () => {
+        const toAccountMeta = getAccountMetaFactory(mockAddress, 'programId');
+        const meta = toAccountMeta('test', { isWritable: false, value: mockAddress });
+        expect(meta).toBeFrozenObject();
+    });
+
+    it('freezes the returned meta object when using the program address as null', () => {
+        const programAddress = address('11111111111111111111111111111111') as Address;
+        const toAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+        const meta = toAccountMeta('test', { isWritable: false, value: null });
+        expect(meta).toBeFrozenObject();
+    });
+});

--- a/packages/program-client-core/src/__typetests__/instruction-input-resolution-typetest.ts
+++ b/packages/program-client-core/src/__typetests__/instruction-input-resolution-typetest.ts
@@ -1,0 +1,107 @@
+import type { Address, ProgramDerivedAddress } from '@solana/addresses';
+import type { AccountMeta } from '@solana/instructions';
+import type { AccountSignerMeta, TransactionSigner } from '@solana/signers';
+
+import {
+    getAccountMetaFactory,
+    getAddressFromResolvedInstructionAccount,
+    getNonNullResolvedInstructionInput,
+    getResolvedInstructionAccountAsProgramDerivedAddress,
+    getResolvedInstructionAccountAsTransactionSigner,
+    ResolvedInstructionAccount,
+} from '../index';
+
+const mockAddress = null as unknown as Address<'1111'>;
+const mockPda = null as unknown as ProgramDerivedAddress<'2222'>;
+const mockSigner = null as unknown as TransactionSigner<'3333'>;
+
+// [DESCRIBE] getNonNullResolvedInstructionInput
+{
+    // It returns the value with its original type.
+    {
+        getNonNullResolvedInstructionInput('test', mockAddress) satisfies Address<'1111'>;
+    }
+
+    // It accepts null or undefined as input (runtime will throw an error).
+    {
+        getNonNullResolvedInstructionInput<string>('test', null) satisfies string;
+        getNonNullResolvedInstructionInput<string>('test', undefined) satisfies string;
+    }
+}
+
+// [DESCRIBE] getAddressFromResolvedInstructionAccount
+{
+    // It extracts an address from an Address value.
+    {
+        getAddressFromResolvedInstructionAccount('test', mockAddress) satisfies Address<'1111'>;
+    }
+
+    // It extracts an address from a ProgramDerivedAddress value.
+    {
+        getAddressFromResolvedInstructionAccount('test', mockPda) satisfies Address<'2222'>;
+    }
+
+    // It extracts an address from a TransactionSigner value.
+    {
+        getAddressFromResolvedInstructionAccount('test', mockSigner) satisfies Address<'3333'>;
+    }
+
+    // It accepts null or undefined as input (runtime will throw an error).
+    {
+        getAddressFromResolvedInstructionAccount('test', null) satisfies Address;
+        getAddressFromResolvedInstructionAccount('test', undefined) satisfies Address;
+    }
+}
+
+// [DESCRIBE] getResolvedInstructionAccountAsProgramDerivedAddress
+{
+    // It returns a ProgramDerivedAddress.
+    {
+        getResolvedInstructionAccountAsProgramDerivedAddress('test', mockPda) satisfies ProgramDerivedAddress<'2222'>;
+    }
+
+    // It accepts null or undefined as input (runtime will throw an error).
+    {
+        getResolvedInstructionAccountAsProgramDerivedAddress('test', null) satisfies ProgramDerivedAddress;
+        getResolvedInstructionAccountAsProgramDerivedAddress('test', undefined) satisfies ProgramDerivedAddress;
+    }
+}
+
+// [DESCRIBE] getResolvedInstructionAccountAsTransactionSigner
+{
+    // It returns a TransactionSigner.
+    {
+        getResolvedInstructionAccountAsTransactionSigner('test', mockSigner) satisfies TransactionSigner<'3333'>;
+    }
+
+    // It accepts null or undefined as input (runtime will throw an error).
+    {
+        getResolvedInstructionAccountAsTransactionSigner('test', null) satisfies TransactionSigner;
+        getResolvedInstructionAccountAsTransactionSigner('test', undefined) satisfies TransactionSigner;
+    }
+}
+
+// [DESCRIBE] ResolvedInstructionAccount
+{
+    // It defaults to allowing Address, ProgramDerivedAddress, TransactionSigner, or null.
+    {
+        const account: ResolvedInstructionAccount = { isWritable: true, value: mockAddress };
+        account satisfies { isWritable: boolean; value: Address | ProgramDerivedAddress | TransactionSigner | null };
+    }
+
+    // It can be narrowed to a specific value type.
+    {
+        const account: ResolvedInstructionAccount<'1111', Address<'1111'>> = { isWritable: false, value: mockAddress };
+        account satisfies { isWritable: boolean; value: Address<'1111'> };
+    }
+}
+
+// [DESCRIBE] getAccountMetaFactory
+{
+    // It returns a factory that produces AccountMeta or AccountSignerMeta.
+    {
+        const toAccountMeta = getAccountMetaFactory(mockAddress, 'programId');
+        const meta = toAccountMeta('test', { isWritable: true, value: mockAddress });
+        meta satisfies AccountMeta | AccountSignerMeta | undefined;
+    }
+}

--- a/packages/program-client-core/src/__typetests__/instructions-typetest.ts
+++ b/packages/program-client-core/src/__typetests__/instructions-typetest.ts
@@ -1,0 +1,14 @@
+import type { InstructionWithByteDelta } from '../index';
+
+// [DESCRIBE] InstructionWithByteDelta
+{
+    // It contains a byteDelta property.
+    {
+        ({ byteDelta: 100 }) satisfies InstructionWithByteDelta;
+    }
+
+    // It accepts negative byte deltas.
+    {
+        ({ byteDelta: -50 }) satisfies InstructionWithByteDelta;
+    }
+}

--- a/packages/program-client-core/src/index.ts
+++ b/packages/program-client-core/src/index.ts
@@ -5,4 +5,5 @@
  *
  * @packageDocumentation
  */
-export {};
+export * from './instruction-input-resolution';
+export * from './instructions';

--- a/packages/program-client-core/src/instruction-input-resolution.ts
+++ b/packages/program-client-core/src/instruction-input-resolution.ts
@@ -1,0 +1,216 @@
+import { type Address, isProgramDerivedAddress, type ProgramDerivedAddress } from '@solana/addresses';
+import {
+    SOLANA_ERROR__PROGRAM_CLIENTS__RESOLVED_INSTRUCTION_INPUT_MUST_BE_NON_NULL,
+    SOLANA_ERROR__PROGRAM_CLIENTS__UNEXPECTED_RESOLVED_INSTRUCTION_INPUT_TYPE,
+    SolanaError,
+} from '@solana/errors';
+import { type AccountMeta, AccountRole, upgradeRoleToSigner } from '@solana/instructions';
+import { type AccountSignerMeta, isTransactionSigner, type TransactionSigner } from '@solana/signers';
+
+/**
+ * Ensures a resolved instruction input is not null or undefined.
+ *
+ * This function is used during instruction resolution to validate that
+ * required inputs have been properly resolved to a non-null value.
+ *
+ * @typeParam T - The expected type of the resolved input value.
+ *
+ * @param inputName - The name of the instruction input, used in error messages.
+ * @param value - The resolved value to validate.
+ * @returns The validated non-null value.
+ *
+ * @throws Throws a {@link SolanaError} if the value is null or undefined.
+ *
+ * @example
+ * ```ts
+ * const resolvedAuthority = getNonNullResolvedInstructionInput(
+ *   'authority',
+ *   maybeAuthority
+ * );
+ * // resolvedAuthority is guaranteed to be non-null here.
+ * ```
+ */
+export function getNonNullResolvedInstructionInput<T>(inputName: string, value: T | null | undefined): T {
+    if (value === null || value === undefined) {
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__RESOLVED_INSTRUCTION_INPUT_MUST_BE_NON_NULL, {
+            inputName,
+        });
+    }
+    return value;
+}
+
+/**
+ * Extracts the address from a resolved instruction account.
+ *
+ * A resolved instruction account can be an {@link Address}, a {@link ProgramDerivedAddress},
+ * or a {@link TransactionSigner}. This function extracts the underlying address from
+ * any of these types.
+ *
+ * @typeParam T - The address type, defaults to `string`.
+ *
+ * @param inputName - The name of the instruction input, used in error messages.
+ * @param value - The resolved account value to extract the address from.
+ * @returns The extracted address.
+ *
+ * @throws Throws a {@link SolanaError} if the value is null or undefined.
+ *
+ * @example
+ * ```ts
+ * const address = getAddressFromResolvedInstructionAccount('mint', resolvedMint);
+ * ```
+ */
+export function getAddressFromResolvedInstructionAccount<T extends string = string>(
+    inputName: string,
+    value: ResolvedInstructionAccount<T>['value'] | undefined,
+): Address<T> {
+    const nonNullValue = getNonNullResolvedInstructionInput(inputName, value);
+    if (typeof value === 'object' && 'address' in nonNullValue) {
+        return nonNullValue.address;
+    }
+    if (Array.isArray(nonNullValue)) {
+        return nonNullValue[0] as Address<T>;
+    }
+    return nonNullValue as Address<T>;
+}
+
+/**
+ * Extracts a {@link ProgramDerivedAddress} from a resolved instruction account.
+ *
+ * This function validates that the resolved account is a PDA and returns it.
+ * Use this when you need access to both the address and the bump seed of a PDA.
+ *
+ * @typeParam T - The address type, defaults to `string`.
+ *
+ * @param inputName - The name of the instruction input, used in error messages.
+ * @param value - The resolved account value expected to be a PDA.
+ * @returns The program-derived address.
+ *
+ * @throws Throws a {@link SolanaError} if the value is not a {@link ProgramDerivedAddress}.
+ *
+ * @example
+ * ```ts
+ * const pda = getResolvedInstructionAccountAsProgramDerivedAddress('metadata', resolvedMetadata);
+ * const [address, bump] = pda;
+ * ```
+ */
+export function getResolvedInstructionAccountAsProgramDerivedAddress<T extends string = string>(
+    inputName: string,
+    value: ResolvedInstructionAccount<T>['value'] | undefined,
+): ProgramDerivedAddress<T> {
+    if (!isProgramDerivedAddress(value)) {
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNEXPECTED_RESOLVED_INSTRUCTION_INPUT_TYPE, {
+            expectedType: 'ProgramDerivedAddress',
+            inputName,
+        });
+    }
+    return value;
+}
+
+/**
+ * Extracts a {@link TransactionSigner} from a resolved instruction account.
+ *
+ * This function validates that the resolved account is a transaction signer and returns it.
+ * Use this when you need the resolved account to be a signer.
+ *
+ * @typeParam T - The address type, defaults to `string`.
+ *
+ * @param inputName - The name of the instruction input, used in error messages.
+ * @param value - The resolved account value expected to be a signer.
+ * @returns The transaction signer.
+ *
+ * @throws Throws a {@link SolanaError} if the value is not a {@link TransactionSigner}.
+ *
+ * @example
+ * ```ts
+ * const signer = getResolvedInstructionAccountAsTransactionSigner('authority', resolvedAuthority);
+ * ```
+ */
+export function getResolvedInstructionAccountAsTransactionSigner<T extends string = string>(
+    inputName: string,
+    value: ResolvedInstructionAccount<T>['value'] | undefined,
+): TransactionSigner<T> {
+    if (!isResolvedInstructionAccountSigner(value)) {
+        throw new SolanaError(SOLANA_ERROR__PROGRAM_CLIENTS__UNEXPECTED_RESOLVED_INSTRUCTION_INPUT_TYPE, {
+            expectedType: 'TransactionSigner',
+            inputName,
+        });
+    }
+    return value;
+}
+
+/**
+ * Represents a resolved account input for an instruction.
+ *
+ * During instruction building, account inputs are resolved to this type which
+ * captures both the account value and whether it should be marked as writable.
+ * The value can be an {@link Address}, a {@link ProgramDerivedAddress}, a
+ * {@link TransactionSigner}, or `null` for optional accounts.
+ *
+ * @typeParam TAddress - The address type, defaults to `string`.
+ * @typeParam TValue - The type of the resolved value.
+ *
+ * @example
+ * ```ts
+ * const mintAccount: ResolvedInstructionAccount = {
+ *   value: mintAddress,
+ *   isWritable: true,
+ * };
+ * ```
+ */
+export type ResolvedInstructionAccount<
+    TAddress extends string = string,
+    TValue extends Address<TAddress> | ProgramDerivedAddress<TAddress> | TransactionSigner<TAddress> | null =
+        | Address<TAddress>
+        | ProgramDerivedAddress<TAddress>
+        | TransactionSigner<TAddress>
+        | null,
+> = {
+    isWritable: boolean;
+    value: TValue;
+};
+
+/**
+ * Creates a factory function that converts resolved instruction accounts to account metas.
+ *
+ * The factory handles the conversion of {@link ResolvedInstructionAccount} objects into
+ * {@link AccountMeta} or {@link AccountSignerMeta} objects suitable for building instructions.
+ * It also determines how to handle optional accounts based on the provided strategy.
+ *
+ * @param programAddress - The program address, used when optional accounts use the `programId` strategy.
+ * @param optionalAccountStrategy - How to handle null account values:
+ *   - `'omitted'`: Optional accounts are excluded from the instruction entirely.
+ *   - `'programId'`: Optional accounts are replaced with the program address as a read-only account.
+ * @returns A factory function that converts a resolved account to an account meta.
+ *
+ * @example
+ * ```ts
+ * const toAccountMeta = getAccountMetaFactory(programAddress, 'programId');
+ * const mintMeta = toAccountMeta('mint', resolvedMint);
+ * ```
+ */
+export function getAccountMetaFactory(programAddress: Address, optionalAccountStrategy: 'omitted' | 'programId') {
+    return (inputName: string, account: ResolvedInstructionAccount): AccountMeta | AccountSignerMeta | undefined => {
+        if (!account.value) {
+            if (optionalAccountStrategy === 'omitted') return;
+            return Object.freeze({ address: programAddress, role: AccountRole.READONLY });
+        }
+
+        const writableRole = account.isWritable ? AccountRole.WRITABLE : AccountRole.READONLY;
+        const isSigner = isResolvedInstructionAccountSigner(account.value);
+        return Object.freeze({
+            address: getAddressFromResolvedInstructionAccount(inputName, account.value),
+            role: isSigner ? upgradeRoleToSigner(writableRole) : writableRole,
+            ...(isSigner ? { signer: account.value } : {}),
+        });
+    };
+}
+
+function isResolvedInstructionAccountSigner(value: unknown): value is TransactionSigner {
+    return (
+        !!value &&
+        typeof value === 'object' &&
+        'address' in value &&
+        typeof value.address === 'string' &&
+        isTransactionSigner(value as { address: Address })
+    );
+}

--- a/packages/program-client-core/src/instructions.ts
+++ b/packages/program-client-core/src/instructions.ts
@@ -1,0 +1,11 @@
+/**
+ * An instruction that tracks how many bytes it adds or removes from on-chain accounts.
+ *
+ * The `byteDelta` indicates the net change in account storage size. A positive value
+ * means bytes are being allocated, while a negative value means bytes are being freed.
+ * This is useful for calculating how much balance a storage payer must have for a
+ * transaction to succeed.
+ */
+export type InstructionWithByteDelta = {
+    byteDelta: number;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -849,6 +849,18 @@ importers:
 
   packages/program-client-core:
     dependencies:
+      '@solana/addresses':
+        specifier: workspace:*
+        version: link:../addresses
+      '@solana/errors':
+        specifier: workspace:*
+        version: link:../errors
+      '@solana/instructions':
+        specifier: workspace:*
+        version: link:../instructions
+      '@solana/signers':
+        specifier: workspace:*
+        version: link:../signers
       typescript:
         specifier: ^5.0.0
         version: 5.9.3


### PR DESCRIPTION
This PR adds a bunch of types and helpers that are currently being generated alongside every generated program clients in a [`shared.ts` file](https://github.com/solana-program/system/blob/000d4ecc961879ab76a36e137ed9c3305e94a643/clients/js/src/generated/shared/index.ts).

These helpers are slightly different than the ones in the `shared.ts` file because their name now needs more context and they require an additional `inputName` attribute so we can provide a better error message. This will be easier to adjust in the JS renderer when we remove the generated `shared.ts` file.