### PR TITLE
Enable pattern match encoder/codec to use type narrowing

### DIFF
--- a/.changeset/soft-cloths-move.md
+++ b/.changeset/soft-cloths-move.md
@@ -1,0 +1,14 @@
+---
+'@solana/codecs-data-structures': patch
+---
+
+Enable pattern match encoder/codec to use type narrowing. This means that if your predicate narrows the type of the value, then the matching encoder only needs to handle the narrowed type.
+
+This means that you can write, for example:
+
+```ts
+getPatternMatchEncoder<string | number>([
+    [(value) => typeof value === 'string', {} as Encoder<string>],
+    [(value) => typeof value === 'number', {} as Encoder<number>]
+])
+```

--- a/packages/codecs-data-structures/src/__typetests__/pattern-match-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/pattern-match-typetest.ts
@@ -17,44 +17,93 @@ const numberValuePredicate = null as unknown as (value: number) => boolean;
 const stringValuePredicate = null as unknown as (value: string) => boolean;
 const bytesPredicate = null as unknown as (bytes: ReadonlyUint8Array) => boolean;
 
+const numberTypePredicate = null as unknown as (value: number | string) => value is number;
+const stringTypePredicate = null as unknown as (value: number | string) => value is string;
+
 // [DESCRIBE] getPatternMatchEncoder
 {
-    // It returns an encoder for the same type as the inputs
-    getPatternMatchEncoder([[numberValuePredicate, {} as Encoder<number>]]) satisfies Encoder<number>;
+    // [DESCRIBE] For boolean predicates
+    {
+        // It returns an encoder for the same type as the inputs
+        getPatternMatchEncoder([[numberValuePredicate, {} as Encoder<number>]]) satisfies Encoder<number>;
 
-    // It returns a FixedSizeEncoder if all encoders are FixedSizeEncoder
-    getPatternMatchEncoder([
-        [numberValuePredicate, {} as FixedSizeEncoder<number>],
-        [numberValuePredicate, {} as FixedSizeEncoder<number>],
-    ]) satisfies FixedSizeEncoder<number>;
+        // It returns a FixedSizeEncoder if all encoders are FixedSizeEncoder
+        getPatternMatchEncoder([
+            [numberValuePredicate, {} as FixedSizeEncoder<number>],
+            [numberValuePredicate, {} as FixedSizeEncoder<number>],
+        ]) satisfies FixedSizeEncoder<number>;
 
-    // It maintains the size if all encoders are FixedSizeEncoder with the same size
-    getPatternMatchEncoder([
-        [stringValuePredicate, {} as FixedSizeEncoder<string, 4>],
-        [stringValuePredicate, {} as FixedSizeEncoder<string, 4>],
-    ]) satisfies FixedSizeEncoder<string, 4>;
+        // It maintains the size if all encoders are FixedSizeEncoder with the same size
+        getPatternMatchEncoder([
+            [stringValuePredicate, {} as FixedSizeEncoder<string, 4>],
+            [stringValuePredicate, {} as FixedSizeEncoder<string, 4>],
+        ]) satisfies FixedSizeEncoder<string, 4>;
 
-    // It returns a VariableSizeEncoder if all encoders are VariableSizeEncoder
-    getPatternMatchEncoder([
-        [numberValuePredicate, {} as VariableSizeEncoder<number>],
-        [numberValuePredicate, {} as VariableSizeEncoder<number>],
-    ]) satisfies VariableSizeEncoder<number>;
+        // It returns a VariableSizeEncoder if all encoders are VariableSizeEncoder
+        getPatternMatchEncoder([
+            [numberValuePredicate, {} as VariableSizeEncoder<number>],
+            [numberValuePredicate, {} as VariableSizeEncoder<number>],
+        ]) satisfies VariableSizeEncoder<number>;
 
-    // It returns an Encoder if some input encoders are VariableSizeEncoder
-    getPatternMatchEncoder([
-        [numberValuePredicate, {} as VariableSizeEncoder<number>],
-        [numberValuePredicate, {} as VariableSizeEncoder<number>],
-    ]) satisfies Encoder<number>;
+        // It returns an Encoder if some input encoders are VariableSizeEncoder
+        getPatternMatchEncoder([
+            [numberValuePredicate, {} as VariableSizeEncoder<number>],
+            [numberValuePredicate, {} as VariableSizeEncoder<number>],
+        ]) satisfies Encoder<number>;
 
-    getPatternMatchEncoder([
-        [numberValuePredicate, {} as FixedSizeEncoder<number>],
-        [numberValuePredicate, {} as VariableSizeEncoder<number>],
-    ]) satisfies Encoder<number>;
+        getPatternMatchEncoder([
+            [numberValuePredicate, {} as FixedSizeEncoder<number>],
+            [numberValuePredicate, {} as VariableSizeEncoder<number>],
+        ]) satisfies Encoder<number>;
 
-    getPatternMatchEncoder([
-        [numberValuePredicate, {} as VariableSizeEncoder<number>],
-        [numberValuePredicate, {} as FixedSizeEncoder<number>],
-    ]) satisfies Encoder<number>;
+        getPatternMatchEncoder([
+            [numberValuePredicate, {} as VariableSizeEncoder<number>],
+            [numberValuePredicate, {} as FixedSizeEncoder<number>],
+        ]) satisfies Encoder<number>;
+    }
+
+    // [DESCRIBE] For type guard predicates
+    {
+        // It returns an encoder for the same type as the inputs
+        getPatternMatchEncoder<number | string>([
+            [numberTypePredicate, {} as Encoder<number>],
+            [stringTypePredicate, {} as Encoder<string>],
+        ]) satisfies Encoder<number | string>;
+
+        // It returns a FixedSizeEncoder if all encoders are FixedSizeEncoder
+        getPatternMatchEncoder<number | string>([
+            [numberTypePredicate, {} as FixedSizeEncoder<number>],
+            [stringTypePredicate, {} as FixedSizeEncoder<string>],
+        ]) satisfies FixedSizeEncoder<number | string>;
+
+        // It maintains the size if all encoders are FixedSizeEncoder with the same size
+        getPatternMatchEncoder<number | string, 4>([
+            [numberTypePredicate, {} as FixedSizeEncoder<number, 4>],
+            [stringTypePredicate, {} as FixedSizeEncoder<string, 4>],
+        ]) satisfies FixedSizeEncoder<number | string, 4>;
+
+        // It returns a VariableSizeEncoder if all encoders are VariableSizeEncoder
+        getPatternMatchEncoder<number | string>([
+            [numberTypePredicate, {} as VariableSizeEncoder<number>],
+            [stringTypePredicate, {} as VariableSizeEncoder<string>],
+        ]) satisfies VariableSizeEncoder<number | string>;
+
+        // It returns an Encoder if some input encoders are VariableSizeEncoder
+        getPatternMatchEncoder<number | string>([
+            [numberTypePredicate, {} as VariableSizeEncoder<number>],
+            [stringTypePredicate, {} as VariableSizeEncoder<string>],
+        ]) satisfies Encoder<number | string>;
+
+        getPatternMatchEncoder<number | string>([
+            [numberTypePredicate, {} as FixedSizeEncoder<number>],
+            [stringTypePredicate, {} as VariableSizeEncoder<string>],
+        ]) satisfies Encoder<number | string>;
+
+        getPatternMatchEncoder<number | string>([
+            [numberTypePredicate, {} as VariableSizeEncoder<number>],
+            [numberTypePredicate, {} as FixedSizeEncoder<number>],
+        ]) satisfies Encoder<number>;
+    }
 }
 
 // [DESCRIBE] getPatternMatchDecoder
@@ -99,40 +148,86 @@ const bytesPredicate = null as unknown as (bytes: ReadonlyUint8Array) => boolean
 
 // [DESCRIBE] getPatternMatchCodec
 {
-    // It returns a codec for the same type as the inputs
-    getPatternMatchCodec([[numberValuePredicate, bytesPredicate, {} as Codec<number>]]) satisfies Codec<number>;
+    // [DESCRIBE] For boolean predicates
+    {
+        // It returns a codec for the same type as the inputs
+        getPatternMatchCodec([[numberValuePredicate, bytesPredicate, {} as Codec<number>]]) satisfies Codec<number>;
 
-    // It returns a FixedSizeCodec if all codecs are FixedSizeCodec
-    getPatternMatchCodec([
-        [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
-        [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
-    ]) satisfies FixedSizeCodec<number>;
+        // It returns a FixedSizeCodec if all codecs are FixedSizeCodec
+        getPatternMatchCodec([
+            [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+            [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+        ]) satisfies FixedSizeCodec<number>;
 
-    // It maintains the size if all codecs are FixedSizeCodec with the same size
-    getPatternMatchCodec([
-        [stringValuePredicate, bytesPredicate, {} as FixedSizeCodec<string, string, 4>],
-        [stringValuePredicate, bytesPredicate, {} as FixedSizeCodec<string, string, 4>],
-    ]) satisfies FixedSizeCodec<string, string, 4>;
+        // It maintains the size if all codecs are FixedSizeCodec with the same size
+        getPatternMatchCodec([
+            [stringValuePredicate, bytesPredicate, {} as FixedSizeCodec<string, string, 4>],
+            [stringValuePredicate, bytesPredicate, {} as FixedSizeCodec<string, string, 4>],
+        ]) satisfies FixedSizeCodec<string, string, 4>;
 
-    // It returns a VariableSizeCodec if all codecs are VariableSizeCodec
-    getPatternMatchCodec([
-        [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
-        [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
-    ]) satisfies VariableSizeCodec<number>;
+        // It returns a VariableSizeCodec if all codecs are VariableSizeCodec
+        getPatternMatchCodec([
+            [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
+            [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
+        ]) satisfies VariableSizeCodec<number>;
 
-    // It returns a Codec if some input codecs are VariableSizeCodec
-    getPatternMatchCodec([
-        [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
-        [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
-    ]) satisfies Codec<number>;
+        // It returns a Codec if some input codecs are VariableSizeCodec
+        getPatternMatchCodec([
+            [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
+            [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
+        ]) satisfies Codec<number>;
 
-    getPatternMatchCodec([
-        [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
-        [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
-    ]) satisfies Codec<number>;
+        getPatternMatchCodec([
+            [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+            [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
+        ]) satisfies Codec<number>;
 
-    getPatternMatchCodec([
-        [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
-        [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
-    ]) satisfies Codec<number>;
+        getPatternMatchCodec([
+            [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
+            [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+        ]) satisfies Codec<number>;
+    }
+
+    // [DESCRIBE] For type guard predicates
+    {
+        // It returns a codec for the same type as the inputs
+        getPatternMatchCodec<number | string>([
+            [numberTypePredicate, bytesPredicate, {} as Codec<number>],
+            [stringTypePredicate, bytesPredicate, {} as Codec<string>],
+        ]) satisfies Codec<number | string>;
+
+        // It returns a FixedSizeCodec if all codecs are FixedSizeCodec
+        getPatternMatchCodec<number | string>([
+            [numberTypePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+            [stringTypePredicate, bytesPredicate, {} as FixedSizeCodec<string>],
+        ]) satisfies FixedSizeCodec<number | string>;
+
+        // It maintains the size if all codecs are FixedSizeCodec with the same size
+        getPatternMatchCodec<number | string, number | string, 4>([
+            [stringTypePredicate, bytesPredicate, {} as FixedSizeCodec<string, string, 4>],
+            [numberTypePredicate, bytesPredicate, {} as FixedSizeCodec<number, number, 4>],
+        ]) satisfies FixedSizeCodec<number | string, number | string, 4>;
+
+        // It returns a VariableSizeCodec if all codecs are VariableSizeCodec
+        getPatternMatchCodec<number | string>([
+            [numberTypePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
+            [stringTypePredicate, bytesPredicate, {} as VariableSizeCodec<string>],
+        ]) satisfies VariableSizeCodec<number | string>;
+
+        // It returns a Codec if some input codecs are VariableSizeCodec
+        getPatternMatchCodec<number | string>([
+            [numberTypePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
+            [stringTypePredicate, bytesPredicate, {} as VariableSizeCodec<string>],
+        ]) satisfies Codec<number | string>;
+
+        getPatternMatchCodec<number | string>([
+            [numberTypePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+            [stringTypePredicate, bytesPredicate, {} as VariableSizeCodec<string>],
+        ]) satisfies Codec<number | string>;
+
+        getPatternMatchCodec<number | string>([
+            [numberTypePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
+            [stringTypePredicate, bytesPredicate, {} as FixedSizeCodec<string>],
+        ]) satisfies Codec<number | string>;
+    }
 }

--- a/packages/codecs-data-structures/src/index.ts
+++ b/packages/codecs-data-structures/src/index.ts
@@ -21,6 +21,7 @@ export * from './hidden-suffix';
 export * from './literal-union';
 export * from './map';
 export * from './nullable';
+export * from './pattern-match';
 export * from './predicate';
 export * from './set';
 export * from './struct';

--- a/packages/codecs-data-structures/src/pattern-match.ts
+++ b/packages/codecs-data-structures/src/pattern-match.ts
@@ -19,6 +19,31 @@ import {
 
 import { getUnionDecoder, getUnionEncoder } from './union';
 
+type PatternMatchEncoderEntry<TNarrowed, TFrom = TNarrowed> = TNarrowed extends TFrom
+    ? // Boolean predicate with original encoder
+          | readonly [(value: TFrom) => boolean, Encoder<TFrom>]
+          // Type predicate with narrowed encoder
+          | readonly [(value: TFrom) => value is TNarrowed, Encoder<TNarrowed>]
+    : never;
+
+type FixedSizePatternMatchEncoderEntry<
+    TNarrowed,
+    TFrom = TNarrowed,
+    TSize extends number = number,
+> = TNarrowed extends TFrom
+    ? // Boolean predicate with original encoder
+          | readonly [(value: TFrom) => boolean, FixedSizeEncoder<TFrom, TSize>]
+          // Type predicate with narrowed encoder
+          | readonly [(value: TFrom) => value is TNarrowed, FixedSizeEncoder<TNarrowed, TSize>]
+    : never;
+
+type VariableSizePatternMatchEncoderEntry<TNarrowed, TFrom = TNarrowed> = TNarrowed extends TFrom
+    ? // Boolean predicate with original encoder
+          | readonly [(value: TFrom) => boolean, VariableSizeEncoder<TFrom>]
+          // Type predicate with narrowed encoder
+          | readonly [(value: TFrom) => value is TNarrowed, VariableSizeEncoder<TNarrowed>]
+    : never;
+
 /**
  * Returns an encoder that selects which variant encoder to use based on pattern matching.
  *
@@ -28,7 +53,9 @@ import { getUnionDecoder, getUnionEncoder } from './union';
  * @typeParam TFrom - The type of the value to encode.
  *
  * @param patterns - An array of `[predicate, encoder]` pairs. Predicates are tested in order
- * and the first matching encoder is used to encode the value.
+ * and the first matching encoder is used to encode the value. Note that predicates can be either
+ * type predicates that narrow the type of the value, or boolean predicates. If using type predicates,
+ * the encoder can be for the narrowed type.
  * @returns An encoder that selects the appropriate variant based on the matched pattern.
  *
  * @throws Throws a {@link SOLANA_ERROR__CODECS__INVALID_PATTERN_MATCH_VALUE} error
@@ -63,16 +90,16 @@ import { getUnionDecoder, getUnionEncoder } from './union';
  * @see {@link getPatternMatchCodec}
  */
 export function getPatternMatchEncoder<TFrom, TSize extends number>(
-    patterns: [(value: TFrom) => boolean, FixedSizeEncoder<TFrom, TSize>][],
+    patterns: FixedSizePatternMatchEncoderEntry<TFrom, TFrom, TSize>[],
 ): FixedSizeEncoder<TFrom, TSize>;
 export function getPatternMatchEncoder<TFrom>(
-    patterns: [(value: TFrom) => boolean, FixedSizeEncoder<TFrom>][],
+    patterns: FixedSizePatternMatchEncoderEntry<TFrom>[],
 ): FixedSizeEncoder<TFrom>;
 export function getPatternMatchEncoder<TFrom>(
-    patterns: [(value: TFrom) => boolean, VariableSizeEncoder<TFrom>][],
+    patterns: VariableSizePatternMatchEncoderEntry<TFrom>[],
 ): VariableSizeEncoder<TFrom>;
-export function getPatternMatchEncoder<TFrom>(patterns: [(value: TFrom) => boolean, Encoder<TFrom>][]): Encoder<TFrom>;
-export function getPatternMatchEncoder<TFrom>(patterns: [(value: TFrom) => boolean, Encoder<TFrom>][]): Encoder<TFrom> {
+export function getPatternMatchEncoder<TFrom>(patterns: PatternMatchEncoderEntry<TFrom>[]): Encoder<TFrom>;
+export function getPatternMatchEncoder<TFrom>(patterns: PatternMatchEncoderEntry<TFrom>[]): Encoder<TFrom> {
     return getUnionEncoder(
         patterns.map(([, encoder]) => encoder),
         (value: TFrom) => {
@@ -148,6 +175,59 @@ export function getPatternMatchDecoder<TTo>(
     );
 }
 
+type PatternMatchCodecEntry<TNarrowedFrom, TFrom = TNarrowedFrom, TTo = TNarrowedFrom> = TNarrowedFrom extends TFrom
+    ? TTo extends TNarrowedFrom
+        ?
+              | readonly [
+                    (value: TFrom) => value is TNarrowedFrom,
+                    (bytes: ReadonlyUint8Array) => boolean,
+                    Codec<TNarrowedFrom, TTo>,
+                ]
+              | readonly [(value: TFrom) => boolean, (bytes: ReadonlyUint8Array) => boolean, Codec<TFrom, TTo>]
+        : never
+    : never;
+
+type FixedSizePatternMatchCodecEntry<
+    TNarrowedFrom,
+    TFrom = TNarrowedFrom,
+    TTo = TNarrowedFrom,
+    TSize extends number = number,
+> = TNarrowedFrom extends TFrom
+    ? TTo extends TNarrowedFrom
+        ?
+              | readonly [
+                    (value: TFrom) => boolean,
+                    (bytes: ReadonlyUint8Array) => boolean,
+                    FixedSizeCodec<TFrom, TTo, TSize>,
+                ]
+              | readonly [
+                    (value: TFrom) => value is TNarrowedFrom,
+                    (bytes: ReadonlyUint8Array) => boolean,
+                    FixedSizeCodec<TNarrowedFrom, TTo, TSize>,
+                ]
+        : never
+    : never;
+
+type VariableSizePatternMatchCodecEntry<
+    TNarrowedFrom,
+    TFrom = TNarrowedFrom,
+    TTo = TNarrowedFrom,
+> = TNarrowedFrom extends TFrom
+    ? TTo extends TNarrowedFrom
+        ?
+              | readonly [
+                    (value: TFrom) => boolean,
+                    (bytes: ReadonlyUint8Array) => boolean,
+                    VariableSizeCodec<TFrom, TTo>,
+                ]
+              | readonly [
+                    (value: TFrom) => value is TNarrowedFrom,
+                    (bytes: ReadonlyUint8Array) => boolean,
+                    VariableSizeCodec<TNarrowedFrom, TTo>,
+                ]
+        : never
+    : never;
+
 /**
  * Returns a codec that selects which variant codec to use based on pattern matching.
  *
@@ -208,23 +288,25 @@ export function getPatternMatchDecoder<TTo>(
  * @see {@link getPatternMatchDecoder}
  * @see {@link getUnionCodec}
  */
-export function getPatternMatchCodec<TFrom, TTo extends TFrom, TSize extends number>(
-    patterns: [(value: TFrom) => boolean, (bytes: ReadonlyUint8Array) => boolean, FixedSizeCodec<TFrom, TTo, TSize>][],
+export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom, TSize extends number = number>(
+    patterns: FixedSizePatternMatchCodecEntry<TFrom, TFrom, TTo, TSize>[],
 ): FixedSizeCodec<TFrom, TTo, TSize>;
-export function getPatternMatchCodec<TFrom, TTo extends TFrom>(
-    patterns: [(value: TFrom) => boolean, (bytes: ReadonlyUint8Array) => boolean, FixedSizeCodec<TFrom, TTo>][],
+export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom>(
+    patterns: FixedSizePatternMatchCodecEntry<TFrom, TFrom, TTo>[],
 ): FixedSizeCodec<TFrom, TTo>;
-export function getPatternMatchCodec<TFrom, TTo extends TFrom>(
-    patterns: [(value: TFrom) => boolean, (bytes: ReadonlyUint8Array) => boolean, VariableSizeCodec<TFrom, TTo>][],
+export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom>(
+    patterns: VariableSizePatternMatchCodecEntry<TFrom, TFrom, TTo>[],
 ): VariableSizeCodec<TFrom, TTo>;
-export function getPatternMatchCodec<TFrom, TTo extends TFrom>(
-    patterns: [(value: TFrom) => boolean, (bytes: ReadonlyUint8Array) => boolean, Codec<TFrom, TTo>][],
+export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom>(
+    patterns: PatternMatchCodecEntry<TFrom, TFrom, TTo>[],
 ): Codec<TFrom, TTo>;
-export function getPatternMatchCodec<TFrom, TTo extends TFrom>(
-    patterns: [(value: TFrom) => boolean, (bytes: ReadonlyUint8Array) => boolean, Codec<TFrom, TTo>][],
+export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom>(
+    patterns: PatternMatchCodecEntry<TFrom, TFrom, TTo>[],
 ): Codec<TFrom, TTo> {
     return combineCodec(
-        getPatternMatchEncoder(patterns.map(([valuePredicate, , codec]) => [valuePredicate, codec])),
-        getPatternMatchDecoder(patterns.map(([, bytesPredicate, codec]) => [bytesPredicate, codec])),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        getPatternMatchEncoder(patterns.map(([valuePredicate, , codec]) => [valuePredicate, codec]) as any),
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        getPatternMatchDecoder(patterns.map(([, bytesPredicate, codec]) => [bytesPredicate, codec]) as any),
     );
 }


### PR DESCRIPTION
#### Problem

I want to use the pattern matching codec for the `CompiledTransactionMessage` codec

We have (simplifying) a legacy codec that takes `LegacyCompiledTransactionMessage` as input, and a v0 one that takes `v0CompiledTransactionMessage` as input

Currently we can't write:

```ts
getPatternMatchEncoder<CompiledTransactionMessage>([
  [(m) => m.version === 'legacy', getLegacyCompiledTransactionMessageEncoder()],
  [(m) => m.version === 0, getV0CompiledTransactionMessageEncoder()]
])
```

Because all the nested encoders are typed as `Encoder<TFrom>` Our version predicate narrows the type, but the encoder type is unaware of that.

#### Summary of Changes

This PR allows narrowing the type in `getPatternMatchEncoder`. Now you can pass a pattern like this:

```ts
[(value: TFrom) => value is TNarrowed, Encoder<TNarrowed>]
```

In other words, if you use a predicate function that narrows the type of the input value, you can use an encoder for that narrowed type.

The previous case with a predicate just returning a boolean remains supported, and still requires an encoder for `TFrom`. 

This means that (in the next PR), we can use the pattern match encoder for `CompiledTransactionMessage`. 
