### PR TITLE
Add an overload for compileTransactionMessage without a known version

### DIFF
--- a/packages/transaction-messages/src/compile/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/compile/__tests__/message-test.ts
@@ -60,7 +60,6 @@ describe('compileTransactionMessage', () => {
             version: 1 as unknown as TransactionMessage['version'],
         } as unknown as TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime;
 
-        // @ts-expect-error - we're intentionally testing an unsupported version, which should not type check
         expect(() => compileTransactionMessage(tx)).toThrow(
             new SolanaError(SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_NOT_SUPPORTED, {
                 version: 1,

--- a/packages/transaction-messages/src/compile/__typetests__/message-typetest.ts
+++ b/packages/transaction-messages/src/compile/__typetests__/message-typetest.ts
@@ -77,4 +77,16 @@ import { compileTransactionMessage } from '../message';
         const message = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { version: 0 };
         compileTransactionMessage(message) satisfies CompiledTransactionMessage & { version: 0 };
     }
+
+    // The version can be narrowed
+    {
+        const message = null as unknown as TransactionMessage & TransactionMessageWithFeePayer;
+        const compiled = compileTransactionMessage(message);
+        compiled satisfies CompiledTransactionMessage;
+        // @ts-expect-error Version could be different
+        compiled satisfies CompiledTransactionMessage & { version: 'legacy' };
+        if (compiled.version === 'legacy') {
+            compiled satisfies CompiledTransactionMessage & { version: 'legacy' };
+        }
+    }
 }

--- a/packages/transaction-messages/src/compile/message.ts
+++ b/packages/transaction-messages/src/compile/message.ts
@@ -54,6 +54,11 @@ export function compileTransactionMessage<
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer,
 >(
     transactionMessage: TTransactionMessage,
+): ForwardTransactionMessageLifetime<CompiledTransactionMessage, TTransactionMessage>;
+export function compileTransactionMessage<
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer,
+>(
+    transactionMessage: TTransactionMessage,
 ): ForwardTransactionMessageLifetime<CompiledTransactionMessage, TTransactionMessage> {
     type ReturnType = ForwardTransactionMessageLifetime<CompiledTransactionMessage, TTransactionMessage>;
 

--- a/packages/transactions/src/compile-transaction.ts
+++ b/packages/transactions/src/compile-transaction.ts
@@ -31,9 +31,7 @@ export function compileTransaction<TTransactionMessage extends TransactionMessag
 ): Readonly<TransactionFromTransactionMessage<TTransactionMessage>> {
     type ReturnType = Readonly<TransactionFromTransactionMessage<TTransactionMessage>>;
 
-    const compiledMessage = compileTransactionMessage(
-        transactionMessage as Parameters<typeof compileTransactionMessage>[0],
-    );
+    const compiledMessage = compileTransactionMessage(transactionMessage);
     const messageBytes = getCompiledTransactionMessageEncoder().encode(compiledMessage) as TransactionMessageBytes;
 
     const transactionSigners = compiledMessage.staticAccounts.slice(0, compiledMessage.header.numSignerAccounts);


### PR DESCRIPTION
#### Problem

My current new version of `compileTransactionMessage` may have a breaking change for callers using `TransactionMessage & TransactionMessageWithFeePayer ` without a known version.

I noticed this when writing the equivalent `decompileTransactionMessage`, which we call in higher-level functions in Kit without a known version.

In that PR I decided to add an overload that is not version aware, and to ensure (with a typetest) that the returned version can be narrowed in the usual way.

#### Summary of Changes

This PR adds the equivalent overload for `compileTransactionMessage`, so that any callers relying on the signature without a known version will not be affected. 

It is still a runtime error to pass an invalid version, but it is not a type error as the version can be unknown.

Both compile and decompile now have the same overloads. If called with a known version then that version is maintained on the returned type. If called without a known version then the version returned could be any valid version, and can be narrowed with eg an `if` check. 