### PR TITLE
Add a codec for v1 CompiledTransactionMessage

### DIFF
--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -772,7 +772,7 @@ export const SolanaErrorMessages: Readonly<{
     [SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_OUT_OF_RANGE]:
         'Transaction version must be in the range [0, 127]. `$actualVersion` given',
     [SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_NOT_SUPPORTED]:
-        'This version of Kit does not support decoding transactions with version $unsupportedVersion. The current max supported version is 0.',
+        'This version of Kit does not support decoding transactions with version $unsupportedVersion. The current max supported version is 1.',
     [SOLANA_ERROR__TRANSACTION__NONCE_ACCOUNT_CANNOT_BE_IN_LOOKUP_TABLE]:
         'The transaction has a durable nonce lifetime (with nonce `$nonce`), but the nonce account address is in a lookup table. The lifetime constraint cannot be constructed without fetching the lookup tables for the transaction.',
     [SOLANA_ERROR__TRANSACTION__INVALID_CONFIG_MASK_PRIORITY_FEE_BITS]:

--- a/packages/transaction-messages/src/codecs/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/codecs/__tests__/message-test.ts
@@ -1,7 +1,13 @@
 import { Address } from '@solana/addresses';
-import { Decoder, Encoder } from '@solana/codecs-core';
+import { SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_NOT_SUPPORTED, SolanaError } from '@solana/errors';
 
-import { CompiledTransactionMessage, CompiledTransactionMessageWithLifetime } from '../../compile/message';
+import {
+    CompiledTransactionMessage,
+    CompiledTransactionMessageWithLifetime,
+    LegacyCompiledTransactionMessage,
+    V0CompiledTransactionMessage,
+    V1CompiledTransactionMessage,
+} from '../../compile/message';
 import {
     getCompiledTransactionMessageCodec,
     getCompiledTransactionMessageDecoder,
@@ -9,137 +15,40 @@ import {
 } from '../message';
 
 describe.each([getCompiledTransactionMessageCodec, getCompiledTransactionMessageEncoder])(
-    'Transaction message serializer %p',
-    serializerFactory => {
-        let compiledMessage: Encoder<
-            CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime)
-        >;
-        beforeEach(() => {
-            compiledMessage = serializerFactory();
-        });
-        it('serializes a transaction according to the spec', () => {
-            const byteArray = compiledMessage.encode({
-                addressTableLookups: [
-                    {
-                        lookupTableAddress: '3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7' as Address, // decodes to [44{32}]
-                        readonlyIndexes: [77],
-                        writableIndexes: [66, 55],
-                    },
-                ],
+    'Message encoder %p',
+    encoderFactory => {
+        const encoder = encoderFactory();
+
+        it('encodes a legacy transaction correctly', () => {
+            const encoder = encoderFactory();
+            const message: CompiledTransactionMessageWithLifetime & LegacyCompiledTransactionMessage = {
                 header: {
                     numReadonlyNonSignerAccounts: 1,
                     numReadonlySignerAccounts: 2,
                     numSignerAccounts: 3,
                 },
                 instructions: [
-                    { programAddressIndex: 44 },
-                    { accountIndices: [77, 66], data: new Uint8Array([7, 8, 9]), programAddressIndex: 55 },
-                ],
-                lifetimeToken: '3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL', // decodes to [33{32}]
-                staticAccounts: [
-                    'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn', // decodes to [11{32}]
-                    '2VDW9dFE1ZXz4zWAbaBDQFynNVdRpQ73HyfSHMzBSL6Z', // decodes to [22{32}]
-                ] as Address[],
-                version: 0,
-            });
-            expect(byteArray).toStrictEqual(
-                // prettier-ignore
-                new Uint8Array([
-                    /** VERSION HEADER */
-                    128, // 0 + version mask
-
-                    /** MESSAGE HEADER */
-                    3, // numSignerAccounts
-                    2, // numReadonlySignerAccount
-                    1, // numReadonlyNonSignerAccounts
-
-                    /** STATIC ADDRESSES */
-                    2, // Number of static accounts
-                    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
-                    22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, // 2VDW9dFE1ZXz4zWAbaBDQFynNVdRpQ73HyfSHMzBSL6Z
-
-                    /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
-                    33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, // 3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL
-
-                    /* INSTRUCTIONS */
-                    2, // Number of instructions
-
-                    // First instruction
-                    44, // Program address index
-                    0, // Number of address indices
-                    0, // Length of instruction data
-
-                    // Second instruction
-                    55, // Program address index
-                    2, // Number of address indices
-                    77, 66, // Address indices
-                    3, // Length of instruction data
-                    7, 8, 9, // Instruction data itself
-
-                    /** ADDRESS TABLE LOOKUPS */
-                    1, // Number of address table lookups
-
-                    // First address table lookup
-                    44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, // Address of lookup table 3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7
-                    2, // Number of writable indices
-                    66, 55, // Writable indices
-                    1, // Number of readonly indices
-                    77, // Readonly indices
-                ]),
-            );
-        });
-        it('serializes a versioned transaction with `undefined` address table lookups', () => {
-            const byteArray = compiledMessage.encode({
-                /** `addressTableLookups` is not defined */
-                header: {
-                    numReadonlyNonSignerAccounts: 1,
-                    numReadonlySignerAccounts: 2,
-                    numSignerAccounts: 3,
-                },
-                instructions: [],
-                lifetimeToken: 'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn', // decodes to [11{32}]
-                staticAccounts: [],
-                version: 0,
-            });
-            expect(byteArray).toStrictEqual(
-                // prettier-ignore
-                new Uint8Array([
-                    /** VERSION HEADER */
-                    128, // 0 + version mask
-
-                    /** MESSAGE HEADER */
-                    3, // numSignerAccounts
-                    2, // numReadonlySignerAccount
-                    1, // numReadonlyNonSignerAccounts
-
-                    /** STATIC ADDRESSES */
-                    0, // Number of static accounts
-
-                    /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
-                    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // 3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL
-
-                    /* INSTRUCTIONS */
-                    0, // Number of instructions
-
-                    /** ADDRESS TABLE LOOKUPS get serialized despite not being in the source object */
-                    0, // Number of address table lookups
-                ]),
-            );
-        });
-        it('omits the version header for `legacy` transactions', () => {
-            expect(
-                compiledMessage.encode({
-                    header: {
-                        numReadonlyNonSignerAccounts: 1,
-                        numReadonlySignerAccounts: 2,
-                        numSignerAccounts: 3,
+                    {
+                        accountIndices: [1, 2],
+                        data: new Uint8Array([4, 5, 6]),
+                        programAddressIndex: 0,
                     },
-                    instructions: [],
-                    lifetimeToken: 'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn', // decodes to [11{32}]
-                    staticAccounts: [],
-                    version: 'legacy',
-                }),
-            ).toStrictEqual(
+                    {
+                        accountIndices: [2],
+                        data: new Uint8Array([7, 8, 9]),
+                        programAddressIndex: 1,
+                    },
+                ],
+                lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5', // encodes to [10{32}]
+                staticAccounts: [
+                    'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address, // encodes to [11{32}]
+                    'p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV' as Address, // encodes to [12{32}]
+                    'swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC' as Address, // encodes to [13{32}]
+                ],
+                version: 'legacy',
+            };
+
+            expect(encoder.encode(message)).toStrictEqual(
                 // prettier-ignore
                 new Uint8Array([
                     /** NO VERSION HEADER */
@@ -150,107 +59,36 @@ describe.each([getCompiledTransactionMessageCodec, getCompiledTransactionMessage
                     1, // numReadonlyNonSignerAccounts
 
                     /** STATIC ADDRESSES */
-                    0, // Number of static accounts
+                    3, // Number of static accounts
+                    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                    12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, // p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV
+                    13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC
 
                     /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
-                    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
-
-                    /* INSTRUCTIONS */
-                    0, // Number of instructions
-                ]),
-            );
-        });
-        it('omits the address table lookups for `legacy` transactions', () => {
-            expect(
-                getCompiledTransactionMessageCodec().encode({
-                    header: {
-                        numReadonlyNonSignerAccounts: 1,
-                        numReadonlySignerAccounts: 2,
-                        numSignerAccounts: 3,
-                    },
-                    instructions: [],
-                    lifetimeToken: 'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn', // decodes to [11{32}]
-                    staticAccounts: [],
-                    version: 'legacy',
-                }),
-            ).toStrictEqual(
-                // prettier-ignore
-                new Uint8Array([
-                    /** MESSAGE HEADER */
-                    3, // numSignerAccounts
-                    2, // numReadonlySignerAccount
-                    1, // numReadonlyNonSignerAccounts
-
-                    /** STATIC ADDRESSES */
-                    0, // Number of static accounts
-
-                    /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
-                    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
-
-                    /* INSTRUCTIONS */
-                    0, // Number of instructions
-
-                    /** NO ADDRESS TABLE LOOKUPS */
-                ]),
-            );
-        });
-    },
-);
-
-describe.each([getCompiledTransactionMessageCodec, getCompiledTransactionMessageDecoder])(
-    'Transaction message deserializer %p',
-    serializerFactory => {
-        let compiledMessage: Decoder<CompiledTransactionMessage>;
-        beforeEach(() => {
-            compiledMessage = serializerFactory();
-        });
-        it('deserializes a version 0 transaction according to the spec', () => {
-            const byteArray =
-                // prettier-ignore
-                new Uint8Array([
-                    /** VERSION HEADER */
-                    128, // 0 + version mask
-
-                    /** MESSAGE HEADER */
-                    3, // numSignerAccounts
-                    2, // numReadonlySignerAccount
-                    1, // numReadonlyNonSignerAccounts
-
-                    /** STATIC ADDRESSES */
-                    2, // Number of static accounts
-                    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
-                    22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, // 2VDW9dFE1ZXz4zWAbaBDQFynNVdRpQ73HyfSHMzBSL6Z
-
-                    /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
-                    33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, // 3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL
+                    10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5
 
                     /* INSTRUCTIONS */
                     2, // Number of instructions
 
                     // First instruction
-                    44, // Program address index
-                    0, // Number of address indices
-                    0, // Length of instruction data
+                    0, // Program address index
+                    2, // Number of address indices
+                    1, 2, // Address indices
+                    3, // Length of instruction data
+                    4, 5, 6, // Instruction data itself
 
                     // Second instruction
-                    55, // Program address index
-                    2, // Number of address indices
-                    77, 66, // Address indices
+                    1, // Program address index
+                    1, // Number of address indices
+                    2, // Address indices
                     3, // Length of instruction data
                     7, 8, 9, // Instruction data itself
+                ]),
+            );
+        });
 
-                    /** ADDRESS TABLE LOOKUPS */
-                    1, // Number of address table lookups
-
-                    // First address table lookup
-                    44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, // Address of lookup table 3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7
-                    2, // Number of writable indices
-                    66, 55, // Writable indices
-                    1, // Number of readonly indices
-                    77, // Readonly indices
-                ]);
-            const [message, offset] = compiledMessage.read(byteArray, 0);
-            expect(message).toStrictEqual({
+        it('encodes a v0 transaction with address lookup tables correctly', () => {
+            const message: CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage = {
                 addressTableLookups: [
                     {
                         lookupTableAddress: '3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7' as Address, // decodes to [44{32}]
@@ -264,96 +102,381 @@ describe.each([getCompiledTransactionMessageCodec, getCompiledTransactionMessage
                     numSignerAccounts: 3,
                 },
                 instructions: [
-                    { programAddressIndex: 44 },
-                    { accountIndices: [77, 66], data: new Uint8Array([7, 8, 9]), programAddressIndex: 55 },
+                    {
+                        accountIndices: [1, 2],
+                        data: new Uint8Array([4, 5, 6]),
+                        programAddressIndex: 0,
+                    },
+                    {
+                        accountIndices: [2],
+                        data: new Uint8Array([7, 8, 9]),
+                        programAddressIndex: 1,
+                    },
                 ],
-                lifetimeToken: '3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL', // decodes to [33{32}]
+                lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5', // encodes to [10{32}]
                 staticAccounts: [
-                    'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn', // decodes to [11{32}]
-                    '2VDW9dFE1ZXz4zWAbaBDQFynNVdRpQ73HyfSHMzBSL6Z', // decodes to [22{32}]
-                ] as Address[],
+                    'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address, // encodes to [11{32}]
+                    'p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV' as Address, // encodes to [12{32}]
+                    'swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC' as Address, // encodes to [13{32}]
+                ],
                 version: 0,
-            });
-            // Expect the entire byte array to have been consumed.
-            expect(offset).toBe(byteArray.byteLength);
-        });
-        it('omits the `addressTableLookups` property of a versioned transaction when the address table lookups are zero-length', () => {
-            expect(
-                compiledMessage.decode(
-                    // prettier-ignore
-                    new Uint8Array([
-                        /** VERSION HEADER */
-                        128, // 0 + version mask
+            };
 
-                        /** MESSAGE HEADER */
-                        3, // numSignerAccounts
-                        2, // numReadonlySignerAccount
-                        1, // numReadonlyNonSignerAccounts
-
-                        /** STATIC ADDRESSES */
-                        0, // Number of static accounts
-
-                        /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
-                        33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, // 3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL
-
-                        /* INSTRUCTIONS */
-                        0, // Number of instructions
-                    ]),
-                ),
-            ).not.toHaveProperty('addressTableLookups');
-        });
-        it('deserializes a legacy transaction according to the spec', () => {
-            const byteArray =
+            expect(encoder.encode(message)).toStrictEqual(
                 // prettier-ignore
                 new Uint8Array([
+                    /** VERSION HEADER */
+                    128, // 0 + version mask
+
                     /** MESSAGE HEADER */
                     3, // numSignerAccounts
                     2, // numReadonlySignerAccount
                     1, // numReadonlyNonSignerAccounts
 
                     /** STATIC ADDRESSES */
-                    2, // Number of static accounts
+                    3, // Number of static accounts
                     11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
-                    22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, // 2VDW9dFE1ZXz4zWAbaBDQFynNVdRpQ73HyfSHMzBSL6Z
+                    12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, // p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV
+                    13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC
 
                     /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
-                    33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, 33, // 3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL
+                    10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5
 
                     /* INSTRUCTIONS */
                     2, // Number of instructions
 
                     // First instruction
-                    44, // Program address index
-                    0, // Number of address indices
-                    0, // Length of instruction data
+                    0, // Program address index
+                    2, // Number of address indices
+                    1, 2, // Address indices
+                    3, // Length of instruction data
+                    4, 5, 6, // Instruction data itself
 
                     // Second instruction
-                    55, // Program address index
+                    1, // Program address index
+                    1, // Number of address indices
+                    2, // Address indices
+                    3, // Length of instruction data
+                    7, 8, 9, // Instruction data itself
+
+                    /** ADDRESS TABLE LOOKUPS */
+                    1, // Number of address table lookups
+
+                    // First address table lookup
+                    44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, // Address of lookup table 3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7
+                    2, // Number of writable indices
+                    66, 55, // Writable indices
+                    1, // Number of readonly indices
+                    77, // Readonly indices
+                ]),
+            );
+        });
+
+        it('encodes a v1 transaction with all config values', () => {
+            const message: CompiledTransactionMessageWithLifetime & V1CompiledTransactionMessage = {
+                configMask: 0b11111,
+                // All config flags set
+                configValues: [
+                    { kind: 'u64', value: 5000n }, // Priority fee
+                    { kind: 'u32', value: 200000 }, // Compute unit limit
+                    { kind: 'u32', value: 64000 }, // Loaded accounts data size limit
+                    { kind: 'u32', value: 256000 }, // Heap size
+                ],
+
+                header: {
+                    numReadonlyNonSignerAccounts: 0,
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1,
+                },
+
+                instructionHeaders: [],
+
+                instructionPayloads: [],
+                lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5',
+                numInstructions: 0,
+                numStaticAccounts: 1,
+                staticAccounts: ['k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address],
+                version: 1,
+            };
+
+            expect(encoder.encode(message)).toStrictEqual(
+                // prettier-ignore
+                new Uint8Array([
+                    /** VERSION HEADER */
+                    129,
+
+                    /** MESSAGE HEADER */
+                    1, 0, 0,
+
+                    /** CONFIG MASK */
+                    31, 0, 0, 0, // configMask (u32) = 0b11111
+
+                    /** LIFETIME TOKEN */
+                    10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+
+                    /** NUM INSTRUCTIONS */
+                    0,
+
+                    /** NUM ADDRESSES */
+                    1,
+
+                    /** STATIC ADDRESSES */
+                    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+
+                    /** CONFIG VALUES */
+                    136, 19, 0, 0, 0, 0, 0, 0, // 5000 as u64
+                    64, 13, 3, 0, // 200000 as u32
+                    0, 250, 0, 0, // 64000 as u32
+                    0, 232, 3, 0, // 256000 as u32
+
+                    /** INSTRUCTION HEADERS */
+                    // (none)
+
+                    /** INSTRUCTION PAYLOADS */
+                    // (none)
+                ]),
+            );
+        });
+
+        it('errors when encoding an unsupported v2 transaction', () => {
+            const message = {
+                version: 2,
+            } as unknown as CompiledTransactionMessage & CompiledTransactionMessageWithLifetime;
+
+            expect(() => encoder.encode(message)).toThrow(
+                new SolanaError(SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_NOT_SUPPORTED, {
+                    unsupportedVersion: 2,
+                }),
+            );
+        });
+    },
+);
+
+describe.each([getCompiledTransactionMessageCodec, getCompiledTransactionMessageDecoder])(
+    'Message decoder %p',
+    decoderFactory => {
+        const decoder = decoderFactory();
+
+        it('decodes a legacy transaction correctly', () => {
+            const byteArray =
+                // prettier-ignore
+                new Uint8Array([
+                    /** NO VERSION HEADER */
+
+                    /** MESSAGE HEADER */
+                    3, // numSignerAccounts
+                    2, // numReadonlySignerAccount
+                    1, // numReadonlyNonSignerAccounts
+
+                    /** STATIC ADDRESSES */
+                    3, // Number of static accounts
+                    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                    12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, // p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV
+                    13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC
+
+                    /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                    10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5
+
+                    /* INSTRUCTIONS */
+                    2, // Number of instructions
+
+                    // First instruction
+                    0, // Program address index
                     2, // Number of address indices
-                    77, 66, // Address indices
+                    1, 2, // Address indices
+                    3, // Length of instruction data
+                    4, 5, 6, // Instruction data itself
+
+                    // Second instruction
+                    1, // Program address index
+                    1, // Number of address indices
+                    2, // Address indices
                     3, // Length of instruction data
                     7, 8, 9, // Instruction data itself
                 ]);
-            const [message, offset] = compiledMessage.read(byteArray, 0);
-            expect(message).toStrictEqual({
+
+            const expectedMessage: CompiledTransactionMessageWithLifetime & LegacyCompiledTransactionMessage = {
                 header: {
                     numReadonlyNonSignerAccounts: 1,
                     numReadonlySignerAccounts: 2,
                     numSignerAccounts: 3,
                 },
                 instructions: [
-                    { programAddressIndex: 44 },
-                    { accountIndices: [77, 66], data: new Uint8Array([7, 8, 9]), programAddressIndex: 55 },
+                    {
+                        accountIndices: [1, 2],
+                        data: new Uint8Array([4, 5, 6]),
+                        programAddressIndex: 0,
+                    },
+                    {
+                        accountIndices: [2],
+                        data: new Uint8Array([7, 8, 9]),
+                        programAddressIndex: 1,
+                    },
                 ],
-                lifetimeToken: '3EKkiwNLWqoUbzFkPrmKbtUB4EweE6f4STzevYUmezeL', // decodes to [33{32}]
+                lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5', // decodes to [10{32}]
                 staticAccounts: [
-                    'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn', // decodes to [11{32}]
-                    '2VDW9dFE1ZXz4zWAbaBDQFynNVdRpQ73HyfSHMzBSL6Z', // decodes to [22{32}]
-                ] as Address[],
+                    'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address, // decodes to [11{32}]
+                    'p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV' as Address, // decodes to [12{32}]
+                    'swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC' as Address, // decodes to [13{32}]
+                ],
                 version: 'legacy',
+            };
+
+            expect(decoder.decode(byteArray)).toStrictEqual(expectedMessage);
+        });
+
+        it('decodes a v0 transaction with address lookup tables correctly', () => {
+            const byteArray =
+                // prettier-ignore
+                new Uint8Array([
+                    /** VERSION HEADER */
+                    128, // 0 + version mask
+
+                    /** MESSAGE HEADER */
+                    3, // numSignerAccounts
+                    2, // numReadonlySignerAccount
+                    1, // numReadonlyNonSignerAccounts
+
+                    /** STATIC ADDRESSES */
+                    3, // Number of static accounts
+                    11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, // k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn
+                    12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, // p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV
+                    13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, // swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC
+
+                    /** TRANSACTION LIFETIME TOKEN (ie. the blockhash) */
+                    10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, // gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5
+
+                    /* INSTRUCTIONS */
+                    2, // Number of instructions
+
+                    // First instruction
+                    0, // Program address index
+                    2, // Number of address indices
+                    1, 2, // Address indices
+                    3, // Length of instruction data
+                    4, 5, 6, // Instruction data itself
+
+                    // Second instruction
+                    1, // Program address index
+                    1, // Number of address indices
+                    2, // Address indices
+                    3, // Length of instruction data
+                    7, 8, 9, // Instruction data itself
+
+                    /** ADDRESS TABLE LOOKUPS */
+                    1, // Number of address table lookups
+
+                    // First address table lookup
+                    44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, 44, // Address of lookup table 3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7
+                    2, // Number of writable indices
+                    66, 55, // Writable indices
+                    1, // Number of readonly indices
+                    77, // Readonly indices
+                ]);
+
+            const expectedMessage: CompiledTransactionMessageWithLifetime & V0CompiledTransactionMessage = {
+                addressTableLookups: [
+                    {
+                        lookupTableAddress: '3yS1JFVT284y8z1LC9MRoWxZjzFrdoD5axKsZiyMsfC7' as Address, // decodes to [44{32}]
+                        readonlyIndexes: [77],
+                        writableIndexes: [66, 55],
+                    },
+                ],
+                header: {
+                    numReadonlyNonSignerAccounts: 1,
+                    numReadonlySignerAccounts: 2,
+                    numSignerAccounts: 3,
+                },
+                instructions: [
+                    {
+                        accountIndices: [1, 2],
+                        data: new Uint8Array([4, 5, 6]),
+                        programAddressIndex: 0,
+                    },
+                    {
+                        accountIndices: [2],
+                        data: new Uint8Array([7, 8, 9]),
+                        programAddressIndex: 1,
+                    },
+                ],
+                lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5', // decodes to [10{32}]
+                staticAccounts: [
+                    'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address, // decodes to [11{32}]
+                    'p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV' as Address, // decodes to [12{32}]
+                    'swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC' as Address, // decodes to [13{32}]
+                ],
+                version: 0,
+            };
+
+            expect(decoder.decode(byteArray)).toStrictEqual(expectedMessage);
+        });
+
+        it('decodes a v1 transaction with all config values', () => {
+            // prettier-ignore
+            const bytes = new Uint8Array([
+                /** VERSION HEADER */
+                129,
+
+                /** MESSAGE HEADER */
+                1, 0, 0,
+
+                /** CONFIG MASK */
+                31, 0, 0, 0, // configMask (u32) = 0b11111
+
+                /** LIFETIME TOKEN */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+
+                /** NUM INSTRUCTIONS */
+                0,
+
+                /** NUM ADDRESSES */
+                1,
+
+                /** STATIC ADDRESSES */
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+
+                /** CONFIG VALUES */
+                136, 19, 0, 0, 0, 0, 0, 0, // 5000 as u64
+                64, 13, 3, 0, // 200000 as u32
+                0, 250, 0, 0, // 64000 as u32
+                0, 232, 3, 0, // 256000 as u32
+
+                /** INSTRUCTION HEADERS */
+                // (none)
+
+                /** INSTRUCTION PAYLOADS */
+                // (none)
+            ]);
+
+            const message = decoder.decode(bytes);
+
+            expect(message).toMatchObject({
+                configMask: 31,
+                configValues: [
+                    { kind: 'u64', value: 5000n },
+                    { kind: 'u32', value: 200000 },
+                    { kind: 'u32', value: 64000 },
+                    { kind: 'u32', value: 256000 },
+                ],
+                version: 1,
             });
-            // Expect the entire byte array to have been consumed.
-            expect(offset).toBe(byteArray.byteLength);
+        });
+
+        it('errors when decoding a transaction with an unsupported version', () => {
+            // prettier-ignore
+            const bytes = new Uint8Array([
+                /** VERSION HEADER */
+                130, // 2 + version mask (0x80)
+
+                /** The rest of the bytes don't matter since the decoder should error on the version */
+                0, 0, 0, 0,
+            ]);
+
+            expect(() => decoder.decode(bytes)).toThrow(
+                new SolanaError(SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_NOT_SUPPORTED, {
+                    unsupportedVersion: 2,
+                }),
+            );
         });
     },
 );

--- a/packages/transaction-messages/src/codecs/message.ts
+++ b/packages/transaction-messages/src/codecs/message.ts
@@ -1,19 +1,23 @@
 import {
     combineCodec,
     createDecoder,
+    transformEncoder,
     VariableSizeCodec,
     VariableSizeDecoder,
     VariableSizeEncoder,
 } from '@solana/codecs-core';
 import { getPatternMatchDecoder, getPatternMatchEncoder } from '@solana/codecs-data-structures';
+import { SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_NOT_SUPPORTED, SolanaError } from '@solana/errors';
 
 import { CompiledTransactionMessage, CompiledTransactionMessageWithLifetime } from '../compile/message';
+import { MAX_SUPPORTED_TRANSACTION_VERSION } from '../transaction-message';
 import {
     getMessageDecoder as getLegacyMessageDecoder,
     getMessageEncoder as getLegacyMessageEncoder,
 } from './legacy/message';
 import { getTransactionVersionDecoder } from './transaction-version';
 import { getMessageDecoder as getV0MessageDecoder, getMessageEncoder as getV0MessageEncoder } from './v0/message';
+import { getMessageDecoder as getV1MessageDecoder, getMessageEncoder as getV1MessageEncoder } from './v1/message';
 
 /**
  * Returns an encoder that you can use to encode a {@link CompiledTransactionMessage} to a byte
@@ -25,12 +29,24 @@ import { getMessageDecoder as getV0MessageDecoder, getMessageEncoder as getV0Mes
 export function getCompiledTransactionMessageEncoder(): VariableSizeEncoder<
     CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime)
 > {
-    return getPatternMatchEncoder<
-        CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime)
-    >([
-        [m => m.version === 'legacy', getLegacyMessageEncoder()],
-        [m => m.version === 0, getV0MessageEncoder()],
-    ]);
+    return transformEncoder(
+        getPatternMatchEncoder<
+            CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime)
+        >([
+            [m => m.version === 'legacy', getLegacyMessageEncoder()],
+            [m => m.version === 0, getV0MessageEncoder()],
+            [m => m.version === 1, getV1MessageEncoder()],
+        ]),
+        value => {
+            // check version is valid before encoding, so we don't get the generic pattern match error
+            if (value.version !== 'legacy' && value.version > MAX_SUPPORTED_TRANSACTION_VERSION) {
+                throw new SolanaError(SOLANA_ERROR__TRANSACTION__VERSION_NUMBER_NOT_SUPPORTED, {
+                    unsupportedVersion: value.version,
+                });
+            }
+            return value;
+        },
+    );
 }
 
 /**
@@ -43,23 +59,16 @@ export function getCompiledTransactionMessageEncoder(): VariableSizeEncoder<
 export function getCompiledTransactionMessageDecoder(): VariableSizeDecoder<
     CompiledTransactionMessage & CompiledTransactionMessageWithLifetime
 > {
+    type ReturnType = VariableSizeDecoder<CompiledTransactionMessage & CompiledTransactionMessageWithLifetime>;
+
     return createDecoder({
         read(bytes, offset) {
             const [version] = getTransactionVersionDecoder().read(bytes, offset);
 
             return getPatternMatchDecoder([
-                [
-                    () => version === 'legacy',
-                    getLegacyMessageDecoder() as VariableSizeDecoder<
-                        CompiledTransactionMessage & CompiledTransactionMessageWithLifetime
-                    >,
-                ],
-                [
-                    () => version === 0,
-                    getV0MessageDecoder() as VariableSizeDecoder<
-                        CompiledTransactionMessage & CompiledTransactionMessageWithLifetime
-                    >,
-                ],
+                [() => version === 'legacy', getLegacyMessageDecoder() as ReturnType],
+                [() => version === 0, getV0MessageDecoder() as ReturnType],
+                [() => version === 1, getV1MessageDecoder() as ReturnType],
             ]).read(bytes, offset);
         },
     });

--- a/packages/transaction-messages/src/codecs/v1/__tests__/config-test.ts
+++ b/packages/transaction-messages/src/codecs/v1/__tests__/config-test.ts
@@ -1,230 +1,36 @@
 import { SOLANA_ERROR__TRANSACTION__INVALID_CONFIG_MASK_PRIORITY_FEE_BITS, SolanaError } from '@solana/errors';
 
-import { TransactionConfig } from '../../../transaction-config';
-import { getTransactionConfigMaskEncoder, getTransactionConfigValuesEncoder } from '../config';
-import { getConfigValuesDecoder } from '../config';
-
-describe('getTransactionConfigMaskEncoder', () => {
-    const encoder = getTransactionConfigMaskEncoder();
-
-    it('should encode a mask with all values unset correctly', () => {
-        const config: TransactionConfig = {};
-        const encoded = encoder.encode(config);
-
-        // All bits 0, the lowest 5 are our config bits
-        const expectedFirstByte = 0b00000000;
-        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
-    });
-
-    it('should encode a mask with all values set correctly', () => {
-        const config: TransactionConfig = {
-            computeUnitLimit: 100,
-            heapSize: 100,
-            loadedAccountsDataSizeLimit: 100,
-            priorityFeeLamports: 100n,
-        };
-        const encoded = encoder.encode(config);
-
-        // Lowest 5 bits set to 1, rest are 0
-        // Followed by 3 bytes of 0 for padding to 4 bytes total
-        const expectedFirstByte = 0b00011111;
-        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
-    });
-
-    it('should encode a mask with just priority fee set correctly', () => {
-        const config: TransactionConfig = {
-            priorityFeeLamports: 100n,
-        };
-        const encoded = encoder.encode(config);
-
-        // Lowest two bits set to 1, rest are 0
-        // Followed by 3 bytes of 0 for padding to 4 bytes total
-        const expectedFirstByte = 0b00000011;
-        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
-    });
-
-    it('should encode a mask with just compute unit limit set correctly', () => {
-        const config: TransactionConfig = {
-            computeUnitLimit: 100,
-        };
-        const encoded = encoder.encode(config);
-
-        // Third lowest bit set to 1, rest are 0
-        // Followed by 3 bytes of 0 for padding to 4 bytes total
-        const expectedFirstByte = 0b00000100;
-        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
-    });
-
-    it('should encode a mask with just loaded accounts data size limit set correctly', () => {
-        const config: TransactionConfig = {
-            loadedAccountsDataSizeLimit: 100,
-        };
-        const encoded = encoder.encode(config);
-
-        // Fourth lowest bit set to 1, rest are 0
-        // Followed by 3 bytes of 0 for padding to 4 bytes total
-        const expectedFirstByte = 0b00001000;
-        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
-    });
-
-    it('should encode a mask with just heap size set correctly', () => {
-        const config: TransactionConfig = {
-            heapSize: 100,
-        };
-        const encoded = encoder.encode(config);
-
-        // Fifth lowest bit set to 1, rest are 0
-        // Followed by 3 bytes of 0 for padding to 4 bytes total
-        const expectedFirstByte = 0b00010000;
-        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
-    });
-
-    it('should encode a mask with multiple values set correctly', () => {
-        const config: TransactionConfig = {
-            loadedAccountsDataSizeLimit: 100,
-            priorityFeeLamports: 100n,
-        };
-        const encoded = encoder.encode(config);
-
-        // First, second and fourth lowest bits set to 1, rest are 0
-        // Followed by 3 bytes of 0 for padding to 4 bytes total
-        const expectedFirstByte = 0b00001011;
-        expect(encoded).toEqual(new Uint8Array([expectedFirstByte, 0, 0, 0]));
-    });
-});
+import { CompiledTransactionConfigValue } from '../../../compile/v1/config';
+import { getCompiledTransactionConfigValuesDecoder, getCompiledTransactionConfigValuesEncoder } from '../config';
 
 describe('getTransactionConfigValuesEncoder', () => {
-    const encoder = getTransactionConfigValuesEncoder();
+    const encoder = getCompiledTransactionConfigValuesEncoder();
 
     it('should encode to an empty array when no values are set', () => {
-        const config: TransactionConfig = {};
+        const config: CompiledTransactionConfigValue[] = [];
         const encoded = encoder.encode(config);
         expect(encoded).toEqual(new Uint8Array([]));
     });
 
-    it('should encode to an array of all values correctly', () => {
-        const config: TransactionConfig = {
-            computeUnitLimit: 20,
-            heapSize: 40,
-            loadedAccountsDataSizeLimit: 30,
-            priorityFeeLamports: 10n,
-        };
+    it('should encode an array of config values correctly', () => {
+        const config: CompiledTransactionConfigValue[] = [
+            { kind: 'u64', value: 40n },
+            { kind: 'u32', value: 30 },
+            { kind: 'u32', value: 20 },
+            { kind: 'u32', value: 10 },
+        ];
         const encoded = encoder.encode(config);
         expect(encoded).toEqual(
             // prettier-ignore
             new Uint8Array([
-                // priority fee lamports (8 bytes)
-                10, 0, 0, 0, 0, 0, 0, 0,
-                // computeUnitLimit (4 bytes)
-                20, 0, 0, 0,
-                // loadedAccountsDataSizeLimit (4 bytes)
+                // first value (8 bytes)
+                40, 0, 0, 0, 0, 0, 0, 0,
+                // second value (4 bytes)
                 30, 0, 0, 0,
-                // heapSize (4 bytes)
-                40, 0, 0, 0
-            ]),
-        );
-    });
-
-    it('should encode to an array of just priority fee correctly', () => {
-        const config: TransactionConfig = {
-            priorityFeeLamports: 10n,
-        };
-        const encoded = encoder.encode(config);
-        expect(encoded).toEqual(
-            // prettier-ignore
-            new Uint8Array([
-                // priority fee lamports (8 bytes)
-                10, 0, 0, 0, 0, 0, 0, 0,
-            ]),
-        );
-    });
-
-    it('should encode a large priority fee value correctly', () => {
-        const config: TransactionConfig = {
-            priorityFeeLamports: 2n ** 64n - 1n,
-        };
-        const encoded = encoder.encode(config);
-        expect(encoded).toEqual(
-            // prettier-ignore
-            new Uint8Array([
-                // priority fee lamports (8 bytes)
-                255, 255, 255, 255, 255, 255, 255, 255,
-            ]),
-        );
-    });
-
-    it('should encode to an array of just compute unit limit correctly', () => {
-        const config: TransactionConfig = {
-            computeUnitLimit: 20,
-        };
-        const encoded = encoder.encode(config);
-        expect(encoded).toEqual(
-            // prettier-ignore
-            new Uint8Array([
-                // computeUnitLimit (4 bytes)
-                20, 0, 0, 0
-            ]),
-        );
-    });
-
-    it('should encode to an array of just loaded accounts data size limit correctly', () => {
-        const config: TransactionConfig = {
-            loadedAccountsDataSizeLimit: 30,
-        };
-        const encoded = encoder.encode(config);
-        expect(encoded).toEqual(
-            // prettier-ignore
-            new Uint8Array([
-                // loadedAccountsDataSizeLimit (4 bytes)
-                30, 0, 0, 0
-            ]),
-        );
-    });
-
-    it('should encode to an array of just heap size correctly', () => {
-        const config: TransactionConfig = {
-            heapSize: 40,
-        };
-        const encoded = encoder.encode(config);
-        expect(encoded).toEqual(
-            // prettier-ignore
-            new Uint8Array([
-                // heapSize (4 bytes)
-                40, 0, 0, 0
-            ]),
-        );
-    });
-
-    it('should encode to an array of multiple values correctly', () => {
-        const config: TransactionConfig = {
-            loadedAccountsDataSizeLimit: 30,
-            priorityFeeLamports: 10n,
-        };
-        const encoded = encoder.encode(config);
-        expect(encoded).toEqual(
-            // prettier-ignore
-            new Uint8Array([
-                // priorityFeeLamports (8 bytes)
-                10, 0, 0, 0, 0, 0, 0, 0,
-                // loadedAccountsDataSizeLimit (4 bytes)
-                30, 0, 0, 0
-            ]),
-        );
-    });
-
-    it('should encode a large priority fee value correctly with another value', () => {
-        const config: TransactionConfig = {
-            computeUnitLimit: 20,
-            priorityFeeLamports: 2n ** 64n - 1n,
-        };
-        const encoded = encoder.encode(config);
-        expect(encoded).toEqual(
-            // prettier-ignore
-            new Uint8Array([
-                // priorityFeeLamports (8 bytes)
-                255, 255, 255, 255, 255, 255, 255, 255,
-                // computeUnitLimit (4 bytes)
-                20, 0, 0, 0
+                // third value (4 bytes)
+                20, 0, 0, 0,
+                // fourth value (4 bytes)
+                10, 0, 0, 0
             ]),
         );
     });
@@ -233,15 +39,16 @@ describe('getTransactionConfigValuesEncoder', () => {
 describe('getTransactionConfigValuesDecoder', () => {
     it('should decode an empty array when no values are set', () => {
         const mask = 0b00000000;
-        const decoder = getConfigValuesDecoder(mask);
+        const decoder = getCompiledTransactionConfigValuesDecoder(mask);
         const decoded = decoder.decode(new Uint8Array([]));
-        expect(decoded).toEqual({});
+        const expected: CompiledTransactionConfigValue[] = [];
+        expect(decoded).toEqual(expected);
     });
 
     it('should decode all values correctly', () => {
         // Mask with all 5 lowest bits set
         const mask = 0b00011111;
-        const decoder = getConfigValuesDecoder(mask);
+        const decoder = getCompiledTransactionConfigValuesDecoder(mask);
         const decoded = decoder.decode(
             // prettier-ignore
             new Uint8Array([
@@ -255,17 +62,18 @@ describe('getTransactionConfigValuesDecoder', () => {
                 40, 0, 0, 0
             ]),
         );
-        expect(decoded).toEqual({
-            computeUnitLimit: 20,
-            heapSize: 40,
-            loadedAccountsDataSizeLimit: 30,
-            priorityFeeLamports: 10n,
-        });
+        const expected: CompiledTransactionConfigValue[] = [
+            { kind: 'u64', value: 10n },
+            { kind: 'u32', value: 20 },
+            { kind: 'u32', value: 30 },
+            { kind: 'u32', value: 40 },
+        ];
+        expect(decoded).toEqual(expected);
     });
 
     it('should decode just priority fee correctly', () => {
         const mask = 0b00000011;
-        const decoder = getConfigValuesDecoder(mask);
+        const decoder = getCompiledTransactionConfigValuesDecoder(mask);
         const decoded = decoder.decode(
             // prettier-ignore
             new Uint8Array([
@@ -273,14 +81,13 @@ describe('getTransactionConfigValuesDecoder', () => {
                 10, 0, 0, 0, 0, 0, 0, 0,
             ]),
         );
-        expect(decoded).toEqual({
-            priorityFeeLamports: 10n,
-        });
+        const expected: CompiledTransactionConfigValue[] = [{ kind: 'u64', value: 10n }];
+        expect(decoded).toEqual(expected);
     });
 
     it('should decode a large priority fee value correctly', () => {
         const mask = 0b00000011;
-        const decoder = getConfigValuesDecoder(mask);
+        const decoder = getCompiledTransactionConfigValuesDecoder(mask);
         const decoded = decoder.decode(
             // prettier-ignore
             new Uint8Array([
@@ -288,14 +95,13 @@ describe('getTransactionConfigValuesDecoder', () => {
                 255, 255, 255, 255, 255, 255, 255, 255,
             ]),
         );
-        expect(decoded).toEqual({
-            priorityFeeLamports: 2n ** 64n - 1n,
-        });
+        const expected: CompiledTransactionConfigValue[] = [{ kind: 'u64', value: 2n ** 64n - 1n }];
+        expect(decoded).toEqual(expected);
     });
 
     it('should decode just compute unit limit correctly', () => {
         const mask = 0b00000100;
-        const decoder = getConfigValuesDecoder(mask);
+        const decoder = getCompiledTransactionConfigValuesDecoder(mask);
         const decoded = decoder.decode(
             // prettier-ignore
             new Uint8Array([
@@ -303,14 +109,13 @@ describe('getTransactionConfigValuesDecoder', () => {
                 20, 0, 0, 0
             ]),
         );
-        expect(decoded).toEqual({
-            computeUnitLimit: 20,
-        });
+        const expected: CompiledTransactionConfigValue[] = [{ kind: 'u32', value: 20 }];
+        expect(decoded).toEqual(expected);
     });
 
     it('should decode just loaded accounts data size limit correctly', () => {
         const mask = 0b00001000;
-        const decoder = getConfigValuesDecoder(mask);
+        const decoder = getCompiledTransactionConfigValuesDecoder(mask);
         const decoded = decoder.decode(
             // prettier-ignore
             new Uint8Array([
@@ -318,14 +123,13 @@ describe('getTransactionConfigValuesDecoder', () => {
                 30, 0, 0, 0
             ]),
         );
-        expect(decoded).toEqual({
-            loadedAccountsDataSizeLimit: 30,
-        });
+        const expected: CompiledTransactionConfigValue[] = [{ kind: 'u32', value: 30 }];
+        expect(decoded).toEqual(expected);
     });
 
     it('should decode just heap size correctly', () => {
         const mask = 0b00010000;
-        const decoder = getConfigValuesDecoder(mask);
+        const decoder = getCompiledTransactionConfigValuesDecoder(mask);
         const decoded = decoder.decode(
             // prettier-ignore
             new Uint8Array([
@@ -333,14 +137,13 @@ describe('getTransactionConfigValuesDecoder', () => {
                 40, 0, 0, 0
             ]),
         );
-        expect(decoded).toEqual({
-            heapSize: 40,
-        });
+        const expected: CompiledTransactionConfigValue[] = [{ kind: 'u32', value: 40 }];
+        expect(decoded).toEqual(expected);
     });
 
     it('should decode multiple values correctly', () => {
         const mask = 0b00001011;
-        const decoder = getConfigValuesDecoder(mask);
+        const decoder = getCompiledTransactionConfigValuesDecoder(mask);
         const decoded = decoder.decode(
             // prettier-ignore
             new Uint8Array([
@@ -350,15 +153,16 @@ describe('getTransactionConfigValuesDecoder', () => {
                 30, 0, 0, 0
             ]),
         );
-        expect(decoded).toEqual({
-            loadedAccountsDataSizeLimit: 30,
-            priorityFeeLamports: 10n,
-        });
+        const expected: CompiledTransactionConfigValue[] = [
+            { kind: 'u64', value: 10n },
+            { kind: 'u32', value: 30 },
+        ];
+        expect(decoded).toEqual(expected);
     });
 
     it('should decode a large priority fee value correctly with another value', () => {
         const mask = 0b00000111;
-        const decoder = getConfigValuesDecoder(mask);
+        const decoder = getCompiledTransactionConfigValuesDecoder(mask);
         const decoded = decoder.decode(
             // prettier-ignore
             new Uint8Array([
@@ -368,16 +172,17 @@ describe('getTransactionConfigValuesDecoder', () => {
                 20, 0, 0, 0
             ]),
         );
-        expect(decoded).toEqual({
-            computeUnitLimit: 20,
-            priorityFeeLamports: 2n ** 64n - 1n,
-        });
+        const expected: CompiledTransactionConfigValue[] = [
+            { kind: 'u64', value: 2n ** 64n - 1n },
+            { kind: 'u32', value: 20 },
+        ];
+        expect(decoded).toEqual(expected);
     });
 
     it('should throw an error if only one priority fee bit is set (malformed)', () => {
         // Only bit 0 set - malformed, bits 0 and 1 must match
         const mask = 0b01;
-        expect(() => getConfigValuesDecoder(mask)).toThrow(
+        expect(() => getCompiledTransactionConfigValuesDecoder(mask)).toThrow(
             new SolanaError(SOLANA_ERROR__TRANSACTION__INVALID_CONFIG_MASK_PRIORITY_FEE_BITS, { mask }),
         );
     });
@@ -385,7 +190,7 @@ describe('getTransactionConfigValuesDecoder', () => {
     it('should throw an error if only the other priority fee bit is set (malformed)', () => {
         // Only bit 1 set - malformed, bits 0 and 1 must match
         const mask = 0b10;
-        expect(() => getConfigValuesDecoder(mask)).toThrow(
+        expect(() => getCompiledTransactionConfigValuesDecoder(mask)).toThrow(
             new SolanaError(SOLANA_ERROR__TRANSACTION__INVALID_CONFIG_MASK_PRIORITY_FEE_BITS, { mask }),
         );
     });

--- a/packages/transaction-messages/src/codecs/v1/__tests__/instruction-test.ts
+++ b/packages/transaction-messages/src/codecs/v1/__tests__/instruction-test.ts
@@ -1,71 +1,64 @@
-import { getCompiledInstructions } from '../../../compile/v0/instructions';
+import { InstructionHeader, InstructionPayload } from '../../../compile/v1/instructions';
 import {
+    getInstructionHeaderCodec,
     getInstructionHeaderDecoder,
     getInstructionHeaderEncoder,
     getInstructionPayloadDecoder,
     getInstructionPayloadEncoder,
 } from '../instruction';
 
-type CompiledInstruction = ReturnType<typeof getCompiledInstructions>[number];
+describe.each([getInstructionHeaderEncoder, getInstructionHeaderCodec])(
+    'instruction header encoder %p',
+    encoderFactory => {
+        const encoder = encoderFactory();
 
-describe('getInstructionHeaderEncoder', () => {
-    const encoder = getInstructionHeaderEncoder();
+        it('encodes the instruction header when all fields are defined', () => {
+            const instructionHeader: InstructionHeader = {
+                numInstructionAccounts: 2,
+                numInstructionDataBytes: 3,
+                programAccountIndex: 1,
+            };
+            expect(encoder.encode(instructionHeader)).toEqual(
+                new Uint8Array([
+                    1, // programAccountIndex (1 byte)
+                    2, // numInstructionAccounts (1 byte)
+                    3,
+                    0, // numInstructionDataBytes (2 bytes)
+                ]),
+            );
+        });
+    },
+);
 
-    it('encodes the instruction header when all fields are defined', () => {
-        const instruction: CompiledInstruction = {
-            accountIndices: [2, 3],
-            data: Uint8Array.from({ length: 2 ** 16 - 1 }, (_, i) => i),
-            programAddressIndex: 1,
-        };
-        expect(encoder.encode(instruction)).toEqual(
-            new Uint8Array([
-                1, // programAddressIndex (1 byte)
+describe.each([getInstructionHeaderDecoder, getInstructionHeaderCodec])(
+    'instruction header decoder %p',
+    decoderFactory => {
+        const decoder = decoderFactory();
+
+        it('decodes the instruction header when all fields are defined', () => {
+            // pretter-ignore
+            const encoded = new Uint8Array([
+                1, // programAccountIndex (1 byte)
                 2, // numInstructionAccounts (1 byte)
-                255,
-                255, // numInstructionDataBytes (2 bytes)
-            ]),
-        );
-    });
-
-    it('encodes 0 accounts when accounts is missing', () => {
-        const instruction: CompiledInstruction = {
-            data: new Uint8Array([1, 2, 3]),
-            programAddressIndex: 1,
-        };
-        expect(encoder.encode(instruction)).toEqual(
-            new Uint8Array([
-                1, // programAddressIndex (1 byte)
-                0, // numInstructionAccounts (1 byte)
                 3,
                 0, // numInstructionDataBytes (2 bytes)
-            ]),
-        );
-    });
-
-    it('encodes 0 data bytes when data is missing', () => {
-        const instruction: CompiledInstruction = {
-            accountIndices: [2, 3],
-            programAddressIndex: 1,
-        };
-        expect(encoder.encode(instruction)).toEqual(
-            new Uint8Array([
-                1, // programAddressIndex (1 byte)
-                2, // numInstructionAccounts (1 byte)
-                0,
-                0, // numInstructionDataBytes (2 bytes)
-            ]),
-        );
-    });
-});
+            ]);
+            expect(decoder.decode(encoded)).toEqual({
+                numInstructionAccounts: 2,
+                numInstructionDataBytes: 3,
+                programAccountIndex: 1,
+            });
+        });
+    },
+);
 
 describe('getInstructionPayloadEncoder', () => {
     const encoder = getInstructionPayloadEncoder();
 
     it('encodes the instruction payload when all fields are defined', () => {
-        const instruction: CompiledInstruction = {
-            accountIndices: [2, 3],
-            data: new Uint8Array([1, 2, 3]),
-            programAddressIndex: 1,
+        const instruction: InstructionPayload = {
+            instructionAccountIndices: [2, 3],
+            instructionData: new Uint8Array([1, 2, 3]),
         };
         expect(encoder.encode(instruction)).toEqual(
             new Uint8Array([
@@ -78,10 +71,10 @@ describe('getInstructionPayloadEncoder', () => {
         );
     });
 
-    it('encodes just the data when `accountIndices` is missing', () => {
-        const instruction: CompiledInstruction = {
-            data: new Uint8Array([1, 2, 3]),
-            programAddressIndex: 1,
+    it('encodes just the data when `instructionAccountIndices` is empty', () => {
+        const instruction: InstructionPayload = {
+            instructionAccountIndices: [],
+            instructionData: new Uint8Array([1, 2, 3]),
         };
         expect(encoder.encode(instruction)).toEqual(
             new Uint8Array([
@@ -92,10 +85,10 @@ describe('getInstructionPayloadEncoder', () => {
         );
     });
 
-    it('encodes just the account indices when `data` is missing', () => {
-        const instruction: CompiledInstruction = {
-            accountIndices: [2, 3],
-            programAddressIndex: 1,
+    it('encodes just the account indices when `instructionData` is empty', () => {
+        const instruction: InstructionPayload = {
+            instructionAccountIndices: [2, 3],
+            instructionData: new Uint8Array([]),
         };
         expect(encoder.encode(instruction)).toEqual(
             new Uint8Array([
@@ -105,41 +98,12 @@ describe('getInstructionPayloadEncoder', () => {
         );
     });
 
-    it('encodes an empty payload when both `accountIndices` and `data` are missing', () => {
-        const instruction: CompiledInstruction = {
-            programAddressIndex: 1,
+    it('encodes an empty payload when both `instructionAccountIndices` and `instructionData` are empty', () => {
+        const instruction: InstructionPayload = {
+            instructionAccountIndices: [],
+            instructionData: new Uint8Array([]),
         };
         expect(encoder.encode(instruction)).toEqual(new Uint8Array([]));
-    });
-});
-
-describe('getInstructionHeaderDecoder', () => {
-    const decoder = getInstructionHeaderDecoder();
-
-    it('decodes the instruction header when all fields are defined', () => {
-        // pretter-ignore
-        const encoded = new Uint8Array([
-            // programAddressIndex (1 byte)
-            1,
-            // numInstructionAccounts (1 byte)
-            2,
-            // numInstructionDataBytes (2 bytes)
-            255, 255,
-        ]);
-        expect(decoder.decode(encoded)).toEqual({
-            numInstructionAccounts: 2,
-            numInstructionDataBytes: 2 ** 16 - 1,
-            programAddressIndex: 1,
-        });
-    });
-
-    it('decodes to all 0s when all fields are 0', () => {
-        const encoded = new Uint8Array(4); // all bytes are 0
-        expect(decoder.decode(encoded)).toEqual({
-            numInstructionAccounts: 0,
-            numInstructionDataBytes: 0,
-            programAddressIndex: 0,
-        });
     });
 });
 
@@ -148,72 +112,62 @@ describe('getInstructionPayloadDecoder', () => {
         const decoder = getInstructionPayloadDecoder({
             numInstructionAccounts: 2,
             numInstructionDataBytes: 3,
-            programAddressIndex: 1,
         });
-        expect(
-            decoder.decode(
-                new Uint8Array([
-                    2,
-                    3, // account indices (2 bytes)
-                    1,
-                    2,
-                    3, // data bytes (3 bytes)
-                ]),
-            ),
-        ).toEqual({
-            accountIndices: [2, 3],
-            data: new Uint8Array([1, 2, 3]),
-            programAddressIndex: 1,
-        });
+        const bytes = new Uint8Array([
+            1,
+            2, // account indices (2 bytes)
+            3,
+            4,
+            5, // data bytes (3 bytes)
+        ]);
+        const expected: InstructionPayload = {
+            instructionAccountIndices: [1, 2],
+            instructionData: new Uint8Array([3, 4, 5]),
+        };
+        expect(decoder.decode(bytes)).toEqual(expected);
     });
 
-    it('omits `accountIndices` when `numInstructionAccounts` is 0', () => {
+    it('reads empty `accountIndices` when `numInstructionAccounts` is 0', () => {
         const decoder = getInstructionPayloadDecoder({
             numInstructionAccounts: 0,
             numInstructionDataBytes: 3,
-            programAddressIndex: 1,
         });
-        expect(
-            decoder.decode(
-                new Uint8Array([
-                    1,
-                    2,
-                    3, // data bytes (3 bytes)
-                ]),
-            ),
-        ).toEqual({
-            data: new Uint8Array([1, 2, 3]),
-            programAddressIndex: 1,
-        });
+        const bytes = new Uint8Array([
+            1,
+            2,
+            3, // data bytes (3 bytes)
+        ]);
+        const expected: InstructionPayload = {
+            instructionAccountIndices: [],
+            instructionData: new Uint8Array([1, 2, 3]),
+        };
+        expect(decoder.decode(bytes)).toEqual(expected);
     });
 
-    it('omits `data` when `numInstructionDataBytes` is 0', () => {
+    it('reads empty `data` when `numInstructionDataBytes` is 0', () => {
         const decoder = getInstructionPayloadDecoder({
             numInstructionAccounts: 2,
             numInstructionDataBytes: 0,
-            programAddressIndex: 1,
         });
-        expect(
-            decoder.decode(
-                new Uint8Array([
-                    2,
-                    3, // account indices (2 bytes)
-                ]),
-            ),
-        ).toEqual({
-            accountIndices: [2, 3],
-            programAddressIndex: 1,
-        });
+        const bytes = new Uint8Array([
+            2,
+            3, // account indices (2 bytes)
+        ]);
+        const expected: InstructionPayload = {
+            instructionAccountIndices: [2, 3],
+            instructionData: new Uint8Array([]),
+        };
+        expect(decoder.decode(bytes)).toEqual(expected);
     });
 
     it('decodes an empty payload when both `numInstructionAccounts` and `numInstructionDataBytes` are 0', () => {
         const decoder = getInstructionPayloadDecoder({
             numInstructionAccounts: 0,
             numInstructionDataBytes: 0,
-            programAddressIndex: 1,
         });
         expect(decoder.decode(new Uint8Array([]))).toEqual({
-            programAddressIndex: 1,
+            instructionAccountIndices: [],
+            instructionData: new Uint8Array([]),
         });
     });
 
@@ -221,39 +175,33 @@ describe('getInstructionPayloadDecoder', () => {
         const decoder = getInstructionPayloadDecoder({
             numInstructionAccounts: 0,
             numInstructionDataBytes: 2,
-            programAddressIndex: 1,
         });
-        expect(
-            decoder.decode(
-                new Uint8Array([
-                    1,
-                    2, // data bytes (2 bytes)
-                    3, // additional byte that should not be read as data
-                ]),
-            ),
-        ).toEqual({
-            data: new Uint8Array([1, 2]),
-            programAddressIndex: 1,
-        });
+        const bytes = new Uint8Array([
+            1,
+            2, // data bytes (2 bytes)
+            3, // additional byte that should not be read as data
+        ]);
+        const expected: InstructionPayload = {
+            instructionAccountIndices: [],
+            instructionData: new Uint8Array([1, 2]),
+        };
+        expect(decoder.decode(bytes)).toEqual(expected);
     });
 
     it('only reads the number of account indices specified by `numInstructionAccounts`', () => {
         const decoder = getInstructionPayloadDecoder({
             numInstructionAccounts: 2,
             numInstructionDataBytes: 0,
-            programAddressIndex: 1,
         });
-        expect(
-            decoder.decode(
-                new Uint8Array([
-                    2,
-                    3, // account indices (2 bytes)
-                    4, // additional byte that should not be read as an account index
-                ]),
-            ),
-        ).toEqual({
-            accountIndices: [2, 3],
-            programAddressIndex: 1,
-        });
+        const bytes = new Uint8Array([
+            2,
+            3, // account indices (2 bytes)
+            4, // additional byte that should not be read as an account index
+        ]);
+        const expected: InstructionPayload = {
+            instructionAccountIndices: [2, 3],
+            instructionData: new Uint8Array([]),
+        };
+        expect(decoder.decode(bytes)).toEqual(expected);
     });
 });

--- a/packages/transaction-messages/src/codecs/v1/__tests__/message-test.ts
+++ b/packages/transaction-messages/src/codecs/v1/__tests__/message-test.ts
@@ -1,0 +1,547 @@
+import { Address } from '@solana/addresses';
+import { Decoder, Encoder, ReadonlyUint8Array } from '@solana/codecs-core';
+
+import { CompiledTransactionMessage, CompiledTransactionMessageWithLifetime } from '../../../compile/message';
+import { getMessageCodec, getMessageDecoder, getMessageEncoder } from '../message';
+
+type V1CompiledTransactionMessage = CompiledTransactionMessage & { version: 1 };
+
+describe.each([getMessageCodec, getMessageEncoder])('V1 Transaction message encoder %p', encoderFactory => {
+    let encoder: Encoder<
+        V1CompiledTransactionMessage | (CompiledTransactionMessageWithLifetime & V1CompiledTransactionMessage)
+    >;
+    beforeEach(() => {
+        encoder = encoderFactory();
+    });
+
+    it('encodes a v1 transaction with no config values', () => {
+        const message: CompiledTransactionMessageWithLifetime & V1CompiledTransactionMessage = {
+            // encodes to [10{32}]
+            configMask: 0,
+
+            configValues: [],
+
+            header: {
+                numReadonlyNonSignerAccounts: 1,
+                numReadonlySignerAccounts: 1,
+                numSignerAccounts: 2,
+            },
+
+            instructionHeaders: [
+                {
+                    numInstructionAccounts: 1,
+                    numInstructionDataBytes: 3,
+                    programAccountIndex: 1,
+                },
+            ],
+            instructionPayloads: [
+                {
+                    instructionAccountIndices: [0],
+                    instructionData: new Uint8Array([1, 2, 3]) as ReadonlyUint8Array,
+                },
+            ],
+            lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5',
+            numInstructions: 1,
+            numStaticAccounts: 2,
+            staticAccounts: [
+                'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address, // encodes to [11{32}]
+                'p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV' as Address, // encodes to [12{32}]
+            ],
+            version: 1,
+        };
+
+        expect(encoder.encode(message)).toStrictEqual(
+            // prettier-ignore
+            new Uint8Array([
+                /** VERSION HEADER */
+                129, // 1 + version mask (0x80)
+
+                /** MESSAGE HEADER */
+                2, // numSignerAccounts
+                1, // numReadonlySignerAccounts
+                1, // numReadonlyNonSignerAccounts
+
+                /** CONFIG MASK */
+                0, 0, 0, 0, // configMask (u32) = 0
+
+                /** LIFETIME TOKEN (blockhash) */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+
+                /** NUM INSTRUCTIONS */
+                1, // numInstructions (u8)
+
+                /** NUM ADDRESSES */
+                2, // numStaticAccounts (u8)
+
+                /** STATIC ADDRESSES */
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+                12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
+
+                /** CONFIG VALUES */
+                // (none - mask is 0)
+
+                /** INSTRUCTION HEADERS */
+                1, // programAccountIndex
+                1, // numInstructionAccounts
+                3, 0, // numInstructionDataBytes (u16, little endian)
+
+                /** INSTRUCTION PAYLOADS */
+                0, // account index
+                1, 2, 3, // instruction data
+            ]),
+        );
+    });
+
+    it('encodes a v1 transaction with priority fee only', () => {
+        const message: CompiledTransactionMessageWithLifetime & V1CompiledTransactionMessage = {
+            configMask: 0b11,
+            // Priority fee bits
+            configValues: [{ kind: 'u64', value: 5000n }],
+
+            header: {
+                numReadonlyNonSignerAccounts: 1,
+                numReadonlySignerAccounts: 0,
+                numSignerAccounts: 1,
+            },
+
+            instructionHeaders: [],
+
+            instructionPayloads: [],
+            lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5',
+            numInstructions: 0,
+            numStaticAccounts: 1,
+            staticAccounts: ['k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address],
+            version: 1,
+        };
+
+        expect(encoder.encode(message)).toStrictEqual(
+            // prettier-ignore
+            new Uint8Array([
+                /** VERSION HEADER */
+                129,
+
+                /** MESSAGE HEADER */
+                1, 0, 1,
+
+                /** CONFIG MASK */
+                3, 0, 0, 0, // configMask (u32) = 0b11
+
+                /** LIFETIME TOKEN */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+
+                /** NUM INSTRUCTIONS */
+                0,
+
+                /** NUM ADDRESSES */
+                1,
+
+                /** STATIC ADDRESSES */
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+
+                /** CONFIG VALUES */
+                136, 19, 0, 0, 0, 0, 0, 0, // 5000 as u64 (little endian)
+
+                /** INSTRUCTION HEADERS */
+                // (none)
+
+                /** INSTRUCTION PAYLOADS */
+                // (none)
+            ]),
+        );
+    });
+
+    it('encodes a v1 transaction with all config values', () => {
+        const message: CompiledTransactionMessageWithLifetime & V1CompiledTransactionMessage = {
+            configMask: 0b11111,
+            // All config flags set
+            configValues: [
+                { kind: 'u64', value: 5000n }, // Priority fee
+                { kind: 'u32', value: 200000 }, // Compute unit limit
+                { kind: 'u32', value: 64000 }, // Loaded accounts data size limit
+                { kind: 'u32', value: 256000 }, // Heap size
+            ],
+
+            header: {
+                numReadonlyNonSignerAccounts: 0,
+                numReadonlySignerAccounts: 0,
+                numSignerAccounts: 1,
+            },
+
+            instructionHeaders: [],
+
+            instructionPayloads: [],
+            lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5',
+            numInstructions: 0,
+            numStaticAccounts: 1,
+            staticAccounts: ['k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address],
+            version: 1,
+        };
+
+        expect(encoder.encode(message)).toStrictEqual(
+            // prettier-ignore
+            new Uint8Array([
+                /** VERSION HEADER */
+                129,
+
+                /** MESSAGE HEADER */
+                1, 0, 0,
+
+                /** CONFIG MASK */
+                31, 0, 0, 0, // configMask (u32) = 0b11111
+
+                /** LIFETIME TOKEN */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+
+                /** NUM INSTRUCTIONS */
+                0,
+
+                /** NUM ADDRESSES */
+                1,
+
+                /** STATIC ADDRESSES */
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+
+                /** CONFIG VALUES */
+                136, 19, 0, 0, 0, 0, 0, 0, // 5000 as u64
+                64, 13, 3, 0, // 200000 as u32
+                0, 250, 0, 0, // 64000 as u32
+                0, 232, 3, 0, // 256000 as u32
+
+                /** INSTRUCTION HEADERS */
+                // (none)
+
+                /** INSTRUCTION PAYLOADS */
+                // (none)
+            ]),
+        );
+    });
+
+    it('encodes a v1 transaction with multiple instructions', () => {
+        const message: CompiledTransactionMessageWithLifetime & V1CompiledTransactionMessage = {
+            configMask: 0,
+            configValues: [],
+            header: {
+                numReadonlyNonSignerAccounts: 2,
+                numReadonlySignerAccounts: 0,
+                numSignerAccounts: 1,
+            },
+            instructionHeaders: [
+                {
+                    numInstructionAccounts: 2,
+                    numInstructionDataBytes: 3,
+                    programAccountIndex: 1,
+                },
+                {
+                    numInstructionAccounts: 1,
+                    numInstructionDataBytes: 0,
+                    programAccountIndex: 2,
+                },
+            ],
+            instructionPayloads: [
+                {
+                    instructionAccountIndices: [0, 2],
+                    instructionData: new Uint8Array([10, 20, 30]) as ReadonlyUint8Array,
+                },
+                {
+                    instructionAccountIndices: [0],
+                    instructionData: new Uint8Array([]) as ReadonlyUint8Array,
+                },
+            ],
+            lifetimeToken: 'gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5',
+            numInstructions: 2,
+            numStaticAccounts: 3,
+            staticAccounts: [
+                'k7FaK87WHGVXzkaoHb7CdVPgkKDQhZ29VLDeBVbDfYn' as Address,
+                'p2Yicb86aZig616Eav2VWG9vuXR5mEqhtzshZYBxzsV' as Address,
+                'swqrv48gsrwpBFbftEwnP2vB4jckpvfGJfXkwaniLCC' as Address,
+            ],
+            version: 1,
+        };
+
+        expect(encoder.encode(message)).toStrictEqual(
+            // prettier-ignore
+            new Uint8Array([
+                /** VERSION HEADER */
+                129,
+
+                /** MESSAGE HEADER */
+                1, 0, 2,
+
+                /** CONFIG MASK */
+                0, 0, 0, 0,
+
+                /** LIFETIME TOKEN */
+                10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+
+                /** NUM INSTRUCTIONS */
+                2,
+
+                /** NUM ADDRESSES */
+                3,
+
+                /** STATIC ADDRESSES */
+                11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+                12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
+                13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+
+                /** CONFIG VALUES */
+                // (none)
+
+                /** INSTRUCTION HEADERS */
+                1, 2, 3, 0, // First header
+                2, 1, 0, 0, // Second header
+
+                /** INSTRUCTION PAYLOADS */
+                0, 2, // First payload account indices
+                10, 20, 30, // First payload data
+                0, // Second payload account index
+                // Second payload has no data
+            ]),
+        );
+    });
+});
+
+describe.each([getMessageCodec, getMessageDecoder])('V1 Transaction message decoder %p', decoderFactory => {
+    let decoder: Decoder<CompiledTransactionMessageWithLifetime & V1CompiledTransactionMessage>;
+    beforeEach(() => {
+        decoder = decoderFactory();
+    });
+
+    it('decodes a v1 transaction with no config values', () => {
+        // prettier-ignore
+        const bytes = new Uint8Array([
+            /** VERSION HEADER */
+            129, // 1 + version mask (0x80)
+
+            /** MESSAGE HEADER */
+            2, // numSignerAccounts
+            1, // numReadonlySignerAccounts
+            1, // numReadonlyNonSignerAccounts
+
+            /** CONFIG MASK */
+            0, 0, 0, 0, // configMask (u32) = 0
+
+            /** LIFETIME TOKEN (blockhash) */
+            10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+
+            /** NUM INSTRUCTIONS */
+            1, // numInstructions (u8)
+
+            /** NUM ADDRESSES */
+            2, // numStaticAccounts (u8)
+
+            /** STATIC ADDRESSES */
+            11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+            12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
+
+            /** CONFIG VALUES */
+            // (none - mask is 0)
+
+            /** INSTRUCTION HEADERS */
+            1, // programAccountIndex
+            1, // numInstructionAccounts
+            3, 0, // numInstructionDataBytes (u16, little endian)
+
+            /** INSTRUCTION PAYLOADS */
+            0, // account index
+            1, 2, 3, // instruction data
+        ]);
+
+        const message = decoder.decode(bytes);
+
+        expect(message).toMatchObject({
+            configMask: 0,
+            configValues: [],
+            header: {
+                numReadonlyNonSignerAccounts: 1,
+                numReadonlySignerAccounts: 1,
+                numSignerAccounts: 2,
+            },
+            instructionHeaders: [
+                {
+                    numInstructionAccounts: 1,
+                    numInstructionDataBytes: 3,
+                    programAccountIndex: 1,
+                },
+            ],
+            instructionPayloads: [
+                {
+                    instructionAccountIndices: [0],
+                    instructionData: new Uint8Array([1, 2, 3]),
+                },
+            ],
+            numInstructions: 1,
+            numStaticAccounts: 2,
+            version: 1,
+        });
+        expect(message.staticAccounts).toHaveLength(2);
+        expect(message.lifetimeToken).toBe('gBxS1f6uyyGPuW5MzGBukidSb71jdsCb5fZaoSzULE5');
+    });
+
+    it('decodes a v1 transaction with priority fee', () => {
+        // prettier-ignore
+        const bytes = new Uint8Array([
+            /** VERSION HEADER */
+            129,
+
+            /** MESSAGE HEADER */
+            1, 0, 1,
+
+            /** CONFIG MASK */
+            3, 0, 0, 0, // configMask (u32) = 0b11
+
+            /** LIFETIME TOKEN */
+            10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+
+            /** NUM INSTRUCTIONS */
+            0,
+
+            /** NUM ADDRESSES */
+            1,
+
+            /** STATIC ADDRESSES */
+            11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+
+            /** CONFIG VALUES */
+            136, 19, 0, 0, 0, 0, 0, 0, // 5000 as u64 (little endian)
+
+            /** INSTRUCTION HEADERS */
+            // (none)
+
+            /** INSTRUCTION PAYLOADS */
+            // (none)
+        ]);
+
+        const message = decoder.decode(bytes);
+
+        expect(message).toMatchObject({
+            configMask: 3,
+            configValues: [{ kind: 'u64', value: 5000n }],
+            numInstructions: 0,
+            numStaticAccounts: 1,
+            version: 1,
+        });
+    });
+
+    it('decodes a v1 transaction with all config values', () => {
+        // prettier-ignore
+        const bytes = new Uint8Array([
+            /** VERSION HEADER */
+            129,
+
+            /** MESSAGE HEADER */
+            1, 0, 0,
+
+            /** CONFIG MASK */
+            31, 0, 0, 0, // configMask (u32) = 0b11111
+
+            /** LIFETIME TOKEN */
+            10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+
+            /** NUM INSTRUCTIONS */
+            0,
+
+            /** NUM ADDRESSES */
+            1,
+
+            /** STATIC ADDRESSES */
+            11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+
+            /** CONFIG VALUES */
+            136, 19, 0, 0, 0, 0, 0, 0, // 5000 as u64
+            64, 13, 3, 0, // 200000 as u32
+            0, 250, 0, 0, // 64000 as u32
+            0, 232, 3, 0, // 256000 as u32
+
+            /** INSTRUCTION HEADERS */
+            // (none)
+
+            /** INSTRUCTION PAYLOADS */
+            // (none)
+        ]);
+
+        const message = decoder.decode(bytes);
+
+        expect(message).toMatchObject({
+            configMask: 31,
+            configValues: [
+                { kind: 'u64', value: 5000n },
+                { kind: 'u32', value: 200000 },
+                { kind: 'u32', value: 64000 },
+                { kind: 'u32', value: 256000 },
+            ],
+            version: 1,
+        });
+    });
+
+    it('decodes a v1 transaction with multiple instructions', () => {
+        // prettier-ignore
+        const bytes = new Uint8Array([
+            /** VERSION HEADER */
+            129,
+
+            /** MESSAGE HEADER */
+            1, 0, 2,
+
+            /** CONFIG MASK */
+            0, 0, 0, 0,
+
+            /** LIFETIME TOKEN */
+            10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10,
+
+            /** NUM INSTRUCTIONS */
+            2,
+
+            /** NUM ADDRESSES */
+            3,
+
+            /** STATIC ADDRESSES */
+            11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+            12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
+            13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13,
+
+            /** CONFIG VALUES */
+            // (none)
+
+            /** INSTRUCTION HEADERS */
+            1, 2, 3, 0, // First header
+            2, 1, 0, 0, // Second header
+
+            /** INSTRUCTION PAYLOADS */
+            0, 2, // First payload account indices
+            10, 20, 30, // First payload data
+            0, // Second payload account index
+            // Second payload has no data
+        ]);
+
+        const message = decoder.decode(bytes);
+
+        expect(message).toMatchObject({
+            instructionHeaders: [
+                {
+                    numInstructionAccounts: 2,
+                    numInstructionDataBytes: 3,
+                    programAccountIndex: 1,
+                },
+                {
+                    numInstructionAccounts: 1,
+                    numInstructionDataBytes: 0,
+                    programAccountIndex: 2,
+                },
+            ],
+            instructionPayloads: [
+                {
+                    instructionAccountIndices: [0, 2],
+                    instructionData: new Uint8Array([10, 20, 30]),
+                },
+                {
+                    instructionAccountIndices: [0],
+                    instructionData: new Uint8Array([]),
+                },
+            ],
+            numInstructions: 2,
+            numStaticAccounts: 3,
+            version: 1,
+        });
+    });
+});

--- a/packages/transaction-messages/src/codecs/v1/config.ts
+++ b/packages/transaction-messages/src/codecs/v1/config.ts
@@ -1,15 +1,35 @@
+import { transformDecoder, VariableSizeDecoder, VariableSizeEncoder } from '@solana/codecs-core';
 import {
-    createDecoder,
-    createEncoder,
-    FixedSizeEncoder,
-    transformEncoder,
-    VariableSizeDecoder,
-    VariableSizeEncoder,
-} from '@solana/codecs-core';
+    getArrayEncoder,
+    getPatternMatchEncoder,
+    getStructEncoder,
+    getTupleDecoder,
+    getUnitDecoder,
+} from '@solana/codecs-data-structures';
 import { getU32Decoder, getU32Encoder, getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
 import { SOLANA_ERROR__TRANSACTION__INVALID_CONFIG_MASK_PRIORITY_FEE_BITS, SolanaError } from '@solana/errors';
 
-import { TransactionConfig } from '../../transaction-config';
+import { CompiledTransactionConfigValue } from '../../compile/v1/config';
+
+/* TODO issue #1143 - we have a type error on `getPatternMatchEncoder` where it incorrectly
+ * types the return as FixedSizeEncoder when used with differently sized FixedSizEencoder
+ * inputs. For now we cast to VariableSizeEncoder, which is what the underlying union codec
+ * actually returns.
+ */
+function getCompiledTransactionConfigValueEncoder(): VariableSizeEncoder<CompiledTransactionConfigValue> {
+    return getPatternMatchEncoder<CompiledTransactionConfigValue>([
+        [value => value.kind === 'u32', getStructEncoder([['value', getU32Encoder()]])],
+        [value => value.kind === 'u64', getStructEncoder([['value', getU64Encoder()]])],
+    ]) as unknown as VariableSizeEncoder<CompiledTransactionConfigValue>;
+}
+
+/**
+ * Encode a {@link TransactionMessageConfig} into a variable length byte array, where the fields set are encoded based on their data size.
+ * @returns An Encoder for {@link TransactionMessageConfig}
+ */
+export function getCompiledTransactionConfigValuesEncoder(): VariableSizeEncoder<CompiledTransactionConfigValue[]> {
+    return getArrayEncoder(getCompiledTransactionConfigValueEncoder(), { size: 'remainder' });
+}
 
 const PRIORITY_FEE_LAMPORTS_BIT_MASK = 0b11;
 const COMPUTE_UNIT_LIMIT_BIT_MASK = 0b100;
@@ -17,64 +37,13 @@ const LOADED_ACCOUNTS_DATA_SIZE_LIMIT_BIT_MASK = 0b1000;
 const HEAP_SIZE_BIT_MASK = 0b10000;
 
 /**
- * Encode a {@link TransactionMessageConfig} into a 4 byte mask, where the lowest bits indicate which fields are set
- * @returns An Encoder for {@link TransactionMessageConfig}
- */
-export function getTransactionConfigMaskEncoder(): FixedSizeEncoder<TransactionConfig, 4> {
-    return transformEncoder(getU32Encoder(), config => {
-        let mask = 0;
-        // Set the lowest 2 bits for priority fee lamports
-        if (config.priorityFeeLamports !== undefined) mask |= PRIORITY_FEE_LAMPORTS_BIT_MASK;
-        // Set the 3rd lowest bit for compute unit limit
-        if (config.computeUnitLimit !== undefined) mask |= COMPUTE_UNIT_LIMIT_BIT_MASK;
-        // Set the 4th lowest bit for loaded accounts data size limit
-        if (config.loadedAccountsDataSizeLimit !== undefined) mask |= LOADED_ACCOUNTS_DATA_SIZE_LIMIT_BIT_MASK;
-        // Set the 5th lowest bit for heap size
-        if (config.heapSize !== undefined) mask |= HEAP_SIZE_BIT_MASK;
-        return mask;
-    });
-}
-
-/**
- * Encode a {@link TransactionMessageConfig} into a variable length byte array, where the fields set are encoded based on their data size.
- * @returns An Encoder for {@link TransactionMessageConfig}
- */
-export function getTransactionConfigValuesEncoder(): VariableSizeEncoder<TransactionConfig> {
-    return createEncoder<TransactionConfig>({
-        getSizeFromValue(config) {
-            let size = 0;
-            // Lamports is 8 bytes, the rest are 4 bytes each
-            if (config.priorityFeeLamports !== undefined) size += 8;
-            if (config.computeUnitLimit !== undefined) size += 4;
-            if (config.loadedAccountsDataSizeLimit !== undefined) size += 4;
-            if (config.heapSize !== undefined) size += 4;
-            return size;
-        },
-        write(config, bytes, offset) {
-            let nextOffset = offset;
-            if (config.priorityFeeLamports !== undefined) {
-                nextOffset = getU64Encoder().write(config.priorityFeeLamports, bytes, nextOffset);
-            }
-            if (config.computeUnitLimit !== undefined) {
-                nextOffset = getU32Encoder().write(BigInt(config.computeUnitLimit), bytes, nextOffset);
-            }
-            if (config.loadedAccountsDataSizeLimit !== undefined) {
-                nextOffset = getU32Encoder().write(BigInt(config.loadedAccountsDataSizeLimit), bytes, nextOffset);
-            }
-            if (config.heapSize !== undefined) {
-                nextOffset = getU32Encoder().write(BigInt(config.heapSize), bytes, nextOffset);
-            }
-            return nextOffset;
-        },
-    });
-}
-
-/**
  * Decode a {@link TransactionMessageConfig} from a byte array of values, using the provided mask.
  * @param mask A mask indicating which fields are set
  * @returns A Decoder for {@link TransactionMessageConfig}
  */
-export function getConfigValuesDecoder(mask: number): VariableSizeDecoder<TransactionConfig> {
+export function getCompiledTransactionConfigValuesDecoder(
+    mask: number,
+): VariableSizeDecoder<CompiledTransactionConfigValue[]> {
     // bits 0 and 1 must both be set or both be unset
     const priorityFeeBits = mask & PRIORITY_FEE_LAMPORTS_BIT_MASK;
     if (priorityFeeBits === 0b01 || priorityFeeBits === 0b10) {
@@ -87,31 +56,17 @@ export function getConfigValuesDecoder(mask: number): VariableSizeDecoder<Transa
     const hasLoadedAccountsDataSizeLimit = (mask & LOADED_ACCOUNTS_DATA_SIZE_LIMIT_BIT_MASK) !== 0;
     const hasHeapSize = (mask & HEAP_SIZE_BIT_MASK) !== 0;
 
-    return createDecoder({
-        read(bytes, offset) {
-            let nextOffset = offset;
-            const config: TransactionConfig = {};
+    const u32Decoder = transformDecoder(getU32Decoder(), value => ({ kind: 'u32', value }));
+    const u64Decoder = transformDecoder(getU64Decoder(), value => ({ kind: 'u64', value }));
+    const unitDecoder = getUnitDecoder();
 
-            if (hasPriorityFee) {
-                [config.priorityFeeLamports, nextOffset] = getU64Decoder().read(bytes, nextOffset);
-            }
-            if (hasComputeUnitLimit) {
-                const [value, next] = getU32Decoder().read(bytes, nextOffset);
-                config.computeUnitLimit = Number(value);
-                nextOffset = next;
-            }
-            if (hasLoadedAccountsDataSizeLimit) {
-                const [value, next] = getU32Decoder().read(bytes, nextOffset);
-                config.loadedAccountsDataSizeLimit = Number(value);
-                nextOffset = next;
-            }
-            if (hasHeapSize) {
-                const [value, next] = getU32Decoder().read(bytes, nextOffset);
-                config.heapSize = Number(value);
-                nextOffset = next;
-            }
-
-            return [config, nextOffset];
-        },
-    });
+    return transformDecoder(
+        getTupleDecoder([
+            hasPriorityFee ? u64Decoder : unitDecoder,
+            hasComputeUnitLimit ? u32Decoder : unitDecoder,
+            hasLoadedAccountsDataSizeLimit ? u32Decoder : unitDecoder,
+            hasHeapSize ? u32Decoder : unitDecoder,
+        ]),
+        arr => arr.filter(Boolean) as CompiledTransactionConfigValue[],
+    );
 }

--- a/packages/transaction-messages/src/codecs/v1/instruction.ts
+++ b/packages/transaction-messages/src/codecs/v1/instruction.ts
@@ -1,10 +1,9 @@
 import {
-    createEncoder,
+    combineCodec,
     fixDecoderSize,
+    FixedSizeCodec,
     FixedSizeDecoder,
     FixedSizeEncoder,
-    transformDecoder,
-    transformEncoder,
     VariableSizeDecoder,
     VariableSizeEncoder,
 } from '@solana/codecs-core';
@@ -18,64 +17,18 @@ import {
 } from '@solana/codecs-data-structures';
 import { getU8Decoder, getU8Encoder, getU16Decoder, getU16Encoder } from '@solana/codecs-numbers';
 
-import { getCompiledInstructions } from '../../compile/v0/instructions';
-
-type CompiledInstruction = ReturnType<typeof getCompiledInstructions>[number];
-
-type InstructionHeader = {
-    numInstructionAccounts: number;
-    numInstructionDataBytes: number;
-    programAddressIndex: number;
-};
+import { InstructionHeader, InstructionPayload } from '../../compile/v1/instructions';
 
 /**
- * Encode the fixed size header of a {@link CompiledInstruction}, which includes the program address index, the number of account indices, and the number of data bytes.
+ * Encode the fixed size {@link InstructionHeader}
  * @returns A FixedSizeEncoder for the instruction header
  */
-export function getInstructionHeaderEncoder(): FixedSizeEncoder<CompiledInstruction> {
-    return transformEncoder(
-        getStructEncoder([
-            ['programAddressIndex', getU8Encoder()],
-            ['numInstructionAccounts', getU8Encoder()],
-            ['numInstructionDataBytes', getU16Encoder()],
-        ]),
-        (instruction: CompiledInstruction): InstructionHeader => {
-            return {
-                numInstructionAccounts: instruction.accountIndices?.length ?? 0,
-                numInstructionDataBytes: instruction.data?.byteLength ?? 0,
-                programAddressIndex: instruction.programAddressIndex,
-            };
-        },
-    );
-}
-
-/**
- * Encode the variable size payload of a {@link CompiledInstruction}, which includes the account indices and instruction data.
- * Both arrays are optional and are omitted if empty
- * @returns A VariableSizeEncoder for the instruction payload
- */
-export function getInstructionPayloadEncoder(): VariableSizeEncoder<CompiledInstruction> {
-    return createEncoder<CompiledInstruction>({
-        getSizeFromValue(instruction) {
-            const accountIndicesSize = instruction.accountIndices ? instruction.accountIndices.length : 0;
-            const dataSize = instruction.data ? instruction.data.byteLength : 0;
-            return accountIndicesSize + dataSize;
-        },
-        write(instruction, bytes, offset) {
-            let nextOffset = offset;
-            if (instruction.accountIndices) {
-                nextOffset = getArrayEncoder(getU8Encoder(), { size: instruction.accountIndices.length }).write(
-                    instruction.accountIndices,
-                    bytes,
-                    nextOffset,
-                );
-            }
-            if (instruction.data) {
-                nextOffset = getBytesEncoder().write(instruction.data, bytes, nextOffset);
-            }
-            return nextOffset;
-        },
-    });
+export function getInstructionHeaderEncoder(): FixedSizeEncoder<InstructionHeader> {
+    return getStructEncoder([
+        ['programAccountIndex', getU8Encoder()],
+        ['numInstructionAccounts', getU8Encoder()],
+        ['numInstructionDataBytes', getU16Encoder()],
+    ]);
 }
 
 /**
@@ -84,32 +37,45 @@ export function getInstructionPayloadEncoder(): VariableSizeEncoder<CompiledInst
  */
 export function getInstructionHeaderDecoder(): FixedSizeDecoder<InstructionHeader> {
     return getStructDecoder([
-        ['programAddressIndex', getU8Decoder()],
+        ['programAccountIndex', getU8Decoder()],
         ['numInstructionAccounts', getU8Decoder()],
         ['numInstructionDataBytes', getU16Decoder()],
     ]);
 }
 
 /**
- * Decode a CompiledInstruction from a byte array, given the instruction header
+ * Get a codec for the {@link InstructionHeader}, which includes both the encoder and decoder
+ * @returns A FixedSizeCodec for the instruction header
+ */
+export function getInstructionHeaderCodec(): FixedSizeCodec<InstructionHeader> {
+    return combineCodec(getInstructionHeaderEncoder(), getInstructionHeaderDecoder());
+}
+
+/**
+ * Encode the variable size {@link InstructionPayload}, which includes the account indices and instruction data.
+ * Both arrays may be empty
+ * @returns A VariableSizeEncoder for the instruction payload
+ */
+export function getInstructionPayloadEncoder(): VariableSizeEncoder<InstructionPayload> {
+    return getStructEncoder([
+        ['instructionAccountIndices', getArrayEncoder(getU8Encoder(), { size: 'remainder' })],
+        ['instructionData', getBytesEncoder()],
+    ]);
+}
+
+/**
+ * Decode an {@link InstructionPayload} from a byte array, given the instruction header
  * @param instructionHeader The header for the instruction
- * @returns A decoder for CompiledInstruction
+ * @returns A decoder for InstructionPayload
  */
 export function getInstructionPayloadDecoder(
-    instructionHeader: InstructionHeader,
-): VariableSizeDecoder<CompiledInstruction> {
-    return transformDecoder(
-        getStructDecoder([
-            ['accountIndices', getArrayDecoder(getU8Decoder(), { size: instructionHeader.numInstructionAccounts })],
-            ['data', fixDecoderSize(getBytesDecoder(), instructionHeader.numInstructionDataBytes)],
-        ]),
-        ({ accountIndices, data }) => {
-            const compiledInstruction: CompiledInstruction = {
-                programAddressIndex: instructionHeader.programAddressIndex,
-                ...(accountIndices.length ? { accountIndices } : null),
-                ...(data.byteLength ? { data } : null),
-            };
-            return compiledInstruction;
-        },
-    );
+    instructionHeader: Pick<InstructionHeader, 'numInstructionAccounts' | 'numInstructionDataBytes'>,
+): VariableSizeDecoder<InstructionPayload> {
+    return getStructDecoder([
+        [
+            'instructionAccountIndices',
+            getArrayDecoder(getU8Decoder(), { size: instructionHeader.numInstructionAccounts }),
+        ],
+        ['instructionData', fixDecoderSize(getBytesDecoder(), instructionHeader.numInstructionDataBytes)],
+    ]);
 }

--- a/packages/transaction-messages/src/codecs/v1/message.ts
+++ b/packages/transaction-messages/src/codecs/v1/message.ts
@@ -1,0 +1,111 @@
+import { getAddressDecoder, getAddressEncoder } from '@solana/addresses';
+import {
+    combineCodec,
+    createDecoder,
+    transformEncoder,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
+} from '@solana/codecs-core';
+import { getArrayDecoder, getArrayEncoder, getStructDecoder, getStructEncoder } from '@solana/codecs-data-structures';
+import { getU8Decoder, getU8Encoder, getU32Decoder, getU32Encoder } from '@solana/codecs-numbers';
+
+import { CompiledTransactionMessageWithLifetime, V1CompiledTransactionMessage } from '../..';
+import { InstructionPayload } from '../../compile/v1/instructions';
+import { getMessageHeaderDecoder, getMessageHeaderEncoder } from '../legacy/header';
+import { getLifetimeTokenDecoder, getLifetimeTokenEncoder } from '../legacy/lifetime-token';
+import { getTransactionVersionDecoder, getTransactionVersionEncoder } from '../transaction-version';
+import { getCompiledTransactionConfigValuesDecoder, getCompiledTransactionConfigValuesEncoder } from './config';
+import {
+    getInstructionHeaderDecoder,
+    getInstructionHeaderEncoder,
+    getInstructionPayloadDecoder,
+    getInstructionPayloadEncoder,
+} from './instruction';
+
+export function getMessageEncoder(): VariableSizeEncoder<
+    V1CompiledTransactionMessage | (CompiledTransactionMessageWithLifetime & V1CompiledTransactionMessage)
+> {
+    return transformEncoder(
+        getStructEncoder([
+            ['version', getTransactionVersionEncoder()],
+            ['header', getMessageHeaderEncoder()],
+            ['configMask', getU32Encoder()],
+            ['lifetimeToken', getLifetimeTokenEncoder()],
+            ['numInstructions', getU8Encoder()],
+            ['numStaticAccounts', getU8Encoder()],
+            ['staticAccounts', getArrayEncoder(getAddressEncoder(), { size: 'remainder' })],
+            ['configValues', getCompiledTransactionConfigValuesEncoder()],
+            ['instructionHeaders', getArrayEncoder(getInstructionHeaderEncoder(), { size: 'remainder' })],
+            ['instructionPayloads', getArrayEncoder(getInstructionPayloadEncoder(), { size: 'remainder' })],
+        ]),
+        value => ({
+            ...value,
+            lifetimeToken: 'lifetimeToken' in value ? value.lifetimeToken : undefined,
+        }),
+    );
+}
+
+export function getMessageDecoder(): VariableSizeDecoder<
+    CompiledTransactionMessageWithLifetime & V1CompiledTransactionMessage
+> {
+    return createDecoder({
+        read(bytes, offset) {
+            const [{ header, configMask, lifetimeToken, numInstructions, numStaticAccounts }, afterFixedFields] =
+                getStructDecoder([
+                    ['version', getTransactionVersionDecoder()],
+                    ['header', getMessageHeaderDecoder()],
+                    ['configMask', getU32Decoder()],
+                    ['lifetimeToken', getLifetimeTokenDecoder()],
+                    ['numInstructions', getU8Decoder()],
+                    ['numStaticAccounts', getU8Decoder()],
+                ]).read(bytes, offset);
+
+            let nextOffset = afterFixedFields;
+            const [staticAccounts, afterAddresses] = getArrayDecoder(getAddressDecoder(), {
+                size: numStaticAccounts,
+            }).read(bytes, nextOffset);
+            nextOffset = afterAddresses;
+
+            const [configValues, afterConfig] = getCompiledTransactionConfigValuesDecoder(configMask).read(
+                bytes,
+                nextOffset,
+            );
+            nextOffset = afterConfig;
+
+            const [instructionHeaders, afterHeaders] = getArrayDecoder(getInstructionHeaderDecoder(), {
+                size: numInstructions,
+            }).read(bytes, nextOffset);
+            nextOffset = afterHeaders;
+
+            const instructionPayloads: InstructionPayload[] = [];
+            for (const header of instructionHeaders) {
+                const [payload, next] = getInstructionPayloadDecoder(header).read(bytes, nextOffset);
+                instructionPayloads.push(payload);
+                nextOffset = next;
+            }
+
+            const compiledMessage: CompiledTransactionMessageWithLifetime & V1CompiledTransactionMessage = {
+                configMask,
+                configValues,
+                header,
+                instructionHeaders,
+                instructionPayloads,
+                lifetimeToken,
+                numInstructions,
+                numStaticAccounts,
+                staticAccounts,
+                version: 1,
+            };
+
+            return [compiledMessage, nextOffset];
+        },
+    });
+}
+
+export function getMessageCodec(): VariableSizeCodec<
+    V1CompiledTransactionMessage | (CompiledTransactionMessageWithLifetime & V1CompiledTransactionMessage),
+    CompiledTransactionMessageWithLifetime & V1CompiledTransactionMessage
+> {
+    return combineCodec(getMessageEncoder(), getMessageDecoder());
+}


### PR DESCRIPTION
#### Summary of Changes

This PR adds the codec for v1 transaciton messages, and uses it in transaction-message codecs/message.ts

- Config values are encoded as either u32 or u64, according to their `kind`
- Config values are decoded sequentially using the mask to know which values are present
- InstructionHeader is trivial from its compiled form
- InstructionPayload is simple to encode, its two fields are just sequentially encoded
- InstructionPayload is decoded using the header to read the size of its fields 

- v1 message encoder is just a struct with the `V1CompiledTransactionMessage` format
- v1 message decoder is manual, because the sizes of later fields depend on things like `numInstructions` and `numStaticAccounts`. 

New tests are added for the v1 codec

I've also reworked the `codecs/message.ts` tests to test one example of each version, these are just copied from the version-specific tests. Previously we didn't have version-specific tests so this was a mixture of different tests and versions.

I decided not to use mocks because it becomes quite messy mocking multiple encoders with different read/write functions, and I think having a case for each version here provides the same test coverage anyway. 
