### PR TITLE
Fix unit test task dependencies to include own `compile:js`

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -82,12 +82,12 @@
             "outputs": []
         },
         "test:unit:browser": {
-            "dependsOn": ["^compile:js"],
+            "dependsOn": ["compile:js"],
             "inputs": ["$TURBO_DEFAULT$", "../../.agave/**/version.yml", "src/**"],
             "outputs": []
         },
         "test:unit:node": {
-            "dependsOn": ["^compile:js"],
+            "dependsOn": ["compile:js"],
             "inputs": ["$TURBO_DEFAULT$", "../../.agave/**/version.yml", "src/**"],
             "outputs": []
         },


### PR DESCRIPTION
#### Problem

The `test:unit:browser` and `test:unit:node` tasks currently depend on `^compile:js`, which only waits for the compile step of a package's dependencies, not its own compile step. This was fine until now because Jest tests don't need a compile step to execute, they have their own environments and their own built-in compile steps.

However, we recently introduced a [new `program-client-core` subpath export](https://github.com/anza-xyz/kit/pull/1356) to the `@solana/kit` library and added a unit test to ensure the subpath export was resolved correctly. This means we now need unit tests to await for the compile step to ensure we can properly resolve and test its export paths.

#### Summary of Changes

This PR makes the `test:unit:*` tasks from Turbo await their own compile step on top of the compile steps of their dependencies. We do this simply by removing the caret `^` which is sufficient because the `compile:js` task already depends on `^compile:js` itself. This meaning dependencies are still compiled transitively before any package's own compilation begins.

Note that we technically only need this for `test:unit:node` for CI to go back to green. However it is best to stay consistent and apply the same dependency logic to `test:unit:browser` to avoid similar gotchas in the future.

Fixes CI