### PR TITLE
Extract lifetime-token into its own codec

### DIFF
--- a/packages/transaction-messages/src/codecs/legacy/__tests__/lifetime-token-test.ts
+++ b/packages/transaction-messages/src/codecs/legacy/__tests__/lifetime-token-test.ts
@@ -1,0 +1,19 @@
+import { getLifetimeTokenDecoder, getLifetimeTokenEncoder } from '../lifetime-token';
+
+describe('getOptionalLifetimeTokenEncoder', () => {
+    it('should encode a 23 byte base58 string', () => {
+        const token = '3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL';
+        expect(getLifetimeTokenEncoder().encode(token)).toStrictEqual(new Uint8Array(32).fill(33));
+    });
+
+    it('should encode undefined as 32 zero bytes', () => {
+        expect(getLifetimeTokenEncoder().encode(undefined)).toStrictEqual(new Uint8Array(32));
+    });
+});
+
+describe('getLifetimeTokenDecoder', () => {
+    it('should decode a valid base58 encoded string', () => {
+        const encoded = new Uint8Array(32).fill(33);
+        expect(getLifetimeTokenDecoder().decode(encoded)).toBe('3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL');
+    });
+});

--- a/packages/transaction-messages/src/codecs/legacy/lifetime-token.ts
+++ b/packages/transaction-messages/src/codecs/legacy/lifetime-token.ts
@@ -1,0 +1,27 @@
+import {
+    fixDecoderSize,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+    fixEncoderSize,
+    transformEncoder,
+} from '@solana/codecs-core';
+import { getNullableEncoder } from '@solana/codecs-data-structures';
+import { getBase58Decoder, getBase58Encoder } from '@solana/codecs-strings';
+
+import { getCompiledLifetimeToken } from '../../compile/lifetime-token';
+
+type LifetimeToken = ReturnType<typeof getCompiledLifetimeToken>;
+
+export function getLifetimeTokenEncoder(): FixedSizeEncoder<LifetimeToken | undefined> {
+    return transformEncoder(
+        getNullableEncoder(fixEncoderSize(getBase58Encoder(), 32), {
+            noneValue: 'zeroes',
+            prefix: null,
+        }),
+        token => token ?? null,
+    );
+}
+
+export function getLifetimeTokenDecoder(): FixedSizeDecoder<LifetimeToken> {
+    return fixDecoderSize(getBase58Decoder(), 32);
+}


### PR DESCRIPTION
#### Summary of Changes

This PR extracts the lifetime-token logic from the messages codec into legacy/lifetime-token. This is useful because it will be used in each of the per-version message codecs.

The logic is the same as it uses in messages:

- We can encode an undefined token, if there is no token we encode to all 0s
- We decode to a token, ie we don't handle the all 0s case on decode

The previous version used `getUnionEncoder` for encode, I've refactored this to use `getNullableEncoder`