### PR TITLE
Fix connect wallet menu in react example app

### DIFF
--- a/examples/react-app/src/components/ConnectWalletMenuItem.tsx
+++ b/examples/react-app/src/components/ConnectWalletMenuItem.tsx
@@ -1,5 +1,4 @@
-import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
-import { DropdownMenu, ThickChevronRightIcon } from '@radix-ui/themes';
+import { DropdownMenu } from '@radix-ui/themes';
 import type { UiWallet, UiWalletAccount } from '@wallet-standard/react';
 import { uiWalletAccountsAreSame, useConnect, useDisconnect } from '@wallet-standard/react';
 import { useCallback, useContext } from 'react';
@@ -41,24 +40,9 @@ export function ConnectWalletMenuItem({ onAccountSelect, onDisconnect, onError, 
     }, [connect, onAccountSelect, onError, wallet.accounts]);
     return (
         <DropdownMenu.Sub open={!isConnected ? false : undefined}>
-            <DropdownMenuPrimitive.SubTrigger
-                asChild={false}
-                className={[
-                    'rt-BaseMenuItem',
-                    'rt-BaseMenuSubTrigger',
-                    'rt-DropdownMenuItem',
-                    'rt-DropdownMenuSubTrigger',
-                ].join(' ')}
-                disabled={isPending}
-                onClick={!isConnected ? handleConnectClick : undefined}
-            >
+            <DropdownMenu.SubTrigger disabled={isPending} onClick={!isConnected ? handleConnectClick : undefined}>
                 <WalletMenuItemContent loading={isPending} wallet={wallet} />
-                {isConnected ? (
-                    <div className="rt-BaseMenuShortcut rt-DropdownMenuShortcut">
-                        <ThickChevronRightIcon className="rt-BaseMenuSubTriggerIcon rt-DropdownMenuSubtriggerIcon" />
-                    </div>
-                ) : null}
-            </DropdownMenuPrimitive.SubTrigger>
+            </DropdownMenu.SubTrigger>
             <DropdownMenu.SubContent>
                 <DropdownMenu.Label>Accounts</DropdownMenu.Label>
                 <DropdownMenu.RadioGroup value={selectedWalletAccount?.address}>


### PR DESCRIPTION
#### Problem

Spotted an issue in the react-app example

<img width="1159" height="519" alt="Screenshot 2026-02-12 at 17 27 17" src="https://github.com/user-attachments/assets/647d4934-2ff2-4aa6-ba3f-1270a57d7b2b" />

The `SubTrigger` element in [ConnectWalletMenuItem.tsx](https://github.com/anza-xyz/kit/compare/menu-fix?expand=1#diff-a208b4749f67bb55e74893e7b834f2ef5899049d138a4ca27b897f8d8701da35) was using `DropdownMenuPrimitive`. I think a newer version of `radix-themes` (which dependabot bumped) added support for `DropdownMenu.SubTrigger`, but also throws an error now if you mix the primitive with the menu. 

#### Summary of Changes

- Just use `DropdownMenu.SubTrigger`
- Remove the classes, because the ones we had were just replicating radix-themes before it had `SubTrigger`

<img width="430" height="276" alt="Screenshot 2026-02-12 at 17 25 46" src="https://github.com/user-attachments/assets/9b187db3-bd74-4373-95f8-e53d87a76812" />


Fixes broken react app example