### PR TITLE
Add support for compiling v1 transaction messages

### DIFF
--- a/packages/transaction-messages/src/compile/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/compile/__tests__/message-test.ts
@@ -10,9 +10,11 @@ import {
 } from '../..';
 import { compileTransactionMessage as compileLegacyTransactionMessage } from '../legacy/message';
 import { compileTransactionMessage as compileV0TransactionMessage } from '../v0/message';
+import { compileTransactionMessage as compileV1TransactionMessage } from '../v1/message';
 
 jest.mock('../legacy/message');
 jest.mock('../v0/message');
+jest.mock('../v1/message');
 
 const MOCK_LIFETIME_CONSTRAINT =
     'SOME_CONSTRAINT' as unknown as TransactionMessageWithBlockhashLifetime['lifetimeConstraint'];
@@ -52,17 +54,33 @@ describe('compileTransactionMessage', () => {
         expect(compileV0TransactionMessage).toHaveBeenCalledWith(tx);
     });
 
-    it('throws for unsupported v1 transaction', () => {
+    it('uses the v1 compiler for v1 messages', () => {
+        const mockCompiledMessage = { version: 1 } as unknown as ReturnType<typeof compileV1TransactionMessage>;
+        jest.mocked(compileV1TransactionMessage).mockReturnValue(mockCompiledMessage);
+
         const tx: TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime = {
             feePayer: { address: 'abc' as Address },
             instructions: [],
             lifetimeConstraint: MOCK_LIFETIME_CONSTRAINT,
-            version: 1 as unknown as TransactionMessage['version'],
+            version: 1,
+        };
+
+        expect(compileTransactionMessage(tx)).toBe(mockCompiledMessage);
+        expect(compileV1TransactionMessage).toHaveBeenCalledTimes(1);
+        expect(compileV1TransactionMessage).toHaveBeenCalledWith(tx);
+    });
+
+    it('throws for unsupported v2 transaction', () => {
+        const tx = {
+            feePayer: { address: 'abc' as Address },
+            instructions: [],
+            lifetimeConstraint: MOCK_LIFETIME_CONSTRAINT,
+            version: 2,
         } as unknown as TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithLifetime;
 
         expect(() => compileTransactionMessage(tx)).toThrow(
             new SolanaError(SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_NOT_SUPPORTED, {
-                version: 1,
+                version: 2,
             }),
         );
     });

--- a/packages/transaction-messages/src/compile/__typetests__/message-typetest.ts
+++ b/packages/transaction-messages/src/compile/__typetests__/message-typetest.ts
@@ -23,6 +23,12 @@ import { compileTransactionMessage } from '../message';
             const message = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { version: 0 };
             compileTransactionMessage(message) satisfies CompiledTransactionMessage;
         }
+
+        // For v1
+        {
+            const message = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { version: 1 };
+            compileTransactionMessage(message) satisfies CompiledTransactionMessage;
+        }
     }
 
     // It does not satisfy `CompiledTransactionMessageWithLifetime` if the source message does not have a lifetime constraint
@@ -39,6 +45,14 @@ import { compileTransactionMessage } from '../message';
         // For v0
         {
             const message = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { version: 0 };
+            const compiled = compileTransactionMessage(message);
+            // @ts-expect-error Should not have a lifetime token
+            compiled satisfies CompiledTransactionMessageWithLifetime;
+        }
+
+        // For v1
+        {
+            const message = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { version: 1 };
             const compiled = compileTransactionMessage(message);
             // @ts-expect-error Should not have a lifetime token
             compiled satisfies CompiledTransactionMessageWithLifetime;
@@ -64,6 +78,15 @@ import { compileTransactionMessage } from '../message';
             const compiled = compileTransactionMessage(message);
             compiled satisfies CompiledTransactionMessageWithLifetime;
         }
+
+        // For v1
+        {
+            const message = null as unknown as TransactionMessage &
+                TransactionMessageWithFeePayer &
+                TransactionMessageWithLifetime & { version: 1 };
+            const compiled = compileTransactionMessage(message);
+            compiled satisfies CompiledTransactionMessageWithLifetime;
+        }
     }
 
     // It forwards a legacy version from the source message to the compiled message
@@ -76,6 +99,12 @@ import { compileTransactionMessage } from '../message';
     {
         const message = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { version: 0 };
         compileTransactionMessage(message) satisfies CompiledTransactionMessage & { version: 0 };
+    }
+
+    // It forwards a v1 version from the source message to the compiled message
+    {
+        const message = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { version: 1 };
+        compileTransactionMessage(message) satisfies CompiledTransactionMessage & { version: 1 };
     }
 
     // The version can be narrowed

--- a/packages/transaction-messages/src/compile/legacy/__tests__/instructions-test.ts
+++ b/packages/transaction-messages/src/compile/legacy/__tests__/instructions-test.ts
@@ -2,7 +2,7 @@ import { Address } from '@solana/addresses';
 import { AccountRole, Instruction } from '@solana/instructions';
 
 import { OrderedAccounts } from '../accounts';
-import { getCompiledInstructions } from '../instructions';
+import { getAccountIndex, getCompiledInstructions } from '../instructions';
 
 let _nextMockAddress = 0;
 function getMockAddress() {
@@ -67,5 +67,46 @@ describe('getCompiledInstructions', () => {
             { address: programAddress, role: AccountRole.READONLY },
         ] as OrderedAccounts);
         expect(compiledInstructions[0]).toHaveProperty('programAddressIndex', 1);
+    });
+});
+
+describe('getAccountIndex', () => {
+    it('returns an empty object when given an empty array', () => {
+        const accountIndex = getAccountIndex([] as unknown as OrderedAccounts);
+        expect(accountIndex).toEqual({});
+    });
+
+    it('returns a mapping of addresses to their indices for a single account', () => {
+        const address = getMockAddress();
+        const accountIndex = getAccountIndex([{ address, role: AccountRole.WRITABLE_SIGNER }] as OrderedAccounts);
+        expect(accountIndex).toEqual({ [address]: 0 });
+    });
+
+    it('returns a mapping of addresses to their indices for multiple accounts', () => {
+        const address0 = getMockAddress();
+        const address1 = getMockAddress();
+        const address2 = getMockAddress();
+        const address3 = getMockAddress();
+        const accountIndex = getAccountIndex([
+            { address: address0, role: AccountRole.WRITABLE_SIGNER },
+            { address: address1, role: AccountRole.READONLY },
+            { address: address2, role: AccountRole.WRITABLE },
+            { address: address3, role: AccountRole.READONLY_SIGNER },
+        ] as OrderedAccounts);
+        expect(accountIndex).toEqual({
+            [address0]: 0,
+            [address1]: 1,
+            [address2]: 2,
+            [address3]: 3,
+        });
+    });
+
+    it('uses the last occurrence when there are duplicate addresses', () => {
+        const address = getMockAddress();
+        const accountIndex = getAccountIndex([
+            { address, role: AccountRole.READONLY },
+            { address, role: AccountRole.WRITABLE_SIGNER },
+        ] as OrderedAccounts);
+        expect(accountIndex).toEqual({ [address]: 1 });
     });
 });

--- a/packages/transaction-messages/src/compile/legacy/instructions.ts
+++ b/packages/transaction-messages/src/compile/legacy/instructions.ts
@@ -19,7 +19,7 @@ type CompiledInstruction = Readonly<{
     programAddressIndex: number;
 }>;
 
-function getAccountIndex(orderedAccounts: OrderedAccounts) {
+export function getAccountIndex(orderedAccounts: OrderedAccounts) {
     const out: Record<Address, number> = {};
     for (const [index, account] of orderedAccounts.entries()) {
         out[account.address] = index;

--- a/packages/transaction-messages/src/compile/legacy/message.ts
+++ b/packages/transaction-messages/src/compile/legacy/message.ts
@@ -8,6 +8,8 @@ import { getCompiledLifetimeToken } from './lifetime-token';
 
 export type LegacyCompiledTransactionMessage = BaseCompiledTransactionMessage &
     Readonly<{
+        /** A list of instructions that this transaction will execute */
+        instructions: ReturnType<typeof getCompiledInstructions>;
         version: 'legacy';
     }>;
 

--- a/packages/transaction-messages/src/compile/message-types.ts
+++ b/packages/transaction-messages/src/compile/message-types.ts
@@ -7,7 +7,6 @@ import { CompiledTransactionMessage, CompiledTransactionMessageWithLifetime } fr
 import { TransactionMessageWithLifetime } from '../lifetime';
 import { TransactionMessage } from '../transaction-message';
 import { getCompiledMessageHeader } from './legacy/header';
-import { getCompiledInstructions } from './v0/instructions';
 import { getCompiledStaticAccounts } from './v0/static-accounts';
 
 export type BaseCompiledTransactionMessage = Readonly<{
@@ -16,7 +15,6 @@ export type BaseCompiledTransactionMessage = Readonly<{
      * loads.
      */
     header: ReturnType<typeof getCompiledMessageHeader>;
-    instructions: ReturnType<typeof getCompiledInstructions>;
     /** A list of addresses indicating which accounts to load */
     staticAccounts: ReturnType<typeof getCompiledStaticAccounts>;
 }>;

--- a/packages/transaction-messages/src/compile/message.ts
+++ b/packages/transaction-messages/src/compile/message.ts
@@ -4,10 +4,12 @@ import { TransactionMessageWithFeePayer } from '../fee-payer';
 import { TransactionMessageWithLifetime } from '../lifetime';
 import { TransactionMessage } from '../transaction-message';
 import { getCompiledLifetimeToken } from './legacy/lifetime-token';
-import { LegacyCompiledTransactionMessage } from './legacy/message';
-import { compileTransactionMessage as compileLegacyTransactionMessage } from './legacy/message';
-import { V0CompiledTransactionMessage } from './v0/message';
-import { compileTransactionMessage as compileV0TransactionMessage } from './v0/message';
+import {
+    compileTransactionMessage as compileLegacyTransactionMessage,
+    LegacyCompiledTransactionMessage,
+} from './legacy/message';
+import { compileTransactionMessage as compileV0TransactionMessage, V0CompiledTransactionMessage } from './v0/message';
+import { compileTransactionMessage as compileV1TransactionMessage, V1CompiledTransactionMessage } from './v1/message';
 
 /**
  * A transaction message in a form suitable for encoding for execution on the network.
@@ -16,7 +18,10 @@ import { compileTransactionMessage as compileV0TransactionMessage } from './v0/m
  * In particular, supporting details about the lifetime constraint and the concrete addresses of
  * accounts sourced from account lookup tables are lost to compilation.
  */
-export type CompiledTransactionMessage = LegacyCompiledTransactionMessage | V0CompiledTransactionMessage;
+export type CompiledTransactionMessage =
+    | LegacyCompiledTransactionMessage
+    | V0CompiledTransactionMessage
+    | V1CompiledTransactionMessage;
 
 export type CompiledTransactionMessageWithLifetime = Readonly<{
     /**
@@ -51,6 +56,16 @@ export function compileTransactionMessage<
     transactionMessage: TTransactionMessage,
 ): ForwardTransactionMessageLifetime<V0CompiledTransactionMessage, TTransactionMessage>;
 export function compileTransactionMessage<
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer & { version: 1 },
+>(
+    transactionMessage: TTransactionMessage,
+): ForwardTransactionMessageLifetime<V1CompiledTransactionMessage, TTransactionMessage>;
+export function compileTransactionMessage<
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer,
+>(
+    transactionMessage: TTransactionMessage,
+): ForwardTransactionMessageLifetime<CompiledTransactionMessage, TTransactionMessage>;
+export function compileTransactionMessage<
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer,
 >(
     transactionMessage: TTransactionMessage,
@@ -67,6 +82,8 @@ export function compileTransactionMessage<
         return compileLegacyTransactionMessage(transactionMessage) as ReturnType;
     } else if (version === 0) {
         return compileV0TransactionMessage(transactionMessage) as ReturnType;
+    } else if (version === 1) {
+        return compileV1TransactionMessage(transactionMessage) as ReturnType;
     } else {
         throw new SolanaError(SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_NOT_SUPPORTED, {
             version,

--- a/packages/transaction-messages/src/compile/v0/message.ts
+++ b/packages/transaction-messages/src/compile/v0/message.ts
@@ -13,6 +13,8 @@ export type V0CompiledTransactionMessage = BaseCompiledTransactionMessage &
     Readonly<{
         /** A list of address tables and the accounts that this transaction loads from them */
         addressTableLookups?: ReturnType<typeof getCompiledAddressTableLookups>;
+        /** A list of instructions that this transaction will execute */
+        instructions: ReturnType<typeof getCompiledInstructions>;
         version: 0;
     }>;
 

--- a/packages/transaction-messages/src/compile/v1/__tests__/config-test.ts
+++ b/packages/transaction-messages/src/compile/v1/__tests__/config-test.ts
@@ -1,0 +1,164 @@
+import { TransactionConfig } from '../../../transaction-config';
+import { getTransactionConfigMask, getTransactionConfigValues } from '../config';
+
+describe('getTransactionConfigMask', () => {
+    it('should return a mask with all values unset correctly', () => {
+        const config: TransactionConfig = {};
+        const mask = getTransactionConfigMask(config);
+
+        // All bits 0
+        expect(mask).toBe(0b00000000);
+    });
+
+    it('should return a mask with all values set correctly', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: 100,
+            heapSize: 100,
+            loadedAccountsDataSizeLimit: 100,
+            priorityFeeLamports: 100n,
+        };
+        const mask = getTransactionConfigMask(config);
+
+        // Lowest 5 bits set to 1, rest are 0
+        expect(mask).toBe(0b00011111);
+    });
+
+    it('should return a mask with just priority fee set correctly', () => {
+        const config: TransactionConfig = {
+            priorityFeeLamports: 100n,
+        };
+        const mask = getTransactionConfigMask(config);
+
+        // Lowest two bits set to 1, rest are 0
+        expect(mask).toBe(0b00000011);
+    });
+
+    it('should return a mask with just compute unit limit set correctly', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: 100,
+        };
+        const mask = getTransactionConfigMask(config);
+
+        // Third lowest bit set to 1, rest are 0
+        expect(mask).toBe(0b00000100);
+    });
+
+    it('should return a mask with just loaded accounts data size limit set correctly', () => {
+        const config: TransactionConfig = {
+            loadedAccountsDataSizeLimit: 100,
+        };
+        const mask = getTransactionConfigMask(config);
+
+        // Fourth lowest bit set to 1, rest are 0
+        expect(mask).toBe(0b00001000);
+    });
+
+    it('should return a mask with just heap size set correctly', () => {
+        const config: TransactionConfig = {
+            heapSize: 100,
+        };
+        const mask = getTransactionConfigMask(config);
+
+        // Fifth lowest bit set to 1, rest are 0
+        expect(mask).toBe(0b00010000);
+    });
+
+    it('should return a mask with multiple values set correctly', () => {
+        const config: TransactionConfig = {
+            loadedAccountsDataSizeLimit: 100,
+            priorityFeeLamports: 100n,
+        };
+        const mask = getTransactionConfigMask(config);
+
+        // First, second and fourth lowest bits set to 1, rest are 0
+        expect(mask).toBe(0b00001011);
+    });
+});
+
+describe('getTransactionConfigValues', () => {
+    it('should return an empty array when no values are set', () => {
+        const config: TransactionConfig = {};
+        const values = getTransactionConfigValues(config);
+        expect(values).toEqual([]);
+    });
+
+    it('should return all values correctly', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: 20,
+            heapSize: 40,
+            loadedAccountsDataSizeLimit: 30,
+            priorityFeeLamports: 10n,
+        };
+        const values = getTransactionConfigValues(config);
+        expect(values).toEqual([
+            { kind: 'u64', value: 10n },
+            { kind: 'u32', value: 20 },
+            { kind: 'u32', value: 30 },
+            { kind: 'u32', value: 40 },
+        ]);
+    });
+
+    it('should return just priority fee correctly', () => {
+        const config: TransactionConfig = {
+            priorityFeeLamports: 10n,
+        };
+        const values = getTransactionConfigValues(config);
+        expect(values).toEqual([{ kind: 'u64', value: 10n }]);
+    });
+
+    it('should return a large priority fee value correctly', () => {
+        const config: TransactionConfig = {
+            priorityFeeLamports: 2n ** 64n - 1n,
+        };
+        const values = getTransactionConfigValues(config);
+        expect(values).toEqual([{ kind: 'u64', value: 2n ** 64n - 1n }]);
+    });
+
+    it('should return just compute unit limit correctly', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: 20,
+        };
+        const values = getTransactionConfigValues(config);
+        expect(values).toEqual([{ kind: 'u32', value: 20 }]);
+    });
+
+    it('should return just loaded accounts data size limit correctly', () => {
+        const config: TransactionConfig = {
+            loadedAccountsDataSizeLimit: 30,
+        };
+        const values = getTransactionConfigValues(config);
+        expect(values).toEqual([{ kind: 'u32', value: 30 }]);
+    });
+
+    it('should return just heap size correctly', () => {
+        const config: TransactionConfig = {
+            heapSize: 40,
+        };
+        const values = getTransactionConfigValues(config);
+        expect(values).toEqual([{ kind: 'u32', value: 40 }]);
+    });
+
+    it('should return multiple values correctly', () => {
+        const config: TransactionConfig = {
+            loadedAccountsDataSizeLimit: 30,
+            priorityFeeLamports: 10n,
+        };
+        const values = getTransactionConfigValues(config);
+        expect(values).toEqual([
+            { kind: 'u64', value: 10n },
+            { kind: 'u32', value: 30 },
+        ]);
+    });
+
+    it('should return a large priority fee value correctly with another value', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: 20,
+            priorityFeeLamports: 2n ** 64n - 1n,
+        };
+        const values = getTransactionConfigValues(config);
+        expect(values).toEqual([
+            { kind: 'u64', value: 2n ** 64n - 1n },
+            { kind: 'u32', value: 20 },
+        ]);
+    });
+});

--- a/packages/transaction-messages/src/compile/v1/__tests__/instructions-test.ts
+++ b/packages/transaction-messages/src/compile/v1/__tests__/instructions-test.ts
@@ -1,0 +1,138 @@
+import { Address } from '@solana/addresses';
+import { Instruction } from '@solana/instructions';
+
+import { getInstructionHeader, getInstructionPayload } from '../instructions';
+
+describe('getInstructionHeader', () => {
+    const programAddress = '11111111111111111111111111111111' as Address;
+    const accountAddress1 = '22222222222222222222222222222222' as Address;
+    const accountAddress2 = '33333333333333333333333333333333' as Address;
+
+    it('returns the instruction header when all fields are defined', () => {
+        const instruction: Instruction = {
+            accounts: [
+                { address: accountAddress1, role: 0 },
+                { address: accountAddress2, role: 0 },
+            ],
+            data: Uint8Array.from({ length: 2 ** 16 - 1 }, (_, i) => i),
+            programAddress,
+        };
+        const accountIndex = {
+            [accountAddress1]: 2,
+            [accountAddress2]: 3,
+            [programAddress]: 1,
+        };
+        expect(getInstructionHeader(instruction, accountIndex)).toEqual({
+            numInstructionAccounts: 2,
+            numInstructionDataBytes: 2 ** 16 - 1,
+            programAccountIndex: 1,
+        });
+    });
+
+    it('returns 0 accounts when accounts is missing', () => {
+        const instruction: Instruction = {
+            data: new Uint8Array([1, 2, 3]),
+            programAddress,
+        };
+        const accountIndex = {
+            [programAddress]: 1,
+        };
+        expect(getInstructionHeader(instruction, accountIndex)).toEqual({
+            numInstructionAccounts: 0,
+            numInstructionDataBytes: 3,
+            programAccountIndex: 1,
+        });
+    });
+
+    it('returns 0 data bytes when data is missing', () => {
+        const instruction: Instruction = {
+            accounts: [
+                { address: accountAddress1, role: 0 },
+                { address: accountAddress2, role: 0 },
+            ],
+            programAddress,
+        };
+        const accountIndex = {
+            [accountAddress1]: 2,
+            [accountAddress2]: 3,
+            [programAddress]: 1,
+        };
+        expect(getInstructionHeader(instruction, accountIndex)).toEqual({
+            numInstructionAccounts: 2,
+            numInstructionDataBytes: 0,
+            programAccountIndex: 1,
+        });
+    });
+});
+
+describe('getInstructionPayload', () => {
+    const programAddress = '11111111111111111111111111111111' as Address;
+    const accountAddress1 = '22222222222222222222222222222222' as Address;
+    const accountAddress2 = '33333333333333333333333333333333' as Address;
+
+    it('returns the instruction payload when all fields are defined', () => {
+        const instruction: Instruction = {
+            accounts: [
+                { address: accountAddress1, role: 0 },
+                { address: accountAddress2, role: 0 },
+            ],
+            data: new Uint8Array([1, 2, 3]),
+            programAddress,
+        };
+        const accountIndex = {
+            [accountAddress1]: 2,
+            [accountAddress2]: 3,
+            [programAddress]: 1,
+        };
+        expect(getInstructionPayload(instruction, accountIndex)).toEqual({
+            instructionAccountIndices: [2, 3],
+            instructionData: new Uint8Array([1, 2, 3]),
+        });
+    });
+
+    it('returns an empty array when `accounts` is missing', () => {
+        const instruction: Instruction = {
+            data: new Uint8Array([1, 2, 3]),
+            programAddress,
+        };
+        const accountIndex = {
+            [programAddress]: 1,
+        };
+        expect(getInstructionPayload(instruction, accountIndex)).toEqual({
+            instructionAccountIndices: [],
+            instructionData: new Uint8Array([1, 2, 3]),
+        });
+    });
+
+    it('returns an empty Uint8Array when `data` is missing', () => {
+        const instruction: Instruction = {
+            accounts: [
+                { address: accountAddress1, role: 0 },
+                { address: accountAddress2, role: 0 },
+            ],
+            programAddress,
+        };
+        const accountIndex = {
+            [accountAddress1]: 2,
+            [accountAddress2]: 3,
+            [programAddress]: 1,
+        };
+        expect(getInstructionPayload(instruction, accountIndex)).toEqual({
+            instructionAccountIndices: [2, 3],
+            instructionData: new Uint8Array(),
+        });
+    });
+
+    it('returns an empty payload when both `accounts` and `data` are missing', () => {
+        const instruction: Instruction = {
+            programAddress,
+        };
+        const accountIndex = {
+            [programAddress]: 1,
+        };
+        expect(getInstructionPayload(instruction, accountIndex)).toEqual({
+            instructionAccountIndices: [],
+            instructionData: new Uint8Array(),
+        });
+    });
+});

--- a/packages/transaction-messages/src/compile/v1/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/compile/v1/__tests__/message-test.ts
@@ -1,0 +1,223 @@
+import { Address } from '@solana/addresses';
+import { AccountRole } from '@solana/instructions';
+
+import { TransactionMessageWithBlockhashLifetime } from '../../../blockhash';
+import { TransactionMessageWithFeePayer } from '../../../fee-payer';
+import { TransactionConfig } from '../../../transaction-config';
+import { TransactionMessage } from '../../../transaction-message';
+import {
+    getAddressMapFromInstructions,
+    getOrderedAccountsFromAddressMap,
+    OrderedAccounts,
+} from '../../legacy/accounts';
+import { getCompiledMessageHeader } from '../../legacy/header';
+import { getAccountIndex } from '../../legacy/instructions';
+import { getCompiledLifetimeToken } from '../../legacy/lifetime-token';
+import { getTransactionConfigMask, getTransactionConfigValues } from '../config';
+import { getInstructionHeader, getInstructionPayload } from '../instructions';
+import { compileTransactionMessage } from '../message';
+
+jest.mock('../../legacy/accounts');
+jest.mock('../../legacy/header');
+jest.mock('../../legacy/instructions');
+jest.mock('../../legacy/lifetime-token');
+jest.mock('../config');
+jest.mock('../instructions');
+
+type V1TransactionMessage = TransactionMessage & TransactionMessageWithFeePayer & { version: 1 };
+type V1Instruction = V1TransactionMessage['instructions'][number];
+
+function makeMockTransactionMessage(overrides?: Partial<V1TransactionMessage>): V1TransactionMessage {
+    return {
+        feePayer: { address: 'abc' as Address },
+        instructions: [] as V1Instruction[],
+        version: 1,
+        ...overrides,
+    };
+}
+
+describe('compileTransactionMessage', () => {
+    beforeEach(() => {
+        jest.mocked(getAddressMapFromInstructions).mockReturnValue({});
+        jest.mocked(getOrderedAccountsFromAddressMap).mockReturnValue([] as unknown as OrderedAccounts);
+        jest.mocked(getAccountIndex).mockReturnValue({});
+    });
+
+    it('returns with version 1', () => {
+        const tx = makeMockTransactionMessage();
+        const message = compileTransactionMessage(tx);
+        expect(message).toHaveProperty('version', 1);
+    });
+
+    it('sets `header` to the return value of `getCompiledMessageHeader`', () => {
+        const expectedCompiledMessageHeader = {
+            numReadonlyNonSignerAccounts: 0,
+            numReadonlySignerAccounts: 0,
+            numSignerAccounts: 1,
+        } as const;
+        jest.mocked(getCompiledMessageHeader).mockReturnValue(expectedCompiledMessageHeader);
+
+        const tx = makeMockTransactionMessage();
+        const message = compileTransactionMessage(tx);
+        expect(getCompiledMessageHeader).toHaveBeenCalled();
+        expect(message.header).toBe(expectedCompiledMessageHeader);
+    });
+
+    describe('config', () => {
+        const expectedConfigMask = 0b00011111;
+        const expectedConfigValues = [
+            { kind: 'u64' as const, value: 10n },
+            { kind: 'u32' as const, value: 20 },
+        ];
+
+        beforeEach(() => {
+            jest.mocked(getTransactionConfigMask).mockReturnValue(expectedConfigMask);
+            jest.mocked(getTransactionConfigValues).mockReturnValue(expectedConfigValues);
+        });
+
+        it('sets `configMask` to the return value of `getTransactionConfigMask`', () => {
+            const config: TransactionConfig = {
+                computeUnitLimit: 10,
+            };
+            const tx = makeMockTransactionMessage({ config });
+            const message = compileTransactionMessage(tx);
+            expect(getTransactionConfigMask).toHaveBeenCalledWith(tx.config);
+            expect(message.configMask).toBe(expectedConfigMask);
+        });
+
+        it('sets `configValues` to the return value of `getTransactionConfigValues`', () => {
+            const config: TransactionConfig = {
+                computeUnitLimit: 10,
+            };
+            const tx = makeMockTransactionMessage({ config });
+            const message = compileTransactionMessage(tx);
+            expect(getTransactionConfigValues).toHaveBeenCalledWith(tx.config);
+            expect(message.configValues).toBe(expectedConfigValues);
+        });
+
+        it('passes an empty object to config functions when config is missing', () => {
+            const txWithoutConfig = makeMockTransactionMessage();
+            compileTransactionMessage(txWithoutConfig);
+            expect(getTransactionConfigMask).toHaveBeenCalledWith({});
+            expect(getTransactionConfigValues).toHaveBeenCalledWith({});
+        });
+    });
+
+    describe('lifetime constraints', () => {
+        beforeEach(() => {
+            jest.mocked(getCompiledLifetimeToken).mockReturnValue('abc');
+        });
+        it('sets `lifetimeToken` to the return value of `getCompiledLifetimeToken`', () => {
+            const blockhash = 'myblockhash' as unknown as TransactionMessageWithBlockhashLifetime['lifetimeConstraint'];
+            const tx = {
+                ...makeMockTransactionMessage(),
+                lifetimeConstraint: blockhash,
+            };
+            const message = compileTransactionMessage(tx);
+            expect(getCompiledLifetimeToken).toHaveBeenCalledWith(blockhash);
+            expect(message.lifetimeToken).toBe('abc');
+        });
+        it('does not set `lifetimeToken` when lifetime constraint is missing', () => {
+            const txWithoutLifetime = makeMockTransactionMessage();
+            const message = compileTransactionMessage(txWithoutLifetime);
+            expect(message).not.toHaveProperty('lifetimeToken');
+        });
+    });
+
+    describe('instructions', () => {
+        const expectedInstructionHeader = {
+            numInstructionAccounts: 2,
+            numInstructionDataBytes: 3,
+            programAccountIndex: 1,
+        };
+
+        const expectedInstructionPayload = {
+            instructionAccountIndices: [2, 3],
+            instructionData: new Uint8Array([1, 2, 3]),
+        };
+
+        beforeEach(() => {
+            jest.mocked(getInstructionHeader).mockReturnValue(expectedInstructionHeader);
+            jest.mocked(getInstructionPayload).mockReturnValue(expectedInstructionPayload);
+        });
+
+        it('sets `numInstructions` to the number of instructions', () => {
+            const tx = makeMockTransactionMessage({
+                instructions: [{} as V1Instruction, {} as V1Instruction],
+            });
+            const message = compileTransactionMessage(tx);
+            expect(message.numInstructions).toBe(2);
+        });
+
+        it('sets `instructionHeaders` to the return values of `getInstructionHeader`', () => {
+            const mockInstruction1 = {} as V1Instruction;
+            const mockInstruction2 = {} as V1Instruction;
+            const tx = makeMockTransactionMessage({
+                instructions: [mockInstruction1, mockInstruction2],
+            });
+            const message = compileTransactionMessage(tx);
+            expect(getInstructionHeader).toHaveBeenCalledTimes(2);
+            expect(getInstructionHeader).toHaveBeenNthCalledWith(
+                1,
+                mockInstruction1,
+                expect.anything() /* accountIndex */,
+            );
+            expect(getInstructionHeader).toHaveBeenNthCalledWith(
+                2,
+                mockInstruction2,
+                expect.anything() /* accountIndex */,
+            );
+            expect(message.instructionHeaders).toEqual([expectedInstructionHeader, expectedInstructionHeader]);
+        });
+
+        it('sets `instructionPayloads` to the return values of `getInstructionPayload`', () => {
+            const mockInstruction1 = {} as V1Instruction;
+            const mockInstruction2 = {} as V1Instruction;
+            const tx = makeMockTransactionMessage({
+                instructions: [mockInstruction1, mockInstruction2],
+            });
+            const message = compileTransactionMessage(tx);
+            expect(getInstructionPayload).toHaveBeenCalledTimes(2);
+            expect(getInstructionPayload).toHaveBeenNthCalledWith(
+                1,
+                mockInstruction1,
+                expect.anything() /* accountIndex */,
+            );
+            expect(getInstructionPayload).toHaveBeenNthCalledWith(
+                2,
+                mockInstruction2,
+                expect.anything() /* accountIndex */,
+            );
+            expect(message.instructionPayloads).toEqual([expectedInstructionPayload, expectedInstructionPayload]);
+        });
+    });
+
+    describe('static accounts', () => {
+        const expectedOrderedAccounts: ReturnType<typeof getOrderedAccountsFromAddressMap> = [
+            {
+                address: 'abc' as Address<'abc'>,
+                role: AccountRole.WRITABLE_SIGNER,
+            },
+            {
+                address: 'def' as Address<'def'>,
+                role: AccountRole.READONLY,
+            },
+        ] as ReturnType<typeof getOrderedAccountsFromAddressMap>;
+
+        beforeEach(() => {
+            jest.mocked(getOrderedAccountsFromAddressMap).mockReturnValue(expectedOrderedAccounts);
+        });
+
+        it('sets `staticAccounts` to the addresses from the ordered accounts', () => {
+            const tx = makeMockTransactionMessage();
+            const message = compileTransactionMessage(tx);
+            expect(getOrderedAccountsFromAddressMap).toHaveBeenCalled();
+            expect(message.staticAccounts).toStrictEqual(['abc' as Address<'abc'>, 'def' as Address<'def'>]);
+        });
+        it('sets `numStaticAccounts` to the number of ordered accounts', () => {
+            const tx = makeMockTransactionMessage();
+            const message = compileTransactionMessage(tx);
+            expect(message.numStaticAccounts).toBe(2);
+        });
+    });
+});

--- a/packages/transaction-messages/src/compile/v1/config.ts
+++ b/packages/transaction-messages/src/compile/v1/config.ts
@@ -1,0 +1,46 @@
+import { TransactionConfig } from '../../transaction-config';
+
+const PRIORITY_FEE_LAMPORTS_BIT_MASK = 0b11;
+const COMPUTE_UNIT_LIMIT_BIT_MASK = 0b100;
+const LOADED_ACCOUNTS_DATA_SIZE_LIMIT_BIT_MASK = 0b1000;
+const HEAP_SIZE_BIT_MASK = 0b10000;
+
+export function getTransactionConfigMask(config: TransactionConfig): number {
+    let mask = 0;
+    // Set the lowest 2 bits for priority fee lamports
+    if (config.priorityFeeLamports !== undefined) mask |= PRIORITY_FEE_LAMPORTS_BIT_MASK;
+    // Set the 3rd lowest bit for compute unit limit
+    if (config.computeUnitLimit !== undefined) mask |= COMPUTE_UNIT_LIMIT_BIT_MASK;
+    // Set the 4th lowest bit for loaded accounts data size limit
+    if (config.loadedAccountsDataSizeLimit !== undefined) mask |= LOADED_ACCOUNTS_DATA_SIZE_LIMIT_BIT_MASK;
+    // Set the 5th lowest bit for heap size
+    if (config.heapSize !== undefined) mask |= HEAP_SIZE_BIT_MASK;
+    return mask;
+}
+
+export type CompiledTransactionConfigValue =
+    | {
+          kind: 'u32';
+          value: number;
+      }
+    | {
+          kind: 'u64';
+          value: bigint;
+      };
+
+export function getTransactionConfigValues(config: TransactionConfig): CompiledTransactionConfigValue[] {
+    const values: CompiledTransactionConfigValue[] = [];
+    if (config.priorityFeeLamports !== undefined) {
+        values.push({ kind: 'u64', value: config.priorityFeeLamports });
+    }
+    if (config.computeUnitLimit !== undefined) {
+        values.push({ kind: 'u32', value: config.computeUnitLimit });
+    }
+    if (config.loadedAccountsDataSizeLimit !== undefined) {
+        values.push({ kind: 'u32', value: config.loadedAccountsDataSizeLimit });
+    }
+    if (config.heapSize !== undefined) {
+        values.push({ kind: 'u32', value: config.heapSize });
+    }
+    return values;
+}

--- a/packages/transaction-messages/src/compile/v1/instructions.ts
+++ b/packages/transaction-messages/src/compile/v1/instructions.ts
@@ -1,0 +1,36 @@
+import { ReadonlyUint8Array } from '@solana/codecs-core';
+import { Instruction } from '@solana/instructions';
+
+import { getAccountIndex } from '../legacy/instructions';
+
+export type InstructionHeader = {
+    numInstructionAccounts: number;
+    numInstructionDataBytes: number;
+    programAccountIndex: number;
+};
+
+export type InstructionPayload = {
+    instructionAccountIndices: number[];
+    instructionData: ReadonlyUint8Array;
+};
+
+export function getInstructionHeader(
+    instruction: Instruction,
+    accountIndex: ReturnType<typeof getAccountIndex>,
+): InstructionHeader {
+    return {
+        numInstructionAccounts: instruction.accounts?.length ?? 0,
+        numInstructionDataBytes: instruction.data?.byteLength ?? 0,
+        programAccountIndex: accountIndex[instruction.programAddress],
+    };
+}
+
+export function getInstructionPayload(
+    instruction: Instruction,
+    accountIndex: ReturnType<typeof getAccountIndex>,
+): InstructionPayload {
+    return {
+        instructionAccountIndices: instruction.accounts?.map(({ address }) => accountIndex[address]) ?? [],
+        instructionData: instruction.data ?? new Uint8Array(),
+    };
+}

--- a/packages/transaction-messages/src/compile/v1/message.ts
+++ b/packages/transaction-messages/src/compile/v1/message.ts
@@ -1,0 +1,80 @@
+import { TransactionMessageWithFeePayer } from '../../fee-payer';
+import { TransactionMessageWithLifetime } from '../../lifetime';
+import { TransactionMessage } from '../../transaction-message';
+import { getAddressMapFromInstructions, getOrderedAccountsFromAddressMap } from '../legacy/accounts';
+import { getCompiledMessageHeader } from '../legacy/header';
+import { getAccountIndex } from '../legacy/instructions';
+import { getCompiledLifetimeToken } from '../legacy/lifetime-token';
+import { BaseCompiledTransactionMessage, ForwardTransactionMessageLifetime } from '../message-types';
+import { getTransactionConfigMask, getTransactionConfigValues } from './config';
+import { getInstructionHeader, getInstructionPayload } from './instructions';
+
+type ConfigValue =
+    | {
+          kind: 'u32';
+          value: number;
+      }
+    | {
+          kind: 'u64';
+          value: bigint;
+      };
+
+type InstructionHeader = {
+    numInstructionAccounts: number;
+    numInstructionDataBytes: number;
+    programAccountIndex: number;
+};
+
+type InstructionPayload = {
+    instructionAccountIndices: number[];
+    instructionData: Uint8Array;
+};
+
+export type V1CompiledTransactionMessage = BaseCompiledTransactionMessage &
+    Readonly<{
+        /** A mask indicating which transaction config values are present */
+        configMask: number;
+        /** The configuration values for the transaction */
+        configValues: ConfigValue[];
+        /** The headers for each instruction in the transaction */
+        instructionHeaders: InstructionHeader[];
+        /** The payload for each instruction in the transaction */
+        instructionPayloads: InstructionPayload[];
+        /** The number of instructions in the transaction */
+        numInstructions: number;
+        /** The number of static accounts in the transaction */
+        numStaticAccounts: number;
+        version: 1;
+    }>;
+
+export function compileTransactionMessage<
+    TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer & { version: 1 },
+>(
+    transactionMessage: TTransactionMessage,
+): ForwardTransactionMessageLifetime<V1CompiledTransactionMessage, TTransactionMessage> {
+    type ReturnType = ForwardTransactionMessageLifetime<V1CompiledTransactionMessage, TTransactionMessage>;
+    const addressMap = getAddressMapFromInstructions(
+        transactionMessage.feePayer.address,
+        transactionMessage.instructions,
+    );
+    const orderedAccounts = getOrderedAccountsFromAddressMap(addressMap);
+    const accountIndex = getAccountIndex(orderedAccounts);
+    const lifetimeConstraint = (transactionMessage as Partial<TransactionMessageWithLifetime>).lifetimeConstraint;
+
+    return {
+        version: 1,
+        ...(lifetimeConstraint ? { lifetimeToken: getCompiledLifetimeToken(lifetimeConstraint) } : null),
+        configMask: getTransactionConfigMask(transactionMessage.config ?? {}),
+        configValues: getTransactionConfigValues(transactionMessage.config ?? {}),
+        header: getCompiledMessageHeader(orderedAccounts),
+        instructionHeaders: transactionMessage.instructions.map(instruction =>
+            getInstructionHeader(instruction, accountIndex),
+        ),
+        instructionPayloads: transactionMessage.instructions.map(instruction =>
+            getInstructionPayload(instruction, accountIndex),
+        ),
+        numInstructions: transactionMessage.instructions.length,
+        numStaticAccounts: orderedAccounts.length,
+        staticAccounts: orderedAccounts.map(account => account.address),
+    } as ReturnType;
+}

--- a/packages/transaction-messages/src/decompile/legacy/convert-instruction.ts
+++ b/packages/transaction-messages/src/decompile/legacy/convert-instruction.ts
@@ -4,10 +4,10 @@ import {
 } from '@solana/errors';
 import { AccountMeta, Instruction } from '@solana/instructions';
 
-import { CompiledTransactionMessage } from '../..';
+import { LegacyCompiledTransactionMessage } from '../../compile/legacy/message';
 
 function convertInstruction(
-    instruction: CompiledTransactionMessage['instructions'][number],
+    instruction: LegacyCompiledTransactionMessage['instructions'][number],
     accountMetas: AccountMeta[],
 ): Instruction {
     const programAddress = accountMetas[instruction.programAddressIndex]?.address;
@@ -28,7 +28,7 @@ function convertInstruction(
 }
 
 export function convertInstructions(
-    instructions: CompiledTransactionMessage['instructions'],
+    instructions: LegacyCompiledTransactionMessage['instructions'],
     accountMetas: AccountMeta[],
 ): Instruction[] {
     return instructions.map(instruction => convertInstruction(instruction, accountMetas));

--- a/packages/transaction-messages/src/transaction-message.ts
+++ b/packages/transaction-messages/src/transaction-message.ts
@@ -1,5 +1,7 @@
 import { AccountMeta, Instruction } from '@solana/instructions';
 
+import { TransactionConfig } from './transaction-config';
+
 type BaseTransactionMessage<
     TVersion extends TransactionVersion = TransactionVersion,
     TInstruction extends Instruction = Instruction,
@@ -10,8 +12,16 @@ type BaseTransactionMessage<
 
 export const MAX_SUPPORTED_TRANSACTION_VERSION = 1;
 
-type LegacyInstruction<TProgramAddress extends string = string> = Instruction<TProgramAddress, readonly AccountMeta[]>;
-type LegacyTransactionMessage = BaseTransactionMessage<'legacy', LegacyInstruction>;
+type InstructionWithoutLookupTables<TProgramAddress extends string = string> = Instruction<
+    TProgramAddress,
+    readonly AccountMeta[]
+>;
+type LegacyTransactionMessage = BaseTransactionMessage<'legacy', InstructionWithoutLookupTables>;
 type V0TransactionMessage = BaseTransactionMessage<0, Instruction>;
-export type TransactionMessage = LegacyTransactionMessage | V0TransactionMessage;
+type V1TransactionMessage = BaseTransactionMessage<1, InstructionWithoutLookupTables> &
+    Readonly<{
+        /** A set of optional configuration values for the transaction */
+        config?: TransactionConfig;
+    }>;
+export type TransactionMessage = LegacyTransactionMessage | V0TransactionMessage | V1TransactionMessage;
 export type TransactionVersion = 'legacy' | 0 | 1;


### PR DESCRIPTION
#### Summary of Changes

This PR adds the `V1CompiledTransactionMessage` type and a function to compile from `TransactionMessage` to it.

- Remove `instructions` from `BaseCompiledTransactionMessage`, and move it to legacy and v0
- `configMask`: compile the bit mask for provided config values.
- `configValues`: compile to a list of tagged u32/u64 values, ready to encode with the respective codecs
- Compile instructions to `InstructionHeader` and `InstructionPayload`
- Includes `numInstructions` and `numStaticAccounts`

Note that most of the tests are copied from the original implementation of this logic in encoders.

These encoders can now be much simpler, with most of the logic moved to this compile stage.