### PR TITLE
Refactor compileTransactionMessage to use the versioned compileTransactionMessage functions

### DIFF
--- a/packages/transaction-messages/src/compile/__typetests__/message-typetest.ts
+++ b/packages/transaction-messages/src/compile/__typetests__/message-typetest.ts
@@ -1,0 +1,80 @@
+import {
+    CompiledTransactionMessage,
+    CompiledTransactionMessageWithLifetime,
+    TransactionMessage,
+    TransactionMessageWithFeePayer,
+    TransactionMessageWithLifetime,
+} from '../..';
+import { compileTransactionMessage } from '../message';
+
+// [DESCRIBE] compileTransactionMessage
+{
+    // It returns a CompiledTransactionMessage
+    {
+        // For legacy
+        {
+            const message = null as unknown as TransactionMessage &
+                TransactionMessageWithFeePayer & { version: 'legacy' };
+            compileTransactionMessage(message) satisfies CompiledTransactionMessage;
+        }
+
+        // For v0
+        {
+            const message = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { version: 0 };
+            compileTransactionMessage(message) satisfies CompiledTransactionMessage;
+        }
+    }
+
+    // It does not satisfy `CompiledTransactionMessageWithLifetime` if the source message does not have a lifetime constraint
+    {
+        // For legacy
+        {
+            const message = null as unknown as TransactionMessage &
+                TransactionMessageWithFeePayer & { version: 'legacy' };
+            const compiled = compileTransactionMessage(message);
+            // @ts-expect-error Should not have a lifetime token
+            compiled satisfies CompiledTransactionMessageWithLifetime;
+        }
+
+        // For v0
+        {
+            const message = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { version: 0 };
+            const compiled = compileTransactionMessage(message);
+            // @ts-expect-error Should not have a lifetime token
+            compiled satisfies CompiledTransactionMessageWithLifetime;
+        }
+    }
+
+    // It satisfies `CompiledTransactionMessageWithLifetime` if the source message has a lifetime constraint
+    {
+        // For legacy
+        {
+            const message = null as unknown as TransactionMessage &
+                TransactionMessageWithFeePayer &
+                TransactionMessageWithLifetime & { version: 'legacy' };
+            const compiled = compileTransactionMessage(message);
+            compiled satisfies CompiledTransactionMessageWithLifetime;
+        }
+
+        // For v0
+        {
+            const message = null as unknown as TransactionMessage &
+                TransactionMessageWithFeePayer &
+                TransactionMessageWithLifetime & { version: 0 };
+            const compiled = compileTransactionMessage(message);
+            compiled satisfies CompiledTransactionMessageWithLifetime;
+        }
+    }
+
+    // It forwards a legacy version from the source message to the compiled message
+    {
+        const message = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { version: 'legacy' };
+        compileTransactionMessage(message) satisfies CompiledTransactionMessage & { version: 'legacy' };
+    }
+
+    // It forwards a v0 version from the source message to the compiled message
+    {
+        const message = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { version: 0 };
+        compileTransactionMessage(message) satisfies CompiledTransactionMessage & { version: 0 };
+    }
+}

--- a/packages/transaction-messages/src/compile/legacy/message.ts
+++ b/packages/transaction-messages/src/compile/legacy/message.ts
@@ -6,7 +6,7 @@ import { getCompiledMessageHeader } from './header';
 import { getCompiledInstructions } from './instructions';
 import { getCompiledLifetimeToken } from './lifetime-token';
 
-type LegacyCompiledTransactionMessage = BaseCompiledTransactionMessage &
+export type LegacyCompiledTransactionMessage = BaseCompiledTransactionMessage &
     Readonly<{
         version: 'legacy';
     }>;

--- a/packages/transaction-messages/src/compile/v0/message.ts
+++ b/packages/transaction-messages/src/compile/v0/message.ts
@@ -9,7 +9,7 @@ import { getCompiledAddressTableLookups } from './address-table-lookups';
 import { getCompiledInstructions } from './instructions';
 import { getCompiledStaticAccounts } from './static-accounts';
 
-type V0CompiledTransactionMessage = BaseCompiledTransactionMessage &
+export type V0CompiledTransactionMessage = BaseCompiledTransactionMessage &
     Readonly<{
         /** A list of address tables and the accounts that this transaction loads from them */
         addressTableLookups?: ReturnType<typeof getCompiledAddressTableLookups>;

--- a/packages/transactions/src/compile-transaction.ts
+++ b/packages/transactions/src/compile-transaction.ts
@@ -31,7 +31,9 @@ export function compileTransaction<TTransactionMessage extends TransactionMessag
 ): Readonly<TransactionFromTransactionMessage<TTransactionMessage>> {
     type ReturnType = Readonly<TransactionFromTransactionMessage<TTransactionMessage>>;
 
-    const compiledMessage = compileTransactionMessage(transactionMessage);
+    const compiledMessage = compileTransactionMessage(
+        transactionMessage as Parameters<typeof compileTransactionMessage>[0],
+    );
     const messageBytes = getCompiledTransactionMessageEncoder().encode(compiledMessage) as TransactionMessageBytes;
 
     const transactionSigners = compiledMessage.staticAccounts.slice(0, compiledMessage.header.numSignerAccounts);


### PR DESCRIPTION
#### Summary of Changes

Now just checks the `version` field and calls `compileTransactionMessage` from either `legacy/message` or `v0/message`

I've also added type overloads to replace the forward transaction version utility type, since we now have types available to return.

This refactoring will make it easy to add our v1 `compileTransactionMesasage` function. 