### PR TITLE
Add a codec for v0 transactions, extracted from the current message codec

### DIFF
--- a/packages/transaction-messages/src/codecs/v0/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/codecs/v0/__tests__/message-test.ts
@@ -1,0 +1,476 @@
+import { Address } from '@solana/addresses';
+import { Decoder, Encoder } from '@solana/codecs-core';
+
+import { CompiledTransactionMessage, CompiledTransactionMessageWithLifetime } from '../../../compile/message';
+import { getMessageCodec, getMessageDecoder, getMessageEncoder } from '../message';
+
+type V0CompiledTransactionMessage = CompiledTransactionMessage & { version: 0 };
+
+describe.each([getMessageCodec, getMessageEncoder])('Transaction message encoder %p', encoderFactory => {
+    let encoder: Encoder<
+        V0CompiledTransactionMessage | (CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage)
+    >;
+    beforeEach(() => {
+        encoder = encoderFactory();
+    });
+
+    it('encodes a v0 transaction with address lookup tables correctly', () => {
+        const message: CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage = {
+            addressTableLookups: [
+                {
+                    lookupTableAddress: '3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7' as Address, // decodes to [44{32}]
+                    readonlyIndexes: [77],
+                    writableIndexes: [66, 55],
+                },
+            ],
+            header: {
+                numReadonlyNonSignerAccounts: 1,
+                numReadonlySignerAccounts: 2,
+                numSignerAccounts: 3,
+            },
+            instructions: [
+                {
+                    accountIndices: [1, 2],
+                    data: new Uint8Array([4, 5, 6]),
+                    programAddressIndex: 0,
+                },
+                {
+                    accountIndices: [2],
+                    data: new Uint8Array([7, 8, 9]),
+                    programAddressIndex: 1,
+                },
+            ],
+            lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5', // encodes to [10{32}]
+            staticAccounts: [
+                'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address, // encodes to [11{32}]
+                'p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV' as Address, // encodes to [12{32}]
+                'swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC' as Address, // encodes to [13{32}]
+            ],
+            version: 0,
+        };
+
+        expect(encoder.encode(message)).toStrictEqual(
+            // prettier-ignore
+            new Uint8Array([
+                /** VERSION HEADER */
+                128, // 0 + version mask
+
+                /** MESSAGE HEADER */
+                3, // numSignerAccounts
+                2, // numReadonlySignerAccount
+                1, // numReadonlyNonSignerAccounts
+
+                /** STATIC ADDRESSES */
+                3, // Number of static accounts
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, // p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV
+                13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC
+
+                /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5
+
+                /* INSTRUCTIONS */
+                2, // Number of instructions
+
+                // First instruction
+                0, // Program address index
+                2, // Number of address indices
+                1, 2, // Address indices
+                3, // Length of instruction data
+                4, 5, 6, // Instruction data itself
+
+                // Second instruction
+                1, // Program address index
+                1, // Number of address indices
+                2, // Address indices
+                3, // Length of instruction data
+                7, 8, 9, // Instruction data itself
+
+                /** ADDRESS TABLE LOOKUPS */
+                1, // Number of address table lookups
+
+                // First address table lookup
+                44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, // Address of lookup table 3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7
+                2, // Number of writable indices
+                66, 55, // Writable indices
+                1, // Number of readonly indices
+                77, // Readonly indices
+            ]),
+        );
+    });
+
+    it('encodes a v0 transaction with no address lookup tables correctly', () => {
+        const message: CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 1,
+                numReadonlySignerAccounts: 2,
+                numSignerAccounts: 3,
+            },
+            instructions: [
+                {
+                    accountIndices: [1, 2],
+                    data: new Uint8Array([4, 5, 6]),
+                    programAddressIndex: 0,
+                },
+                {
+                    accountIndices: [2],
+                    data: new Uint8Array([7, 8, 9]),
+                    programAddressIndex: 1,
+                },
+            ],
+            lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5', // encodes to [10{32}]
+            staticAccounts: [
+                'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address, // encodes to [11{32}]
+                'p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV' as Address, // encodes to [12{32}]
+                'swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC' as Address, // encodes to [13{32}]
+            ],
+            version: 0,
+        };
+
+        expect(encoder.encode(message)).toStrictEqual(
+            // prettier-ignore
+            new Uint8Array([
+                /** VERSION HEADER */
+                128, // 0 + version mask
+
+                /** MESSAGE HEADER */
+                3, // numSignerAccounts
+                2, // numReadonlySignerAccount
+                1, // numReadonlyNonSignerAccounts
+
+                /** STATIC ADDRESSES */
+                3, // Number of static accounts
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, // p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV
+                13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC
+
+                /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5
+
+                /* INSTRUCTIONS */
+                2, // Number of instructions
+
+                // First instruction
+                0, // Program address index
+                2, // Number of address indices
+                1, 2, // Address indices
+                3, // Length of instruction data
+                4, 5, 6, // Instruction data itself
+
+                // Second instruction
+                1, // Program address index
+                1, // Number of address indices
+                2, // Address indices
+                3, // Length of instruction data
+                7, 8, 9, // Instruction data itself
+
+                /** ADDRESS TABLE LOOKUPS */
+                0, // Number of address table lookups
+            ]),
+        );
+    });
+
+    it('encodes a v0 transaction with no instructions correctly', () => {
+        const message: CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 1,
+                numReadonlySignerAccounts: 2,
+                numSignerAccounts: 3,
+            },
+            instructions: [],
+            lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5', // encodes to [10{32}]
+            staticAccounts: [
+                'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address, // encodes to [11{32}]
+                'p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV' as Address, // encodes to [12{32}]
+                'swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC' as Address, // encodes to [13{32}]
+            ],
+            version: 0,
+        };
+
+        expect(encoder.encode(message)).toStrictEqual(
+            // prettier-ignore
+            new Uint8Array([
+                /** VERSION HEADER */
+                128, // 0 + version mask
+
+                /** MESSAGE HEADER */
+                3, // numSignerAccounts
+                2, // numReadonlySignerAccount
+                1, // numReadonlyNonSignerAccounts
+
+                /** STATIC ADDRESSES */
+                3, // Number of static accounts
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, // p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV
+                13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC
+
+                /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5
+
+                /* INSTRUCTIONS */
+                0, // Number of instructions
+
+                /** ADDRESS TABLE LOOKUPS */
+                0, // Number of address table lookups
+            ]),
+        );
+    });
+
+    it('encodes a v0 transaction with no instructions and no accounts correctly', () => {
+        const message: CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 1,
+                numReadonlySignerAccounts: 2,
+                numSignerAccounts: 3,
+            },
+            instructions: [],
+            lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5', // encodes to [10{32}]
+            staticAccounts: [],
+            version: 0,
+        };
+
+        expect(encoder.encode(message)).toStrictEqual(
+            // prettier-ignore
+            new Uint8Array([
+                /** VERSION HEADER */
+                128, // 0 + version mask
+
+                /** MESSAGE HEADER */
+                3, // numSignerAccounts
+                2, // numReadonlySignerAccount
+                1, // numReadonlyNonSignerAccounts
+
+                /** STATIC ADDRESSES */
+                0, // Number of static accounts
+
+                /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5
+
+                /* INSTRUCTIONS */
+                0, // Number of instructions
+
+                /** ADDRESS TABLE LOOKUPS */
+                0, // Number of address table lookups
+            ]),
+        );
+    });
+});
+
+describe.each([getMessageCodec, getMessageDecoder])('Transaction message decoder %p', decoderFactory => {
+    let decoder: Decoder<V0CompiledTransactionMessage>;
+    beforeEach(() => {
+        decoder = decoderFactory();
+    });
+
+    it('decodes a v0 transaction with address lookup tables correctly', () => {
+        const byteArray =
+            // prettier-ignore
+            new Uint8Array([
+                /** VERSION HEADER */
+                128, // 0 + version mask
+
+                /** MESSAGE HEADER */
+                3, // numSignerAccounts
+                2, // numReadonlySignerAccount
+                1, // numReadonlyNonSignerAccounts
+
+                /** STATIC ADDRESSES */
+                3, // Number of static accounts
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, // p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV
+                13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC
+
+                /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5
+
+                /* INSTRUCTIONS */
+                2, // Number of instructions
+
+                // First instruction
+                0, // Program address index
+                2, // Number of address indices
+                1, 2, // Address indices
+                3, // Length of instruction data
+                4, 5, 6, // Instruction data itself
+
+                // Second instruction
+                1, // Program address index
+                1, // Number of address indices
+                2, // Address indices
+                3, // Length of instruction data
+                7, 8, 9, // Instruction data itself
+
+                /** ADDRESS TABLE LOOKUPS */
+                1, // Number of address table lookups
+
+                // First address table lookup
+                44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, // Address of lookup table 3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7
+                2, // Number of writable indices
+                66, 55, // Writable indices
+                1, // Number of readonly indices
+                77, // Readonly indices
+            ]);
+
+        const expectedMessage: CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage = {
+            addressTableLookups: [
+                {
+                    lookupTableAddress: '3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7' as Address, // decodes to [44{32}]
+                    readonlyIndexes: [77],
+                    writableIndexes: [66, 55],
+                },
+            ],
+            header: {
+                numReadonlyNonSignerAccounts: 1,
+                numReadonlySignerAccounts: 2,
+                numSignerAccounts: 3,
+            },
+            instructions: [
+                {
+                    accountIndices: [1, 2],
+                    data: new Uint8Array([4, 5, 6]),
+                    programAddressIndex: 0,
+                },
+                {
+                    accountIndices: [2],
+                    data: new Uint8Array([7, 8, 9]),
+                    programAddressIndex: 1,
+                },
+            ],
+            lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5', // decodes to [10{32}]
+            staticAccounts: [
+                'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address, // decodes to [11{32}]
+                'p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV' as Address, // decodes to [12{32}]
+                'swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC' as Address, // decodes to [13{32}]
+            ],
+            version: 0,
+        };
+
+        expect(decoder.decode(byteArray)).toStrictEqual(expectedMessage);
+    });
+
+    it('decodes a v0 transaction with no address lookup tables to exclude the addressLookupTables field', () => {
+        const byteArray =
+            // prettier-ignore
+            new Uint8Array([
+                /** VERSION HEADER */
+                128, // 0 + version mask
+
+                /** MESSAGE HEADER */
+                3, // numSignerAccounts
+                2, // numReadonlySignerAccount
+                1, // numReadonlyNonSignerAccounts
+
+                /** STATIC ADDRESSES */
+                3, // Number of static accounts
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, // p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV
+                13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC
+
+                /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5
+
+                /* INSTRUCTIONS */
+                2, // Number of instructions
+
+                // First instruction
+                0, // Program address index
+                2, // Number of address indices
+                1, 2, // Address indices
+                3, // Length of instruction data
+                4, 5, 6, // Instruction data itself
+
+                // Second instruction
+                1, // Program address index
+                1, // Number of address indices
+                2, // Address indices
+                3, // Length of instruction data
+                7, 8, 9, // Instruction data itself
+
+                /** ADDRESS TABLE LOOKUPS */
+                0, // Number of address table lookups
+            ]);
+
+        expect(decoder.decode(byteArray)).not.toHaveProperty('addressTableLookups');
+    });
+
+    it('decodes a v0 transaction with no instructions correctly', () => {
+        const byteArray =
+            // prettier-ignore
+            new Uint8Array([
+                /** VERSION HEADER */
+                128, // 0 + version mask
+
+                /** MESSAGE HEADER */
+                3, // numSignerAccounts
+                2, // numReadonlySignerAccount
+                1, // numReadonlyNonSignerAccounts
+
+                /** STATIC ADDRESSES */
+                3, // Number of static accounts
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, // p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV
+                13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC
+
+                /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5
+
+                /* INSTRUCTIONS */
+                0, // Number of instructions
+            ]);
+
+        const expectedMessage: CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 1,
+                numReadonlySignerAccounts: 2,
+                numSignerAccounts: 3,
+            },
+            instructions: [],
+            lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5', // encodes to [10{32}]
+            staticAccounts: [
+                'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address, // encodes to [11{32}]
+                'p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV' as Address, // encodes to [12{32}]
+                'swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC' as Address, // encodes to [13{32}]
+            ],
+            version: 0,
+        };
+
+        expect(decoder.decode(byteArray)).toStrictEqual(expectedMessage);
+    });
+
+    it('decodes a v0 transaction with no instructions and no accounts correctly', () => {
+        const byteArray =
+            // prettier-ignore
+            new Uint8Array([
+                /** VERSION HEADER */
+                128, // 0 + version mask
+
+                /** MESSAGE HEADER */
+                3, // numSignerAccounts
+                2, // numReadonlySignerAccount
+                1, // numReadonlyNonSignerAccounts
+
+                /** STATIC ADDRESSES */
+                0, // Number of static accounts
+
+                /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5
+
+                /* INSTRUCTIONS */
+                0, // Number of instructions
+            ]);
+
+        const expectedMessage: CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 1,
+                numReadonlySignerAccounts: 2,
+                numSignerAccounts: 3,
+            },
+            instructions: [],
+            lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5', // encodes to [10{32}]
+            staticAccounts: [],
+            version: 0,
+        };
+
+        expect(decoder.decode(byteArray)).toStrictEqual(expectedMessage);
+    });
+});

--- a/packages/transaction-messages/src/codecs/v0/message.ts
+++ b/packages/transaction-messages/src/codecs/v0/message.ts
@@ -1,0 +1,72 @@
+import { getAddressDecoder, getAddressEncoder } from '@solana/addresses';
+import {
+    combineCodec,
+    transformDecoder,
+    transformEncoder,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
+} from '@solana/codecs-core';
+import { getArrayDecoder, getArrayEncoder, getStructDecoder, getStructEncoder } from '@solana/codecs-data-structures';
+import { getShortU16Decoder, getShortU16Encoder } from '@solana/codecs-numbers';
+
+import {
+    CompiledTransactionMessage,
+    CompiledTransactionMessageWithLifetime,
+    getTransactionVersionDecoder,
+    getTransactionVersionEncoder,
+} from '../..';
+import { getMessageHeaderDecoder, getMessageHeaderEncoder } from '../legacy/header';
+import { getInstructionDecoder, getInstructionEncoder } from '../legacy/instruction';
+import { getLifetimeTokenDecoder, getLifetimeTokenEncoder } from '../legacy/lifetime-token';
+import { getAddressTableLookupDecoder, getAddressTableLookupEncoder } from './address-table-lookup';
+
+type V0CompiledTransactionMessage = CompiledTransactionMessage & { version: 0 };
+
+export function getMessageEncoder(): VariableSizeEncoder<
+    V0CompiledTransactionMessage | (CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage)
+> {
+    return transformEncoder(
+        getStructEncoder([
+            ['version', getTransactionVersionEncoder()],
+            ['header', getMessageHeaderEncoder()],
+            ['staticAccounts', getArrayEncoder(getAddressEncoder(), { size: getShortU16Encoder() })],
+            ['lifetimeToken', getLifetimeTokenEncoder()],
+            ['instructions', getArrayEncoder(getInstructionEncoder(), { size: getShortU16Encoder() })],
+            ['addressTableLookups', getArrayEncoder(getAddressTableLookupEncoder(), { size: getShortU16Encoder() })],
+        ]),
+        value => ({
+            ...value,
+            addressTableLookups: value.addressTableLookups ?? [],
+            lifetimeToken: 'lifetimeToken' in value ? value.lifetimeToken : undefined,
+        }),
+    );
+}
+
+export function getMessageDecoder(): VariableSizeDecoder<
+    CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage
+> {
+    return transformDecoder(
+        getStructDecoder([
+            ['version', getTransactionVersionDecoder()],
+            ['header', getMessageHeaderDecoder()],
+            ['staticAccounts', getArrayDecoder(getAddressDecoder(), { size: getShortU16Decoder() })],
+            ['lifetimeToken', getLifetimeTokenDecoder()],
+            ['instructions', getArrayDecoder(getInstructionDecoder(), { size: getShortU16Decoder() })],
+            ['addressTableLookups', getArrayDecoder(getAddressTableLookupDecoder(), { size: getShortU16Decoder() })],
+        ]),
+        ({ addressTableLookups, ...restOfMessage }) => {
+            if (!addressTableLookups?.length) {
+                return { ...restOfMessage, version: 0 };
+            }
+            return { ...restOfMessage, addressTableLookups, version: 0 };
+        },
+    );
+}
+
+export function getMessageCodec(): VariableSizeCodec<
+    V0CompiledTransactionMessage | (CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage),
+    CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage
+> {
+    return combineCodec(getMessageEncoder(), getMessageDecoder());
+}


### PR DESCRIPTION
#### Summary of Changes

As part of adding v1 transactions, I'm adding separate codecs for v0 and legacy, instead of the combined one we currently have.

This PR adds a new codec in codecs/v0/message. It includes the legacy fields - the header, accounts, lifetime token, instructions, in addition to `version` and `addressTableLookups`. 

Tests are based on the existing ones for getCompiledMessageVersioned{}, but expanded the coverage a bit.

Not used yet, but will replace the v0 message parts of getCompiledMessageVersioned{}.