### PR TITLE
Add `abortReason` to `FAILED_TO_EXECUTE_TRANSACTION_PLAN` error context

### DIFF
--- a/.changeset/wild-yaks-go.md
+++ b/.changeset/wild-yaks-go.md
@@ -1,0 +1,6 @@
+---
+'@solana/errors': patch
+'@solana/instruction-plans': patch
+---
+
+Add `abortReason` to the `SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN` error context so consumers can access the abort reason when converting this error to higher-level error types.

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -468,6 +468,7 @@ export type SolanaErrorContext = ReadonlyContextValue<
                 transactionPlanResult: unknown;
             };
             [SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN]: {
+                abortReason?: unknown;
                 transactionPlanResult: unknown;
             };
             [SOLANA_ERROR__INSTRUCTION_PLANS__MESSAGE_CANNOT_ACCOMMODATE_PLAN]: {

--- a/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
@@ -362,6 +362,28 @@ describe('createTransactionPlanExecutor', () => {
             expect(executeTransactionMessage).not.toHaveBeenCalled();
         });
 
+        it('includes the abort reason in the error context', async () => {
+            expect.assertions(1);
+            const messageA = createMessage('A');
+            const abortController = new AbortController();
+            const abortSignal = abortController.signal;
+            const abortReason = new Error('User canceled');
+            const executeTransactionMessage = jest.fn().mockReturnValueOnce(FOREVER_PROMISE);
+            const executor = createTransactionPlanExecutor({ executeTransactionMessage });
+
+            const promise = executor(singleTransactionPlan(messageA), { abortSignal });
+            await jest.runAllTimersAsync();
+            abortController.abort(abortReason);
+
+            await expect(promise).rejects.toThrow(
+                expect.objectContaining({
+                    context: expect.objectContaining({
+                        abortReason,
+                    }),
+                }),
+            );
+        });
+
         it('freezes the returned single transaction plan result', async () => {
             expect.assertions(1);
             const executeTransactionMessage = jest.fn().mockImplementation(forwardId);

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -140,7 +140,10 @@ export function createTransactionPlanExecutor<
 
         if (traverseConfig.canceled) {
             const abortReason = abortSignal?.aborted ? abortSignal.reason : undefined;
-            const context = { cause: findErrorFromTransactionPlanResult(transactionPlanResult) ?? abortReason };
+            const context = {
+                abortReason,
+                cause: findErrorFromTransactionPlanResult(transactionPlanResult) ?? abortReason,
+            };
             // Here we want the `transactionPlanResult` to be available in the error context
             // so applications can create recovery plans but we don't want this object to be
             // serialized with the error. This is why we set it as a non-enumerable property.


### PR DESCRIPTION
This PR adds an optional `abortReason` field to the `SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN` error context. Previously, the abort reason was only used as a fallback for `cause` and was not directly accessible in the error context. This makes it possible for consumers to extract the abort reason when converting this low-level error into higher-level error types like `SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION(S)`.