### PR TITLE
Improve `FAILED_TO_EXECUTE_TRANSACTION_PLAN` error with flattened errors list

### DIFF
--- a/.changeset/slimy-ads-buy.md
+++ b/.changeset/slimy-ads-buy.md
@@ -1,0 +1,6 @@
+---
+'@solana/errors': patch
+'@solana/instruction-plans': patch
+---
+
+Add `errors` and `errorsList` to the `FAILED_TO_EXECUTE_TRANSACTION_PLAN` error context and include a formatted list of failed transactions in the error message. Extract error construction into a public `createFailedToExecuteTransactionPlanError` function for use by custom executors.

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -450,6 +450,8 @@ export type SolanaErrorContext = ReadonlyContextValue<
                 transactionPlanResult: unknown;
             };
             [SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN]: {
+                errors: readonly Error[];
+                errorsList: string;
                 transactionPlanResult: unknown;
             };
             [SOLANA_ERROR__INSTRUCTION_PLANS__MESSAGE_CANNOT_ACCOMMODATE_PLAN]: {

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -456,7 +456,7 @@ export const SolanaErrorMessages: Readonly<{
     [SOLANA_ERROR__INSTRUCTION_PLANS__NON_DIVISIBLE_TRANSACTION_PLANS_NOT_SUPPORTED]:
         'This transaction plan executor does not support non-divisible sequential plans. To support them, you may create your own executor such that multi-transaction atomicity is preserved — e.g. by targetting RPCs that support transaction bundles.',
     [SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN]:
-        'The provided transaction plan failed to execute. See the `transactionPlanResult` attribute for more details. Note that the `cause` property is deprecated, and a future version will not set it.',
+        'The provided transaction plan failed to execute.$errorsList\n\nNote that the `cause` property is deprecated, and a future version will not set it.',
     [SOLANA_ERROR__INSTRUCTION_PLANS__MESSAGE_CANNOT_ACCOMMODATE_PLAN]:
         'The provided message has insufficient capacity to accommodate the next instruction(s) in this plan. Expected at least $numBytesRequired free byte(s), got $numFreeBytes byte(s).',
     [SOLANA_ERROR__INVARIANT_VIOLATION__INVALID_TRANSACTION_PLAN_KIND]: 'Invalid transaction plan kind: $kind.',

--- a/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
@@ -12,6 +12,7 @@ import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/tran
 
 import {
     canceledSingleTransactionPlanResult,
+    createFailedToExecuteTransactionPlanError,
     createTransactionPlanExecutor,
     failedSingleTransactionPlanResult,
     nonDivisibleSequentialTransactionPlan,
@@ -33,12 +34,14 @@ async function expectFailedToExecute(
     promise: Promise<TransactionPlanResult>,
     error: SolanaError<typeof SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN>,
 ): Promise<void> {
-    const transactionPlanResult = error.context.transactionPlanResult;
-    // Check for the error code and message (but not the full context since transactionPlanResult is non-enumerable)
+    const { errors, errorsList, transactionPlanResult } = error.context;
+    // Check for the error code, errors, and errorsList (but not the full context since transactionPlanResult is non-enumerable)
     await expect(promise).rejects.toThrow(
         expect.objectContaining({
             context: expect.objectContaining({
                 __code: SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
+                errors,
+                errorsList,
             }),
             name: 'SolanaError',
         }),
@@ -229,6 +232,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [cause],
+                    errorsList: `\n[Tx #1] ${cause.message}`,
                     transactionPlanResult: failedSingleTransactionPlanResult(messageA, cause),
                 }),
             );
@@ -260,6 +265,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [cause],
+                    errorsList: `\n[Tx #1] ${cause.message}`,
                     transactionPlanResult: failedSingleTransactionPlanResult(messageA, cause, {
                         beforeFailure: 'before failure',
                         message: messageB,
@@ -291,6 +298,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [cause],
+                    errorsList: `\n[Tx #1] ${cause.message}`,
                     transactionPlanResult: failedSingleTransactionPlanResult(messageA, cause, {
                         signature: 'A' as Signature,
                         transaction: transactionA,
@@ -312,6 +321,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [cause],
+                    errorsList: `\n[Tx #1] ${cause.message}`,
                     transactionPlanResult: failedSingleTransactionPlanResult(messageA, cause),
                 }),
             );
@@ -334,6 +345,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [cause],
+                    errorsList: `\n[Tx #1] ${cause.message}`,
                     transactionPlanResult: failedSingleTransactionPlanResult(messageA, cause),
                 }),
             );
@@ -355,6 +368,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [],
+                    errorsList: '',
                     transactionPlanResult: canceledSingleTransactionPlanResult(messageA),
                 }),
             );
@@ -476,6 +491,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [cause],
+                    errorsList: `\n[Tx #2] ${cause.message}`,
                     transactionPlanResult: sequentialTransactionPlanResult([
                         successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
                         failedSingleTransactionPlanResult(messageB, cause),
@@ -497,6 +514,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [cause],
+                    errorsList: `\n[Tx #1] ${cause.message}`,
                     transactionPlanResult: sequentialTransactionPlanResult([
                         failedSingleTransactionPlanResult(messageA, cause),
                         canceledSingleTransactionPlanResult(messageB),
@@ -543,6 +562,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [cause],
+                    errorsList: `\n[Tx #2] ${cause.message}`,
                     transactionPlanResult: sequentialTransactionPlanResult([
                         successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
                         failedSingleTransactionPlanResult(messageB, cause),
@@ -574,6 +595,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [],
+                    errorsList: '',
                     transactionPlanResult: sequentialTransactionPlanResult([
                         canceledSingleTransactionPlanResult(messageA),
                         canceledSingleTransactionPlanResult(messageB),
@@ -679,6 +702,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [cause],
+                    errorsList: `\n[Tx #2] ${cause.message}`,
                     transactionPlanResult: parallelTransactionPlanResult([
                         successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
                         failedSingleTransactionPlanResult(messageB, cause),
@@ -716,6 +741,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [cause],
+                    errorsList: `\n[Tx #2] ${cause.message}`,
                     transactionPlanResult: parallelTransactionPlanResult([
                         successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
                         failedSingleTransactionPlanResult(messageB, cause),
@@ -743,6 +770,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [],
+                    errorsList: '',
                     transactionPlanResult: parallelTransactionPlanResult([
                         canceledSingleTransactionPlanResult(messageA),
                         canceledSingleTransactionPlanResult(messageB),
@@ -836,6 +865,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [cause],
+                    errorsList: `\n[Tx #3] ${cause.message}`,
                     transactionPlanResult: parallelTransactionPlanResult([
                         sequentialTransactionPlanResult([
                             successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
@@ -895,6 +926,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [cause],
+                    errorsList: `\n[Tx #3] ${cause.message}`,
                     transactionPlanResult: parallelTransactionPlanResult([
                         sequentialTransactionPlanResult([
                             successfulSingleTransactionPlanResultFromTransaction(messageA, createTransaction('A')),
@@ -943,6 +976,8 @@ describe('createTransactionPlanExecutor', () => {
                 promise,
                 new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
                     cause,
+                    errors: [],
+                    errorsList: '',
                     transactionPlanResult: parallelTransactionPlanResult([
                         sequentialTransactionPlanResult([
                             canceledSingleTransactionPlanResult(messageA),
@@ -964,6 +999,90 @@ describe('createTransactionPlanExecutor', () => {
     });
 });
 
+describe('createFailedToExecuteTransactionPlanError', () => {
+    it('creates an error with the correct error code', () => {
+        const cause = new Error('tx failed');
+        const result = failedSingleTransactionPlanResult(createMessage('A'), cause);
+        const error = createFailedToExecuteTransactionPlanError(result);
+        expect(error.context.__code).toBe(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN);
+    });
+
+    it('includes all errors from a complex plan result', () => {
+        const causeB = new Error('B failed');
+        const causeD = new Error('D failed');
+        const result = parallelTransactionPlanResult([
+            sequentialTransactionPlanResult([
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
+                failedSingleTransactionPlanResult(createMessage('B'), causeB),
+            ]),
+            sequentialTransactionPlanResult([
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('C'), createTransaction('C')),
+                failedSingleTransactionPlanResult(createMessage('D'), causeD),
+            ]),
+        ]);
+        const error = createFailedToExecuteTransactionPlanError(result);
+        expect(error.context.errors).toStrictEqual([causeB, causeD]);
+    });
+
+    it('formats errorsList with correct transaction indices based on flattened position', () => {
+        const causeB = new Error('B failed');
+        const causeD = new Error('D failed');
+        const result = parallelTransactionPlanResult([
+            sequentialTransactionPlanResult([
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('A'), createTransaction('A')),
+                failedSingleTransactionPlanResult(createMessage('B'), causeB),
+            ]),
+            sequentialTransactionPlanResult([
+                successfulSingleTransactionPlanResultFromTransaction(createMessage('C'), createTransaction('C')),
+                failedSingleTransactionPlanResult(createMessage('D'), causeD),
+            ]),
+        ]);
+        const error = createFailedToExecuteTransactionPlanError(result);
+        expect(error.context.errorsList).toBe('\n[Tx #2] B failed\n[Tx #4] D failed');
+    });
+
+    it('uses the first error found in the results as cause', () => {
+        const cause = new Error('tx failed');
+        const result = failedSingleTransactionPlanResult(createMessage('A'), cause);
+        const error = createFailedToExecuteTransactionPlanError(result);
+        expect(error.cause).toBe(cause);
+    });
+
+    it('uses the abort reason as cause when no errors are present in results', () => {
+        const abortReason = new Error('Aborted');
+        const result = canceledSingleTransactionPlanResult(createMessage('A'));
+        const error = createFailedToExecuteTransactionPlanError(result, abortReason);
+        expect(error.cause).toBe(abortReason);
+    });
+
+    it('prefers the first error over the abort reason as cause', () => {
+        const cause = new Error('tx failed');
+        const abortReason = new Error('Aborted');
+        const result = failedSingleTransactionPlanResult(createMessage('A'), cause);
+        const error = createFailedToExecuteTransactionPlanError(result, abortReason);
+        expect(error.cause).toBe(cause);
+    });
+
+    it('sets transactionPlanResult as a non-enumerable property', () => {
+        const cause = new Error('tx failed');
+        const result = failedSingleTransactionPlanResult(createMessage('A'), cause);
+        const error = createFailedToExecuteTransactionPlanError(result);
+        expect(error.context.transactionPlanResult).toBe(result);
+        const descriptor = Object.getOwnPropertyDescriptor(error.context, 'transactionPlanResult');
+        expect(descriptor?.enumerable).toBe(false);
+    });
+
+    it('produces empty errors and errorsList when all transactions are canceled', () => {
+        const result = parallelTransactionPlanResult([
+            canceledSingleTransactionPlanResult(createMessage('A')),
+            canceledSingleTransactionPlanResult(createMessage('B')),
+        ]);
+        const error = createFailedToExecuteTransactionPlanError(result);
+        expect(error.context.errors).toStrictEqual([]);
+        expect(error.context.errorsList).toBe('');
+    });
+});
+
 describe('passthroughFailedTransactionPlanExecution', () => {
     it('returns the resolved result as-is', async () => {
         expect.assertions(1);
@@ -973,12 +1092,12 @@ describe('passthroughFailedTransactionPlanExecution', () => {
     });
     it('returns the result inside the rejected execution error', async () => {
         expect.assertions(1);
-        const result = failedSingleTransactionPlanResult(
-            createMessage('A'),
-            new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE),
-        );
+        const cause = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+        const result = failedSingleTransactionPlanResult(createMessage('A'), cause);
         const promise = Promise.reject(
             new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, {
+                errors: [cause],
+                errorsList: `\n[Tx #1] ${cause.message}`,
                 transactionPlanResult: result,
             }),
         );

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -20,6 +20,7 @@ import {
     BaseTransactionPlanResultContext,
     canceledSingleTransactionPlanResult,
     failedSingleTransactionPlanResult,
+    flattenTransactionPlanResult,
     parallelTransactionPlanResult,
     sequentialTransactionPlanResult,
     SingleTransactionPlanResult,
@@ -66,6 +67,58 @@ export type TransactionPlanExecutorConfig<
     /** Called whenever a transaction message must be sent to the blockchain. */
     executeTransactionMessage: ExecuteTransactionMessage<TContext>;
 };
+
+/**
+ * Creates a {@link SolanaError} with the
+ * {@link SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN} error code
+ * from a {@link TransactionPlanResult}.
+ *
+ * This is useful for custom transaction plan executors that need to throw the
+ * same error as the one thrown by {@link createTransactionPlanExecutor} when a
+ * transaction plan fails to execute.
+ *
+ * @param transactionPlanResult - The result of the transaction plan execution.
+ * @param abortReason - An optional abort reason if the execution was aborted.
+ * @returns A {@link SolanaError} with the appropriate error code, context, and cause.
+ *
+ * @example
+ * ```ts
+ * const result = await myCustomExecutor(plan);
+ * if (hasFailed(result)) {
+ *     throw createFailedToExecuteTransactionPlanError(result);
+ * }
+ * ```
+ *
+ * @see {@link createTransactionPlanExecutor}
+ */
+export function createFailedToExecuteTransactionPlanError(
+    transactionPlanResult: TransactionPlanResult,
+    abortReason?: unknown,
+): SolanaError<typeof SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN> {
+    const flattenedResults = flattenTransactionPlanResult(transactionPlanResult);
+    const errors = flattenedResults
+        .filter((result): result is typeof result & { status: 'failed' } => result.status === 'failed')
+        .map(result => result.error);
+    const errorsList = flattenedResults
+        .map((result, index) => (result.status === 'failed' ? `\n[Tx #${index + 1}] ${result.error.message}` : null))
+        .filter((line): line is string => line !== null)
+        .join('');
+    const context = {
+        cause: findFirstErrorFromTransactionPlanResult(transactionPlanResult) ?? abortReason,
+        errors,
+        errorsList,
+    };
+    // Here we want the `transactionPlanResult` to be available in the error context
+    // so applications can create recovery plans but we don't want this object to be
+    // serialized with the error. This is why we set it as a non-enumerable property.
+    Object.defineProperty(context, 'transactionPlanResult', {
+        configurable: false,
+        enumerable: false,
+        value: transactionPlanResult,
+        writable: false,
+    });
+    return new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, context);
+}
 
 /**
  * Creates a new transaction plan executor based on the provided configuration.
@@ -140,17 +193,7 @@ export function createTransactionPlanExecutor<
 
         if (traverseConfig.canceled) {
             const abortReason = abortSignal?.aborted ? abortSignal.reason : undefined;
-            const context = { cause: findErrorFromTransactionPlanResult(transactionPlanResult) ?? abortReason };
-            // Here we want the `transactionPlanResult` to be available in the error context
-            // so applications can create recovery plans but we don't want this object to be
-            // serialized with the error. This is why we set it as a non-enumerable property.
-            Object.defineProperty(context, 'transactionPlanResult', {
-                configurable: false,
-                enumerable: false,
-                value: transactionPlanResult,
-                writable: false,
-            });
-            throw new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, context);
+            throw createFailedToExecuteTransactionPlanError(transactionPlanResult, abortReason);
         }
 
         return transactionPlanResult;
@@ -235,12 +278,12 @@ async function traverseSingle<TContext extends TransactionPlanResultContext>(
     }
 }
 
-function findErrorFromTransactionPlanResult(result: TransactionPlanResult): Error | undefined {
+function findFirstErrorFromTransactionPlanResult(result: TransactionPlanResult): Error | undefined {
     if (result.kind === 'single') {
         return result.status === 'failed' ? result.error : undefined;
     }
     for (const plan of result.plans) {
-        const error = findErrorFromTransactionPlanResult(plan);
+        const error = findFirstErrorFromTransactionPlanResult(plan);
         if (error) {
             return error;
         }


### PR DESCRIPTION
#### Problem

The `SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN` error provides limited context when a transaction plan fails. Developers must inspect the non-enumerable `transactionPlanResult` to understand which transactions failed and why. The error construction logic is also internal, making it harder for custom executor implementations to throw the same well-structured error.

#### Summary of Changes

This PR adds an `errors` array and a formatted `errorsList` string to the error context, so failed transactions are visible directly in the error message (e.g. `[Tx https://github.com/anza-xyz/kit/pull/3] custom program error: #6002`). The deprecation notice for the `cause` property is moved to the end of the message for better readability.

The error construction logic is extracted into a new public `createFailedToExecuteTransactionPlanError` function so that custom transaction plan executors can produce the same error structure.