### PR TITLE
Add a v0-specific decompileTransactionMessage

### DIFF
--- a/packages/transaction-messages/src/decompile/v0/__tests__/address-lookup-metas-test.ts
+++ b/packages/transaction-messages/src/decompile/v0/__tests__/address-lookup-metas-test.ts
@@ -1,0 +1,582 @@
+import { Address } from '@solana/addresses';
+import {
+    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_CONTENTS_MISSING,
+    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_INDEX_OUT_OF_RANGE,
+    SolanaError,
+} from '@solana/errors';
+import { AccountRole } from '@solana/instructions';
+
+import { AddressesByLookupTableAddress } from '../../../addresses-by-lookup-table-address';
+import { getAddressLookupMetas } from '../address-lookup-metas';
+
+describe('getAddressLookupMetas', () => {
+    const lookupTableAddress1 = '9wnrQTq5MKhYfp379pKvpy1PvRyteseQmKv4Bw3uQrUw' as Address;
+    const lookupTableAddress2 = 'GS7Rphk6CZLoCGbTcbRaPZzD3k4ZK8XiA5BAj89Fi2Eg' as Address;
+
+    describe('for a single lookup table', () => {
+        it('should return readonly account lookup metas for a single index', () => {
+            const addressInLookup = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [0],
+                    writableIndexes: [],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup],
+            };
+
+            const lookupMetas = getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress);
+
+            expect(lookupMetas).toStrictEqual([
+                {
+                    address: addressInLookup,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.READONLY,
+                },
+            ]);
+        });
+
+        it('should return readonly account lookup metas for multiple indexes', () => {
+            const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const addressInLookup2 = '5g6b4v8ivF7haRWMUXT1aewBGsc8xY7B6efGadNc3xYk' as Address;
+            const addressInLookup3 = 'HAv2PXRjwr4AL1odpoMNfvsw6bWxjDzURy1nPA6QBhDj' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [0, 2],
+                    writableIndexes: [],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup1, addressInLookup3, addressInLookup2],
+            };
+
+            const lookupMetas = getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress);
+
+            expect(lookupMetas).toStrictEqual([
+                {
+                    address: addressInLookup1,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.READONLY,
+                },
+                {
+                    address: addressInLookup2,
+                    addressIndex: 2,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.READONLY,
+                },
+            ]);
+        });
+
+        it('should return writable account lookup metas for a single index', () => {
+            const addressInLookup = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [],
+                    writableIndexes: [0],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup],
+            };
+
+            const lookupMetas = getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress);
+
+            expect(lookupMetas).toStrictEqual([
+                {
+                    address: addressInLookup,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.WRITABLE,
+                },
+            ]);
+        });
+
+        it('should return writable account lookup metas for multiple indexes', () => {
+            const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const addressInLookup2 = '5g6b4v8ivF7haRWMUXT1aewBGsc8xY7B6efGadNc3xYk' as Address;
+            const addressInLookup3 = 'HAv2PXRjwr4AL1odpoMNfvsw6bWxjDzURy1nPA6QBhDj' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [],
+                    writableIndexes: [0, 2],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup1, addressInLookup3, addressInLookup2],
+            };
+
+            const lookupMetas = getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress);
+
+            expect(lookupMetas).toStrictEqual([
+                {
+                    address: addressInLookup1,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.WRITABLE,
+                },
+                {
+                    address: addressInLookup2,
+                    addressIndex: 2,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.WRITABLE,
+                },
+            ]);
+        });
+
+        it('should return writable metas first, then readonly metas', () => {
+            const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const addressInLookup2 = '5g6b4v8ivF7haRWMUXT1aewBGsc8xY7B6efGadNc3xYk' as Address;
+            const addressInLookup3 = 'HAv2PXRjwr4AL1odpoMNfvsw6bWxjDzURy1nPA6QBhDj' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [0],
+                    writableIndexes: [2],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup1, addressInLookup3, addressInLookup2],
+            };
+
+            const lookupMetas = getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress);
+
+            expect(lookupMetas).toStrictEqual([
+                {
+                    address: addressInLookup2,
+                    addressIndex: 2,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.WRITABLE,
+                },
+                {
+                    address: addressInLookup1,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.READONLY,
+                },
+            ]);
+        });
+
+        it('should return empty array when no indexes are provided', () => {
+            const addressInLookup = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [],
+                    writableIndexes: [],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup],
+            };
+
+            const lookupMetas = getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress);
+
+            expect(lookupMetas).toStrictEqual([]);
+        });
+    });
+
+    describe('for multiple lookup tables', () => {
+        it('should return readonly account lookup metas from multiple tables', () => {
+            const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const addressInLookup2 = 'E7p56hzZZEs9vJ1yjxAFjhUP3fN2UJNk2nWvcY7Hz3ee' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [0],
+                    writableIndexes: [],
+                },
+                {
+                    lookupTableAddress: lookupTableAddress2,
+                    readonlyIndexes: [0],
+                    writableIndexes: [],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup1],
+                [lookupTableAddress2]: [addressInLookup2],
+            };
+
+            const lookupMetas = getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress);
+
+            expect(lookupMetas).toStrictEqual([
+                {
+                    address: addressInLookup1,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.READONLY,
+                },
+                {
+                    address: addressInLookup2,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress2,
+                    role: AccountRole.READONLY,
+                },
+            ]);
+        });
+
+        it('should return writable account lookup metas from multiple tables', () => {
+            const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const addressInLookup2 = 'E7p56hzZZEs9vJ1yjxAFjhUP3fN2UJNk2nWvcY7Hz3ee' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [],
+                    writableIndexes: [0],
+                },
+                {
+                    lookupTableAddress: lookupTableAddress2,
+                    readonlyIndexes: [],
+                    writableIndexes: [0],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup1],
+                [lookupTableAddress2]: [addressInLookup2],
+            };
+
+            const lookupMetas = getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress);
+
+            expect(lookupMetas).toStrictEqual([
+                {
+                    address: addressInLookup1,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.WRITABLE,
+                },
+                {
+                    address: addressInLookup2,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress2,
+                    role: AccountRole.WRITABLE,
+                },
+            ]);
+        });
+
+        it('should return writable metas first across all lookup tables', () => {
+            const readonlyAddressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const readonlyAddressInLookup2 = 'E7p56hzZZEs9vJ1yjxAFjhUP3fN2UJNk2nWvcY7Hz3ee' as Address;
+            const writableAddressInLookup1 = 'FgNrG1D7AoqNJuLc5eqmsXSHWta6Tfu41mQ9dgc5yaXo' as Address;
+            const writableAddressInLookup2 = '9jEBzMuJfwWH1qcG4g1bj24iSLGCmTsedgisui7SVHes' as Address;
+
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [0],
+                    writableIndexes: [1],
+                },
+                {
+                    lookupTableAddress: lookupTableAddress2,
+                    readonlyIndexes: [0],
+                    writableIndexes: [1],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [readonlyAddressInLookup1, writableAddressInLookup1],
+                [lookupTableAddress2]: [readonlyAddressInLookup2, writableAddressInLookup2],
+            };
+
+            const lookupMetas = getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress);
+
+            expect(lookupMetas).toStrictEqual([
+                {
+                    address: writableAddressInLookup1,
+                    addressIndex: 1,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.WRITABLE,
+                },
+                {
+                    address: writableAddressInLookup2,
+                    addressIndex: 1,
+                    lookupTableAddress: lookupTableAddress2,
+                    role: AccountRole.WRITABLE,
+                },
+                {
+                    address: readonlyAddressInLookup1,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.READONLY,
+                },
+                {
+                    address: readonlyAddressInLookup2,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress2,
+                    role: AccountRole.READONLY,
+                },
+            ]);
+        });
+
+        it('should handle multiple indexes across multiple tables', () => {
+            const readonlyAddress1InLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const readonlyAddress2InLookup1 = 'HAv2PXRjwr4AL1odpoMNfvsw6bWxjDzURy1nPA6QBhDj' as Address;
+            const writableAddress1InLookup1 = 'FgNrG1D7AoqNJuLc5eqmsXSHWta6Tfu41mQ9dgc5yaXo' as Address;
+            const writableAddress2InLookup1 = '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Address;
+
+            const readonlyAddressInLookup2 = 'E7p56hzZZEs9vJ1yjxAFjhUP3fN2UJNk2nWvcY7Hz3ee' as Address;
+            const writableAddressInLookup2 = '9jEBzMuJfwWH1qcG4g1bj24iSLGCmTsedgisui7SVHes' as Address;
+
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [0, 3],
+                    writableIndexes: [1, 2],
+                },
+                {
+                    lookupTableAddress: lookupTableAddress2,
+                    readonlyIndexes: [0],
+                    writableIndexes: [1],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [
+                    readonlyAddress1InLookup1,
+                    writableAddress1InLookup1,
+                    writableAddress2InLookup1,
+                    readonlyAddress2InLookup1,
+                ],
+                [lookupTableAddress2]: [readonlyAddressInLookup2, writableAddressInLookup2],
+            };
+
+            const lookupMetas = getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress);
+
+            expect(lookupMetas).toStrictEqual([
+                {
+                    address: writableAddress1InLookup1,
+                    addressIndex: 1,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.WRITABLE,
+                },
+                {
+                    address: writableAddress2InLookup1,
+                    addressIndex: 2,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.WRITABLE,
+                },
+                {
+                    address: writableAddressInLookup2,
+                    addressIndex: 1,
+                    lookupTableAddress: lookupTableAddress2,
+                    role: AccountRole.WRITABLE,
+                },
+                {
+                    address: readonlyAddress1InLookup1,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.READONLY,
+                },
+                {
+                    address: readonlyAddress2InLookup1,
+                    addressIndex: 3,
+                    lookupTableAddress: lookupTableAddress1,
+                    role: AccountRole.READONLY,
+                },
+                {
+                    address: readonlyAddressInLookup2,
+                    addressIndex: 0,
+                    lookupTableAddress: lookupTableAddress2,
+                    role: AccountRole.READONLY,
+                },
+            ]);
+        });
+    });
+
+    describe('error cases', () => {
+        it('should throw when lookup table is not provided', () => {
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [0],
+                    writableIndexes: [],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {};
+
+            expect(() => getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress)).toThrow(
+                new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_CONTENTS_MISSING, {
+                    lookupTableAddresses: [lookupTableAddress1],
+                }),
+            );
+        });
+
+        it('should throw when multiple lookup tables are not provided', () => {
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [0],
+                    writableIndexes: [],
+                },
+                {
+                    lookupTableAddress: lookupTableAddress2,
+                    readonlyIndexes: [0],
+                    writableIndexes: [],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {};
+
+            expect(() => getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress)).toThrow(
+                new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_CONTENTS_MISSING, {
+                    lookupTableAddresses: [lookupTableAddress1, lookupTableAddress2],
+                }),
+            );
+        });
+
+        it('should throw when one of multiple lookup tables is not provided', () => {
+            const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [0],
+                    writableIndexes: [],
+                },
+                {
+                    lookupTableAddress: lookupTableAddress2,
+                    readonlyIndexes: [0],
+                    writableIndexes: [],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup1],
+            };
+
+            expect(() => getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress)).toThrow(
+                new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_CONTENTS_MISSING, {
+                    lookupTableAddresses: [lookupTableAddress2],
+                }),
+            );
+        });
+
+        it('should throw when readonly index is out of range', () => {
+            const addressInLookup = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [1],
+                    writableIndexes: [],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup],
+            };
+
+            expect(() => getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress)).toThrow(
+                new SolanaError(
+                    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_INDEX_OUT_OF_RANGE,
+                    {
+                        highestKnownIndex: 0,
+                        highestRequestedIndex: 1,
+                        lookupTableAddress: lookupTableAddress1,
+                    },
+                ),
+            );
+        });
+
+        it('should throw when writable index is out of range', () => {
+            const addressInLookup = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [],
+                    writableIndexes: [1],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup],
+            };
+
+            expect(() => getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress)).toThrow(
+                new SolanaError(
+                    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_INDEX_OUT_OF_RANGE,
+                    {
+                        highestKnownIndex: 0,
+                        highestRequestedIndex: 1,
+                        lookupTableAddress: lookupTableAddress1,
+                    },
+                ),
+            );
+        });
+
+        it('should throw when highest readonly index is out of range', () => {
+            const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const addressInLookup2 = '5g6b4v8ivF7haRWMUXT1aewBGsc8xY7B6efGadNc3xYk' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [0, 1, 5],
+                    writableIndexes: [],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup1, addressInLookup2],
+            };
+
+            expect(() => getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress)).toThrow(
+                new SolanaError(
+                    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_INDEX_OUT_OF_RANGE,
+                    {
+                        highestKnownIndex: 1,
+                        highestRequestedIndex: 5,
+                        lookupTableAddress: lookupTableAddress1,
+                    },
+                ),
+            );
+        });
+
+        it('should throw when highest writable index is out of range', () => {
+            const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const addressInLookup2 = '5g6b4v8ivF7haRWMUXT1aewBGsc8xY7B6efGadNc3xYk' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [],
+                    writableIndexes: [0, 1, 5],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup1, addressInLookup2],
+            };
+
+            expect(() => getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress)).toThrow(
+                new SolanaError(
+                    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_INDEX_OUT_OF_RANGE,
+                    {
+                        highestKnownIndex: 1,
+                        highestRequestedIndex: 5,
+                        lookupTableAddress: lookupTableAddress1,
+                    },
+                ),
+            );
+        });
+
+        it('should throw when index is out of range across mixed readonly and writable', () => {
+            const addressInLookup1 = 'F1Vc6AGoxXLwGB7QV8f4So3C5d8SXEk3KKGHxKGEJ8qn' as Address;
+            const addressInLookup2 = '5g6b4v8ivF7haRWMUXT1aewBGsc8xY7B6efGadNc3xYk' as Address;
+            const compiledAddressTableLookups = [
+                {
+                    lookupTableAddress: lookupTableAddress1,
+                    readonlyIndexes: [0],
+                    writableIndexes: [3],
+                },
+            ];
+            const addressesByLookupTableAddress: AddressesByLookupTableAddress = {
+                [lookupTableAddress1]: [addressInLookup1, addressInLookup2],
+            };
+
+            expect(() => getAddressLookupMetas(compiledAddressTableLookups, addressesByLookupTableAddress)).toThrow(
+                new SolanaError(
+                    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_INDEX_OUT_OF_RANGE,
+                    {
+                        highestKnownIndex: 1,
+                        highestRequestedIndex: 3,
+                        lookupTableAddress: lookupTableAddress1,
+                    },
+                ),
+            );
+        });
+    });
+});

--- a/packages/transaction-messages/src/decompile/v0/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/decompile/v0/__tests__/message-test.ts
@@ -1,0 +1,878 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import { Address } from '@solana/addresses';
+import {
+    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_CONTENTS_MISSING,
+    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_INDEX_OUT_OF_RANGE,
+    SolanaError,
+} from '@solana/errors';
+import { AccountRole } from '@solana/instructions';
+
+import { CompiledTransactionMessage, CompiledTransactionMessageWithLifetime } from '../../..';
+import { Nonce } from '../../../durable-nonce';
+import { decompileTransactionMessage } from '../message';
+
+describe('decompileTransactionMessage (v0)', () => {
+    const U64_MAX = 2n ** 64n - 1n;
+    const feePayer = '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK' as Address;
+
+    describe('for a transaction with a blockhash lifetime', () => {
+        const blockhash = 'J4yED2jcMAHyQUg61DBmm4njmEydUr2WqrV9cdEcDDgL';
+
+        it('converts a v0 transaction with no instructions', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 0,
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1,
+                },
+                instructions: [],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+
+            expect(transaction.version).toBe(0);
+            expect(transaction.feePayer.address).toBe(feePayer);
+            expect(transaction.lifetimeConstraint).toStrictEqual({
+                blockhash,
+                lastValidBlockHeight: U64_MAX,
+            });
+            expect(transaction.instructions).toStrictEqual([]);
+        });
+
+        it('freezes the blockhash lifetime constraint', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 0,
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1,
+                },
+                instructions: [],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.lifetimeConstraint).toBeFrozenObject();
+        });
+
+        it('converts a transaction with one instruction with no accounts or data', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 1, // program address
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1, // fee payer
+                },
+                instructions: [{ programAddressIndex: 1 }],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer, programAddress],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    programAddress,
+                },
+            ]);
+        });
+
+        it('converts a transaction with one instruction with accounts and data', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 2, // 1 passed into instruction + 1 program
+                    numReadonlySignerAccounts: 1,
+                    numSignerAccounts: 3, // fee payer + 2 passed into instruction
+                },
+                instructions: [
+                    {
+                        accountIndices: [1, 2, 3, 4],
+                        data: new Uint8Array([0, 1, 2, 3, 4]),
+                        programAddressIndex: 5,
+                    },
+                ],
+                lifetimeToken: blockhash,
+                staticAccounts: [
+                    // writable signers
+                    feePayer,
+                    'H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x' as Address,
+                    // read-only signers
+                    'G35QeFd4jpXWfRkuRKwn8g4vYrmn8DWJ5v88Kkpd8z1V' as Address,
+                    // writable non-signers
+                    '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd' as Address,
+                    // read-only non-signers
+                    '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Address,
+                    programAddress,
+                ],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    accounts: [
+                        {
+                            address: 'H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x' as Address,
+                            role: AccountRole.WRITABLE_SIGNER,
+                        },
+                        {
+                            address: 'G35QeFd4jpXWfRkuRKwn8g4vYrmn8DWJ5v88Kkpd8z1V' as Address,
+                            role: AccountRole.READONLY_SIGNER,
+                        },
+                        {
+                            address: '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd' as Address,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Address,
+                            role: AccountRole.READONLY,
+                        },
+                    ],
+                    data: new Uint8Array([0, 1, 2, 3, 4]),
+                    programAddress,
+                },
+            ]);
+        });
+
+        it('freezes the instruction accounts', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 2, // 1 passed into instruction + 1 program
+                    numReadonlySignerAccounts: 1,
+                    numSignerAccounts: 3, // fee payer + 2 passed into instruction
+                },
+                instructions: [
+                    {
+                        accountIndices: [1, 2, 3, 4],
+                        data: new Uint8Array([0, 1, 2, 3, 4]),
+                        programAddressIndex: 5,
+                    },
+                ],
+                lifetimeToken: blockhash,
+                staticAccounts: [
+                    // writable signers
+                    feePayer,
+                    'H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x' as Address,
+                    // read-only signers
+                    'G35QeFd4jpXWfRkuRKwn8g4vYrmn8DWJ5v88Kkpd8z1V' as Address,
+                    // writable non-signers
+                    '3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd' as Address,
+                    // read-only non-signers
+                    '8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e' as Address,
+                    programAddress,
+                ],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions[0].accounts).toBeFrozenObject();
+        });
+
+        it('converts a transaction with multiple instructions', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 3, // 3 programs
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1, // fee payer
+                },
+                instructions: [{ programAddressIndex: 1 }, { programAddressIndex: 2 }, { programAddressIndex: 3 }],
+                lifetimeToken: blockhash,
+                staticAccounts: [
+                    feePayer,
+                    '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
+                    'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
+                    'GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S' as Address,
+                ],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    programAddress: '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
+                },
+                {
+                    programAddress: 'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
+                },
+                {
+                    programAddress: 'GJRYBLa6XpfswT1AN5tpGp8NHtUirwAdTPdSYXsW9L3S' as Address,
+                },
+            ]);
+        });
+
+        it('converts a transaction with a given lastValidBlockHeight', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 0,
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1,
+                },
+                instructions: [],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction, { lastValidBlockHeight: 100n });
+            expect(transaction.lifetimeConstraint).toStrictEqual({
+                blockhash,
+                lastValidBlockHeight: 100n,
+            });
+        });
+
+        it('freezes the instructions within the transaction', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 1,
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1, // fee payer
+                },
+                instructions: [{ programAddressIndex: 1 }],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer, programAddress],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions[0]).toBeFrozenObject();
+        });
+    });
+
+    describe('for a transaction with a durable nonce lifetime', () => {
+        const nonce = '27kqzE1RifbyoFtibDRTjbnfZ894jsNpuR77JJkt3vgH' as Nonce;
+
+        // added as writable non-signer in the durable nonce instruction
+        const nonceAccountAddress = 'DhezFECsqmzuDxeuitFChbghTrwKLdsKdVsGArYbFEtm' as Address;
+
+        // added as read-only signer in the durable nonce instruction
+        const nonceAuthorityAddress = '2KntmCrnaf63tpNb8UMFFjFGGnYYAKQdmW9SbuCiRvhM' as Address;
+
+        const systemProgramAddress = '11111111111111111111111111111111' as Address;
+        const recentBlockhashesSysvarAddress = 'SysvarRecentB1ockHashes11111111111111111111' as Address;
+
+        it('converts a transaction with one instruction which is advance nonce (fee payer is nonce authority)', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 2, // recent blockhashes sysvar, system program
+                    numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
+                    numSignerAccounts: 1, // fee payer and nonce authority are the same account
+                },
+                instructions: [
+                    {
+                        accountIndices: [
+                            1, // nonce account address
+                            3, // recent blockhashes sysvar
+                            0, // nonce authority address
+                        ],
+                        data: new Uint8Array([4, 0, 0, 0]),
+                        programAddressIndex: 2,
+                    },
+                ],
+                lifetimeToken: nonce,
+                staticAccounts: [
+                    // writable signers
+                    nonceAuthorityAddress,
+                    // no read-only signers
+                    // writable non-signers
+                    nonceAccountAddress,
+                    // read-only non-signers
+                    systemProgramAddress,
+                    recentBlockhashesSysvarAddress,
+                ],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    accounts: [
+                        {
+                            address: nonceAccountAddress,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: recentBlockhashesSysvarAddress,
+                            role: AccountRole.READONLY,
+                        },
+                        {
+                            address: nonceAuthorityAddress,
+                            role: AccountRole.WRITABLE_SIGNER,
+                        },
+                    ],
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: systemProgramAddress,
+                },
+            ]);
+            expect(transaction.feePayer.address).toBe(nonceAuthorityAddress);
+            expect(transaction.lifetimeConstraint).toStrictEqual({ nonce });
+        });
+
+        it('freezes the nonce lifetime constraint', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 2, // recent blockhashes sysvar, system program
+                    numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
+                    numSignerAccounts: 1, // fee payer and nonce authority are the same account
+                },
+                instructions: [
+                    {
+                        accountIndices: [
+                            1, // nonce account address
+                            3, // recent blockhashes sysvar
+                            0, // nonce authority address
+                        ],
+                        data: new Uint8Array([4, 0, 0, 0]),
+                        programAddressIndex: 2,
+                    },
+                ],
+                lifetimeToken: nonce,
+                staticAccounts: [
+                    // writable signers
+                    nonceAuthorityAddress,
+                    // no read-only signers
+                    // writable non-signers
+                    nonceAccountAddress,
+                    // read-only non-signers
+                    systemProgramAddress,
+                    recentBlockhashesSysvarAddress,
+                ],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.lifetimeConstraint).toBeFrozenObject();
+        });
+
+        it('converts a transaction with one instruction which is advance nonce (fee payer is not nonce authority)', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 2, // recent blockhashes sysvar, system program
+                    numReadonlySignerAccounts: 1, // nonce authority
+                    numSignerAccounts: 2, // fee payer, nonce authority
+                },
+                instructions: [
+                    {
+                        accountIndices: [
+                            2, // nonce account address
+                            4, // recent blockhashes sysvar
+                            1, // nonce authority address
+                        ],
+                        data: new Uint8Array([4, 0, 0, 0]),
+                        programAddressIndex: 3,
+                    },
+                ],
+                lifetimeToken: nonce,
+                staticAccounts: [
+                    // writable signers
+                    feePayer,
+                    // read-only signers
+                    nonceAuthorityAddress,
+                    // writable non-signers
+                    nonceAccountAddress,
+                    // read-only non-signers
+                    systemProgramAddress,
+                    recentBlockhashesSysvarAddress,
+                ],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    accounts: [
+                        {
+                            address: nonceAccountAddress,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: recentBlockhashesSysvarAddress,
+                            role: AccountRole.READONLY,
+                        },
+                        {
+                            address: nonceAuthorityAddress,
+                            role: AccountRole.READONLY_SIGNER,
+                        },
+                    ],
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: systemProgramAddress,
+                },
+            ]);
+            expect(transaction.feePayer.address).toBe(feePayer);
+        });
+
+        it('converts a durable nonce transaction with multiple instructions', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 4, // recent blockhashes sysvar, system program, 2 other program addresses
+                    numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
+                    numSignerAccounts: 1, // fee payer and nonce authority are the same account
+                },
+                instructions: [
+                    {
+                        accountIndices: [
+                            1, // nonce account address
+                            3, // recent blockhashes sysvar
+                            0, // nonce authority address
+                        ],
+                        data: new Uint8Array([4, 0, 0, 0]),
+                        programAddressIndex: 2,
+                    },
+                    {
+                        accountIndices: [0, 1],
+                        data: new Uint8Array([1, 2, 3, 4]),
+                        programAddressIndex: 4,
+                    },
+                    { programAddressIndex: 5 },
+                ],
+                lifetimeToken: nonce,
+                staticAccounts: [
+                    // writable signers
+                    nonceAuthorityAddress,
+                    // no read-only signers
+                    // writable non-signers
+                    nonceAccountAddress,
+                    // read-only non-signers
+                    systemProgramAddress,
+                    recentBlockhashesSysvarAddress,
+                    '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
+                    'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
+                ],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    accounts: [
+                        {
+                            address: nonceAccountAddress,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: recentBlockhashesSysvarAddress,
+                            role: AccountRole.READONLY,
+                        },
+                        {
+                            address: nonceAuthorityAddress,
+                            role: AccountRole.WRITABLE_SIGNER,
+                        },
+                    ],
+                    data: new Uint8Array([4, 0, 0, 0]),
+                    programAddress: systemProgramAddress,
+                },
+                {
+                    accounts: [
+                        {
+                            address: nonceAuthorityAddress,
+                            role: AccountRole.WRITABLE_SIGNER,
+                        },
+                        {
+                            address: nonceAccountAddress,
+                            role: AccountRole.WRITABLE,
+                        },
+                    ],
+                    data: new Uint8Array([1, 2, 3, 4]),
+                    programAddress: '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
+                },
+                {
+                    programAddress: 'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
+                },
+            ]);
+            expect(transaction.lifetimeConstraint).toStrictEqual({ nonce });
+        });
+
+        it('freezes the instructions within the transaction', () => {
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & { version: 0 } = {
+                header: {
+                    numReadonlyNonSignerAccounts: 4, // recent blockhashes sysvar, system program, 2 other program addresses
+                    numReadonlySignerAccounts: 0, // nonce authority already added as fee payer
+                    numSignerAccounts: 1, // fee payer and nonce authority are the same account
+                },
+                instructions: [
+                    {
+                        accountIndices: [
+                            1, // nonce account address
+                            3, // recent blockhashes sysvar
+                            0, // nonce authority address
+                        ],
+                        data: new Uint8Array([4, 0, 0, 0]),
+                        programAddressIndex: 2,
+                    },
+                    {
+                        accountIndices: [0, 1],
+                        data: new Uint8Array([1, 2, 3, 4]),
+                        programAddressIndex: 4,
+                    },
+                    { programAddressIndex: 5 },
+                ],
+                lifetimeToken: nonce,
+                staticAccounts: [
+                    // writable signers
+                    nonceAuthorityAddress,
+                    // no read-only signers
+                    // writable non-signers
+                    nonceAccountAddress,
+                    // read-only non-signers
+                    systemProgramAddress,
+                    recentBlockhashesSysvarAddress,
+                    '3hpECiFPtnyxoWqWqcVyfBUDhPKSZXWDduNXFywo8ncP' as Address,
+                    'Cmqw16pVQvmW1b7Ek1ioQ5Ggf1PaoXi5XxsK9iVSbRKC' as Address,
+                ],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions[0]).toBeFrozenObject();
+            expect(transaction.instructions[1]).toBeFrozenObject();
+            expect(transaction.instructions[2]).toBeFrozenObject();
+        });
+    });
+
+    describe('for a transaction with address lookup tables', () => {
+        const blockhash = 'J4yED2jcMAHyQUg61DBmm4njmEydUr2WqrV9cdEcDDgL';
+        const lookupTableAddress = 'FwR5Cu5b5zXHa5KHuGQkN7UhSNebc756N1EhR2aHHLHq' as Address;
+
+        it('converts a transaction with accounts from a lookup table', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+            const lookupAccount1 = '9fhzQgdY7y7TpYHvH4sVBjJRzgq2LbqNq7hPvWvKAzWz' as Address;
+            const lookupAccount2 = 'BqN3g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & {
+                    addressTableLookups: readonly {
+                        lookupTableAddress: Address;
+                        readonlyIndexes: readonly number[];
+                        writableIndexes: readonly number[];
+                    }[];
+                    version: 0;
+                } = {
+                addressTableLookups: [
+                    {
+                        lookupTableAddress,
+                        readonlyIndexes: [1],
+                        writableIndexes: [0],
+                    },
+                ],
+                header: {
+                    numReadonlyNonSignerAccounts: 1, // program address
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1, // fee payer
+                },
+                instructions: [
+                    {
+                        accountIndices: [2, 3], // indexes 2 and 3 reference lookup table accounts
+                        programAddressIndex: 1,
+                    },
+                ],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer, programAddress],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction, {
+                addressesByLookupTableAddress: {
+                    [lookupTableAddress]: [lookupAccount1, lookupAccount2],
+                },
+            });
+
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    accounts: [
+                        {
+                            address: lookupAccount1,
+                            addressIndex: 0,
+                            lookupTableAddress,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: lookupAccount2,
+                            addressIndex: 1,
+                            lookupTableAddress,
+                            role: AccountRole.READONLY,
+                        },
+                    ],
+                    programAddress,
+                },
+            ]);
+        });
+
+        it('converts a transaction with both static and lookup table accounts', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+            const staticAccount = 'H4RdPRWYk3pKw2CkNznxQK6J6herjgQke2pzFJW4GC6x' as Address;
+            const lookupAccount = '9fhzQgdY7y7TpYHvH4sVBjJRzgq2LbqNq7hPvWvKAzWz' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & {
+                    addressTableLookups: readonly {
+                        lookupTableAddress: Address;
+                        readonlyIndexes: readonly number[];
+                        writableIndexes: readonly number[];
+                    }[];
+                    version: 0;
+                } = {
+                addressTableLookups: [
+                    {
+                        lookupTableAddress,
+                        readonlyIndexes: [0],
+                        writableIndexes: [],
+                    },
+                ],
+                header: {
+                    numReadonlyNonSignerAccounts: 1, // program address
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 2, // fee payer + static account
+                },
+                instructions: [
+                    {
+                        accountIndices: [1, 3], // index 1 is static, index 3 is from lookup table
+                        programAddressIndex: 2,
+                    },
+                ],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer, staticAccount, programAddress],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction, {
+                addressesByLookupTableAddress: {
+                    [lookupTableAddress]: [lookupAccount],
+                },
+            });
+
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    accounts: [
+                        {
+                            address: staticAccount,
+                            role: AccountRole.WRITABLE_SIGNER,
+                        },
+                        {
+                            address: lookupAccount,
+                            addressIndex: 0,
+                            lookupTableAddress,
+                            role: AccountRole.READONLY,
+                        },
+                    ],
+                    programAddress,
+                },
+            ]);
+        });
+
+        it('converts a transaction with multiple lookup tables', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+            const lookupTableAddress2 = '8qN8g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7' as Address;
+            const lookupAccount1 = '9fhzQgdY7y7TpYHvH4sVBjJRzgq2LbqNq7hPvWvKAzWz' as Address;
+            const lookupAccount2 = 'BqN3g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7g7' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & {
+                    addressTableLookups: readonly {
+                        lookupTableAddress: Address;
+                        readonlyIndexes: readonly number[];
+                        writableIndexes: readonly number[];
+                    }[];
+                    version: 0;
+                } = {
+                addressTableLookups: [
+                    {
+                        lookupTableAddress,
+                        readonlyIndexes: [0],
+                        writableIndexes: [],
+                    },
+                    {
+                        lookupTableAddress: lookupTableAddress2,
+                        readonlyIndexes: [],
+                        writableIndexes: [0],
+                    },
+                ],
+                header: {
+                    numReadonlyNonSignerAccounts: 1, // program address
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1, // fee payer
+                },
+                instructions: [
+                    {
+                        accountIndices: [2, 3], // indexes from two different lookup tables
+                        programAddressIndex: 1,
+                    },
+                ],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer, programAddress],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction, {
+                addressesByLookupTableAddress: {
+                    [lookupTableAddress]: [lookupAccount1],
+                    [lookupTableAddress2]: [lookupAccount2],
+                },
+            });
+
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    accounts: [
+                        {
+                            address: lookupAccount2,
+                            addressIndex: 0,
+                            lookupTableAddress: lookupTableAddress2,
+                            role: AccountRole.WRITABLE,
+                        },
+                        {
+                            address: lookupAccount1,
+                            addressIndex: 0,
+                            lookupTableAddress,
+                            role: AccountRole.READONLY,
+                        },
+                    ],
+                    programAddress,
+                },
+            ]);
+        });
+
+        it('converts a transaction with empty address table lookups array', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & {
+                    addressTableLookups: readonly {
+                        lookupTableAddress: Address;
+                        readonlyIndexes: readonly number[];
+                        writableIndexes: readonly number[];
+                    }[];
+                    version: 0;
+                } = {
+                addressTableLookups: [],
+                header: {
+                    numReadonlyNonSignerAccounts: 1, // program address
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1, // fee payer
+                },
+                instructions: [{ programAddressIndex: 1 }],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer, programAddress],
+                version: 0,
+            };
+
+            const transaction = decompileTransactionMessage(compiledTransaction);
+            expect(transaction.instructions).toStrictEqual([
+                {
+                    programAddress,
+                },
+            ]);
+        });
+
+        it('throws when address lookup table content is missing', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & {
+                    addressTableLookups: readonly {
+                        lookupTableAddress: Address;
+                        readonlyIndexes: readonly number[];
+                        writableIndexes: readonly number[];
+                    }[];
+                    version: 0;
+                } = {
+                addressTableLookups: [
+                    {
+                        lookupTableAddress,
+                        readonlyIndexes: [0],
+                        writableIndexes: [],
+                    },
+                ],
+                header: {
+                    numReadonlyNonSignerAccounts: 1, // program address
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1, // fee payer
+                },
+                instructions: [{ programAddressIndex: 1 }],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer, programAddress],
+                version: 0,
+            };
+
+            expect(() => {
+                decompileTransactionMessage(compiledTransaction);
+            }).toThrow(
+                new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_CONTENTS_MISSING, {
+                    lookupTableAddresses: [lookupTableAddress],
+                }),
+            );
+        });
+
+        it('throws when address lookup table index is out of range', () => {
+            const programAddress = 'HZMKVnRrWLyQLwPLTTLKtY7ET4Cf7pQugrTr9eTBrpsf' as Address;
+            const lookupAccount = '9fhzQgdY7y7TpYHvH4sVBjJRzgq2LbqNq7hPvWvKAzWz' as Address;
+
+            const compiledTransaction: CompiledTransactionMessage &
+                CompiledTransactionMessageWithLifetime & {
+                    addressTableLookups: readonly {
+                        lookupTableAddress: Address;
+                        readonlyIndexes: readonly number[];
+                        writableIndexes: readonly number[];
+                    }[];
+                    version: 0;
+                } = {
+                addressTableLookups: [
+                    {
+                        lookupTableAddress,
+                        readonlyIndexes: [5], // index 5 is out of range (only 1 account in lookup table)
+                        writableIndexes: [],
+                    },
+                ],
+                header: {
+                    numReadonlyNonSignerAccounts: 1, // program address
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1, // fee payer
+                },
+                instructions: [{ programAddressIndex: 1 }],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer, programAddress],
+                version: 0,
+            };
+
+            expect(() => {
+                decompileTransactionMessage(compiledTransaction, {
+                    addressesByLookupTableAddress: {
+                        [lookupTableAddress]: [lookupAccount],
+                    },
+                });
+            }).toThrow(
+                new SolanaError(
+                    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_INDEX_OUT_OF_RANGE,
+                    {
+                        highestKnownIndex: 0,
+                        highestRequestedIndex: 5,
+                        lookupTableAddress,
+                    },
+                ),
+            );
+        });
+    });
+});

--- a/packages/transaction-messages/src/decompile/v0/address-lookup-metas.ts
+++ b/packages/transaction-messages/src/decompile/v0/address-lookup-metas.ts
@@ -1,0 +1,63 @@
+import {
+    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_CONTENTS_MISSING,
+    SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_INDEX_OUT_OF_RANGE,
+    SolanaError,
+} from '@solana/errors';
+import { AccountLookupMeta, AccountRole } from '@solana/instructions';
+
+import { AddressesByLookupTableAddress } from '../../addresses-by-lookup-table-address';
+import { getCompiledAddressTableLookups } from '../../compile/v0/address-table-lookups';
+
+export function getAddressLookupMetas(
+    compiledAddressTableLookups: ReturnType<typeof getCompiledAddressTableLookups>,
+    addressesByLookupTableAddress: AddressesByLookupTableAddress,
+): AccountLookupMeta[] {
+    // check that all message lookups are known
+    const compiledAddressTableLookupAddresses = compiledAddressTableLookups.map(l => l.lookupTableAddress);
+    const missing = compiledAddressTableLookupAddresses.filter(a => addressesByLookupTableAddress[a] === undefined);
+    if (missing.length > 0) {
+        throw new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_CONTENTS_MISSING, {
+            lookupTableAddresses: missing,
+        });
+    }
+
+    const readOnlyMetas: AccountLookupMeta[] = [];
+    const writableMetas: AccountLookupMeta[] = [];
+
+    // we know that for each lookup, knownLookups[lookup.lookupTableAddress] is defined
+    for (const lookup of compiledAddressTableLookups) {
+        const addresses = addressesByLookupTableAddress[lookup.lookupTableAddress];
+        const readonlyIndexes = lookup.readonlyIndexes;
+        const writableIndexes = lookup.writableIndexes;
+
+        const highestIndex = Math.max(...readonlyIndexes, ...writableIndexes);
+        if (highestIndex >= addresses.length) {
+            throw new SolanaError(
+                SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_ADDRESS_LOOKUP_TABLE_INDEX_OUT_OF_RANGE,
+                {
+                    highestKnownIndex: addresses.length - 1,
+                    highestRequestedIndex: highestIndex,
+                    lookupTableAddress: lookup.lookupTableAddress,
+                },
+            );
+        }
+
+        const readOnlyForLookup: AccountLookupMeta[] = readonlyIndexes.map(r => ({
+            address: addresses[r],
+            addressIndex: r,
+            lookupTableAddress: lookup.lookupTableAddress,
+            role: AccountRole.READONLY,
+        }));
+        readOnlyMetas.push(...readOnlyForLookup);
+
+        const writableForLookup: AccountLookupMeta[] = writableIndexes.map(w => ({
+            address: addresses[w],
+            addressIndex: w,
+            lookupTableAddress: lookup.lookupTableAddress,
+            role: AccountRole.WRITABLE,
+        }));
+        writableMetas.push(...writableForLookup);
+    }
+
+    return [...writableMetas, ...readOnlyMetas];
+}

--- a/packages/transaction-messages/src/decompile/v0/message.ts
+++ b/packages/transaction-messages/src/decompile/v0/message.ts
@@ -1,0 +1,57 @@
+import { pipe } from '@solana/functional';
+
+import { CompiledTransactionMessage, CompiledTransactionMessageWithLifetime } from '../..';
+import { AddressesByLookupTableAddress } from '../../addresses-by-lookup-table-address';
+import { setTransactionMessageLifetimeUsingBlockhash } from '../../blockhash';
+import { createTransactionMessage } from '../../create-transaction-message';
+import { setTransactionMessageLifetimeUsingDurableNonce } from '../../durable-nonce';
+import { setTransactionMessageFeePayer, TransactionMessageWithFeePayer } from '../../fee-payer';
+import { appendTransactionMessageInstructions } from '../../instructions';
+import { TransactionMessageWithLifetime } from '../../lifetime';
+import { TransactionMessage } from '../../transaction-message';
+import { getAccountMetas } from '../legacy/account-metas';
+import { convertInstructions } from '../legacy/convert-instruction';
+import { getFeePayer } from '../legacy/fee-payer';
+import { getLifetimeConstraint } from '../legacy/lifetime-constraint';
+import { getAddressLookupMetas } from './address-lookup-metas';
+
+export type DecompileTransactionMessageConfig = {
+    addressesByLookupTableAddress?: AddressesByLookupTableAddress;
+    lastValidBlockHeight?: bigint;
+};
+
+export function decompileTransactionMessage(
+    compiledTransactionMessage: CompiledTransactionMessage & CompiledTransactionMessageWithLifetime & { version: 0 },
+    config?: DecompileTransactionMessageConfig,
+): TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime {
+    const feePayer = getFeePayer(compiledTransactionMessage.staticAccounts);
+
+    const accountMetas = getAccountMetas(compiledTransactionMessage);
+    const accountLookupMetas =
+        'addressTableLookups' in compiledTransactionMessage &&
+        compiledTransactionMessage.addressTableLookups !== undefined &&
+        compiledTransactionMessage.addressTableLookups.length > 0
+            ? getAddressLookupMetas(
+                  compiledTransactionMessage.addressTableLookups,
+                  config?.addressesByLookupTableAddress ?? {},
+              )
+            : [];
+    const transactionMetas = [...accountMetas, ...accountLookupMetas];
+    const instructions = convertInstructions(compiledTransactionMessage.instructions, transactionMetas);
+
+    const lifetimeConstraint = getLifetimeConstraint(
+        compiledTransactionMessage.lifetimeToken,
+        instructions,
+        config?.lastValidBlockHeight,
+    );
+
+    return pipe(
+        createTransactionMessage({ version: 0 }),
+        m => setTransactionMessageFeePayer(feePayer, m),
+        m => appendTransactionMessageInstructions(instructions, m),
+        m =>
+            'blockhash' in lifetimeConstraint
+                ? setTransactionMessageLifetimeUsingBlockhash(lifetimeConstraint, m)
+                : setTransactionMessageLifetimeUsingDurableNonce(lifetimeConstraint, m),
+    ) as TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime;
+}


### PR DESCRIPTION
#### Summary of Changes

This PR follows up the previous one by adding a `decompileTransactionMessage` function specifically for v0 transactions.

The new function `getAddressLookupMetas` is copied from the existing `decompileTransactionMessage` function. The only difference between legacy and v0 is that v0 uses this function (if the v0 message has address table lookups) to resolve the lookup account metas. These are then additionally passed to `convertInstructions`, meaning that instructions can reference addresses contained in the lookup tables.

Similarly to with legacy, the PR adds a lot more test coverage but tests are broadly based on the existing decompile tests. 

Fixes #