### PR TITLE
Add an overload to predicate, return Variable if both inputs are

### DIFF
--- a/packages/codecs-data-structures/src/__typetests__/predicate-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/predicate-typetest.ts
@@ -33,6 +33,13 @@ const predicate = null as unknown as () => boolean;
         {} as FixedSizeEncoder<string, 4>,
     ) satisfies FixedSizeEncoder<string, 4>;
 
+    // It returns a VariableSizeEncoder if both encoders are VariableSizeEncoder
+    getPredicateEncoder(
+        predicate,
+        {} as VariableSizeEncoder<number>,
+        {} as VariableSizeEncoder<number>,
+    ) satisfies VariableSizeEncoder<number>;
+
     // It returns an Encoder if some input encoders are VariableSizeEncoder
     getPredicateEncoder(
         predicate,
@@ -77,6 +84,13 @@ const predicate = null as unknown as () => boolean;
         {} as FixedSizeDecoder<string, 4>,
         {} as FixedSizeDecoder<string, 4>,
     ) satisfies FixedSizeDecoder<string, 4>;
+
+    // It returns a VariableSizeDecoder if both decoders are VariableSizeDecoder
+    getPredicateDecoder(
+        predicate,
+        {} as VariableSizeDecoder<number>,
+        {} as VariableSizeDecoder<number>,
+    ) satisfies VariableSizeDecoder<number>;
 
     // It returns an Decoder if some input Decoders are VariableSizeDecoder
     getPredicateDecoder(
@@ -124,6 +138,14 @@ const predicate = null as unknown as () => boolean;
         {} as FixedSizeCodec<string, string, 4>,
         {} as FixedSizeCodec<string, string, 4>,
     ) satisfies FixedSizeCodec<string, string, 4>;
+
+    // It returns a VariableSizeCodec if both codecs are VariableSizeCodec
+    getPredicateCodec(
+        predicate,
+        predicate,
+        {} as VariableSizeCodec<number>,
+        {} as VariableSizeCodec<number>,
+    ) satisfies VariableSizeCodec<number>;
 
     // It returns a Codec if some input codecs are VariableSizeCodec
     getPredicateCodec(

--- a/packages/codecs-data-structures/src/predicate.ts
+++ b/packages/codecs-data-structures/src/predicate.ts
@@ -6,6 +6,9 @@ import {
     FixedSizeDecoder,
     FixedSizeEncoder,
     ReadonlyUint8Array,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
 } from '@solana/codecs-core';
 
 import { getUnionCodec, getUnionDecoder, getUnionEncoder } from './union';
@@ -54,6 +57,11 @@ export function getPredicateEncoder<TFrom>(
     ifTrue: FixedSizeEncoder<TFrom>,
     ifFalse: FixedSizeEncoder<TFrom>,
 ): FixedSizeEncoder<TFrom>;
+export function getPredicateEncoder<TFrom>(
+    predicate: (value: TFrom) => boolean,
+    ifTrue: VariableSizeEncoder<TFrom>,
+    ifFalse: VariableSizeEncoder<TFrom>,
+): VariableSizeEncoder<TFrom>;
 export function getPredicateEncoder<TFrom>(
     predicate: (value: TFrom) => boolean,
     ifTrue: Encoder<TFrom>,
@@ -109,6 +117,11 @@ export function getPredicateDecoder<TTo>(
     ifTrue: FixedSizeDecoder<TTo>,
     ifFalse: FixedSizeDecoder<TTo>,
 ): FixedSizeDecoder<TTo>;
+export function getPredicateDecoder<TTo>(
+    predicate: (value: ReadonlyUint8Array) => boolean,
+    ifTrue: VariableSizeDecoder<TTo>,
+    ifFalse: VariableSizeDecoder<TTo>,
+): VariableSizeDecoder<TTo>;
 export function getPredicateDecoder<TTo>(
     predicate: (value: ReadonlyUint8Array) => boolean,
     ifTrue: Decoder<TTo>,
@@ -175,6 +188,12 @@ export function getPredicateCodec<TFrom, TTo extends TFrom>(
     ifTrue: FixedSizeCodec<TFrom, TTo>,
     ifFalse: FixedSizeCodec<TFrom, TTo>,
 ): FixedSizeCodec<TFrom, TTo>;
+export function getPredicateCodec<TFrom, TTo extends TFrom>(
+    encodePredicate: (value: TFrom) => boolean,
+    decodePredicate: (value: ReadonlyUint8Array) => boolean,
+    ifTrue: VariableSizeCodec<TFrom, TTo>,
+    ifFalse: VariableSizeCodec<TFrom, TTo>,
+): VariableSizeCodec<TFrom, TTo>;
 export function getPredicateCodec<TFrom, TTo extends TFrom>(
     encodePredicate: (value: TFrom) => boolean,
     decodePredicate: (value: ReadonlyUint8Array) => boolean,


### PR DESCRIPTION
#### Problem

The `getPredicateEncoder` (etc) functions take a predicate and two encoder, and choose between them.

Currently if both inputs are `FixedSize` then we return `FixedSize`, otherwise we return `Encoder`

This loses some specificity if both inputs are `VariableSize`. In this case we know we are choosing a `VariableSize` but we just return `Encoder`

#### Summary of Changes

Add an overload for each function so that if both inputs are `VariableSize` then so is the returned encoder

This is useful for the transaction encoder where we will be switching between two variable size encoders. With this new overload, we will be able to keep the resulting transaction encoder typed as `VariableSize`. 

Note: I haven't added a changeset because we haven't published the new functions yet and the existing changeset is general enough not to need this specified. 
