### PR TITLE
Add self plan and send helpers to `program-client-core`

### DIFF
--- a/packages/program-client-core/package.json
+++ b/packages/program-client-core/package.json
@@ -76,6 +76,8 @@
         "@solana/addresses": "workspace:*",
         "@solana/errors": "workspace:*",
         "@solana/instructions": "workspace:*",
+        "@solana/instruction-plans": "workspace:*",
+        "@solana/plugin-interfaces": "workspace:*",
         "@solana/signers": "workspace:*"
     },
     "peerDependencies": {

--- a/packages/program-client-core/src/__tests__/self-plan-and-send-functions-test.ts
+++ b/packages/program-client-core/src/__tests__/self-plan-and-send-functions-test.ts
@@ -1,0 +1,208 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import type { InstructionPlan } from '@solana/instruction-plans';
+import type { Instruction } from '@solana/instructions';
+import type { ClientWithTransactionPlanning, ClientWithTransactionSending } from '@solana/plugin-interfaces';
+
+import { addSelfPlanAndSendFunctions } from '../self-plan-and-send-functions';
+
+const mockInstruction: Instruction = {
+    programAddress: '11111111111111111111111111111111' as Instruction['programAddress'],
+};
+
+const mockInstructionPlan: InstructionPlan = {
+    instruction: mockInstruction,
+    kind: 'single',
+    planType: 'instructionPlan',
+};
+
+function createMockClient() {
+    return {
+        planTransaction: jest.fn().mockResolvedValue({ message: 'planned' }),
+        planTransactions: jest.fn().mockResolvedValue({ plan: 'transactions' }),
+        sendTransaction: jest.fn().mockResolvedValue({ result: 'sent' }),
+        sendTransactions: jest.fn().mockResolvedValue({ results: 'sent-all' }),
+    } as unknown as ClientWithTransactionPlanning & ClientWithTransactionSending;
+}
+
+describe('addSelfPlanAndSendFunctions', () => {
+    describe('with synchronous inputs', () => {
+        it('adds planTransaction method that delegates to the client', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const result = addSelfPlanAndSendFunctions(client, mockInstruction);
+            const config = { abortSignal: new AbortController().signal };
+            await result.planTransaction(config);
+
+            expect(client.planTransaction).toHaveBeenCalledWith(mockInstruction, config);
+        });
+
+        it('adds planTransactions method that delegates to the client', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const result = addSelfPlanAndSendFunctions(client, mockInstruction);
+            const config = { abortSignal: new AbortController().signal };
+            await result.planTransactions(config);
+
+            expect(client.planTransactions).toHaveBeenCalledWith(mockInstruction, config);
+        });
+
+        it('adds sendTransaction method that delegates to the client', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const result = addSelfPlanAndSendFunctions(client, mockInstruction);
+            const config = { abortSignal: new AbortController().signal };
+            await result.sendTransaction(config);
+
+            expect(client.sendTransaction).toHaveBeenCalledWith(mockInstruction, config);
+        });
+
+        it('adds sendTransactions method that delegates to the client', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const result = addSelfPlanAndSendFunctions(client, mockInstruction);
+            const config = { abortSignal: new AbortController().signal };
+            await result.sendTransactions(config);
+
+            expect(client.sendTransactions).toHaveBeenCalledWith(mockInstruction, config);
+        });
+
+        it('works with instruction plans', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const result = addSelfPlanAndSendFunctions(client, mockInstructionPlan);
+            await result.sendTransaction();
+
+            expect(client.sendTransaction).toHaveBeenCalledWith(mockInstructionPlan, undefined);
+        });
+
+        it('preserves the original instruction properties', () => {
+            const client = createMockClient();
+            const result = addSelfPlanAndSendFunctions(client, { ...mockInstruction, custom: 42 });
+
+            expect(result.custom).toBe(42);
+        });
+
+        it('preserves the original instruction plan properties', () => {
+            const client = createMockClient();
+            const result = addSelfPlanAndSendFunctions(client, { ...mockInstructionPlan, custom: 42 });
+
+            expect(result.custom).toBe(42);
+        });
+
+        it('returns a frozen object', () => {
+            const client = createMockClient();
+            const result = addSelfPlanAndSendFunctions(client, mockInstruction);
+
+            expect(result).toBeFrozenObject();
+        });
+    });
+
+    describe('with promise-like inputs', () => {
+        it('adds planTransaction method that awaits the input before delegating', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const instructionPromise = Promise.resolve(mockInstruction);
+            const result = addSelfPlanAndSendFunctions(client, instructionPromise);
+            const config = { abortSignal: new AbortController().signal };
+            await result.planTransaction(config);
+
+            expect(client.planTransaction).toHaveBeenCalledWith(mockInstruction, config);
+        });
+
+        it('adds planTransactions method that awaits the input before delegating', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const instructionPromise = Promise.resolve(mockInstruction);
+            const result = addSelfPlanAndSendFunctions(client, instructionPromise);
+            const config = { abortSignal: new AbortController().signal };
+            await result.planTransactions(config);
+
+            expect(client.planTransactions).toHaveBeenCalledWith(mockInstruction, config);
+        });
+
+        it('adds sendTransaction method that awaits the input before delegating', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const instructionPromise = Promise.resolve(mockInstruction);
+            const result = addSelfPlanAndSendFunctions(client, instructionPromise);
+            const config = { abortSignal: new AbortController().signal };
+            await result.sendTransaction(config);
+
+            expect(client.sendTransaction).toHaveBeenCalledWith(mockInstruction, config);
+        });
+
+        it('adds sendTransactions method that awaits the input before delegating', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const instructionPromise = Promise.resolve(mockInstruction);
+            const result = addSelfPlanAndSendFunctions(client, instructionPromise);
+            const config = { abortSignal: new AbortController().signal };
+            await result.sendTransactions(config);
+
+            expect(client.sendTransactions).toHaveBeenCalledWith(mockInstruction, config);
+        });
+
+        it('works with promise-like instruction plans', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const planPromise = Promise.resolve(mockInstructionPlan);
+            const result = addSelfPlanAndSendFunctions(client, planPromise);
+            await result.sendTransaction();
+
+            expect(client.sendTransaction).toHaveBeenCalledWith(mockInstructionPlan, undefined);
+        });
+
+        it('preserves the original promise', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const instructionPromise = Promise.resolve(mockInstruction);
+            const result = addSelfPlanAndSendFunctions(client, instructionPromise);
+            const resolved = await result;
+
+            expect(resolved).toBe(mockInstruction);
+        });
+
+        it('works with custom promise-like objects', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const customPromiseLike: PromiseLike<Instruction> = {
+                then(onFulfilled) {
+                    return Promise.resolve(mockInstruction).then(onFulfilled);
+                },
+            };
+            const result = addSelfPlanAndSendFunctions(client, customPromiseLike);
+            await result.sendTransaction();
+
+            expect(client.sendTransaction).toHaveBeenCalledWith(mockInstruction, undefined);
+        });
+
+        it('preserves the original instruction properties', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const instructionPromise = Promise.resolve({ ...mockInstruction, custom: 42 });
+            const result = addSelfPlanAndSendFunctions(client, instructionPromise);
+            const resolved = await result;
+
+            expect(resolved.custom).toBe(42);
+        });
+
+        it('preserves the original instruction plan properties', async () => {
+            expect.assertions(1);
+            const client = createMockClient();
+            const instructionPlanPromise = Promise.resolve({ ...mockInstructionPlan, custom: 42 });
+            const result = addSelfPlanAndSendFunctions(client, instructionPlanPromise);
+            const resolved = await result;
+
+            expect(resolved.custom).toBe(42);
+        });
+
+        it('does not freeze promises', () => {
+            const client = createMockClient();
+            const instructionPromise = Promise.resolve({ ...mockInstruction, custom: 42 });
+            const result = addSelfPlanAndSendFunctions(client, instructionPromise);
+
+            expect(result).not.toBeFrozenObject();
+        });
+    });
+});

--- a/packages/program-client-core/src/__typetests__/self-plan-and-send-functions-typetest.ts
+++ b/packages/program-client-core/src/__typetests__/self-plan-and-send-functions-typetest.ts
@@ -1,0 +1,121 @@
+import type {
+    InstructionPlan,
+    SingleInstructionPlan,
+    SingleTransactionPlan,
+    SuccessfulSingleTransactionPlanResult,
+    TransactionPlan,
+    TransactionPlanResult,
+} from '@solana/instruction-plans';
+import type { Instruction } from '@solana/instructions';
+import type { ClientWithTransactionPlanning, ClientWithTransactionSending } from '@solana/plugin-interfaces';
+
+import { addSelfPlanAndSendFunctions, type SelfPlanAndSendFunctions } from '../index';
+
+type FullClient = ClientWithTransactionPlanning & ClientWithTransactionSending;
+
+// [DESCRIBE] SelfPlanAndSendFunctions.
+{
+    // It provides a planTransaction method that returns a promise of a transaction message.
+    {
+        const self = null as unknown as SelfPlanAndSendFunctions;
+        void (self.planTransaction() satisfies Promise<SingleTransactionPlan['message']>);
+    }
+
+    // It provides a planTransactions method that returns a promise of a transaction plan.
+    {
+        const self = null as unknown as SelfPlanAndSendFunctions;
+        void (self.planTransactions() satisfies Promise<TransactionPlan>);
+    }
+
+    // It provides a sendTransaction method that returns a promise of a single successful result.
+    {
+        const self = null as unknown as SelfPlanAndSendFunctions;
+        void (self.sendTransaction() satisfies Promise<SuccessfulSingleTransactionPlanResult>);
+    }
+
+    // It provides a sendTransactions method that returns a promise of a transaction plan result.
+    {
+        const self = null as unknown as SelfPlanAndSendFunctions;
+        void (self.sendTransactions() satisfies Promise<TransactionPlanResult>);
+    }
+
+    // All methods accept an optional config with abortSignal.
+    {
+        const self = null as unknown as SelfPlanAndSendFunctions;
+        const abortController = new AbortController();
+        void (self.planTransaction({
+            abortSignal: abortController.signal,
+        }) satisfies Promise<SingleTransactionPlan['message']>);
+        void (self.planTransactions({
+            abortSignal: abortController.signal,
+        }) satisfies Promise<TransactionPlan>);
+        void (self.sendTransaction({
+            abortSignal: abortController.signal,
+        }) satisfies Promise<SuccessfulSingleTransactionPlanResult>);
+        void (self.sendTransactions({
+            abortSignal: abortController.signal,
+        }) satisfies Promise<TransactionPlanResult>);
+    }
+}
+
+// [DESCRIBE] addSelfPlanAndSendFunctions.
+{
+    // It returns an Instruction with SelfPlanAndSendFunctions when given an Instruction.
+    {
+        const client = null as unknown as FullClient;
+        const instruction = null as unknown as Instruction;
+        const result = addSelfPlanAndSendFunctions(client, instruction);
+        result satisfies Instruction & SelfPlanAndSendFunctions;
+    }
+
+    // It returns an InstructionPlan with SelfPlanAndSendFunctions when given an InstructionPlan.
+    {
+        const client = null as unknown as FullClient;
+        const plan = null as unknown as InstructionPlan;
+        const result = addSelfPlanAndSendFunctions(client, plan);
+        result satisfies InstructionPlan & SelfPlanAndSendFunctions;
+    }
+
+    // It returns a PromiseLike<Instruction> with SelfPlanAndSendFunctions when given a PromiseLike<Instruction>.
+    {
+        const client = null as unknown as FullClient;
+        const instructionPromise = null as unknown as PromiseLike<Instruction>;
+        const result = addSelfPlanAndSendFunctions(client, instructionPromise);
+        result satisfies PromiseLike<Instruction> & SelfPlanAndSendFunctions;
+    }
+
+    // It returns a PromiseLike<InstructionPlan> with SelfPlanAndSendFunctions when given a PromiseLike<InstructionPlan>.
+    {
+        const client = null as unknown as FullClient;
+        const planPromise = null as unknown as PromiseLike<InstructionPlan>;
+        const result = addSelfPlanAndSendFunctions(client, planPromise);
+        result satisfies PromiseLike<InstructionPlan> & SelfPlanAndSendFunctions;
+    }
+
+    // It preserves the specific instruction type.
+    {
+        type MyInstruction = Instruction<'MyProgram111111111111111111111111'> & { custom: 42 };
+        const client = null as unknown as FullClient;
+        const instruction = null as unknown as MyInstruction;
+        const result = addSelfPlanAndSendFunctions(client, instruction);
+        result satisfies MyInstruction;
+    }
+
+    // It preserves the specific instruction plan type.
+    {
+        type MyPlan = SingleInstructionPlan & { custom: 42 };
+        const client = null as unknown as FullClient;
+        const plan = null as unknown as MyPlan;
+        const result = addSelfPlanAndSendFunctions(client, plan);
+        result satisfies MyPlan;
+    }
+
+    // It preserves the Promise type with specific instruction.
+    {
+        type MyInstruction = Instruction<'MyProgram111111111111111111111111'>;
+        const client = null as unknown as FullClient;
+        const instructionPromise = null as unknown as Promise<MyInstruction>;
+        const result = addSelfPlanAndSendFunctions(client, instructionPromise);
+        void (result satisfies Promise<MyInstruction>);
+    }
+}

--- a/packages/program-client-core/src/index.ts
+++ b/packages/program-client-core/src/index.ts
@@ -7,3 +7,4 @@
  */
 export * from './instruction-input-resolution';
 export * from './instructions';
+export * from './self-plan-and-send-functions';

--- a/packages/program-client-core/src/self-plan-and-send-functions.ts
+++ b/packages/program-client-core/src/self-plan-and-send-functions.ts
@@ -1,0 +1,118 @@
+import type { InstructionPlan } from '@solana/instruction-plans';
+import type { Instruction } from '@solana/instructions';
+import type { ClientWithTransactionPlanning, ClientWithTransactionSending } from '@solana/plugin-interfaces';
+
+type PlanTransaction = ClientWithTransactionPlanning['planTransaction'];
+type PlanTransactions = ClientWithTransactionPlanning['planTransactions'];
+type SendTransaction = ClientWithTransactionSending['sendTransaction'];
+type SendTransactions = ClientWithTransactionSending['sendTransactions'];
+
+/**
+ * Methods that allow an instruction or instruction plan to plan and send itself.
+ *
+ * These methods are added to instruction or instruction plan objects via
+ * {@link addSelfPlanAndSendFunctions}, enabling a fluent API where you can call
+ * `.sendTransaction()` directly on an instruction without passing it to a separate function.
+ *
+ * @example
+ * Sending a transfer instruction directly.
+ * ```ts
+ * const result = await getTransferInstruction({ source, destination, amount }).sendTransaction();
+ * ```
+ *
+ * @example
+ * Planning multiple transactions from an instruction plan.
+ * ```ts
+ * const plan = await getComplexInstructionPlan(/* ... *\/).planTransactions();
+ * ```
+ *
+ * @see {@link addSelfPlanAndSendFunctions}
+ */
+export type SelfPlanAndSendFunctions = {
+    /** Plans a single transaction. */
+    planTransaction: (config?: Parameters<PlanTransaction>[1]) => ReturnType<PlanTransaction>;
+    /** Plans one or more transactions. */
+    planTransactions: (config?: Parameters<PlanTransactions>[1]) => ReturnType<PlanTransactions>;
+    /** Sends a single transaction. */
+    sendTransaction: (config?: Parameters<SendTransaction>[1]) => ReturnType<SendTransaction>;
+    /** Sends one or more transactions. */
+    sendTransactions: (config?: Parameters<SendTransactions>[1]) => ReturnType<SendTransactions>;
+};
+
+/**
+ * Adds self-planning and self-sending methods to an instruction or instruction plan.
+ *
+ * This function augments the provided instruction or instruction plan with methods
+ * that allow it to plan and send itself using the provided client. It enables a fluent API
+ * where you can call methods like `.sendTransaction()` directly on the instruction.
+ *
+ * The function supports both synchronous inputs (instructions, instruction plans) and
+ * promise-like inputs, making it suitable for use with async instruction builders.
+ *
+ * @typeParam TItem - The type of the instruction, instruction plan, or a promise resolving to one.
+ *
+ * @param client - A client that provides transaction planning and sending capabilities.
+ * @param input - The instruction, instruction plan, or promise to augment with self-plan/send methods.
+ * @returns The input augmented with {@link SelfPlanAndSendFunctions} methods.
+ *
+ * @example
+ * Adding self-plan and send to a transfer instruction.
+ * ```ts
+ * import { addSelfPlanAndSendFunctions } from '@solana/program-client-core';
+ *
+ * const transferInstruction = addSelfPlanAndSendFunctions(
+ *     client,
+ *     getTransferInstruction({ payer, source, destination, amount })
+ * );
+ *
+ * // Now you can send directly from the instruction.
+ * const result = await transferInstruction.sendTransaction();
+ * ```
+ *
+ * @example
+ * Using with an async instruction builder.
+ * ```ts
+ * const asyncInstruction = addSelfPlanAndSendFunctions(
+ *     client,
+ *     fetchAndBuildInstruction(/* ... *\/)
+ * );
+ *
+ * // The promise is augmented with self-plan/send methods.
+ * const result = await asyncInstruction.sendTransaction();
+ * ```
+ *
+ * @see {@link SelfPlanAndSendFunctions}
+ */
+export function addSelfPlanAndSendFunctions<
+    TItem extends Instruction | InstructionPlan | PromiseLike<Instruction> | PromiseLike<InstructionPlan>,
+>(
+    client: ClientWithTransactionPlanning & ClientWithTransactionSending,
+    input: TItem,
+): SelfPlanAndSendFunctions & TItem {
+    if (isPromiseLike(input)) {
+        const newInput = input as SelfPlanAndSendFunctions & TItem;
+        newInput.planTransaction = async config => await client.planTransaction(await input, config);
+        newInput.planTransactions = async config => await client.planTransactions(await input, config);
+        newInput.sendTransaction = async config => await client.sendTransaction(await input, config);
+        newInput.sendTransactions = async config => await client.sendTransactions(await input, config);
+        return newInput;
+    }
+
+    return Object.freeze(<SelfPlanAndSendFunctions & (Instruction | InstructionPlan)>{
+        ...input,
+        planTransaction: config => client.planTransaction(input, config),
+        planTransactions: config => client.planTransactions(input, config),
+        sendTransaction: config => client.sendTransaction(input, config),
+        sendTransactions: config => client.sendTransactions(input, config),
+    }) as unknown as SelfPlanAndSendFunctions & TItem;
+}
+
+function isPromiseLike(
+    item: Instruction | InstructionPlan | PromiseLike<Instruction> | PromiseLike<InstructionPlan>,
+): item is PromiseLike<Instruction> | PromiseLike<InstructionPlan> {
+    return (
+        !!item &&
+        (typeof item === 'object' || typeof item === 'function') &&
+        typeof (item as PromiseLike<unknown>).then === 'function'
+    );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -855,9 +855,15 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      '@solana/instruction-plans':
+        specifier: workspace:*
+        version: link:../instruction-plans
       '@solana/instructions':
         specifier: workspace:*
         version: link:../instructions
+      '@solana/plugin-interfaces':
+        specifier: workspace:*
+        version: link:../plugin-interfaces
       '@solana/signers':
         specifier: workspace:*
         version: link:../signers


### PR DESCRIPTION
This PR adds a new `SelfPlanAndSendFunctions` type that describes an object that is able to plan itself into a `TransactionPlan` or execute itself and return a `TransactionPlanResult`.

It also provides a `addSelfPlanAndSendFunctions` function that adds these functions to any `Instruction`, `InstructionPlan` (or a promise of either).