### PR TITLE
Add `CLAUDE.md` and agent skills for AI-assisted development

### DIFF
--- a/.agents/skills/changesets/INJECT.md
+++ b/.agents/skills/changesets/INJECT.md
@@ -1,0 +1,10 @@
+---
+heading: Changesets
+---
+
+- Any PR that should trigger a package release MUST include a changeset.
+- Identify affected packages by mapping changed files to their nearest `package.json`.
+- Choose the right bump: `patch` for fixes, `minor` for features, `major` for breaking changes.
+- While a project is pre-1.0, `minor` bumps may be treated as breaking.
+- ALWAYS use `npx changeset add --empty` to generate a new changeset file with a random name. NEVER create changeset files manually.
+- No changeset needed for: docs-only changes, CI config, dev dependency updates, test-only changes.

--- a/.agents/skills/changesets/SKILL.md
+++ b/.agents/skills/changesets/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: changesets
+description: Generate a changeset file with a changelog entry for package releases. Use when a PR introduces user-facing changes that should trigger a version bump.
+argument-hint: "[patch|minor|major]"
+allowed-tools: Bash(npx changeset add --empty)
+---
+
+# Generate Changeset
+
+Create a new changeset file for the current project using the [changesets CLI](https://github.com/changesets/changesets), then fill it with a proper changelog entry based on recent changes.
+
+## Key Rules
+
+- Any PR that should trigger a package release MUST include a changeset.
+- Identify affected packages by mapping changed files to their nearest `package.json`.
+- Choose the right bump: `patch` for fixes, `minor` for features, `major` for breaking changes.
+- While a project is pre-1.0, `minor` bumps may be treated as breaking.
+- ALWAYS use `npx changeset add --empty` to generate a new changeset file with a random name. NEVER create changeset files manually.
+- No changeset needed for: docs-only changes, CI config, dev dependency updates, test-only changes.
+- Do NOT modify any existing changeset files.
+- Only create one new changeset file per invocation.
+
+## Guidelines
+
+### Changeset Format
+
+```
+---
+'<package-a>': patch
+'<package-b>': patch
+---
+
+<concise changelog entry>
+```
+
+### Changelog Entries
+
+- Write a concise but informative changelog entry (1-3 sentences).
+- Start with a verb — e.g. "Add", "Remove", "Replace", "Fix", "Update".
+- Focus on what changed from the user's perspective, not implementation details.
+- Mention renamed or removed APIs explicitly.
+
+### Breaking Changes
+
+Add a `**BREAKING CHANGES**` section (bold paragraph, not a header) after the changelog entry when:
+
+- The bump level is `major`, OR
+- The bump level is `minor` AND the current major version is `0` (i.e. pre-1.0)
+
+...and the changes actually introduce breaking changes.
+
+The breaking changes section should list each breaking change with a bold title summarizing the change, followed by a brief explanation and a `diff` code block showing the before/after migration when applicable. For example:
+
+```
+Replace the `useGranularImports` boolean option with a new `importStrategy` option.
+
+**BREAKING CHANGES**
+
+**`useGranularImports` replaced with `importStrategy`.** The boolean option has been replaced with a string union for finer control.
+
+\`\`\`diff
+- renderVisitor('./output', { useGranularImports: true });
++ renderVisitor('./output', { importStrategy: 'granular' });
+\`\`\`
+
+**Default import behavior changed.** The default strategy is now `'preferRoot'`, which falls back to granular packages for symbols not on the root entrypoint.
+
+\`\`\`diff
+- renderVisitor('./output'); // equivalent to useGranularImports: false
++ renderVisitor('./output'); // equivalent to importStrategy: 'preferRoot'
+\`\`\`
+```
+
+Not every breaking change needs a diff — use them when there's a clear before/after code change to show. For type removals or behavioral changes, a text explanation is sufficient.
+
+## Command Process
+
+When invoked as a command, follow these steps:
+
+### Arguments
+
+- `[patch|minor|major]` (optional): Override the bump level for all affected packages.
+
+### Steps
+
+1. **Determine the change source.** Check `git status` for uncommitted changes. If there are meaningful working tree changes, use those. Otherwise, use the latest commit(s) on the current branch (compared to the base branch from `.changeset/config.json`).
+2. **Identify which packages changed.** Look at which files were modified and map them to their nearest `package.json` to determine affected packages. Ignore changes that are not relevant to a changeset — e.g. typo fixes in comments, dependency version bumps in `package.json`, changes to CI config, docs-only changes in non-doc packages, etc. Use your judgement to filter out noise.
+3. **Run `npx changeset add --empty`** to generate a new changeset file with a random name.
+4. **Identify the newly created file** — it will be the most recently created `.md` file in `.changeset/` (excluding `README.md`).
+5. **Write the changeset file** with the proper frontmatter listing each affected package and the bump level, followed by the changelog entry.

--- a/.agents/skills/shipping-git/INJECT.md
+++ b/.agents/skills/shipping-git/INJECT.md
@@ -1,0 +1,9 @@
+---
+heading: Shipping (Git)
+---
+
+- NEVER commit, push, create branches, or create PRs without explicit user approval.
+- Before any git operation that creates or modifies a commit, present a review block containing: changeset entry (if applicable), commit title, and commit/PR description. ALWAYS wait for approval.
+- Use standard `git add` and `git commit` workflows. Concise title on the first line, blank line, then description body.
+- Use `gh pr create` for pull requests.
+- Write commit and PR descriptions as natural flowing prose. Do NOT insert hard line breaks mid-paragraph.

--- a/.agents/skills/shipping-git/SKILL.md
+++ b/.agents/skills/shipping-git/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: shipping-git
+description: Shipping workflow using standard Git and GitHub CLI. Provides guidance for committing, branching, and creating PRs.
+---
+
+# Ship Code Using Git
+
+Guidance for shipping code using standard Git and the GitHub CLI (`gh`). This skill teaches the agent how to create commits, branches, and pull requests following conventional workflows.
+
+## Key Rules
+
+- NEVER commit, push, create branches, or create PRs without explicit user approval.
+- Before any git operation that creates or modifies a commit, present a review block containing: changeset content (if applicable), commit title, and commit/PR description. ALWAYS wait for approval.
+- Show the proposed changeset entry for review before writing the changeset file.
+- Use standard `git add` and `git commit` workflows. Concise title on the first line, blank line, then description body.
+- Use `gh pr create` for pull requests.
+- Write commit and PR descriptions as natural flowing prose. Do NOT insert hard line breaks mid-paragraph.
+
+## Guidelines
+
+### Creating Commits
+
+Follow conventional commit message format:
+
+```sh
+git add -A
+git commit -m "Commit title" -m "Description body explaining what changed and why."
+```
+
+- The first `-m` sets the commit title (first line). Keep it concise and descriptive.
+- The second `-m` sets the commit body. Explain what changed and why.
+- Use present tense, imperative mood (e.g. "Add feature" not "Added feature").
+
+### Creating Branches
+
+Create a descriptive branch name before committing:
+
+```sh
+git checkout -b feature/short-description
+```
+
+Common prefixes: `feature/`, `fix/`, `refactor/`, `docs/`, `chore/`.
+
+### Creating Pull Requests
+
+Use the GitHub CLI to create PRs:
+
+```sh
+gh pr create --title "PR title" --body "Description explaining what changed and why."
+```
+
+- If a `.github/PULL_REQUEST_TEMPLATE.md` exists, use it as a guide for structuring the PR description. Fill in sections that are relevant and omit sections that don't apply (e.g. don't add "Fixes #" if there's no related issue).
+
+### Pushing Changes
+
+Push the branch and set the upstream:
+
+```sh
+git push -u origin HEAD
+```
+
+### Review Block Format
+
+Before any git operation, present this review block and wait for approval:
+
+1. **Changeset entry** (if applicable) — the proposed changelog entry and bump type.
+2. **Commit title** — a concise title for the commit.
+3. **Commit/PR description** — a short description that explains what changed and why.

--- a/.agents/skills/shipping-graphite/INJECT.md
+++ b/.agents/skills/shipping-graphite/INJECT.md
@@ -1,0 +1,12 @@
+---
+heading: Shipping (Graphite)
+---
+
+- Check if [Graphite](https://graphite.dev/) is installed (`which gt`). Prefer Graphite when available; fall back to the Git shipping workflow otherwise.
+- NEVER commit, push, create branches, or create PRs without explicit user approval.
+- Before any git operation that creates or modifies a commit, present a review block containing: changeset entry (if applicable), commit title, and commit/PR description. ALWAYS wait for approval.
+- Use `gt create -am "Title" -m "Description body"` for new PRs. The first `-m` sets the commit title; the second sets the PR description.
+- Use `gt modify -a` to amend the current branch with follow-up changes (NEVER create additional commits on the same branch).
+- ALWAYS escape backticks in commit messages with backslashes for shell compatibility (e.g. `"Update \`my-package\` config"`).
+- Do NOT run `gt submit` after committing. Only run it when the user explicitly asks to submit or push.
+- Write commit and PR descriptions as natural flowing prose. Do NOT insert hard line breaks mid-paragraph.

--- a/.agents/skills/shipping-graphite/SKILL.md
+++ b/.agents/skills/shipping-graphite/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: shipping-graphite
+description: Shipping workflow using Graphite CLI. Provides guidance for committing, branching, and creating PRs with Graphite's single-commit-per-branch model.
+---
+
+# Ship Code Using Graphite
+
+Guidance for shipping code using the [Graphite](https://graphite.dev/) CLI (`gt`). This skill teaches the agent how to create commits, branches, and PRs using Graphite's single-commit-per-branch model.
+
+## Key Rules
+
+- NEVER commit, push, create branches, or create PRs without explicit user approval.
+- Before any git operation that creates or modifies a commit, present a review block containing: changeset content (if applicable), commit title, and commit/PR description. ALWAYS wait for approval.
+- Show the proposed changeset entry for review before writing the changeset file.
+- Use `gt create -am "Title" -m "Description body"` for new PRs. The first `-m` sets the commit title; the second sets the PR description.
+- Use `gt modify -a` to amend the current branch with follow-up changes (NEVER create additional commits on the same branch).
+- ALWAYS escape backticks in commit messages with backslashes for shell compatibility (e.g. `"Update \`my-package\` config"`).
+- Write commit and PR descriptions as natural flowing prose. Do NOT insert hard line breaks mid-paragraph.
+
+## Guidelines
+
+### Creating a New PR
+
+Use `gt create` to create a new branch with a single commit:
+
+```sh
+gt create -am "Commit title" -m "Description body explaining what changed and why."
+```
+
+- The first `-m` flag sets the commit title (first line of the commit message).
+- The second `-m` flag sets the commit body, which Graphite uses as the PR description when the stack is submitted.
+- Write the body as a concise flowing summary. Avoid excessive blank lines.
+- If a `.github/PULL_REQUEST_TEMPLATE.md` exists, use it as a guide for structuring the PR description. Fill in sections that are relevant and omit sections that don't apply (e.g. don't add "Fixes #" if there's no related issue).
+
+### Amending an Existing PR
+
+When making follow-up changes to the current branch, ALWAYS amend rather than creating new commits:
+
+```sh
+gt modify -a
+```
+
+This amends the single commit on the current branch. Since Graphite uses a one-commit-per-branch model, ALWAYS use `gt modify -a` for follow-up changes on the same PR.
+
+### Submitting PRs
+
+Do NOT run `gt submit` (or `gt ss`) after creating or modifying branches. The `gt create` and `gt modify` steps are the end of the workflow unless the user explicitly asks to submit or push.
+
+When the user asks to submit, first run `gt sync` to ensure the local stack is up-to-date. This will restack branches from the main branch and prompt to delete any stale (merged) branches. If `gt sync` encounters any issues or conflicts, stop immediately and report the problem to the user before proceeding — await their instructions on how to resolve it.
+
+Only after a clean sync, run `gt submit` to create or update PRs for all branches in the current stack.
+
+### Shell Escaping
+
+When commit titles or descriptions contain backticks (e.g. for package names or code references), escape them with a backslash so the shell passes them through literally:
+
+```sh
+gt create -am "Align \`kit-plugins\` infrastructure" -m "This PR updates the shared config."
+```
+
+### Review Block Format
+
+Before any git operation, present this review block and wait for approval:
+
+1. **Changeset entry** (if applicable) — the proposed changelog entry and bump type.
+2. **Commit title** — a concise title for the commit.
+3. **Commit/PR description** — a short description that explains what changed and why.

--- a/.agents/skills/ts-docblocks/INJECT.md
+++ b/.agents/skills/ts-docblocks/INJECT.md
@@ -1,0 +1,9 @@
+---
+heading: TypeScript Docblocks
+---
+
+- All exported functions, types, interfaces, and constants MUST have JSDoc docblocks.
+- Start with `/**`, use `*` prefix for each line, end with `*/` — each on its own line.
+- Begin with a clear one-to-two line summary. Add a blank line before tags.
+- Include `@param`, `@typeParam`, `@return`, `@throws`, and at least one `@example` when helpful.
+- Use `{@link ...}` to reference related items. Add `@see` tags at the end for related APIs.

--- a/.agents/skills/ts-docblocks/SKILL.md
+++ b/.agents/skills/ts-docblocks/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: ts-docblocks
+description: Add missing JSDoc docblocks to exported symbols in TypeScript projects. Use when writing new exports or when code is missing documentation.
+argument-hint: "[path] [--all]"
+---
+
+# Add Missing Docblocks
+
+Scan the specified path (or entire repository if no path given) and add missing docblocks to all exported functions, classes, interfaces, types, and constants.
+
+## Key Rules
+
+- All exported functions, types, interfaces, and constants MUST have JSDoc docblocks.
+- Start with `/**`, use `*` prefix for each line, end with `*/` — each on its own line.
+- Begin with a clear one-to-two line summary. Add a blank line before tags.
+- Include `@param`, `@typeParam`, `@return`, `@throws`, and at least one `@example` when helpful.
+- Use `{@link ...}` to reference related items. Add `@see` tags at the end for related APIs.
+- Do NOT modify real code outside of docblocks. Do NOT modify existing docblocks.
+
+## Guidelines
+
+### Style
+
+Use JSDoc format with the following conventions:
+
+- Start with `/**` on its own line.
+- Use `*` prefix for each line.
+- End with `*/` on its own line.
+- Keep descriptions concise but complete.
+- Start your sentences with a capital letter and end with a period.
+- Limit your usage of em dashes but, when you do use them, use spaces on both sides.
+- Begin with a clear one or two line summary (no `@summary` tag needed).
+- Add a blank line after the summary if adding more details.
+- Include `@param` tags for all parameters.
+- Include `@typeParam` tags for all type parameters. Use `@typeParam`, not `@template`.
+- Include `@return` tag briefly describing the return value.
+- Add `@throws` for functions that may throw errors and list these errors.
+- Include at least one `@example` section whenever usage examples would be helpful. If the file is a TypeScript file, use TypeScript syntax in examples. Try to make the examples realistic but concise and pleasant to read. They must illustrate the concepts clearly at first glance. When more than one example is preferred, use multiple `@example` tags and keep the first one as simple as possible to illustrate the basic usage. Never use `any` type in examples. Display the `import` statements required for the example to work when imports from multiple libraries are required. It is acceptable to use placeholder variable names like `myUser` or even `/* ... */` for parts that are not relevant to the example. When multiple example sections are provided, add a brief description before each code block to quickly explain what the example illustrates.
+- In the rare case where more advanced documentation is also needed for the item, use the `@remarks` tag to add this extra information after any example sections. These remarks can include longer explanations and even additional code blocks if necessary.
+- When an item is deprecated, include a `@deprecated` tag with a brief explanation and, if applicable, suggest an alternative.
+- Use `{@link ...}` tags to reference other items in the codebase when relevant.
+- Add `@see` tags at the very end when applicable to point to other related items or documentation. Use `@see {@link ...}` format when linking to other code items.
+
+### Examples
+
+````ts
+/**
+ * Creates a retry wrapper around an async function.
+ *
+ * Retries the given function up to `maxRetries` times with exponential
+ * backoff between attempts.
+ *
+ * @param fn - The async function to retry.
+ * @param maxRetries - Maximum number of retry attempts.
+ * @param baseDelay - Base delay in milliseconds between retries.
+ * @return A wrapped version of `fn` that retries on failure.
+ * @throws Throws the last error if all retry attempts are exhausted.
+ *
+ * @example
+ * ```ts
+ * const fetchWithRetry = withRetry(fetchData, 3, 1000);
+ * const data = await fetchWithRetry('/api/users');
+ * ```
+ *
+ * @example
+ * Custom retry configuration for flaky network calls.
+ * ```ts
+ * const resilientFetch = withRetry(
+ *   () => fetch('https://api.example.com/data'),
+ *   5,
+ *   500,
+ * );
+ * ```
+ */
+export function withRetry<T>(
+    fn: (...args: unknown[]) => Promise<T>,
+    maxRetries: number,
+    baseDelay: number,
+): (...args: unknown[]) => Promise<T>;
+````
+
+````ts
+/**
+ * Fixes a `Uint8Array` to the specified length.
+ *
+ * If the array is longer than the specified length, it is truncated.
+ * If the array is shorter than the specified length, it is padded with zeroes.
+ *
+ * @param bytes - The byte array to truncate or pad.
+ * @param length - The desired length of the byte array.
+ * @return The byte array truncated or padded to the desired length.
+ *
+ * @example
+ * Truncates the byte array to the desired length.
+ * ```ts
+ * const bytes = new Uint8Array([0x01, 0x02, 0x03, 0x04]);
+ * const fixedBytes = fixBytes(bytes, 2);
+ * //    ^ [0x01, 0x02]
+ * ```
+ *
+ * @example
+ * Adds zeroes to the end of the byte array to reach the desired length.
+ * ```ts
+ * const bytes = new Uint8Array([0x01, 0x02]);
+ * const fixedBytes = fixBytes(bytes, 4);
+ * //    ^ [0x01, 0x02, 0x00, 0x00]
+ * ```
+ */
+export const fixBytes = (
+    bytes: ReadonlyUint8Array | Uint8Array,
+    length: number,
+): ReadonlyUint8Array | Uint8Array;
+````
+
+````ts
+/**
+ * A tree structure representing a set of instructions with execution constraints.
+ *
+ * Supports parallel execution, sequential execution, and combinations of both
+ * through recursive composition of plan nodes.
+ *
+ * @example
+ * ```ts
+ * const plan: InstructionPlan = parallelPlan([
+ *     sequentialPlan([instructionA, instructionB]),
+ *     instructionC,
+ *     instructionD,
+ * ]);
+ * ```
+ *
+ * @see {@link SingleInstructionPlan}
+ * @see {@link ParallelInstructionPlan}
+ * @see {@link SequentialInstructionPlan}
+ */
+export type InstructionPlan =
+    | ParallelInstructionPlan
+    | SequentialInstructionPlan
+    | SingleInstructionPlan;
+````
+
+## Command Process
+
+When invoked as a command, follow these steps:
+
+### Arguments
+
+- `[path]` (optional): Narrow the scan to a specific path (e.g. `src/utils` or `packages/my-lib/src`).
+- `[--all]` (optional): Also scan non-exported items.
+
+### Steps
+
+1. If a path argument is provided, scan only that path; otherwise scan the entire repository.
+2. Look for TypeScript/JavaScript files (`.ts`, `.tsx`, `.js`, `.jsx`).
+3. Identify exported items without docblocks:
+    - `export function`
+    - `export class`
+    - `export interface`
+    - `export type`
+    - `export const` (for constants and arrow functions)
+4. If `--all` is passed, also identify non-exported items.
+5. For each item missing a docblock:
+    - Analyze the code to understand its purpose (this may span multiple files).
+    - Examine parameters, return types, and behavior.
+    - Generate an appropriate docblock following the style guide.
+6. Present all changes clearly, grouped by file. Apply all changes without requiring further approval.

--- a/.agents/skills/ts-readme/INJECT.md
+++ b/.agents/skills/ts-readme/INJECT.md
@@ -1,0 +1,8 @@
+---
+heading: TypeScript READMEs
+---
+
+- When adding a new public API, add or update the package's README.
+- Structure: brief intro, installation, usage (with code snippet), deep-dive sections.
+- Code snippets must be realistic, concise, and use TypeScript syntax.
+- Focus on the quickest path to success. Developers should feel excited, not overwhelmed.

--- a/.agents/skills/ts-readme/SKILL.md
+++ b/.agents/skills/ts-readme/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: ts-readme
+description: Guidelines for writing developer-friendly READMEs for TypeScript libraries. Use when creating a new package, changing a public API, or updating documentation.
+argument-hint: "[path]"
+---
+
+# Create or Update README
+
+Create a new README or update an existing one for a TypeScript package, library, or project.
+
+## Key Rules
+
+- When adding a new public API, add or update the package's README.
+- Structure: brief intro, installation, usage (with code snippet), deep-dive sections.
+- Code snippets must be realistic, concise, and use TypeScript syntax.
+- Focus on the quickest path to success. Developers should feel excited, not overwhelmed.
+- Do NOT update any real code outside of the README file itself. If you identify errors in the codebase, warn the user but do not fix them.
+
+## Guidelines
+
+A deep understanding of the project is necessary to create an effective README. Analyze the codebase, key features, and typical usage patterns to inform the content. If the project relies on other libraries or frameworks, consider how those influence usage and installation.
+
+### Structure
+
+The layout of a README will vary from project to project, but they should generally follow these guidelines.
+
+#### 1. Intro Section
+
+- Package/library name as the main heading.
+- Badges for tests, package version, downloads, etc. (npm, GitHub, etc.).
+- **Very brief summary (ELI5)** — A single sentence or short paragraph that anyone can understand at first glance.
+- Only update the intro if you can meaningfully improve the summary; otherwise leave it intact.
+
+#### 2. Installation Section
+
+- Keep it extremely concise (1-2 lines of explanation max if necessary).
+- Show the install command in a code block.
+
+#### 3. Usage Section (Most Critical)
+
+- This is where readers' attention lands first after the intro.
+- Show the **quickest path to success** with this library.
+- **Must include a code snippet** illustrating basic usage.
+- Balance between brevity and clarity to create an "aha moment."
+- Optional: Brief text before/after the snippet if it adds clarity.
+- The code snippet should be realistic, concise, and immediately understandable.
+
+#### 4. Deep Dive Sections
+
+- Structure varies case-by-case based on the project.
+- Document key features, concepts, or use cases.
+- Each section should include **at least one code snippet**. Similar guidelines as the Usage section, that is, realistic and concise (shortest path to "aha moment").
+- Organize logically (e.g. by feature, by use case, by complexity).
+- Common patterns:
+    - **Features**: Individual feature documentation with examples.
+    - **API Reference**: Core APIs or functions.
+    - **Advanced Usage**: More complex scenarios.
+    - **Configuration**: Setup and customization options.
+    - **Examples**: Real-world use cases.
+- No need for a "Requirements" section for peer dependencies. Just mention them in the "Installation" section if necessary to get started.
+
+### Code Snippets
+
+- Use TypeScript syntax for TypeScript projects.
+- Show realistic but concise examples.
+- Include necessary imports when relevant (e.g. when importing from multiple modules).
+- Use descriptive variable names (not `foo`, `bar`).
+- Keep examples focused on one concept at a time when possible.
+- Format for readability (proper indentation, spacing).
+
+### Tone
+
+- Friendly and approachable.
+- Clear and direct.
+- Avoid marketing speak.
+- Focus on practical value.
+- Use active voice.
+- Assume the reader is a developer who wants to get started quickly.
+
+### What to Avoid
+
+- Overly long introductions or preambles.
+- Walls of text without code examples.
+- Complex examples in the Usage section.
+- Unexplained jargon or acronyms.
+- Marketing-heavy language.
+- Duplicating information unnecessarily.
+
+### Monorepo Considerations
+
+When working in a monorepo:
+
+- **Package READMEs**: Focus on the specific package — its API, installation, usage, and features. Include an installation note pointing to an umbrella package as an alternative if one exists.
+- **Root README**: Provides an overview of the entire monorepo, links to individual package READMEs for details. Focus on the quick-start experience rather than deep-diving into each package.
+- **Consistency**: When updating a package README, check other package READMEs for structural consistency (heading levels, section order, code example style).
+
+## Command Process
+
+When invoked as a command, follow these steps:
+
+### Arguments
+
+- `[path]` (optional): Path to the README file or its parent directory. Defaults to `./README.md`.
+
+### Steps
+
+1. Determine the target README path:
+    - If a path argument is provided and ends with `.md`, use it directly.
+    - If the argument is a directory path, use `<path>/README.md`.
+    - If no argument is provided, use `./README.md`.
+
+2. Check if the README exists:
+    - If it exists, read it to understand the current structure.
+    - If it doesn't exist, prepare to create one from scratch.
+
+3. Analyze the project context:
+    - Examine `package.json` (if exists) for package name, description, dependencies.
+    - Look at the source code to understand what the library does.
+    - Identify key exports, main functions, and typical usage patterns.
+    - Check for existing tests or examples that show usage.
+    - Research any related libraries or frameworks that influence usage.
+    - If in a monorepo, examine other package READMEs to ensure consistency in style and structure.
+
+4. Create or update the README:
+    - **For existing READMEs**: Identify missing sections or areas needing improvement.
+    - **For new READMEs**: Build the full structure following the guidelines.
+    - Preserve the intro unless improvements are clear.
+    - Ensure the Usage section has a strong, clear example.
+    - Add or improve deep dive sections as needed.
+    - Include realistic code snippets throughout.
+
+5. Present the complete README for review before applying changes.

--- a/.claude/skills/changesets
+++ b/.claude/skills/changesets
@@ -1,0 +1,1 @@
+../../.agents/skills/changesets

--- a/.claude/skills/shipping-git
+++ b/.claude/skills/shipping-git
@@ -1,0 +1,1 @@
+../../.agents/skills/shipping-git

--- a/.claude/skills/shipping-graphite
+++ b/.claude/skills/shipping-graphite
@@ -1,0 +1,1 @@
+../../.agents/skills/shipping-graphite

--- a/.claude/skills/ts-docblocks
+++ b/.claude/skills/ts-docblocks
@@ -1,0 +1,1 @@
+../../.agents/skills/ts-docblocks

--- a/.claude/skills/ts-readme
+++ b/.claude/skills/ts-readme
@@ -1,0 +1,1 @@
+../../.agents/skills/ts-readme

--- a/.skills-inject.json
+++ b/.skills-inject.json
@@ -1,0 +1,9 @@
+{
+  "targets": [
+    "CLAUDE.md"
+  ],
+  "skillsDirs": [
+    ".agents/skills",
+    ".claude/skills"
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,135 @@
+# Agent Instructions
+
+## Project Overview
+
+Kit (`@solana/kit`) is the official JavaScript SDK for building Solana applications, maintained by Anza. The official documentation lives at https://solanakit.com (docs at `/docs`, API reference at `/api`). The GitHub repo is `anza-xyz/kit`.
+
+This is a pnpm monorepo with ~57 packages under `packages/`, orchestrated by Turborepo. The main `@solana/kit` package is a facade that re-exports ~20 workspace packages (accounts, addresses, codecs, errors, keys, rpc, signers, transactions, etc.) and adds its own convenience helpers like `sendAndConfirmTransaction`, `airdrop`, and `fetchLookupTables`.
+
+The documentation website supports an `.mdx` suffix on any page (e.g. `https://solanakit.com/docs/concepts/transactions.mdx`) which returns a cleaner markdown representation suitable for LLM consumption. Use this when you need to look up Kit APIs or concepts.
+
+There is also a companion [`anza-xyz/kit-plugins`](https://github.com/anza-xyz/kit-plugins) monorepo that builds an abstraction layer on top of Kit by offering composable plugins and ready-to-use clients (which are essentially curated sets of plugins). The plugin system relies on the `@solana/plugin-core` and `@solana/plugin-interfaces` packages defined in this repo. Additionally, `@solana/program-client-core` (re-exported from `@solana/kit/program-client-core`) provides the helpers used by the [Codama JS renderer](https://github.com/codama-idl/renderers-js) to generate Kit-compatible program clients.
+
+## Getting Started
+
+```shell
+pnpm install                                   # Install dependencies
+pnpm test:setup                                # Install the Agave test validator (first time only)
+./scripts/start-shared-test-validator.sh       # Start shared test validator (needed for some tests)
+pnpm build                                     # Build + test all packages
+```
+
+For single-package development:
+
+```shell
+cd packages/<name>
+pnpm turbo compile:js compile:typedefs         # Compile the package and its dependencies
+pnpm dev                                       # Run tests in watch mode
+```
+
+## Architecture
+
+The packages form a layered dependency graph. `@solana/errors` is the foundational leaf package with no internal dependencies — nearly every other package depends on it. Core encoding lives in `@solana/codecs-core`, `@solana/codecs-numbers`, `@solana/codecs-strings`, and `@solana/codecs-data-structures`, unified by the `@solana/codecs` facade. `@solana/keys` and `@solana/addresses` build on these codecs and `@solana/nominal-types`. Higher-level packages like `@solana/transactions`, `@solana/rpc`, and `@solana/signers` compose these primitives. `@solana/kit` sits at the top as the consumer-facing umbrella.
+
+Four private "impl" packages (`@solana/crypto-impl`, `@solana/text-encoding-impl`, `@solana/ws-impl`, `@solana/event-target-impl`) provide platform-specific implementations and are **inlined at build time** by tsup — they are never published to npm.
+
+## Build System
+
+- **JS compilation**: tsup (esbuild) via configs in `packages/build-scripts/`.
+- **Type declarations**: tsc with per-package `tsconfig.declarations.json`.
+- **Build artifacts per package**: Node CJS + ESM, Browser CJS + ESM, React Native ESM. `@solana/kit` additionally produces IIFE bundles (minified production + development with sourcemaps).
+- **Platform constants** (set at build time): `__BROWSER__`, `__NODEJS__`, `__REACTNATIVE__`, `__VERSION__`. These are mutually exclusive booleans enabling platform-specific code paths to be tree-shaken.
+- **`__DEV__`**: In IIFE builds, statically `true`/`false`. In library builds, replaced with `process.env.NODE_ENV !== 'production'` by the DevFlagPlugin, deferring the decision to the consumer's bundler.
+
+## Testing
+
+- **Framework**: Jest v30 with `@swc/jest` for TypeScript transformation.
+- **Shared config**: `packages/test-config/` (`@solana/test-config`).
+- **File naming**: `*-test.ts` (runs in both environments), `*-test.node.ts` (Node only), `*-test.browser.ts` (browser/jsdom only). Tests live in `src/__tests__/`.
+- **Type tests**: `src/__typetests__/` directories contain compile-time type tests using `satisfies` and `@ts-expect-error`.
+- **Lint/prettier**: Also run through Jest runners (`jest-runner-eslint`, `jest-runner-prettier`).
+- **Commands**: `pnpm test` runs all unit tests. `pnpm lint` runs lint checks. `pnpm style:fix` auto-fixes formatting.
+
+## Error System
+
+All errors use the `SolanaError` class from `@solana/errors`. Key rules:
+
+- Error codes are numeric constants in `packages/errors/src/codes.ts`, named `SOLANA_ERROR__<DOMAIN>__<DESCRIPTION>` (double-underscore separated).
+- Each domain reserves a dedicated numeric range. Never reuse, remove, or reorder error codes.
+- Human-readable messages live in `packages/errors/src/messages.ts` with `$key` context interpolation.
+- In production builds, messages are stripped. Use `npx @solana/errors decode -- <code>` to decode them.
+- To add a new error: add the constant to `codes.ts`, add it to the `SolanaErrorCode` union, optionally define context in `context.ts`, and add the message to `messages.ts`.
+
+## Coding Conventions
+
+- **TypeScript strict mode**, ESM-first.
+- **Branded/nominal types**: `@solana/nominal-types` provides `Brand<T, Name>` for types like `Address`, `Signature`, `Lamports` — these are branded primitives, not classes.
+- **Functional composition**: Use `pipe()` from `@solana/functional` to compose operations on transaction messages and other data structures.
+- **Platform-specific code**: Use `__BROWSER__`, `__NODEJS__`, `__REACTNATIVE__` guards. The build system will tree-shake unused branches.
+- **Dev-only code**: Guard with `__DEV__` (e.g. verbose error messages, debug assertions).
+- **Formatting**: ESLint via `@solana/eslint-config-solana`, Prettier via `@solana/prettier-config-solana`. Run `pnpm style:fix` to auto-fix.
+- **All publishable packages share a fixed version** (currently in lockstep).
+
+## Changesets & Releases
+
+- Use `npx changeset add --empty` to generate changeset files — never create them manually.
+- `patch` for fixes, `minor` for features, `major` for breaking changes (while pre-1.0, `minor` may be treated as breaking).
+- No changeset needed for docs-only changes, CI config, dev dependency updates, or test-only changes.
+- All publishable packages are version-locked via the `fixed` config in `.changeset/config.json`.
+
+## CI
+
+- **PRs**: Build + test on Node `current` and `lts/*`.
+- **Bundle size**: Monitored via BundleMon on every PR.
+- **Publishing**: On merge to `main`, changesets action creates a "Version Packages" PR or publishes to npm. Canary snapshots are published on every push to `main`.
+
+<!-- skills-inject:start -->
+
+## Skill Instructions
+
+The following instructions come from installed skills (autogenerated, do not edit manually) and should always be followed.
+
+### Changesets
+
+- Any PR that should trigger a package release MUST include a changeset.
+- Identify affected packages by mapping changed files to their nearest `package.json`.
+- Choose the right bump: `patch` for fixes, `minor` for features, `major` for breaking changes.
+- While a project is pre-1.0, `minor` bumps may be treated as breaking.
+- ALWAYS use `npx changeset add --empty` to generate a new changeset file with a random name. NEVER create changeset files manually.
+- No changeset needed for: docs-only changes, CI config, dev dependency updates, test-only changes.
+
+### Shipping (Git)
+
+- NEVER commit, push, create branches, or create PRs without explicit user approval.
+- Before any git operation that creates or modifies a commit, present a review block containing: changeset entry (if applicable), commit title, and commit/PR description. ALWAYS wait for approval.
+- Use standard `git add` and `git commit` workflows. Concise title on the first line, blank line, then description body.
+- Use `gh pr create` for pull requests.
+- Write commit and PR descriptions as natural flowing prose. Do NOT insert hard line breaks mid-paragraph.
+
+### Shipping (Graphite)
+
+- Check if [Graphite](https://graphite.dev/) is installed (`which gt`). Prefer Graphite when available; fall back to the Git shipping workflow otherwise.
+- NEVER commit, push, create branches, or create PRs without explicit user approval.
+- Before any git operation that creates or modifies a commit, present a review block containing: changeset entry (if applicable), commit title, and commit/PR description. ALWAYS wait for approval.
+- Use `gt create -am "Title" -m "Description body"` for new PRs. The first `-m` sets the commit title; the second sets the PR description.
+- Use `gt modify -a` to amend the current branch with follow-up changes (NEVER create additional commits on the same branch).
+- ALWAYS escape backticks in commit messages with backslashes for shell compatibility (e.g. `"Update \`my-package\` config"`).
+- Do NOT run `gt submit` after committing. Only run it when the user explicitly asks to submit or push.
+- Write commit and PR descriptions as natural flowing prose. Do NOT insert hard line breaks mid-paragraph.
+
+### TypeScript Docblocks
+
+- All exported functions, types, interfaces, and constants MUST have JSDoc docblocks.
+- Start with `/**`, use `*` prefix for each line, end with `*/` — each on its own line.
+- Begin with a clear one-to-two line summary. Add a blank line before tags.
+- Include `@param`, `@typeParam`, `@return`, `@throws`, and at least one `@example` when helpful.
+- Use `{@link ...}` to reference related items. Add `@see` tags at the end for related APIs.
+
+### TypeScript READMEs
+
+- When adding a new public API, add or update the package's README.
+- Structure: brief intro, installation, usage (with code snippet), deep-dive sections.
+- Code snippets must be realistic, concise, and use TypeScript syntax.
+- Focus on the quickest path to success. Developers should feel excited, not overwhelmed.
+
+<!-- skills-inject:end -->

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "skills": {
+    "changesets": {
+      "source": "lorisleiva/skills",
+      "sourceType": "github",
+      "computedHash": "d3cf32b97909632ddafd1af39de1b66f9b013990e13e78a83ab97abb50094364"
+    },
+    "shipping-git": {
+      "source": "lorisleiva/skills",
+      "sourceType": "github",
+      "computedHash": "1e730a4eadb36e5dccae01d0609fc9cfe634349961aa0e45f1b718dd31c2327f"
+    },
+    "shipping-graphite": {
+      "source": "lorisleiva/skills",
+      "sourceType": "github",
+      "computedHash": "bd7eebc15668ad09a6dac4c56f981c423a37b17b5fcce869ac93d5c6de36e26e"
+    },
+    "ts-docblocks": {
+      "source": "lorisleiva/skills",
+      "sourceType": "github",
+      "computedHash": "5aff2666b4cee7cd31cd21ff71a6951c7874b9df3ad3e8ca29367e11877d7824"
+    },
+    "ts-readme": {
+      "source": "lorisleiva/skills",
+      "sourceType": "github",
+      "computedHash": "e693e5a3f3c8a63786ecf52a8c4f8cb0f3870476c7266340ab950c705df08b9f"
+    }
+  }
+}


### PR DESCRIPTION
#### Problem

The repo had no `CLAUDE.md` file, so AI coding agents lacked the project context needed to work effectively within the Kit monorepo.

#### Summary of Changes

Adds a `CLAUDE.md` with comprehensive project context covering the monorepo overview, the companion `anza-xyz/kit-plugins` repo and Codama JS renderer relationship, getting started commands, package architecture and dependency layering, the build system (tsup/tsc, platform constants, `__DEV__`), testing conventions, the `SolanaError` system, coding conventions (branded types, `pipe()`, platform guards), changesets/releases, and CI. It also points agents to the `?format=md` query parameter on solanakit.com for LLM-friendly documentation access.

Additionally installs five reusable skills from `lorisleiva/skills` (changesets, shipping-git, shipping-graphite, ts-docblocks, ts-readme) under `.agents/skills/` and `.claude/skills/`, with their summaries injected into the `CLAUDE.md` via `skills-inject`.