### PR TITLE
Add self fetch helpers to `program-client-core`

### DIFF
--- a/packages/program-client-core/package.json
+++ b/packages/program-client-core/package.json
@@ -73,12 +73,19 @@
         "maintained node versions"
     ],
     "dependencies": {
+        "@solana/accounts": "workspace:*",
         "@solana/addresses": "workspace:*",
+        "@solana/codecs-core": "workspace:*",
         "@solana/errors": "workspace:*",
         "@solana/instructions": "workspace:*",
         "@solana/instruction-plans": "workspace:*",
         "@solana/plugin-interfaces": "workspace:*",
+        "@solana/rpc-api": "workspace:*",
         "@solana/signers": "workspace:*"
+    },
+    "devDependencies": {
+        "@solana/codecs-data-structures": "workspace:*",
+        "@solana/codecs-numbers": "workspace:*"
     },
     "peerDependencies": {
         "typescript": "^5.0.0"

--- a/packages/program-client-core/src/__tests__/self-fetch-functions-test.ts
+++ b/packages/program-client-core/src/__tests__/self-fetch-functions-test.ts
@@ -1,0 +1,171 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import { fetchEncodedAccount, fetchEncodedAccounts, type MaybeEncodedAccount } from '@solana/accounts';
+import type { Address } from '@solana/addresses';
+import { getStructCodec } from '@solana/codecs-data-structures';
+import { getU8Codec } from '@solana/codecs-numbers';
+import {
+    SOLANA_ERROR__ACCOUNTS__ACCOUNT_NOT_FOUND,
+    SOLANA_ERROR__ACCOUNTS__ONE_OR_MORE_ACCOUNTS_NOT_FOUND,
+    SolanaError,
+} from '@solana/errors';
+import type { ClientWithRpc } from '@solana/plugin-interfaces';
+import type { GetAccountInfoApi, GetMultipleAccountsApi } from '@solana/rpc-api';
+
+import { addSelfFetchFunctions } from '../index';
+
+jest.mock('@solana/accounts', () => ({
+    ...jest.requireActual('@solana/accounts'),
+    fetchEncodedAccount: jest.fn(),
+    fetchEncodedAccounts: jest.fn(),
+}));
+
+const mockClient = { rpc: {} } as ClientWithRpc<GetAccountInfoApi & GetMultipleAccountsApi>;
+const mockAddressA = '1111' as Address<'1111'>;
+const mockAddressB = '2222' as Address<'2222'>;
+const mockAddressMissing = '3333' as Address<'3333'>;
+
+function getMockCodec() {
+    return getStructCodec([['value', getU8Codec()]]);
+}
+
+function fetchEncodedAccountImpl(address: Address): MaybeEncodedAccount {
+    switch (address) {
+        case mockAddressA:
+            return { address, data: new Uint8Array([1]), exists: true } as MaybeEncodedAccount;
+        case mockAddressB:
+            return { address, data: new Uint8Array([2]), exists: true } as MaybeEncodedAccount;
+        default:
+            return { address, exists: false };
+    }
+}
+
+describe('addSelfFetchFunctions', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.mocked(fetchEncodedAccount).mockImplementation((_rpc, address) =>
+            Promise.resolve(fetchEncodedAccountImpl(address)),
+        );
+        jest.mocked(fetchEncodedAccounts).mockImplementation((_rpc, addresses) =>
+            Promise.resolve(addresses.map(fetchEncodedAccountImpl)),
+        );
+    });
+
+    describe('fetch', () => {
+        it('fetches and decodes a single account', async () => {
+            expect.assertions(2);
+            const codec = addSelfFetchFunctions(mockClient, getMockCodec());
+            const config = { commitment: 'confirmed' as const };
+            const result = await codec.fetch(mockAddressA, config);
+
+            expect(fetchEncodedAccount).toHaveBeenCalledWith(mockClient.rpc, mockAddressA, config);
+            expect(result).toMatchObject({ address: mockAddressA, data: { value: 1 } });
+        });
+
+        it('throws when account does not exist', async () => {
+            expect.assertions(1);
+            const codec = addSelfFetchFunctions(mockClient, getMockCodec());
+
+            await expect(codec.fetch(mockAddressMissing)).rejects.toThrow(
+                new SolanaError(SOLANA_ERROR__ACCOUNTS__ACCOUNT_NOT_FOUND, { address: mockAddressMissing }),
+            );
+        });
+    });
+
+    describe('fetchMaybe', () => {
+        it('fetches and decodes a single account without asserting existence', async () => {
+            expect.assertions(2);
+            const codec = addSelfFetchFunctions(mockClient, getMockCodec());
+            const config = { commitment: 'confirmed' as const };
+            const result = await codec.fetchMaybe(mockAddressA, config);
+
+            expect(fetchEncodedAccount).toHaveBeenCalledWith(mockClient.rpc, mockAddressA, config);
+            expect(result).toMatchObject({ address: mockAddressA, data: { value: 1 }, exists: true });
+        });
+
+        it('returns a MaybeAccount for missing accounts without throwing', async () => {
+            expect.assertions(1);
+            const codec = addSelfFetchFunctions(mockClient, getMockCodec());
+            const result = await codec.fetchMaybe(mockAddressMissing);
+
+            expect(result).toStrictEqual({ address: mockAddressMissing, exists: false });
+        });
+    });
+
+    describe('fetchAll', () => {
+        it('fetches and decodes multiple accounts', async () => {
+            expect.assertions(4);
+            const codec = addSelfFetchFunctions(mockClient, getMockCodec());
+            const addresses = [mockAddressA, mockAddressB];
+            const config = { commitment: 'confirmed' as const };
+            const result = await codec.fetchAll(addresses, config);
+
+            expect(fetchEncodedAccounts).toHaveBeenCalledWith(mockClient.rpc, addresses, config);
+            expect(result).toHaveLength(2);
+            expect(result[0]).toMatchObject({ address: mockAddressA, data: { value: 1 } });
+            expect(result[1]).toMatchObject({ address: mockAddressB, data: { value: 2 } });
+        });
+
+        it('throws when any account does not exist', async () => {
+            expect.assertions(1);
+            const codec = addSelfFetchFunctions(mockClient, getMockCodec());
+
+            await expect(codec.fetchAll([mockAddressA, mockAddressMissing])).rejects.toThrow(
+                new SolanaError(SOLANA_ERROR__ACCOUNTS__ONE_OR_MORE_ACCOUNTS_NOT_FOUND, {
+                    addresses: [mockAddressMissing],
+                }),
+            );
+        });
+    });
+
+    describe('fetchAllMaybe', () => {
+        it('fetches and decodes multiple accounts without asserting existence', async () => {
+            expect.assertions(4);
+            const codec = addSelfFetchFunctions(mockClient, getMockCodec());
+            const addresses = [mockAddressA, mockAddressB];
+            const config = { commitment: 'confirmed' as const };
+            const result = await codec.fetchAllMaybe(addresses, config);
+
+            expect(fetchEncodedAccounts).toHaveBeenCalledWith(mockClient.rpc, addresses, config);
+            expect(result).toHaveLength(2);
+            expect(result[0]).toMatchObject({ address: mockAddressA, data: { value: 1 }, exists: true });
+            expect(result[1]).toMatchObject({ address: mockAddressB, data: { value: 2 }, exists: true });
+        });
+
+        it('returns MaybeAccounts including missing accounts without throwing', async () => {
+            expect.assertions(3);
+            const codec = addSelfFetchFunctions(mockClient, getMockCodec());
+            const result = await codec.fetchAllMaybe([mockAddressA, mockAddressMissing]);
+
+            expect(result).toHaveLength(2);
+            expect(result[0]).toMatchObject({ address: mockAddressA, data: { value: 1 }, exists: true });
+            expect(result[1]).toStrictEqual({ address: mockAddressMissing, exists: false });
+        });
+    });
+
+    describe('codec preservation', () => {
+        it('preserves the original codec methods', () => {
+            const originalCodec = getMockCodec();
+            const result = addSelfFetchFunctions(mockClient, originalCodec);
+
+            expect(result.encode).toBe(originalCodec.encode);
+            expect(result.decode).toBe(originalCodec.decode);
+            expect(result.read).toBe(originalCodec.read);
+            expect(result.write).toBe(originalCodec.write);
+            expect(result.fixedSize).toBe(originalCodec.fixedSize);
+        });
+
+        it('preserves custom properties from the codec', () => {
+            const customCodec = { ...getMockCodec(), custom: 42 };
+            const result = addSelfFetchFunctions(mockClient, customCodec);
+
+            expect(result.custom).toBe(42);
+        });
+
+        it('returns a frozen object', () => {
+            const result = addSelfFetchFunctions(mockClient, getMockCodec());
+
+            expect(result).toBeFrozenObject();
+        });
+    });
+});

--- a/packages/program-client-core/src/__typetests__/self-fetch-functions-typetest.ts
+++ b/packages/program-client-core/src/__typetests__/self-fetch-functions-typetest.ts
@@ -1,0 +1,129 @@
+import type { Account, FetchAccountConfig, FetchAccountsConfig, MaybeAccount } from '@solana/accounts';
+import type { Address } from '@solana/addresses';
+import type { Codec, FixedSizeCodec, ReadonlyUint8Array, VariableSizeCodec } from '@solana/codecs-core';
+import type { ClientWithRpc } from '@solana/plugin-interfaces';
+import type { GetAccountInfoApi, GetMultipleAccountsApi } from '@solana/rpc-api';
+
+import { addSelfFetchFunctions, type SelfFetchFunctions } from '../index';
+
+type RpcClient = ClientWithRpc<GetAccountInfoApi & GetMultipleAccountsApi>;
+
+type MyAccountData = { age: number; name: string };
+
+// [DESCRIBE] SelfFetchFunctions.
+{
+    // It provides a fetch method that returns a promise of an Account.
+    {
+        const self = null as unknown as SelfFetchFunctions<MyAccountData, MyAccountData>;
+        const address = null as unknown as Address<'1111'>;
+        void (self.fetch(address) satisfies Promise<Account<MyAccountData, '1111'>>);
+    }
+
+    // It provides a fetchMaybe method that returns a promise of a MaybeAccount.
+    {
+        const self = null as unknown as SelfFetchFunctions<MyAccountData, MyAccountData>;
+        const address = null as unknown as Address<'1111'>;
+        void (self.fetchMaybe(address) satisfies Promise<MaybeAccount<MyAccountData, '1111'>>);
+    }
+
+    // It provides a fetchAll method that returns a promise of an array of Accounts.
+    {
+        const self = null as unknown as SelfFetchFunctions<MyAccountData, MyAccountData>;
+        const addresses = null as unknown as Address[];
+        void (self.fetchAll(addresses) satisfies Promise<Account<MyAccountData>[]>);
+    }
+
+    // It provides a fetchAllMaybe method that returns a promise of an array of MaybeAccounts.
+    {
+        const self = null as unknown as SelfFetchFunctions<MyAccountData, MyAccountData>;
+        const addresses = null as unknown as Address[];
+        void (self.fetchAllMaybe(addresses) satisfies Promise<MaybeAccount<MyAccountData>[]>);
+    }
+
+    // All single-account methods accept an optional FetchAccountConfig.
+    {
+        const self = null as unknown as SelfFetchFunctions<MyAccountData, MyAccountData>;
+        const address = null as unknown as Address<'1111'>;
+        const config: FetchAccountConfig = { commitment: 'confirmed' };
+        void (self.fetch(address, config) satisfies Promise<Account<MyAccountData, '1111'>>);
+        void (self.fetchMaybe(address, config) satisfies Promise<MaybeAccount<MyAccountData, '1111'>>);
+    }
+
+    // All multi-account methods accept an optional FetchAccountsConfig.
+    {
+        const self = null as unknown as SelfFetchFunctions<MyAccountData, MyAccountData>;
+        const addresses = null as unknown as Address[];
+        const config: FetchAccountsConfig = { commitment: 'confirmed' };
+        void (self.fetchAll(addresses, config) satisfies Promise<Account<MyAccountData>[]>);
+        void (self.fetchAllMaybe(addresses, config) satisfies Promise<MaybeAccount<MyAccountData>[]>);
+    }
+
+    // It supports different TFrom and TTo types.
+    {
+        type MyAccountInput = { age: bigint | number; name: string };
+        const self = null as unknown as SelfFetchFunctions<MyAccountInput, MyAccountData>;
+        const address = null as unknown as Address<'1111'>;
+        // The decoded type should be TTo (MyAccountData), not TFrom (MyAccountInput).
+        void (self.fetch(address) satisfies Promise<Account<MyAccountData, '1111'>>);
+    }
+}
+
+// [DESCRIBE] addSelfFetchFunctions.
+{
+    // It returns a Codec with SelfFetchFunctions when given a Codec.
+    {
+        const client = null as unknown as RpcClient;
+        const codec = null as unknown as FixedSizeCodec<MyAccountData>;
+        const result = addSelfFetchFunctions(client, codec);
+        result satisfies Codec<MyAccountData> & SelfFetchFunctions<MyAccountData, MyAccountData>;
+    }
+
+    // It preserves the specific codec type.
+    {
+        type MyCodec = FixedSizeCodec<MyAccountData> & { custom: 42 };
+        const client = null as unknown as RpcClient;
+        const codec = null as unknown as MyCodec;
+        const result = addSelfFetchFunctions(client, codec);
+        result satisfies MyCodec;
+    }
+
+    // It supports codecs with different TFrom and TTo types.
+    {
+        type MyAccountInput = { age: bigint | number; name: string };
+        const client = null as unknown as RpcClient;
+        const codec = null as unknown as Codec<MyAccountInput, MyAccountData>;
+        const result = addSelfFetchFunctions(client, codec);
+        result satisfies Codec<MyAccountInput, MyAccountData> & SelfFetchFunctions<MyAccountInput, MyAccountData>;
+    }
+
+    // The fetch methods use the TTo type for Account data.
+    {
+        type MyAccountInput = { age: bigint | number; name: string };
+        const client = null as unknown as RpcClient;
+        const codec = null as unknown as Codec<MyAccountInput, MyAccountData>;
+        const result = addSelfFetchFunctions(client, codec);
+        const address = null as unknown as Address<'1111'>;
+        // The fetched account should have TTo (MyAccountData) as its data type.
+        void (result.fetch(address) satisfies Promise<Account<MyAccountData, '1111'>>);
+    }
+
+    // It retains codec methods like encode, decode and size attributes.
+    {
+        const client = null as unknown as RpcClient;
+        const codec = null as unknown as VariableSizeCodec<MyAccountData>;
+        const result = addSelfFetchFunctions(client, codec);
+        // Should still be able to use codec methods.
+        result.encode({ age: 30, name: 'Alice' }) satisfies ReadonlyUint8Array;
+        result.decode(new Uint8Array()) satisfies MyAccountData;
+        result.getSizeFromValue({ age: 30, name: 'Alice' }) satisfies number;
+    }
+
+    // It works with a codec factory function that returns a Codec.
+    {
+        type MyAccountInput = { age: bigint | number; name: string };
+        const client = null as unknown as RpcClient;
+        const getMyAccountCodec = null as unknown as () => FixedSizeCodec<MyAccountInput, MyAccountData>;
+        const result = addSelfFetchFunctions(client, getMyAccountCodec());
+        result satisfies ReturnType<typeof getMyAccountCodec> & SelfFetchFunctions<MyAccountInput, MyAccountData>;
+    }
+}

--- a/packages/program-client-core/src/index.ts
+++ b/packages/program-client-core/src/index.ts
@@ -7,4 +7,5 @@
  */
 export * from './instruction-input-resolution';
 export * from './instructions';
+export * from './self-fetch-functions';
 export * from './self-plan-and-send-functions';

--- a/packages/program-client-core/src/self-fetch-functions.ts
+++ b/packages/program-client-core/src/self-fetch-functions.ts
@@ -1,0 +1,156 @@
+import {
+    type Account,
+    assertAccountExists,
+    assertAccountsExist,
+    decodeAccount,
+    type FetchAccountConfig,
+    type FetchAccountsConfig,
+    fetchEncodedAccount,
+    fetchEncodedAccounts,
+    type MaybeAccount,
+} from '@solana/accounts';
+import type { Address } from '@solana/addresses';
+import type { Codec } from '@solana/codecs-core';
+import type { ClientWithRpc } from '@solana/plugin-interfaces';
+import type { GetAccountInfoApi, GetMultipleAccountsApi } from '@solana/rpc-api';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyObjectCodec = Codec<any, object>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type InferTFrom<T> = T extends Codec<infer TFrom, any> ? TFrom : never;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type InferTTo<T> = T extends Codec<any, infer TTo> ? TTo : never;
+
+/**
+ * Methods that allow a codec to fetch and decode accounts directly.
+ *
+ * These methods are added to codec objects via {@link addSelfFetchFunctions},
+ * enabling a fluent API where you can call `.fetch()` directly on a codec
+ * to retrieve and decode accounts in one step.
+ *
+ * @typeParam TFrom - The type that the codec encodes from.
+ * @typeParam TTo - The type that the codec decodes to.
+ *
+ * @example
+ * Fetching a single account and asserting it exists.
+ * ```ts
+ * const account = await myAccountCodec.fetch(address);
+ * // account.data is of type TTo.
+ * ```
+ *
+ * @example
+ * Fetching a single account that may not exist.
+ * ```ts
+ * const maybeAccount = await myAccountCodec.fetchMaybe(address);
+ * if (maybeAccount.exists) {
+ *     // maybeAccount.data is of type TTo.
+ * }
+ * ```
+ *
+ * @example
+ * Fetching multiple accounts at once.
+ * ```ts
+ * const accounts = await myAccountCodec.fetchAll([addressA, addressB]);
+ * // All accounts exist.
+ * ```
+ *
+ * @see {@link addSelfFetchFunctions}
+ */
+export type SelfFetchFunctions<TFrom extends object, TTo extends TFrom> = {
+    /** Fetches and decodes a single account, throwing if it does not exist. */
+    readonly fetch: <TAddress extends string>(
+        address: Address<TAddress>,
+        config?: FetchAccountConfig,
+    ) => Promise<Account<TTo, TAddress>>;
+    /** Fetches and decodes multiple accounts, throwing if any do not exist. */
+    readonly fetchAll: (addresses: Address[], config?: FetchAccountsConfig) => Promise<Account<TTo>[]>;
+    /** Fetches and decodes multiple accounts, returning {@link MaybeAccount} for each. */
+    readonly fetchAllMaybe: (addresses: Address[], config?: FetchAccountsConfig) => Promise<MaybeAccount<TTo>[]>;
+    /** Fetches and decodes a single account, returning a {@link MaybeAccount}. */
+    readonly fetchMaybe: <TAddress extends string>(
+        address: Address<TAddress>,
+        config?: FetchAccountConfig,
+    ) => Promise<MaybeAccount<TTo, TAddress>>;
+};
+
+/**
+ * Adds self-fetching methods to a codec for retrieving and decoding accounts.
+ *
+ * This function augments the provided codec with methods that allow it to fetch
+ * accounts from the network and decode them in one step. It enables a fluent API
+ * where you can call methods like `.fetch()` directly on the codec.
+ *
+ * @typeParam TFrom - The type that the codec encodes from.
+ * @typeParam TTo - The type that the codec decodes to.
+ * @typeParam TCodec - The codec type being augmented.
+ *
+ * @param client - A client that provides RPC access for fetching accounts.
+ * @param codec - The codec to augment with self-fetch methods.
+ * @returns The codec augmented with {@link SelfFetchFunctions} methods.
+ *
+ * @example
+ * Adding self-fetch functions to an account codec.
+ * ```ts
+ * import { addSelfFetchFunctions } from '@solana/program-client-core';
+ *
+ * const myAccountCodec = addSelfFetchFunctions(client, getMyAccountCodec());
+ *
+ * // Fetch and decode an account in one step.
+ * const account = await myAccountCodec.fetch(accountAddress);
+ * ```
+ *
+ * @example
+ * Handling accounts that may not exist.
+ * ```ts
+ * const myAccountCodec = addSelfFetchFunctions(client, getMyAccountCodec());
+ *
+ * const maybeAccount = await myAccountCodec.fetchMaybe(accountAddress);
+ * if (maybeAccount.exists) {
+ *     console.log('Account data:', maybeAccount.data);
+ * } else {
+ *     console.log(`Account ${maybeAccount.address} does not exist`);
+ * }
+ * ```
+ *
+ * @example
+ * Fetching multiple accounts at once.
+ * ```ts
+ * const myAccountCodec = addSelfFetchFunctions(client, getMyAccountCodec());
+ *
+ * // Throws if any account does not exist.
+ * const accounts = await myAccountCodec.fetchAll([addressA, addressB, addressC]);
+ *
+ * // Returns MaybeAccount for each, allowing some to not exist.
+ * const maybeAccounts = await myAccountCodec.fetchAllMaybe([addressA, addressB]);
+ * ```
+ *
+ * @see {@link SelfFetchFunctions}
+ */
+export function addSelfFetchFunctions<TCodec extends AnyObjectCodec>(
+    client: ClientWithRpc<GetAccountInfoApi & GetMultipleAccountsApi>,
+    codec: TCodec,
+): SelfFetchFunctions<InferTFrom<TCodec>, InferTTo<TCodec>> & TCodec {
+    type Functions = SelfFetchFunctions<InferTFrom<TCodec>, InferTTo<TCodec>>;
+    type InferredCodec = Codec<InferTFrom<TCodec>, InferTTo<TCodec>>;
+    const fetchMaybe: Functions['fetchMaybe'] = async (address, config?) => {
+        const maybeAccount = await fetchEncodedAccount(client.rpc, address, config);
+        return decodeAccount(maybeAccount, codec as InferredCodec);
+    };
+    const fetchAllMaybe: Functions['fetchAllMaybe'] = async (addresses, config?) => {
+        const maybeAccounts = await fetchEncodedAccounts(client.rpc, addresses, config);
+        return maybeAccounts.map(maybeAccount => decodeAccount(maybeAccount, codec as InferredCodec));
+    };
+    const fetch: Functions['fetch'] = async (address, config?) => {
+        const maybeAccount = await fetchMaybe(address, config);
+        assertAccountExists(maybeAccount);
+        return maybeAccount;
+    };
+    const fetchAll: Functions['fetchAll'] = async (addresses, config?) => {
+        const maybeAccounts = await fetchAllMaybe(addresses, config);
+        assertAccountsExist(maybeAccounts);
+        return maybeAccounts;
+    };
+
+    const out = { ...codec, fetch, fetchAll, fetchAllMaybe, fetchMaybe };
+    return Object.freeze<typeof out>(out);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -849,9 +849,15 @@ importers:
 
   packages/program-client-core:
     dependencies:
+      '@solana/accounts':
+        specifier: workspace:*
+        version: link:../accounts
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
+      '@solana/codecs-core':
+        specifier: workspace:*
+        version: link:../codecs-core
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
@@ -864,12 +870,22 @@ importers:
       '@solana/plugin-interfaces':
         specifier: workspace:*
         version: link:../plugin-interfaces
+      '@solana/rpc-api':
+        specifier: workspace:*
+        version: link:../rpc-api
       '@solana/signers':
         specifier: workspace:*
         version: link:../signers
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
+    devDependencies:
+      '@solana/codecs-data-structures':
+        specifier: workspace:*
+        version: link:../codecs-data-structures
+      '@solana/codecs-numbers':
+        specifier: workspace:*
+        version: link:../codecs-numbers
 
   packages/programs:
     dependencies:


### PR DESCRIPTION
This PR adds a new `SelfFetchFunctions` type that describes an object that is able to fetch one or multiple accounts using its own encoding/decoding logic.

It also provides a `addSelfFetchFunctions` function that adds these functions to any `Codec`, ensuring that the returned codec does not lose any properties from the original one.