### PR TITLE
Add a function to encode an instruction payload

### DIFF
--- a/packages/transaction-messages/src/codecs/__tests__/instruction-test.ts
+++ b/packages/transaction-messages/src/codecs/__tests__/instruction-test.ts
@@ -4,6 +4,7 @@ import {
     getInstructionDecoder,
     getInstructionEncoder,
     getInstructionHeaderEncoder,
+    getInstructionPayloadEncoder,
 } from '../instruction';
 
 type CompiledInstruction = ReturnType<typeof getCompiledInstructions>[number];
@@ -189,5 +190,60 @@ describe('getInstructionHeaderEncoder', () => {
                 0, // numInstructionDataBytes (2 bytes)
             ]),
         );
+    });
+});
+
+describe('getInstructionPayloadEncoder', () => {
+    const encoder = getInstructionPayloadEncoder();
+
+    it('encodes the instruction payload when all fields are defined', () => {
+        const instruction: CompiledInstruction = {
+            accountIndices: [2, 3],
+            data: new Uint8Array([1, 2, 3]),
+            programAddressIndex: 1,
+        };
+        expect(encoder.encode(instruction)).toEqual(
+            new Uint8Array([
+                2,
+                3, // account indices (2 bytes)
+                1,
+                2,
+                3, // data bytes (3 bytes)
+            ]),
+        );
+    });
+
+    it('encodes just the data when `accountIndices` is missing', () => {
+        const instruction: CompiledInstruction = {
+            data: new Uint8Array([1, 2, 3]),
+            programAddressIndex: 1,
+        };
+        expect(encoder.encode(instruction)).toEqual(
+            new Uint8Array([
+                1,
+                2,
+                3, // data bytes (3 bytes)
+            ]),
+        );
+    });
+
+    it('encodes just the account indices when `data` is missing', () => {
+        const instruction: CompiledInstruction = {
+            accountIndices: [2, 3],
+            programAddressIndex: 1,
+        };
+        expect(encoder.encode(instruction)).toEqual(
+            new Uint8Array([
+                2,
+                3, // account indices (2 bytes)
+            ]),
+        );
+    });
+
+    it('encodes an empty payload when both `accountIndices` and `data` are missing', () => {
+        const instruction: CompiledInstruction = {
+            programAddressIndex: 1,
+        };
+        expect(encoder.encode(instruction)).toEqual(new Uint8Array([]));
     });
 });


### PR DESCRIPTION
#### Summary of Changes

[See SIMD spec for v1 transactions
](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0385-transaction-v1.md#instructionheaders)

As mentioned in the previous PR, in v1 transactions the instructions are encoded to both a fixed size header and a variable size payload. This PR adds encoding an instruction to the variable size payload.

[The variable size instruction payload](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0385-transaction-v1.md#instructionheaders) is (for each instruction):

- the account indices
- the bytes of the data

Note that I used a hand-written encoder here instead of `getStructEncoder`, because the fields are encoded without a size prefix (the size comes from the header in the previous PR). So we need a size on the `getArrayEncoder` used for account indices. An alternative approach would be to convert account indices to a `Uint8Array`, and then use `getBytesEncoder` for each field which doesn't require a size. But we don't use `Uint8Array` for arrays of numbers like this anywhere else so I thought that might be more confusing.
