### PR TITLE
Add the v1 TransactionMessageconfig and functions to encode it to a mask and value array

### DIFF
--- a/packages/transaction-messages/src/codecs/__tests__/config-test.ts
+++ b/packages/transaction-messages/src/codecs/__tests__/config-test.ts
@@ -1,0 +1,228 @@
+import { TransactionConfig } from '../../transaction-config';
+import { getTransactionConfigMaskEncoder, getTransactionConfigValuesEncoder } from '../config';
+
+describe('getConfigMaskEncoder', () => {
+    const encoder = getTransactionConfigMaskEncoder();
+
+    it('should encode a mask with all values unset correctly', () => {
+        const config: TransactionConfig = {};
+        const encoded = encoder.encode(config);
+
+        // All bits 0, the lowest 5 are our config bits
+        const expectedFirstByte = 0b00000000;
+        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
+    });
+
+    it('should encode a mask with all values set correctly', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: 100,
+            heapSize: 100,
+            loadedAccountsDataSizeLimit: 100,
+            priorityFeeLamports: 100n,
+        };
+        const encoded = encoder.encode(config);
+
+        // Lowest 5 bits set to 1, rest are 0
+        // Followed by 3 bytes of 0 for padding to 4 bytes total
+        const expectedFirstByte = 0b00011111;
+        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
+    });
+
+    it('should encode a mask with just priority fee set correctly', () => {
+        const config: TransactionConfig = {
+            priorityFeeLamports: 100n,
+        };
+        const encoded = encoder.encode(config);
+
+        // Lowest two bits set to 1, rest are 0
+        // Followed by 3 bytes of 0 for padding to 4 bytes total
+        const expectedFirstByte = 0b00000011;
+        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
+    });
+
+    it('should encode a mask with just compute unit limit set correctly', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: 100,
+        };
+        const encoded = encoder.encode(config);
+
+        // Third lowest bit set to 1, rest are 0
+        // Followed by 3 bytes of 0 for padding to 4 bytes total
+        const expectedFirstByte = 0b00000100;
+        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
+    });
+
+    it('should encode a mask with just loaded accounts data size limit set correctly', () => {
+        const config: TransactionConfig = {
+            loadedAccountsDataSizeLimit: 100,
+        };
+        const encoded = encoder.encode(config);
+
+        // Fourth lowest bit set to 1, rest are 0
+        // Followed by 3 bytes of 0 for padding to 4 bytes total
+        const expectedFirstByte = 0b00001000;
+        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
+    });
+
+    it('should encode a mask with just heap size set correctly', () => {
+        const config: TransactionConfig = {
+            heapSize: 100,
+        };
+        const encoded = encoder.encode(config);
+
+        // Fifth lowest bit set to 1, rest are 0
+        // Followed by 3 bytes of 0 for padding to 4 bytes total
+        const expectedFirstByte = 0b00010000;
+        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
+    });
+
+    it('should encode a mask with some values set correctly', () => {
+        const config: TransactionConfig = {
+            loadedAccountsDataSizeLimit: 100,
+            priorityFeeLamports: 100n,
+        };
+        const encoded = encoder.encode(config);
+
+        // First, second and fourth lowest bits set to 1, rest are 0
+        // Followed by 3 bytes of 0 for padding to 4 bytes total
+        const expectedFirstByte = 0b00001011;
+        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
+    });
+});
+
+describe('getConfigValuesEncoder', () => {
+    const encoder = getTransactionConfigValuesEncoder();
+
+    it('should encode to an empty array when no values are set', () => {
+        const config: TransactionConfig = {};
+        const encoded = encoder.encode(config);
+        expect(encoded).toEqual(new Uint8Array([]));
+    });
+
+    it('should encode to an array of all values correctly', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: 20,
+            heapSize: 40,
+            loadedAccountsDataSizeLimit: 30,
+            priorityFeeLamports: 10n,
+        };
+        const encoded = encoder.encode(config);
+        expect(encoded).toEqual(
+            // prettier-ignore
+            new Uint8Array([
+                // priority fee lamports (8 bytes)
+                10, 0, 0, 0, 0, 0, 0, 0,
+                // computeUnitLimit (4 bytes)
+                20, 0, 0, 0,
+                // loadedAccountsDataSizeLimit (4 bytes)
+                30, 0, 0, 0,
+                // heapSize (4 bytes)
+                40, 0, 0, 0
+            ]),
+        );
+    });
+
+    it('should encode to an array of just priority fee correctly', () => {
+        const config: TransactionConfig = {
+            priorityFeeLamports: 10n,
+        };
+        const encoded = encoder.encode(config);
+        expect(encoded).toEqual(
+            // prettier-ignore
+            new Uint8Array([
+                // priority fee lamports (8 bytes)
+                10, 0, 0, 0, 0, 0, 0, 0,
+            ]),
+        );
+    });
+
+    it('should encode a large priority fee value correctly', () => {
+        const config: TransactionConfig = {
+            priorityFeeLamports: 2n ** 64n - 1n,
+        };
+        const encoded = encoder.encode(config);
+        expect(encoded).toEqual(
+            // prettier-ignore
+            new Uint8Array([
+                // priority fee lamports (8 bytes)
+                255, 255, 255, 255, 255, 255, 255, 255,
+            ]),
+        );
+    });
+
+    it('should encode to an array of just compute unit limit correctly', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: 20,
+        };
+        const encoded = encoder.encode(config);
+        expect(encoded).toEqual(
+            // prettier-ignore
+            new Uint8Array([
+                // computeUnitLimit (4 bytes)
+                20, 0, 0, 0
+            ]),
+        );
+    });
+
+    it('should encode to an array of just loaded accounts data size limit correctly', () => {
+        const config: TransactionConfig = {
+            loadedAccountsDataSizeLimit: 30,
+        };
+        const encoded = encoder.encode(config);
+        expect(encoded).toEqual(
+            // prettier-ignore
+            new Uint8Array([
+                // loadedAccountsDataSizeLimit (4 bytes)
+                30, 0, 0, 0
+            ]),
+        );
+    });
+
+    it('should encode to an array of just heap size correctly', () => {
+        const config: TransactionConfig = {
+            heapSize: 40,
+        };
+        const encoded = encoder.encode(config);
+        expect(encoded).toEqual(
+            // prettier-ignore
+            new Uint8Array([
+                // heapSize (4 bytes)
+                40, 0, 0, 0
+            ]),
+        );
+    });
+
+    it('should encode to an array of some values correctly', () => {
+        const config: TransactionConfig = {
+            loadedAccountsDataSizeLimit: 30,
+            priorityFeeLamports: 10n,
+        };
+        const encoded = encoder.encode(config);
+        expect(encoded).toEqual(
+            // prettier-ignore
+            new Uint8Array([
+                // priorityFeeLamports (8 bytes)
+                10, 0, 0, 0, 0, 0, 0, 0,
+                // loadedAccountsDataSizeLimit (4 bytes)
+                30, 0, 0, 0
+            ]),
+        );
+    });
+
+    it('should encode a large priority fee value correctly with some other values', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: 20,
+            priorityFeeLamports: 2n ** 64n - 1n,
+        };
+        const encoded = encoder.encode(config);
+        expect(encoded).toEqual(
+            // prettier-ignore
+            new Uint8Array([
+                // priorityFeeLamports (8 bytes)
+                255, 255, 255, 255, 255, 255, 255, 255,
+                // computeUnitLimit (4 bytes)
+                20, 0, 0, 0
+            ]),
+        );
+    });
+});

--- a/packages/transaction-messages/src/codecs/config.ts
+++ b/packages/transaction-messages/src/codecs/config.ts
@@ -1,0 +1,62 @@
+import { createEncoder, FixedSizeEncoder, transformEncoder, VariableSizeEncoder } from '@solana/codecs-core';
+import { getU32Encoder, getU64Encoder } from '@solana/codecs-numbers';
+
+import { TransactionConfig as TransactionConfig } from '../transaction-config';
+
+const PRIORITY_FEE_LAMPORTS_BIT_MASK = 0b11;
+const COMPUTE_UNIT_LIMIT_BIT_MASK = 0b100;
+const LOADED_ACCOUNTS_DATA_SIZE_LIMIT_BIT_MASK = 0b1000;
+const HEAP_SIZE_BIT_MASK = 0b10000;
+
+/**
+ * Encode a {@link TransactionMessageConfig} into a 4 byte mask, where the lowest bits indicate which fields are set
+ * @returns An Encoder for {@link TransactionMessageConfig}
+ */
+export function getTransactionConfigMaskEncoder(): FixedSizeEncoder<TransactionConfig, 4> {
+    return transformEncoder(getU32Encoder(), config => {
+        let mask = 0;
+        // Set the lowest 2 bits for priority fee lamports
+        if (config.priorityFeeLamports !== undefined) mask |= PRIORITY_FEE_LAMPORTS_BIT_MASK;
+        // Set the 3rd lowest bit for compute unit limit
+        if (config.computeUnitLimit !== undefined) mask |= COMPUTE_UNIT_LIMIT_BIT_MASK;
+        // Set the 4th lowest bit for loaded accounts data size limit
+        if (config.loadedAccountsDataSizeLimit !== undefined) mask |= LOADED_ACCOUNTS_DATA_SIZE_LIMIT_BIT_MASK;
+        // Set the 5th lowest bit for heap size
+        if (config.heapSize !== undefined) mask |= HEAP_SIZE_BIT_MASK;
+        return mask;
+    });
+}
+
+/**
+ * Encode a {@link TransactionMessageConfig} into a variable length byte array, where the fields set are encoded based on their data size.
+ * @returns An Encoder for {@link TransactionMessageConfig}
+ */
+export function getTransactionConfigValuesEncoder(): VariableSizeEncoder<TransactionConfig> {
+    return createEncoder<TransactionConfig>({
+        getSizeFromValue(config) {
+            let size = 0;
+            // Lamports is 8 bytes, the rest are 4 bytes each
+            if (config.priorityFeeLamports !== undefined) size += 8;
+            if (config.computeUnitLimit !== undefined) size += 4;
+            if (config.loadedAccountsDataSizeLimit !== undefined) size += 4;
+            if (config.heapSize !== undefined) size += 4;
+            return size;
+        },
+        write(config, bytes, offset) {
+            let nextOffset = offset;
+            if (config.priorityFeeLamports !== undefined) {
+                nextOffset = getU64Encoder().write(config.priorityFeeLamports, bytes, nextOffset);
+            }
+            if (config.computeUnitLimit !== undefined) {
+                nextOffset = getU32Encoder().write(BigInt(config.computeUnitLimit), bytes, nextOffset);
+            }
+            if (config.loadedAccountsDataSizeLimit !== undefined) {
+                nextOffset = getU32Encoder().write(BigInt(config.loadedAccountsDataSizeLimit), bytes, nextOffset);
+            }
+            if (config.heapSize !== undefined) {
+                nextOffset = getU32Encoder().write(BigInt(config.heapSize), bytes, nextOffset);
+            }
+            return nextOffset;
+        },
+    });
+}

--- a/packages/transaction-messages/src/transaction-config.ts
+++ b/packages/transaction-messages/src/transaction-config.ts
@@ -1,0 +1,6 @@
+export type TransactionConfig = {
+    computeUnitLimit?: number;
+    heapSize?: number;
+    loadedAccountsDataSizeLimit?: number;
+    priorityFeeLamports?: bigint;
+};


### PR DESCRIPTION
#### Summary of Changes

The Transaction v1 format introduces a `TransactionConfig`, initially to replace the current compute budget program instructions. See from the SIMD: https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0385-transaction-v1.md#transactionconfigmask-1

It encodes (in order, all optional):
- total priority fee in Lamports (u64)
- compute unit limit (u32)
- loaded account data size limit (u32)
- heap size (u32)

This PR adds this type, and functions to encode it for transaction message encoding.

In the [Transaction v1 encoding spec](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0385-transaction-v1.md#transaction-v1-specification) the config is encoded in 2 separate places.

First, it's encoded as a 32 bit mask which identifies which values are set. The lowest 2 bits are both set if priority fee is set. The 3rd bit is set if compute unit limit is set, the 4th bit for loaded account data size, and the 5th bit for heap size. The rest of the bits are unset and reserved for future config values.

Second, the actual values are encoded into an array of u32 values. Only the values actually set are stored in this array, so it can be empty if none are set. Its length (in u32) is equivalent to the number of set bits in the mask. For the priority fee we use 8 bytes (2 u32 values), for all other current fields we use 4 bytes.

For reference, the `solana-sdk` code for encoding the mask: https://github.com/anza-xyz/solana-sdk/blob/1cf4c970e5dedbbf5cb6c2081d8f40e73f053c74/message/src/versions/v1/config.rs#L87

And for encoding the config values: https://github.com/anza-xyz/solana-sdk/blob/1cf4c970e5dedbbf5cb6c2081d8f40e73f053c74/message/src/versions/v1/message.rs#L606 