### PR TITLE
Add v1 to TransactionVersion, but not to transaction message functions

### DIFF
--- a/packages/kit/src/__typetests__/scenarios/transaction-signers-typetest.ts
+++ b/packages/kit/src/__typetests__/scenarios/transaction-signers-typetest.ts
@@ -16,17 +16,21 @@ import {
     TransactionVersion,
 } from '@solana/transaction-messages';
 
+// Temporary, until we support v1 transactions in `createTransactionMessage`
+// When this is removed, use `TransactionVersion`
+type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
+
 // [DESCRIBE] TransactionMessageWithSigners type
 {
     // It is satisfied by a transaction message from `createTransactionMessage`
     {
-        const result = createTransactionMessage({ version: null as unknown as TransactionVersion });
+        const result = createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 });
         result satisfies TransactionMessage & TransactionMessageWithSigners;
     }
 
     // It is satisfied after adding an address fee payer
     {
-        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
             setTransactionMessageFeePayer(null as unknown as Address, m),
         );
         result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
@@ -34,7 +38,7 @@ import {
 
     // It is satisfied after adding a signer fee payer
     {
-        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
             setTransactionMessageFeePayerSigner(null as unknown as TransactionSigner, m),
         );
         result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
@@ -42,7 +46,7 @@ import {
 
     // It is satisfied after appending instructions
     {
-        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
             appendTransactionMessageInstructions(null as unknown as Instruction[], m),
         );
         result satisfies TransactionMessage & TransactionMessageWithSigners;
@@ -50,7 +54,7 @@ import {
 
     // It is satisfied after appending instructions with signers
     {
-        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
             appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
         );
         result satisfies TransactionMessage & TransactionMessageWithSigners;
@@ -59,7 +63,7 @@ import {
     // It is satisfied after adding a fee payer and instructions
     {
         const result = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageFeePayer(null as unknown as Address, m),
             m => appendTransactionMessageInstructions(null as unknown as Instruction[], m),
         );
@@ -69,7 +73,7 @@ import {
     // It is satisfied after adding a signer fee payer and instructions
     {
         const result = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageFeePayerSigner(null as unknown as TransactionSigner, m),
             m => appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
         );
@@ -79,7 +83,7 @@ import {
     // It is satisfied after adding a fee payer and instructions with signers
     {
         const result = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageFeePayer(null as unknown as Address, m),
             m => appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
         );
@@ -89,7 +93,7 @@ import {
     // It is satisfied after adding a signer fee payer and instructions with signers
     {
         const result = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageFeePayerSigner(null as unknown as TransactionSigner, m),
             m => appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
         );

--- a/packages/rpc-types/src/transaction.ts
+++ b/packages/rpc-types/src/transaction.ts
@@ -7,7 +7,7 @@ import type { TokenBalance } from './token-balance';
 import type { TransactionError } from './transaction-error';
 import type { SignedLamports } from './typed-numbers';
 
-type TransactionVersion = 'legacy' | 0;
+type TransactionVersion = 'legacy' | 0 | 1;
 
 type AddressTableLookup = Readonly<{
     /** Address of the address lookup table account. */

--- a/packages/transaction-messages/src/__typetests__/create-transaction-message-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/create-transaction-message-typetest.ts
@@ -21,6 +21,12 @@ type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
     message satisfies LegacyTransactionMessage;
 }
 
+// It does not create v1 transaction messages.
+{
+    // @ts-expect-error Does not support version 1.
+    createTransactionMessage({ version: 1 });
+}
+
 // It returns an empty transaction message with size limit type safety.
 {
     createTransactionMessage({ version: 'legacy' }) satisfies TransactionMessageWithinSizeLimit;

--- a/packages/transaction-messages/src/__typetests__/scenarios/message-modifications-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/scenarios/message-modifications-typetest.ts
@@ -28,11 +28,15 @@ const compiledTransactionMessage = null as unknown as Parameters<typeof decompil
 const feePayer = null as unknown as Address;
 const instruction = null as unknown as Instruction;
 
+// Temporary, until we support v1 transactions in `createTransactionMessage`
+// When this is removed, use `TransactionVersion`
+type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
+
 // [DESCRIBE] setTransactionMessageLifetimeUsingBlockhash
 {
     // It sets the blockhash after `createTransactionMessage`
     {
-        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
             setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
         message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
@@ -41,7 +45,7 @@ const instruction = null as unknown as Instruction;
     // It sets the blockhash after other transformations
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageFeePayer(null as unknown as Address, m),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
@@ -51,7 +55,7 @@ const instruction = null as unknown as Instruction;
     // It sets the blockhash after a durable nonce lifetime
     {
         const messageWithDurableNonce = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
         );
         messageWithDurableNonce satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
@@ -86,7 +90,7 @@ const instruction = null as unknown as Instruction;
     // It sets the blockhash with instructions
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => appendTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstruction(instruction, m),
             m => appendTransactionMessageInstructions([instruction], m),
@@ -99,7 +103,7 @@ const instruction = null as unknown as Instruction;
     // It sets the blockhash multiple times
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
@@ -112,7 +116,7 @@ const instruction = null as unknown as Instruction;
 {
     // It sets the durable nonce after `createTransactionMessage`
     {
-        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
             setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
         );
         message satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
@@ -121,7 +125,7 @@ const instruction = null as unknown as Instruction;
     // It sets the durable nonce after other transformations
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageFeePayer(null as unknown as Address, m),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
         );
@@ -133,7 +137,7 @@ const instruction = null as unknown as Instruction;
     // It sets the durable nonce after a blockhash lifetime
     {
         const messageWithBlockhash = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
         messageWithBlockhash satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
@@ -168,7 +172,7 @@ const instruction = null as unknown as Instruction;
     // It sets the durable nonce with instructions
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => appendTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstruction(instruction, m),
             m => appendTransactionMessageInstructions([instruction], m),
@@ -181,7 +185,7 @@ const instruction = null as unknown as Instruction;
     // It sets the durable nonce multiple times
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
@@ -249,14 +253,14 @@ const instruction = null as unknown as Instruction;
 {
     // It sets the fee payer after `createTransactionMessage`
     {
-        const message = createTransactionMessage({ version: null as unknown as TransactionVersion });
+        const message = createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 });
         const newMessage = setTransactionMessageFeePayer(feePayer, message);
         newMessage satisfies TransactionMessage & TransactionMessageWithFeePayer;
     }
 
     // It sets the fee payer after setting a blockhash lifetime
     {
-        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
             setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
         const newMessage = setTransactionMessageFeePayer(feePayer, message);
@@ -267,7 +271,7 @@ const instruction = null as unknown as Instruction;
 
     // It sets the fee payer after setting a durable nonce lifetime
     {
-        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
+        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
             setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
         );
         const newMessage = setTransactionMessageFeePayer(feePayer, message);
@@ -279,7 +283,7 @@ const instruction = null as unknown as Instruction;
     // It sets the fee payer multiple times
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageFeePayer(feePayer, m),
             m => setTransactionMessageFeePayer(feePayer, m),
             m => setTransactionMessageFeePayer(feePayer, m),
@@ -293,7 +297,7 @@ const instruction = null as unknown as Instruction;
     // It can call instruction functions after `createTransactionMessage`
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => appendTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstruction(instruction, m),
             m => appendTransactionMessageInstructions([instruction], m),
@@ -305,7 +309,7 @@ const instruction = null as unknown as Instruction;
     // It can call instruction functions after setting a blockhash lifetime
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
             m => appendTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstruction(instruction, m),
@@ -318,7 +322,7 @@ const instruction = null as unknown as Instruction;
     // It can call append instruction functions after setting a durable nonce lifetime
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
             m => appendTransactionMessageInstruction(instruction, m),
             m => appendTransactionMessageInstructions([instruction], m),
@@ -330,7 +334,7 @@ const instruction = null as unknown as Instruction;
     // the durable nonce lifetime is stripped because the first instruction must be the AdvanceNonceAccount instruction
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
             m => prependTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstructions([instruction], m),
@@ -343,7 +347,7 @@ const instruction = null as unknown as Instruction;
     // It can call instruction functions after setting a fee payer
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersion }),
+            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
             m => setTransactionMessageFeePayer(feePayer, m),
             m => appendTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstruction(instruction, m),

--- a/packages/transaction-messages/src/codecs/__tests__/transaction-version-test.ts
+++ b/packages/transaction-messages/src/codecs/__tests__/transaction-version-test.ts
@@ -11,7 +11,7 @@ import {
 const VERSION_FLAG_MASK = 0x80;
 const VERSION_TEST_CASES = // Versions 0–127
     [...Array(128).keys()].map(version => [version | VERSION_FLAG_MASK, version as TransactionVersion] as const);
-const UNSUPPORTED_VERSION_TEST_CASES = VERSION_TEST_CASES.slice(1); // versions 1-127
+const UNSUPPORTED_VERSION_TEST_CASES = VERSION_TEST_CASES.slice(2); // versions 2-127
 
 describe.each([getTransactionVersionCodec, getTransactionVersionEncoder])(
     'Transaction version encoder',
@@ -25,6 +25,9 @@ describe.each([getTransactionVersionCodec, getTransactionVersionEncoder])(
         });
         it('serializes to `0x80` when the version is `0`', () => {
             expect(transactionVersion.encode(0)).toEqual(new Uint8Array([0x80]));
+        });
+        it('serializes to `0x81` when the version is `1`', () => {
+            expect(transactionVersion.encode(1)).toEqual(new Uint8Array([0x81]));
         });
         it.each(UNSUPPORTED_VERSION_TEST_CASES)('fatals for unsupported version `%s`', (_byte, version) => {
             expect(() => transactionVersion.encode(version)).toThrow(
@@ -63,6 +66,13 @@ describe.each([getTransactionVersionCodec, getTransactionVersionDecoder])(
                     new Uint8Array([0 | VERSION_FLAG_MASK]), // version 0 with the version flag
                 ),
             ).toBe(0);
+        });
+        it('deserializes to 1 for a version 1 transaction', () => {
+            expect(
+                transactionVersion.decode(
+                    new Uint8Array([1 | VERSION_FLAG_MASK]), // version 1 with the version flag
+                ),
+            ).toBe(1);
         });
         it.each(UNSUPPORTED_VERSION_TEST_CASES)('fatals for unsupported version `%s`', (byte, version) => {
             expect(() => transactionVersion.decode(new Uint8Array([byte]))).toThrow(

--- a/packages/transaction-messages/src/create-transaction-message.ts
+++ b/packages/transaction-messages/src/create-transaction-message.ts
@@ -1,11 +1,14 @@
 import { TransactionMessage, TransactionVersion } from './transaction-message';
 import { TransactionMessageWithinSizeLimit } from './transaction-message-size';
 
-type TransactionConfig<TVersion extends TransactionVersion> = Readonly<{
+// Note: v1 transactions are not yet supported by these functions
+type SupportedTransactionVersion = Exclude<TransactionVersion, 1>;
+
+type TransactionConfig<TVersion extends SupportedTransactionVersion> = Readonly<{
     version: TVersion;
 }>;
 
-type EmptyTransactionMessage<TVersion extends TransactionVersion> = Omit<
+type EmptyTransactionMessage<TVersion extends SupportedTransactionVersion> = Omit<
     Extract<TransactionMessage, { version: TVersion }>,
     'instructions'
 > &
@@ -22,7 +25,7 @@ type EmptyTransactionMessage<TVersion extends TransactionVersion> = Omit<
  * const message = createTransactionMessage({ version: 0 });
  * ```
  */
-export function createTransactionMessage<TVersion extends TransactionVersion>(
+export function createTransactionMessage<TVersion extends SupportedTransactionVersion>(
     config: TransactionConfig<TVersion>,
 ): EmptyTransactionMessage<TVersion> {
     return Object.freeze({

--- a/packages/transaction-messages/src/decompile-message.ts
+++ b/packages/transaction-messages/src/decompile-message.ts
@@ -20,7 +20,7 @@ import { isAdvanceNonceAccountInstruction } from './durable-nonce-instruction';
 import { setTransactionMessageFeePayer, TransactionMessageWithFeePayer } from './fee-payer';
 import { appendTransactionMessageInstruction } from './instructions';
 import { TransactionMessageWithLifetime } from './lifetime';
-import { TransactionMessage, TransactionVersion } from './transaction-message';
+import { TransactionMessage } from './transaction-message';
 
 function getAccountMetas(message: CompiledTransactionMessage): AccountMeta[] {
     const { header } = message;
@@ -237,7 +237,8 @@ export function decompileTransactionMessage(
     );
 
     return pipe(
-        createTransactionMessage({ version: compiledTransactionMessage.version as TransactionVersion }),
+        // We don't currently support v1 transactions
+        createTransactionMessage({ version: compiledTransactionMessage.version }),
         m => setTransactionMessageFeePayer(feePayer, m),
         m =>
             instructions.reduce(

--- a/packages/transaction-messages/src/transaction-message.ts
+++ b/packages/transaction-messages/src/transaction-message.ts
@@ -8,11 +8,10 @@ type BaseTransactionMessage<
     version: TVersion;
 }>;
 
-export const MAX_SUPPORTED_TRANSACTION_VERSION = 0;
+export const MAX_SUPPORTED_TRANSACTION_VERSION = 1;
 
 type LegacyInstruction<TProgramAddress extends string = string> = Instruction<TProgramAddress, readonly AccountMeta[]>;
 type LegacyTransactionMessage = BaseTransactionMessage<'legacy', LegacyInstruction>;
 type V0TransactionMessage = BaseTransactionMessage<0, Instruction>;
-
 export type TransactionMessage = LegacyTransactionMessage | V0TransactionMessage;
-export type TransactionVersion = 'legacy' | 0;
+export type TransactionVersion = 'legacy' | 0 | 1;

--- a/packages/transactions/src/codecs/__tests__/transaction-codec-test.ts
+++ b/packages/transactions/src/codecs/__tests__/transaction-codec-test.ts
@@ -246,11 +246,11 @@ describe.each([getTransactionDecoder, getTransactionCodec])('Transaction decoder
             expect(decoded.signatures).toBeFrozenObject();
         });
 
-        it('should fatal for unsupported transaction version 1', () => {
+        it('should fatal for unsupported transaction version 2', () => {
             const signature = new Uint8Array(64).fill(0) as ReadonlyUint8Array as SignatureBytes;
             const messageBytes = new Uint8Array([
                 /** VERSION HEADER */
-                129, // 1 + version mask
+                130, // 2 + version mask
 
                 /** MESSAGE HEADER */
                 1, // numSignerAccounts
@@ -276,7 +276,7 @@ describe.each([getTransactionDecoder, getTransactionCodec])('Transaction decoder
             ]);
 
             expect(() => decoder.decode(encodedTransaction)).toThrow(
-                new SolanaError(SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_NOT_SUPPORTED, { unsupportedVersion: 1 }),
+                new SolanaError(SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_NOT_SUPPORTED, { unsupportedVersion: 2 }),
             );
         });
     });


### PR DESCRIPTION
#### Summary of Changes

This commit adds v1 to the `TransactionVersion` type, and to the relevant codec and its tests. It is not added to the `TransactionMessage` type, and is explicitly disallowed by the `createTransactionMessage` type.

This allows us to use the `TransactionVersion` decoder in the `Transaction` decoder, while not yet having support for the v1 functionality in the rest of transaction messages.

Note that this also makes v1 valid in `rpc-types`, which means it's a valid transaction version to use as `maxSupportedTransactionVersion`. 