### PR TITLE
Add a decoder for the InstructionHeader

### DIFF
--- a/packages/transaction-messages/src/codecs/__tests__/instruction-test.ts
+++ b/packages/transaction-messages/src/codecs/__tests__/instruction-test.ts
@@ -3,6 +3,7 @@ import {
     getInstructionCodec,
     getInstructionDecoder,
     getInstructionEncoder,
+    getInstructionHeaderDecoder,
     getInstructionHeaderEncoder,
     getInstructionPayloadDecoder,
     getInstructionPayloadEncoder,
@@ -246,6 +247,36 @@ describe('getInstructionPayloadEncoder', () => {
             programAddressIndex: 1,
         };
         expect(encoder.encode(instruction)).toEqual(new Uint8Array([]));
+    });
+});
+
+describe('getInstructionHeaderDecoder', () => {
+    const decoder = getInstructionHeaderDecoder();
+
+    it('decodes the instruction header when all fields are defined', () => {
+        // pretter-ignore
+        const encoded = new Uint8Array([
+            // programAddressIndex (1 byte)
+            1,
+            // numInstructionAccounts (1 byte)
+            2,
+            // numInstructionDataBytes (2 bytes)
+            255, 255,
+        ]);
+        expect(decoder.decode(encoded)).toEqual({
+            numInstructionAccounts: 2,
+            numInstructionDataBytes: 2 ** 16 - 1,
+            programAddressIndex: 1,
+        });
+    });
+
+    it('decodes to all 0s when all fields are 0', () => {
+        const encoded = new Uint8Array(4); // all bytes are 0
+        expect(decoder.decode(encoded)).toEqual({
+            numInstructionAccounts: 0,
+            numInstructionDataBytes: 0,
+            programAddressIndex: 0,
+        });
     });
 });
 

--- a/packages/transaction-messages/src/codecs/instruction.ts
+++ b/packages/transaction-messages/src/codecs/instruction.ts
@@ -4,6 +4,7 @@ import {
     combineCodec,
     createEncoder,
     fixDecoderSize,
+    FixedSizeDecoder,
     FixedSizeEncoder,
     transformDecoder,
     transformEncoder,
@@ -24,6 +25,7 @@ import {
     getShortU16Encoder,
     getU8Decoder,
     getU8Encoder,
+    getU16Decoder,
     getU16Encoder,
 } from '@solana/codecs-numbers';
 
@@ -144,6 +146,18 @@ export function getInstructionPayloadEncoder(): VariableSizeEncoder<CompiledInst
             return nextOffset;
         },
     });
+}
+
+/**
+ * Decode an {@link InstructionHeader} from a byte array
+ * @returns A FixedSizeDecoder for the instruction header
+ */
+export function getInstructionHeaderDecoder(): FixedSizeDecoder<InstructionHeader> {
+    return getStructDecoder([
+        ['programAddressIndex', getU8Decoder()],
+        ['numInstructionAccounts', getU8Decoder()],
+        ['numInstructionDataBytes', getU16Decoder()],
+    ]);
 }
 
 /**


### PR DESCRIPTION
#### Summary of Changes

Straightforward fixed size struct decoder - but needed so that we can decode the instruction header, and then use it to decode the instruction payload.