### PR TITLE
Add a legacy-specific decompileTransactionMessage

### DIFF
--- a/packages/transaction-messages/src/decompile/legacy/__tests__/account-metas-test.ts
+++ b/packages/transaction-messages/src/decompile/legacy/__tests__/account-metas-test.ts
@@ -1,0 +1,165 @@
+import { Address } from '@solana/addresses';
+import { AccountRole } from '@solana/instructions';
+
+import { CompiledTransactionMessage } from '../../..';
+import { getAccountMetas } from '../account-metas';
+
+describe('getAccountMetas', () => {
+    it('should return account metas with all four types of accounts', () => {
+        const compiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 2,
+                numReadonlySignerAccounts: 1,
+                numSignerAccounts: 3,
+            },
+            staticAccounts: [
+                'writable-signer-1' as Address,
+                'writable-signer-2' as Address,
+                'readonly-signer' as Address,
+                'writable-non-signer-1' as Address,
+                'writable-non-signer-2' as Address,
+                'readonly-non-signer-1' as Address,
+                'readonly-non-signer-2' as Address,
+            ],
+        } as CompiledTransactionMessage;
+
+        const accountMetas = getAccountMetas(compiledTransactionMessage);
+
+        expect(accountMetas).toStrictEqual([
+            { address: 'writable-signer-1', role: AccountRole.WRITABLE_SIGNER },
+            { address: 'writable-signer-2', role: AccountRole.WRITABLE_SIGNER },
+            { address: 'readonly-signer', role: AccountRole.READONLY_SIGNER },
+            { address: 'writable-non-signer-1', role: AccountRole.WRITABLE },
+            { address: 'writable-non-signer-2', role: AccountRole.WRITABLE },
+            { address: 'readonly-non-signer-1', role: AccountRole.READONLY },
+            { address: 'readonly-non-signer-2', role: AccountRole.READONLY },
+        ]);
+    });
+
+    it('should return account metas with only writable signers', () => {
+        const compiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 0,
+                numReadonlySignerAccounts: 0,
+                numSignerAccounts: 2,
+            },
+            staticAccounts: ['writable-signer-1' as Address, 'writable-signer-2' as Address],
+        } as CompiledTransactionMessage;
+
+        const accountMetas = getAccountMetas(compiledTransactionMessage);
+
+        expect(accountMetas).toStrictEqual([
+            { address: 'writable-signer-1', role: AccountRole.WRITABLE_SIGNER },
+            { address: 'writable-signer-2', role: AccountRole.WRITABLE_SIGNER },
+        ]);
+    });
+
+    it('should return account metas with only readonly signers', () => {
+        const compiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 0,
+                numReadonlySignerAccounts: 2,
+                numSignerAccounts: 2,
+            },
+            staticAccounts: ['readonly-signer-1' as Address, 'readonly-signer-2' as Address],
+        } as CompiledTransactionMessage;
+
+        const accountMetas = getAccountMetas(compiledTransactionMessage);
+
+        expect(accountMetas).toStrictEqual([
+            { address: 'readonly-signer-1', role: AccountRole.READONLY_SIGNER },
+            { address: 'readonly-signer-2', role: AccountRole.READONLY_SIGNER },
+        ]);
+    });
+
+    it('should return account metas with only writable non-signers', () => {
+        const compiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 0,
+                numReadonlySignerAccounts: 0,
+                numSignerAccounts: 0,
+            },
+            staticAccounts: ['writable-non-signer-1' as Address, 'writable-non-signer-2' as Address],
+        } as CompiledTransactionMessage;
+
+        const accountMetas = getAccountMetas(compiledTransactionMessage);
+
+        expect(accountMetas).toStrictEqual([
+            { address: 'writable-non-signer-1', role: AccountRole.WRITABLE },
+            { address: 'writable-non-signer-2', role: AccountRole.WRITABLE },
+        ]);
+    });
+
+    it('should return account metas with only readonly non-signers', () => {
+        const compiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 2,
+                numReadonlySignerAccounts: 0,
+                numSignerAccounts: 0,
+            },
+            staticAccounts: ['readonly-non-signer-1' as Address, 'readonly-non-signer-2' as Address],
+        } as CompiledTransactionMessage;
+
+        const accountMetas = getAccountMetas(compiledTransactionMessage);
+
+        expect(accountMetas).toStrictEqual([
+            { address: 'readonly-non-signer-1', role: AccountRole.READONLY },
+            { address: 'readonly-non-signer-2', role: AccountRole.READONLY },
+        ]);
+    });
+
+    it('should return empty array when no accounts are present', () => {
+        const compiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 0,
+                numReadonlySignerAccounts: 0,
+                numSignerAccounts: 0,
+            },
+            staticAccounts: [] as Address[],
+        } as CompiledTransactionMessage;
+
+        const accountMetas = getAccountMetas(compiledTransactionMessage);
+
+        expect(accountMetas).toStrictEqual([]);
+    });
+
+    it('should handle a single writable signer (fee payer only)', () => {
+        const compiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 0,
+                numReadonlySignerAccounts: 0,
+                numSignerAccounts: 1,
+            },
+            staticAccounts: ['fee-payer' as Address],
+        } as CompiledTransactionMessage;
+
+        const accountMetas = getAccountMetas(compiledTransactionMessage);
+
+        expect(accountMetas).toStrictEqual([{ address: 'fee-payer', role: AccountRole.WRITABLE_SIGNER }]);
+    });
+
+    it('should correctly handle mixed writable signers and readonly non-signers', () => {
+        const compiledTransactionMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 2,
+                numReadonlySignerAccounts: 0,
+                numSignerAccounts: 2,
+            },
+            staticAccounts: [
+                'writable-signer-1' as Address,
+                'writable-signer-2' as Address,
+                'readonly-non-signer-1' as Address,
+                'readonly-non-signer-2' as Address,
+            ],
+        } as CompiledTransactionMessage;
+
+        const accountMetas = getAccountMetas(compiledTransactionMessage);
+
+        expect(accountMetas).toStrictEqual([
+            { address: 'writable-signer-1', role: AccountRole.WRITABLE_SIGNER },
+            { address: 'writable-signer-2', role: AccountRole.WRITABLE_SIGNER },
+            { address: 'readonly-non-signer-1', role: AccountRole.READONLY },
+            { address: 'readonly-non-signer-2', role: AccountRole.READONLY },
+        ]);
+    });
+});

--- a/packages/transaction-messages/src/decompile/legacy/__tests__/convert-instruction-test.ts
+++ b/packages/transaction-messages/src/decompile/legacy/__tests__/convert-instruction-test.ts
@@ -1,0 +1,278 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import { Address } from '@solana/addresses';
+import {
+    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_INSTRUCTION_PROGRAM_ADDRESS_NOT_FOUND,
+    SolanaError,
+} from '@solana/errors';
+import { AccountRole } from '@solana/instructions';
+
+import { CompiledTransactionMessage } from '../../..';
+import { convertInstructions } from '../convert-instruction';
+
+describe('convertInstructions', () => {
+    it('should convert a single instruction with program address, accounts, and data', () => {
+        const compiledInstructions: CompiledTransactionMessage['instructions'] = [
+            {
+                accountIndices: [0, 1],
+                data: new Uint8Array([1, 2, 3]),
+                programAddressIndex: 2,
+            },
+        ];
+
+        const accountMetas = [
+            { address: 'account0' as Address, role: AccountRole.WRITABLE_SIGNER },
+            { address: 'account1' as Address, role: AccountRole.READONLY },
+            { address: 'program' as Address, role: AccountRole.READONLY },
+        ];
+
+        const instructions = convertInstructions(compiledInstructions, accountMetas);
+
+        expect(instructions).toStrictEqual([
+            {
+                accounts: [
+                    { address: 'account0', role: AccountRole.WRITABLE_SIGNER },
+                    { address: 'account1', role: AccountRole.READONLY },
+                ],
+                data: new Uint8Array([1, 2, 3]),
+                programAddress: 'program',
+            },
+        ]);
+    });
+
+    it('should convert an instruction with only program address (no accounts or data)', () => {
+        const compiledInstructions: CompiledTransactionMessage['instructions'] = [
+            {
+                programAddressIndex: 0,
+            },
+        ];
+
+        const accountMetas = [{ address: 'program' as Address, role: AccountRole.READONLY }];
+
+        const instructions = convertInstructions(compiledInstructions, accountMetas);
+
+        expect(instructions).toStrictEqual([
+            {
+                programAddress: 'program',
+            },
+        ]);
+    });
+
+    it('should convert an instruction with program address and accounts but no data', () => {
+        const compiledInstructions: CompiledTransactionMessage['instructions'] = [
+            {
+                accountIndices: [0],
+                programAddressIndex: 1,
+            },
+        ];
+
+        const accountMetas = [
+            { address: 'account0' as Address, role: AccountRole.WRITABLE },
+            { address: 'program' as Address, role: AccountRole.READONLY },
+        ];
+
+        const instructions = convertInstructions(compiledInstructions, accountMetas);
+
+        expect(instructions).toStrictEqual([
+            {
+                accounts: [{ address: 'account0', role: AccountRole.WRITABLE }],
+                programAddress: 'program',
+            },
+        ]);
+    });
+
+    it('should convert an instruction with program address and data but no accounts', () => {
+        const compiledInstructions: CompiledTransactionMessage['instructions'] = [
+            {
+                data: new Uint8Array([4, 5, 6]),
+                programAddressIndex: 0,
+            },
+        ];
+
+        const accountMetas = [{ address: 'program' as Address, role: AccountRole.READONLY }];
+
+        const instructions = convertInstructions(compiledInstructions, accountMetas);
+
+        expect(instructions).toStrictEqual([
+            {
+                data: new Uint8Array([4, 5, 6]),
+                programAddress: 'program',
+            },
+        ]);
+    });
+
+    it('should not include accounts field when accountIndices is empty array', () => {
+        const compiledInstructions: CompiledTransactionMessage['instructions'] = [
+            {
+                accountIndices: [],
+                programAddressIndex: 0,
+            },
+        ];
+
+        const accountMetas = [{ address: 'program' as Address, role: AccountRole.READONLY }];
+
+        const instructions = convertInstructions(compiledInstructions, accountMetas);
+
+        expect(instructions).toStrictEqual([
+            {
+                programAddress: 'program',
+            },
+        ]);
+        expect(instructions[0]).not.toHaveProperty('accounts');
+    });
+
+    it('should not include data field when data is empty array', () => {
+        const compiledInstructions: CompiledTransactionMessage['instructions'] = [
+            {
+                data: new Uint8Array(),
+                programAddressIndex: 0,
+            },
+        ];
+
+        const accountMetas = [{ address: 'program' as Address, role: AccountRole.READONLY }];
+
+        const instructions = convertInstructions(compiledInstructions, accountMetas);
+
+        expect(instructions).toStrictEqual([
+            {
+                programAddress: 'program',
+            },
+        ]);
+        expect(instructions[0]).not.toHaveProperty('data');
+    });
+
+    it('should convert multiple instructions', () => {
+        const compiledInstructions: CompiledTransactionMessage['instructions'] = [
+            {
+                accountIndices: [0],
+                data: new Uint8Array([1]),
+                programAddressIndex: 2,
+            },
+            {
+                accountIndices: [1],
+                data: new Uint8Array([2]),
+                programAddressIndex: 3,
+            },
+            {
+                programAddressIndex: 4,
+            },
+        ];
+
+        const accountMetas = [
+            { address: 'account0' as Address, role: AccountRole.WRITABLE_SIGNER },
+            { address: 'account1' as Address, role: AccountRole.READONLY_SIGNER },
+            { address: 'program1' as Address, role: AccountRole.READONLY },
+            { address: 'program2' as Address, role: AccountRole.READONLY },
+            { address: 'program3' as Address, role: AccountRole.READONLY },
+        ];
+
+        const instructions = convertInstructions(compiledInstructions, accountMetas);
+
+        expect(instructions).toStrictEqual([
+            {
+                accounts: [{ address: 'account0', role: AccountRole.WRITABLE_SIGNER }],
+                data: new Uint8Array([1]),
+                programAddress: 'program1',
+            },
+            {
+                accounts: [{ address: 'account1', role: AccountRole.READONLY_SIGNER }],
+                data: new Uint8Array([2]),
+                programAddress: 'program2',
+            },
+            {
+                programAddress: 'program3',
+            },
+        ]);
+    });
+
+    it('should handle instructions with multiple account indices', () => {
+        const compiledInstructions: CompiledTransactionMessage['instructions'] = [
+            {
+                accountIndices: [0, 1, 2, 3],
+                programAddressIndex: 4,
+            },
+        ];
+
+        const accountMetas = [
+            { address: 'account0' as Address, role: AccountRole.WRITABLE_SIGNER },
+            { address: 'account1' as Address, role: AccountRole.READONLY_SIGNER },
+            { address: 'account2' as Address, role: AccountRole.WRITABLE },
+            { address: 'account3' as Address, role: AccountRole.READONLY },
+            { address: 'program' as Address, role: AccountRole.READONLY },
+        ];
+
+        const instructions = convertInstructions(compiledInstructions, accountMetas);
+
+        expect(instructions).toStrictEqual([
+            {
+                accounts: [
+                    { address: 'account0', role: AccountRole.WRITABLE_SIGNER },
+                    { address: 'account1', role: AccountRole.READONLY_SIGNER },
+                    { address: 'account2', role: AccountRole.WRITABLE },
+                    { address: 'account3', role: AccountRole.READONLY },
+                ],
+                programAddress: 'program',
+            },
+        ]);
+    });
+
+    it('should throw when program address index is out of bounds', () => {
+        const compiledInstructions: CompiledTransactionMessage['instructions'] = [
+            {
+                programAddressIndex: 5,
+            },
+        ];
+
+        const accountMetas = [{ address: 'account0' as Address, role: AccountRole.WRITABLE_SIGNER }];
+
+        expect(() => convertInstructions(compiledInstructions, accountMetas)).toThrow(
+            new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_INSTRUCTION_PROGRAM_ADDRESS_NOT_FOUND, {
+                index: 5,
+            }),
+        );
+    });
+
+    it('should throw when program address index is negative', () => {
+        const compiledInstructions: CompiledTransactionMessage['instructions'] = [
+            {
+                programAddressIndex: -1,
+            },
+        ];
+
+        const accountMetas = [{ address: 'account0' as Address, role: AccountRole.WRITABLE_SIGNER }];
+
+        expect(() => convertInstructions(compiledInstructions, accountMetas)).toThrow(
+            new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_INSTRUCTION_PROGRAM_ADDRESS_NOT_FOUND, {
+                index: -1,
+            }),
+        );
+    });
+
+    it('should return empty array when no instructions provided', () => {
+        const compiledInstructions: CompiledTransactionMessage['instructions'] = [];
+        const accountMetas = [{ address: 'account0' as Address, role: AccountRole.WRITABLE_SIGNER }];
+
+        const instructions = convertInstructions(compiledInstructions, accountMetas);
+
+        expect(instructions).toStrictEqual([]);
+    });
+
+    it('should freeze the returned instruction objects', () => {
+        const compiledInstructions: CompiledTransactionMessage['instructions'] = [
+            {
+                accountIndices: [0],
+                programAddressIndex: 1,
+            },
+        ];
+
+        const accountMetas = [
+            { address: 'account0' as Address, role: AccountRole.WRITABLE },
+            { address: 'program' as Address, role: AccountRole.READONLY },
+        ];
+
+        const instructions = convertInstructions(compiledInstructions, accountMetas);
+
+        expect(instructions[0]).toBeFrozenObject();
+        expect(instructions[0].accounts).toBeFrozenObject();
+    });
+});

--- a/packages/transaction-messages/src/decompile/legacy/__tests__/fee-payer-test.ts
+++ b/packages/transaction-messages/src/decompile/legacy/__tests__/fee-payer-test.ts
@@ -1,0 +1,19 @@
+import { Address } from '@solana/addresses';
+import { SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_FEE_PAYER_MISSING, SolanaError } from '@solana/errors';
+
+import { getFeePayer } from '../fee-payer';
+
+describe('getFeePayer', () => {
+    it('should return the fee payer from the compiled transaction message', () => {
+        const staticAccounts = ['fee-payer' as Address, 'account1' as Address, 'account2' as Address];
+        const feePayer = getFeePayer(staticAccounts);
+        expect(feePayer).toBe('fee-payer');
+    });
+
+    it('should throw when staticAccounts is empty', () => {
+        const staticAccounts: Address[] = [];
+        expect(() => getFeePayer(staticAccounts)).toThrow(
+            new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_FEE_PAYER_MISSING),
+        );
+    });
+});

--- a/packages/transaction-messages/src/decompile/legacy/__tests__/lifetime-constraint-test.ts
+++ b/packages/transaction-messages/src/decompile/legacy/__tests__/lifetime-constraint-test.ts
@@ -1,0 +1,305 @@
+import { Address } from '@solana/addresses';
+import { AccountRole, Instruction } from '@solana/instructions';
+import { Blockhash } from '@solana/rpc-types';
+
+import { getLifetimeConstraint } from '../lifetime-constraint';
+
+describe('getLifetimeConstraint', () => {
+    describe('blockhash lifetime constraint', () => {
+        it('should return blockhash lifetime constraint when no instructions provided', () => {
+            const lifetimeToken = 'blockhash123' as Blockhash;
+            const instructions: Instruction[] = [];
+            const constraint = getLifetimeConstraint(lifetimeToken, instructions);
+
+            expect(constraint).toStrictEqual({
+                blockhash: lifetimeToken,
+                lastValidBlockHeight: 2n ** 64n - 1n,
+            });
+        });
+
+        it('should return blockhash lifetime constraint when first instruction is not advance nonce', () => {
+            const lifetimeToken = 'blockhash456' as Blockhash;
+            const instructions: Instruction[] = [
+                {
+                    accounts: [{ address: 'account1' as Address, role: AccountRole.WRITABLE }],
+                    programAddress: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address,
+                },
+            ];
+
+            const constraint = getLifetimeConstraint(lifetimeToken, instructions);
+
+            expect(constraint).toStrictEqual({
+                blockhash: lifetimeToken,
+                lastValidBlockHeight: 2n ** 64n - 1n,
+            });
+        });
+
+        it('should use provided lastValidBlockHeight when given', () => {
+            const lifetimeToken = 'blockhash789' as Blockhash;
+            const instructions: Instruction[] = [];
+            const lastValidBlockHeight = 12345n;
+
+            const constraint = getLifetimeConstraint(lifetimeToken, instructions, lastValidBlockHeight);
+
+            expect(constraint).toStrictEqual({
+                blockhash: lifetimeToken,
+                lastValidBlockHeight: 12345n,
+            });
+        });
+
+        it('should return blockhash when first instruction has wrong program address', () => {
+            const lifetimeToken = 'blockhash000' as Blockhash;
+            const instructions: Instruction[] = [
+                {
+                    accounts: [
+                        { address: 'nonce-account' as Address, role: AccountRole.WRITABLE },
+                        {
+                            address: 'SysvarRecentB1ockHashes11111111111111111111' as Address,
+                            role: AccountRole.READONLY,
+                        },
+                        { address: 'authority' as Address, role: AccountRole.READONLY_SIGNER },
+                    ],
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: 'WrongProgram1111111111111111111111111111' as Address,
+                },
+            ];
+
+            const constraint = getLifetimeConstraint(lifetimeToken, instructions);
+
+            expect(constraint).toStrictEqual({
+                blockhash: lifetimeToken,
+                lastValidBlockHeight: 2n ** 64n - 1n,
+            });
+        });
+
+        it('should return blockhash when first instruction has wrong data', () => {
+            const lifetimeToken = 'blockhash111' as Blockhash;
+            const instructions = [
+                {
+                    accounts: [
+                        { address: 'nonce-account' as Address, role: AccountRole.WRITABLE },
+                        {
+                            address: 'SysvarRecentB1ockHashes11111111111111111111' as Address,
+                            role: AccountRole.READONLY,
+                        },
+                        { address: 'authority' as Address, role: AccountRole.READONLY_SIGNER },
+                    ],
+                    data: new Uint8Array([5, 0, 0, 0]),
+                    programAddress: '11111111111111111111111111111111' as Address, // wrong instruction discriminator
+                },
+            ];
+
+            const constraint = getLifetimeConstraint(lifetimeToken, instructions);
+
+            expect(constraint).toStrictEqual({
+                blockhash: lifetimeToken,
+                lastValidBlockHeight: 2n ** 64n - 1n,
+            });
+        });
+
+        it('should return blockhash when first instruction has wrong number of accounts', () => {
+            const lifetimeToken = 'blockhash222' as Blockhash;
+            const instructions = [
+                {
+                    accounts: [
+                        { address: 'nonce-account' as Address, role: AccountRole.WRITABLE },
+                        {
+                            address: 'SysvarRecentB1ockHashes11111111111111111111' as Address,
+                            role: AccountRole.READONLY,
+                        },
+                    ],
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: '11111111111111111111111111111111' as Address,
+                },
+            ];
+
+            const constraint = getLifetimeConstraint(lifetimeToken, instructions);
+
+            expect(constraint).toStrictEqual({
+                blockhash: lifetimeToken,
+                lastValidBlockHeight: 2n ** 64n - 1n,
+            });
+        });
+
+        it('should return blockhash when first instruction has no accounts', () => {
+            const lifetimeToken = 'blockhash-no-accounts' as Blockhash;
+            const instructions: Instruction[] = [
+                {
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: '11111111111111111111111111111111' as Address,
+                },
+            ];
+
+            const constraint = getLifetimeConstraint(lifetimeToken, instructions);
+
+            expect(constraint).toStrictEqual({
+                blockhash: lifetimeToken,
+                lastValidBlockHeight: 2n ** 64n - 1n,
+            });
+        });
+
+        it('should return blockhash when first instruction has no data', () => {
+            const lifetimeToken = 'blockhash-no-data' as Blockhash;
+            const instructions: Instruction[] = [
+                {
+                    accounts: [
+                        { address: 'nonce-account' as Address, role: AccountRole.WRITABLE },
+                        {
+                            address: 'SysvarRecentB1ockHashes11111111111111111111' as Address,
+                            role: AccountRole.READONLY,
+                        },
+                        { address: 'authority' as Address, role: AccountRole.READONLY_SIGNER },
+                    ],
+                    programAddress: '11111111111111111111111111111111' as Address,
+                },
+            ];
+
+            const constraint = getLifetimeConstraint(lifetimeToken, instructions);
+
+            expect(constraint).toStrictEqual({
+                blockhash: lifetimeToken,
+                lastValidBlockHeight: 2n ** 64n - 1n,
+            });
+        });
+    });
+
+    describe('nonce lifetime constraint', () => {
+        it('should return nonce lifetime constraint when first instruction is advance nonce with readonly signer', () => {
+            const lifetimeToken = 'nonce123';
+            const instructions = [
+                {
+                    accounts: [
+                        {
+                            address: '4wBqpZM9xaSheZzJSMawUHDgH36fBXoKrcna28MqTQF1' as Address,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: 'SysvarRecentB1ockHashes11111111111111111111' as Address,
+                            role: AccountRole.READONLY,
+                        },
+                        {
+                            address: 'FYZJxv6E1UB1AZReeakjUZgnkYvsHxqPMVkDsjdbWs3L' as Address,
+                            role: AccountRole.READONLY_SIGNER,
+                        },
+                    ],
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: '11111111111111111111111111111111' as Address,
+                },
+            ];
+
+            const constraint = getLifetimeConstraint(lifetimeToken, instructions);
+
+            expect(constraint).toStrictEqual({
+                nonce: lifetimeToken,
+                nonceAccountAddress: '4wBqpZM9xaSheZzJSMawUHDgH36fBXoKrcna28MqTQF1',
+                nonceAuthorityAddress: 'FYZJxv6E1UB1AZReeakjUZgnkYvsHxqPMVkDsjdbWs3L',
+            });
+        });
+
+        it('should return nonce lifetime constraint when first instruction is advance nonce with writable signer', () => {
+            const lifetimeToken = 'nonce456';
+            const instructions = [
+                {
+                    accounts: [
+                        {
+                            address: '8vCf5aVJkPzzkW34WFq9tHHVmgYMNzJf2jPKvv7YF5Ah' as Address,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: 'SysvarRecentB1ockHashes11111111111111111111' as Address,
+                            role: AccountRole.READONLY,
+                        },
+                        {
+                            address: 'GZz8aVQBfN7wXT8F2vKvK4kZ5J1xYPaM3wQE4pqBv8Qj' as Address,
+                            role: AccountRole.WRITABLE_SIGNER,
+                        },
+                    ],
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: '11111111111111111111111111111111' as Address,
+                },
+            ];
+
+            const constraint = getLifetimeConstraint(lifetimeToken, instructions);
+
+            expect(constraint).toStrictEqual({
+                nonce: lifetimeToken,
+                nonceAccountAddress: '8vCf5aVJkPzzkW34WFq9tHHVmgYMNzJf2jPKvv7YF5Ah',
+                nonceAuthorityAddress: 'GZz8aVQBfN7wXT8F2vKvK4kZ5J1xYPaM3wQE4pqBv8Qj',
+            });
+        });
+
+        it('should return nonce lifetime constraint even when lastValidBlockHeight is provided', () => {
+            const lifetimeToken = 'nonce789';
+            const instructions = [
+                {
+                    accounts: [
+                        {
+                            address: 'CsJmqbHTR5pY8CLH8TnQXh5rL2qp1fS9Y8wSVkv8pPWy' as Address,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: 'SysvarRecentB1ockHashes11111111111111111111' as Address,
+                            role: AccountRole.READONLY,
+                        },
+                        {
+                            address: 'DnVsJPvU3iW9rJqbLbGxFdp4xVkLZKRLw8pnhqVkpN3H' as Address,
+                            role: AccountRole.READONLY_SIGNER,
+                        },
+                    ],
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: '11111111111111111111111111111111' as Address,
+                },
+            ];
+            const lastValidBlockHeight = 99999n;
+
+            const constraint = getLifetimeConstraint(lifetimeToken, instructions, lastValidBlockHeight);
+
+            expect(constraint).toStrictEqual({
+                nonce: lifetimeToken,
+                nonceAccountAddress: 'CsJmqbHTR5pY8CLH8TnQXh5rL2qp1fS9Y8wSVkv8pPWy',
+                nonceAuthorityAddress: 'DnVsJPvU3iW9rJqbLbGxFdp4xVkLZKRLw8pnhqVkpN3H',
+            });
+        });
+
+        it('should return nonce lifetime constraint when there are multiple instructions', () => {
+            const lifetimeToken = 'nonce000';
+            const instructions = [
+                {
+                    accounts: [
+                        {
+                            address: '2mGq8vz9Z3e3vQWaP9sPfYvYzrh8jrE1VQ4TH2wLFRp6' as Address,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: 'SysvarRecentB1ockHashes11111111111111111111' as Address,
+                            role: AccountRole.READONLY,
+                        },
+                        {
+                            address: '7hBjZqWmR3JvE4QfxqKjvFZnkxqYpLCz4xJ9Fn8MTy2D' as Address,
+                            role: AccountRole.READONLY_SIGNER,
+                        },
+                    ],
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: '11111111111111111111111111111111' as Address,
+                },
+                {
+                    accounts: [
+                        {
+                            address: '3pKvN2wV8qhLZjP6YfmR7qWJdkzVxH5RKLnfU9sQ2tY8' as Address,
+                            role: AccountRole.WRITABLE,
+                        },
+                    ],
+                    programAddress: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address,
+                },
+            ];
+
+            const constraint = getLifetimeConstraint(lifetimeToken, instructions);
+
+            expect(constraint).toStrictEqual({
+                nonce: lifetimeToken,
+                nonceAccountAddress: '2mGq8vz9Z3e3vQWaP9sPfYvYzrh8jrE1VQ4TH2wLFRp6',
+                nonceAuthorityAddress: '7hBjZqWmR3JvE4QfxqKjvFZnkxqYpLCz4xJ9Fn8MTy2D',
+            });
+        });
+    });
+});

--- a/packages/transaction-messages/src/decompile/legacy/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/decompile/legacy/__tests__/message-test.ts
@@ -1,0 +1,552 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import { Address } from '@solana/addresses';
+import { AccountRole } from '@solana/instructions';
+
+import { CompiledTransactionMessage, CompiledTransactionMessageWithLifetime } from '../../..';
+import { Nonce } from '../../../durable-nonce';
+import { decompileTransactionMessage } from '../message';
+
+describe('decompileTransactionMessage (legacy)', () => {
+    const U64_MAX = 2n ** 64n - 1n;
+    const feePayer = '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK' as Address;
+
+    describe('for a transaction with a blockhash lifetime', () => {
+        const blockhash = 'J4yED2jcMAHyQUg61DBmm4njmEydUr2WqrV9cdEcDDgL';
+
+        it('converts a legacy transaction with no instructions', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 0,
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1,
+                },
+                instructions: [],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+
+            expect(transaction.version).toBe('legacy');
+            expect(transaction.feePayer.address).toBe(feePayer);
+            expect(transaction.lifetimeConstraint).toStrictEqual({
+                blockhash,
+                lastValidBlockHeight: U64_MAX,
+            });
+            expect(transaction.instructions).toStrictEqual([]);
+        });
+
+        it('freezes the blockhash lifetime constraint', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 0,
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1,
+                },
+                instructions: [],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.lifetimeConstraint).toBeFrozenObject();
+        });
+
+        it('converts a transaction with one instruction with no accounts or data', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 1, // program address
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1, // fee payer
+                },
+                instructions: [{ programAddressIndex: 1 }],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer, programAddress],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    programAddress,
+                },
+            ]);
+        });
+
+        it('converts a transaction with one instruction with accounts and data', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 2, // 1 passed into instruction + 1 program
+                    numReadonlySignerAccounts: 1,
+                    numSignerAccounts: 3, // fee payer + 2 passed into instruction
+                },
+                instructions: [
+                    {
+                        accountIndices: [1, 2, 3, 4],
+                        data: new Uint8Array([0, 1, 2, 3, 4]),
+                        programAddressIndex: 5,
+                    },
+                ],
+                lifetimeToken: blockhash,
+                staticAccounts: [
+                    // writable signers
+                    feePayer,
+                    'H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x' as Address,
+                    // read-only signers
+                    'G35QeFd4jpXWfRkuRKwn8g4vYrmn8DWJ5v88Kkpd8z1V' as Address,
+                    // writable non-signers
+                    '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd' as Address,
+                    // read-only non-signers
+                    '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Address,
+                    programAddress,
+                ],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions).toHaveLength(1);
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    accounts: [
+                        {
+                            address: 'H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x' as Address,
+                            role: AccountRole.WRITABLE_SIGNER,
+                        },
+                        {
+                            address: 'G35QeFd4jpXWfRkuRKwn8g4vYrmn8DWJ5v88Kkpd8z1V' as Address,
+                            role: AccountRole.READONLY_SIGNER,
+                        },
+                        {
+                            address: '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd' as Address,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Address,
+                            role: AccountRole.READONLY,
+                        },
+                    ],
+                    data: new Uint8Array([0, 1, 2, 3, 4]),
+                    programAddress,
+                },
+            ]);
+        });
+
+        it('freezes the instruction accounts', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 2, // 1 passed into instruction + 1 program
+                    numReadonlySignerAccounts: 1,
+                    numSignerAccounts: 3, // fee payer + 2 passed into instruction
+                },
+                instructions: [
+                    {
+                        accountIndices: [1, 2, 3, 4],
+                        data: new Uint8Array([0, 1, 2, 3, 4]),
+                        programAddressIndex: 5,
+                    },
+                ],
+                lifetimeToken: blockhash,
+                staticAccounts: [
+                    // writable signers
+                    feePayer,
+                    'H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x' as Address,
+                    // read-only signers
+                    'G35QeFd4jpXWfRkuRKwn8g4vYrmn8DWJ5v88Kkpd8z1V' as Address,
+                    // writable non-signers
+                    '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd' as Address,
+                    // read-only non-signers
+                    '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Address,
+                    programAddress,
+                ],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions[0].accounts).toBeFrozenObject();
+        });
+
+        it('converts a transaction with multiple instructions', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 3, // 3 programs
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1, // fee payer
+                },
+                instructions: [{ programAddressIndex: 1 }, { programAddressIndex: 2 }, { programAddressIndex: 3 }],
+                lifetimeToken: blockhash,
+                staticAccounts: [
+                    feePayer,
+                    '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
+                    'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
+                    'GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S' as Address,
+                ],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    programAddress: '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
+                },
+                {
+                    programAddress: 'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
+                },
+                {
+                    programAddress: 'GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S' as Address,
+                },
+            ]);
+        });
+
+        it('converts a transaction with a given lastValidBlockHeight', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 0,
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1,
+                },
+                instructions: [],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction, { lastValidBlockHeight: 100n });
+            expect(transaction.lifetimeConstraint).toStrictEqual({
+                blockhash,
+                lastValidBlockHeight: 100n,
+            });
+        });
+
+        it('freezes the instructions within the transaction', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 1,
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1, // fee payer
+                },
+                instructions: [{ programAddressIndex: 1 }],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer, programAddress],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions[0]).toBeFrozenObject();
+        });
+    });
+
+    describe('for a transaction with a durable nonce lifetime', () => {
+        const nonce = '27kqzE1RifbyoFtibDRTjbnfZ894jsNpuR77JJkt3vgH' as Nonce;
+
+        // added as writable non-signer in the durable nonce instruction
+        const nonceAccountAddress = 'DhezFECsqmzuDxeuitFChbghTrwKLdsKdVsGArYbFEtm' as Address;
+
+        // added as read-only signer in the durable nonce instruction
+        const nonceAuthorityAddress = '2KntmCrnaf63tpNb8UMFFjFGGnYYAKQdmW9SbuCiRvhM' as Address;
+
+        const systemProgramAddress = '11111111111111111111111111111111' as Address;
+        const recentBlockhashesSysvarAddress = 'SysvarRecentB1ockHashes11111111111111111111' as Address;
+
+        it('converts a transaction with one instruction which is advance nonce (fee payer is nonce authority)', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 2, // recent blockhashes sysvar, system program
+                    numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
+                    numSignerAccounts: 1, // fee payer and nonce authority are the same account
+                },
+                instructions: [
+                    {
+                        accountIndices: [
+                            1, // nonce account address
+                            3, // recent blockhashes sysvar
+                            0, // nonce authority address
+                        ],
+                        data: new Uint8Array([4, 0, 0, 0]),
+                        programAddressIndex: 2,
+                    },
+                ],
+                lifetimeToken: nonce,
+                staticAccounts: [
+                    // writable signers
+                    nonceAuthorityAddress,
+                    // no read-only signers
+                    // writable non-signers
+                    nonceAccountAddress,
+                    // read-only non-signers
+                    systemProgramAddress,
+                    recentBlockhashesSysvarAddress,
+                ],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    accounts: [
+                        {
+                            address: nonceAccountAddress,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: recentBlockhashesSysvarAddress,
+                            role: AccountRole.READONLY,
+                        },
+                        {
+                            address: nonceAuthorityAddress,
+                            role: AccountRole.WRITABLE_SIGNER,
+                        },
+                    ],
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: systemProgramAddress,
+                },
+            ]);
+            expect(transaction.feePayer.address).toBe(nonceAuthorityAddress);
+            expect(transaction.lifetimeConstraint).toStrictEqual({ nonce });
+        });
+
+        it('freezes the nonce lifetime constraint', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 2, // recent blockhashes sysvar, system program
+                    numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
+                    numSignerAccounts: 1, // fee payer and nonce authority are the same account
+                },
+                instructions: [
+                    {
+                        accountIndices: [
+                            1, // nonce account address
+                            3, // recent blockhashes sysvar
+                            0, // nonce authority address
+                        ],
+                        data: new Uint8Array([4, 0, 0, 0]),
+                        programAddressIndex: 2,
+                    },
+                ],
+                lifetimeToken: nonce,
+                staticAccounts: [
+                    // writable signers
+                    nonceAuthorityAddress,
+                    // no read-only signers
+                    // writable non-signers
+                    nonceAccountAddress,
+                    // read-only non-signers
+                    systemProgramAddress,
+                    recentBlockhashesSysvarAddress,
+                ],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.lifetimeConstraint).toBeFrozenObject();
+        });
+
+        it('converts a transaction with one instruction which is advance nonce (fee payer is not nonce authority)', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 2, // recent blockhashes sysvar, system program
+                    numReadonlySignerAccounts: 1, // nonce authority
+                    numSignerAccounts: 2, // fee payer, nonce authority
+                },
+                instructions: [
+                    {
+                        accountIndices: [
+                            2, // nonce account address
+                            4, // recent blockhashes sysvar
+                            1, // nonce authority address
+                        ],
+                        data: new Uint8Array([4, 0, 0, 0]),
+                        programAddressIndex: 3,
+                    },
+                ],
+                lifetimeToken: nonce,
+                staticAccounts: [
+                    // writable signers
+                    feePayer,
+                    // read-only signers
+                    nonceAuthorityAddress,
+                    // writable non-signers
+                    nonceAccountAddress,
+                    // read-only non-signers
+                    systemProgramAddress,
+                    recentBlockhashesSysvarAddress,
+                ],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    accounts: [
+                        {
+                            address: nonceAccountAddress,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: recentBlockhashesSysvarAddress,
+                            role: AccountRole.READONLY,
+                        },
+                        {
+                            address: nonceAuthorityAddress,
+                            role: AccountRole.READONLY_SIGNER,
+                        },
+                    ],
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: systemProgramAddress,
+                },
+            ]);
+            expect(transaction.feePayer.address).toBe(feePayer);
+        });
+
+        it('converts a durable nonce transaction with multiple instructions', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 4, // recent blockhashes sysvar, system program, 2 other program addresses
+                    numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
+                    numSignerAccounts: 1, // fee payer and nonce authority are the same account
+                },
+                instructions: [
+                    {
+                        accountIndices: [
+                            1, // nonce account address
+                            3, // recent blockhashes sysvar
+                            0, // nonce authority address
+                        ],
+                        data: new Uint8Array([4, 0, 0, 0]),
+                        programAddressIndex: 2,
+                    },
+                    {
+                        accountIndices: [0, 1],
+                        data: new Uint8Array([1, 2, 3, 4]),
+                        programAddressIndex: 4,
+                    },
+                    { programAddressIndex: 5 },
+                ],
+                lifetimeToken: nonce,
+                staticAccounts: [
+                    // writable signers
+                    nonceAuthorityAddress,
+                    // no read-only signers
+                    // writable non-signers
+                    nonceAccountAddress,
+                    // read-only non-signers
+                    systemProgramAddress,
+                    recentBlockhashesSysvarAddress,
+                    '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
+                    'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
+                ],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    accounts: [
+                        {
+                            address: nonceAccountAddress,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: recentBlockhashesSysvarAddress,
+                            role: AccountRole.READONLY,
+                        },
+                        {
+                            address: nonceAuthorityAddress,
+                            role: AccountRole.WRITABLE_SIGNER,
+                        },
+                    ],
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: systemProgramAddress,
+                },
+                {
+                    accounts: [
+                        {
+                            address: nonceAuthorityAddress,
+                            role: AccountRole.WRITABLE_SIGNER,
+                        },
+                        {
+                            address: nonceAccountAddress,
+                            role: AccountRole.WRITABLE,
+                        },
+                    ],
+                    data: new Uint8Array([1, 2, 3, 4]),
+                    programAddress: '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
+                },
+                {
+                    programAddress: 'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
+                },
+            ]);
+            expect(transaction.lifetimeConstraint).toStrictEqual({ nonce });
+        });
+
+        it('freezes the instructions within the transaction', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 'legacy' } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 4, // recent blockhashes sysvar, system program, 2 other program addresses
+                    numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
+                    numSignerAccounts: 1, // fee payer and nonce authority are the same account
+                },
+                instructions: [
+                    {
+                        accountIndices: [
+                            1, // nonce account address
+                            3, // recent blockhashes sysvar
+                            0, // nonce authority address
+                        ],
+                        data: new Uint8Array([4, 0, 0, 0]),
+                        programAddressIndex: 2,
+                    },
+                    {
+                        accountIndices: [0, 1],
+                        data: new Uint8Array([1, 2, 3, 4]),
+                        programAddressIndex: 4,
+                    },
+                    { programAddressIndex: 5 },
+                ],
+                lifetimeToken: nonce,
+                staticAccounts: [
+                    // writable signers
+                    nonceAuthorityAddress,
+                    // no read-only signers
+                    // writable non-signers
+                    nonceAccountAddress,
+                    // read-only non-signers
+                    systemProgramAddress,
+                    recentBlockhashesSysvarAddress,
+                    '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
+                    'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
+                ],
+                version: 'legacy',
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions[0]).toBeFrozenObject();
+            expect(transaction.instructions[1]).toBeFrozenObject();
+            expect(transaction.instructions[2]).toBeFrozenObject();
+        });
+    });
+});

--- a/packages/transaction-messages/src/decompile/legacy/account-metas.ts
+++ b/packages/transaction-messages/src/decompile/legacy/account-metas.ts
@@ -1,0 +1,47 @@
+import { AccountMeta, AccountRole } from '@solana/instructions';
+
+import { CompiledTransactionMessage } from '../..';
+
+export function getAccountMetas(message: CompiledTransactionMessage): AccountMeta[] {
+    const { header } = message;
+    const numWritableSignerAccounts = header.numSignerAccounts - header.numReadonlySignerAccounts;
+    const numWritableNonSignerAccounts =
+        message.staticAccounts.length - header.numSignerAccounts - header.numReadonlyNonSignerAccounts;
+
+    const accountMetas: AccountMeta[] = [];
+
+    let accountIndex = 0;
+    for (let i = 0; i < numWritableSignerAccounts; i++) {
+        accountMetas.push({
+            address: message.staticAccounts[accountIndex],
+            role: AccountRole.WRITABLE_SIGNER,
+        });
+        accountIndex++;
+    }
+
+    for (let i = 0; i < header.numReadonlySignerAccounts; i++) {
+        accountMetas.push({
+            address: message.staticAccounts[accountIndex],
+            role: AccountRole.READONLY_SIGNER,
+        });
+        accountIndex++;
+    }
+
+    for (let i = 0; i < numWritableNonSignerAccounts; i++) {
+        accountMetas.push({
+            address: message.staticAccounts[accountIndex],
+            role: AccountRole.WRITABLE,
+        });
+        accountIndex++;
+    }
+
+    for (let i = 0; i < header.numReadonlyNonSignerAccounts; i++) {
+        accountMetas.push({
+            address: message.staticAccounts[accountIndex],
+            role: AccountRole.READONLY,
+        });
+        accountIndex++;
+    }
+
+    return accountMetas;
+}

--- a/packages/transaction-messages/src/decompile/legacy/convert-instruction.ts
+++ b/packages/transaction-messages/src/decompile/legacy/convert-instruction.ts
@@ -1,0 +1,35 @@
+import {
+    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_INSTRUCTION_PROGRAM_ADDRESS_NOT_FOUND,
+    SolanaError,
+} from '@solana/errors';
+import { AccountMeta, Instruction } from '@solana/instructions';
+
+import { CompiledTransactionMessage } from '../..';
+
+function convertInstruction(
+    instruction: CompiledTransactionMessage['instructions'][number],
+    accountMetas: AccountMeta[],
+): Instruction {
+    const programAddress = accountMetas[instruction.programAddressIndex]?.address;
+    if (!programAddress) {
+        throw new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_INSTRUCTION_PROGRAM_ADDRESS_NOT_FOUND, {
+            index: instruction.programAddressIndex,
+        });
+    }
+
+    const accounts = instruction.accountIndices?.map(accountIndex => accountMetas[accountIndex]);
+    const { data } = instruction;
+
+    return Object.freeze({
+        programAddress,
+        ...(accounts && accounts.length ? { accounts: Object.freeze(accounts) } : {}),
+        ...(data && data.length ? { data } : {}),
+    });
+}
+
+export function convertInstructions(
+    instructions: CompiledTransactionMessage['instructions'],
+    accountMetas: AccountMeta[],
+): Instruction[] {
+    return instructions.map(instruction => convertInstruction(instruction, accountMetas));
+}

--- a/packages/transaction-messages/src/decompile/legacy/fee-payer.ts
+++ b/packages/transaction-messages/src/decompile/legacy/fee-payer.ts
@@ -1,0 +1,11 @@
+import { SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_FEE_PAYER_MISSING, SolanaError } from '@solana/errors';
+
+import { CompiledTransactionMessage } from '../..';
+
+export function getFeePayer(staticAccounts: CompiledTransactionMessage['staticAccounts']) {
+    const feePayer = staticAccounts[0];
+    if (!feePayer) {
+        throw new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_FEE_PAYER_MISSING);
+    }
+    return feePayer;
+}

--- a/packages/transaction-messages/src/decompile/legacy/lifetime-constraint.ts
+++ b/packages/transaction-messages/src/decompile/legacy/lifetime-constraint.ts
@@ -1,0 +1,39 @@
+import { assertIsAddress } from '@solana/addresses';
+import { Instruction } from '@solana/instructions';
+import { Blockhash } from '@solana/rpc-types';
+
+import { BlockhashLifetimeConstraint } from '../../blockhash';
+import { Nonce, setTransactionMessageLifetimeUsingDurableNonce } from '../../durable-nonce';
+import { isAdvanceNonceAccountInstruction } from '../../durable-nonce-instruction';
+
+type LifetimeConstraint =
+    | BlockhashLifetimeConstraint
+    | Parameters<typeof setTransactionMessageLifetimeUsingDurableNonce>[0];
+
+export function getLifetimeConstraint(
+    messageLifetimeToken: string,
+    instructions: Instruction[],
+    lastValidBlockHeight?: bigint,
+): LifetimeConstraint {
+    const firstInstruction = instructions[0];
+    if (!firstInstruction || !isAdvanceNonceAccountInstruction(firstInstruction)) {
+        // first instruction is not advance durable nonce, so use blockhash lifetime constraint
+        return {
+            blockhash: messageLifetimeToken as Blockhash,
+            lastValidBlockHeight: lastValidBlockHeight ?? 2n ** 64n - 1n, // U64 MAX
+        };
+    } else {
+        // We know these accounts are defined because we checked `isAdvanceNonceAccountInstruction`
+        const nonceAccountAddress = firstInstruction.accounts[0].address;
+        assertIsAddress(nonceAccountAddress);
+
+        const nonceAuthorityAddress = firstInstruction.accounts[2].address;
+        assertIsAddress(nonceAuthorityAddress);
+
+        return {
+            nonce: messageLifetimeToken as Nonce,
+            nonceAccountAddress,
+            nonceAuthorityAddress,
+        };
+    }
+}

--- a/packages/transaction-messages/src/decompile/legacy/message.ts
+++ b/packages/transaction-messages/src/decompile/legacy/message.ts
@@ -1,0 +1,44 @@
+import { pipe } from '@solana/functional';
+
+import {
+    appendTransactionMessageInstructions,
+    CompiledTransactionMessage,
+    CompiledTransactionMessageWithLifetime,
+    createTransactionMessage,
+    setTransactionMessageLifetimeUsingBlockhash,
+    setTransactionMessageLifetimeUsingDurableNonce,
+} from '../..';
+import { setTransactionMessageFeePayer, TransactionMessageWithFeePayer } from '../../fee-payer';
+import { TransactionMessageWithLifetime } from '../../lifetime';
+import { TransactionMessage } from '../../transaction-message';
+import { getAccountMetas } from './account-metas';
+import { convertInstructions } from './convert-instruction';
+import { getFeePayer } from './fee-payer';
+import { getLifetimeConstraint } from './lifetime-constraint';
+
+export function decompileTransactionMessage(
+    compiledTransactionMessage: CompiledTransactionMessage &
+        CompiledTransactionMessageWithLifetime & { version: 'legacy' },
+    config?: {
+        lastValidBlockHeight?: bigint;
+    },
+): TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime & { version: 'legacy' } {
+    const feePayer = getFeePayer(compiledTransactionMessage.staticAccounts);
+    const accountMetas = getAccountMetas(compiledTransactionMessage);
+    const instructions = convertInstructions(compiledTransactionMessage.instructions, accountMetas);
+    const lifetimeConstraint = getLifetimeConstraint(
+        compiledTransactionMessage.lifetimeToken,
+        instructions,
+        config?.lastValidBlockHeight,
+    );
+
+    return pipe(
+        createTransactionMessage({ version: 'legacy' }),
+        m => setTransactionMessageFeePayer(feePayer, m),
+        m => appendTransactionMessageInstructions(instructions, m),
+        m =>
+            'blockhash' in lifetimeConstraint
+                ? setTransactionMessageLifetimeUsingBlockhash(lifetimeConstraint, m)
+                : setTransactionMessageLifetimeUsingDurableNonce(lifetimeConstraint, m),
+    );
+}


### PR DESCRIPTION
#### Problem

Similar to with `compileTransactionMessage`, our current implementation of `decompileTransactionMessage` is handling both legacy and v0 transactions. This is basically fine as-is, but won't work well when we add v1.

#### Summary of Changes

This PR adds a new `decompile/legacy` directory and the `decompileTransactionMessage` function for it. All of this code is extracted from the existing `decompileTransactionMessage`.

I've split it into separate files for each part (like we do with compile), both to add test coverage and because we will want to import them into the v0 version.

The difference between legacy and v0 is much smaller on decompile than it was on compile, so almost all of this will be re-used. The justification for this refactor is entirely v1, which will be significantly different. 
