### PR TITLE
Add `program-client-core` subpath export

### DIFF
--- a/.changeset/wild-candles-throw.md
+++ b/.changeset/wild-candles-throw.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit': minor
+---
+
+Add `@solana/kit/program-client-core` as a subpath export for `@solana/program-client-core` without changing root `@solana/kit` exports.

--- a/packages/build-scripts/getBaseConfig.ts
+++ b/packages/build-scripts/getBaseConfig.ts
@@ -14,6 +14,12 @@ type Platform =
 const BROWSERSLIST_TARGETS = browsersListToEsBuild();
 
 export function getBaseConfig(platform: Platform, formats: Format[], _options: Options): Options[] {
+    // `@solana/kit` has an additional subpath entry point that should be published separately.
+    const moduleEntry =
+        env.npm_package_name === '@solana/kit'
+            ? ['./src/index.ts', './src/program-client-core.ts']
+            : ['./src/index.ts'];
+
     return [true, false]
         .flatMap<Options | null>(isDebugBuild =>
             formats.map(format =>
@@ -26,7 +32,8 @@ export function getBaseConfig(platform: Platform, formats: Format[], _options: O
                               __REACTNATIVE__: `${platform === 'native'}`,
                               __VERSION__: `"${env.npm_package_version}"`,
                           },
-                          entry: [`./src/index.ts`],
+                          // We don't need subpath exports for iife bundles.
+                          entry: format === 'iife' ? ['./src/index.ts'] : moduleEntry,
                           esbuildOptions(options, context) {
                               const { format } = context;
                               options.minify = format === 'iife' && !isDebugBuild;

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -4,28 +4,52 @@
     "description": "Solana Javascript API",
     "homepage": "https://www.solanakit.com",
     "exports": {
-        "edge-light": {
-            "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs"
+        ".": {
+            "edge-light": {
+                "import": "./dist/index.node.mjs",
+                "require": "./dist/index.node.cjs"
+            },
+            "workerd": {
+                "import": "./dist/index.node.mjs",
+                "require": "./dist/index.node.cjs"
+            },
+            "browser": {
+                "import": "./dist/index.browser.mjs",
+                "require": "./dist/index.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/index.node.mjs",
+                "require": "./dist/index.node.cjs"
+            },
+            "react-native": "./dist/index.native.mjs",
+            "types": "./dist/types/index.d.ts"
         },
-        "workerd": {
-            "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs"
-        },
-        "browser": {
-            "import": "./dist/index.browser.mjs",
-            "require": "./dist/index.browser.cjs"
-        },
-        "node": {
-            "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs"
-        },
-        "react-native": "./dist/index.native.mjs",
-        "types": "./dist/types/index.d.ts"
+        "./program-client-core": {
+            "edge-light": {
+                "import": "./dist/program-client-core.node.mjs",
+                "require": "./dist/program-client-core.node.cjs"
+            },
+            "workerd": {
+                "import": "./dist/program-client-core.node.mjs",
+                "require": "./dist/program-client-core.node.cjs"
+            },
+            "browser": {
+                "import": "./dist/program-client-core.browser.mjs",
+                "require": "./dist/program-client-core.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/program-client-core.node.mjs",
+                "require": "./dist/program-client-core.node.cjs"
+            },
+            "react-native": "./dist/program-client-core.native.mjs",
+            "types": "./dist/types/program-client-core.d.ts"
+        }
     },
     "browser": {
         "./dist/index.node.cjs": "./dist/index.browser.cjs",
-        "./dist/index.node.mjs": "./dist/index.browser.mjs"
+        "./dist/index.node.mjs": "./dist/index.browser.mjs",
+        "./dist/program-client-core.node.cjs": "./dist/program-client-core.browser.cjs",
+        "./dist/program-client-core.node.mjs": "./dist/program-client-core.browser.mjs"
     },
     "jsdelivr": "./dist/index.production.min.js",
     "umd": "./dist/index.production.min.js",
@@ -87,6 +111,7 @@
         "@solana/offchain-messages": "workspace:*",
         "@solana/plugin-core": "workspace:*",
         "@solana/plugin-interfaces": "workspace:*",
+        "@solana/program-client-core": "workspace:*",
         "@solana/programs": "workspace:*",
         "@solana/rpc": "workspace:*",
         "@solana/rpc-api": "workspace:*",

--- a/packages/kit/src/__tests__/program-client-core-subpath-export-test.node.ts
+++ b/packages/kit/src/__tests__/program-client-core-subpath-export-test.node.ts
@@ -1,0 +1,20 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const kitPackageFolder = path.resolve(__dirname, '../../');
+const requireFromKit = createRequire(path.join(kitPackageFolder, 'package.json'));
+
+describe('@solana/kit program-client-core subpath export', () => {
+    it('resolves `@solana/kit/program-client-core` to its dedicated dist entrypoint', () => {
+        const resolvedSubpathExport = requireFromKit.resolve('@solana/kit/program-client-core');
+        expect(resolvedSubpathExport).toBe(path.join(kitPackageFolder, 'dist', 'program-client-core.node.cjs'));
+    });
+
+    it('keeps root and subpath exports distinct', () => {
+        const resolvedRootExport = requireFromKit.resolve('@solana/kit');
+        const resolvedSubpathExport = requireFromKit.resolve('@solana/kit/program-client-core');
+
+        expect(resolvedRootExport).toBe(path.join(kitPackageFolder, 'dist', 'index.node.cjs'));
+        expect(resolvedRootExport).not.toBe(resolvedSubpathExport);
+    });
+});

--- a/packages/kit/src/program-client-core.ts
+++ b/packages/kit/src/program-client-core.ts
@@ -1,0 +1,1 @@
+export * from '@solana/program-client-core';

--- a/packages/kit/tsconfig.declarations.json
+++ b/packages/kit/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts", "src/program-client-core.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -717,6 +717,9 @@ importers:
       '@solana/plugin-interfaces':
         specifier: workspace:*
         version: link:../plugin-interfaces
+      '@solana/program-client-core':
+        specifier: workspace:*
+        version: link:../program-client-core
       '@solana/programs':
         specifier: workspace:*
         version: link:../programs


### PR DESCRIPTION
This PR adds `@solana/program-client-core` to `@solana/kit` as a subpath export available via `@solana/kit/program-client-core`.

It also adds a small test in node only to ensure that `@solana/kit/program-client-core` resolves to the correct dist file whereas importing `@solana/kit` stays unchanged.