### PR TITLE
Add `createFailedToSendTransactionError` and `createFailedToSendTransactionsError` helpers

### DIFF
--- a/.changeset/silly-flowers-cut.md
+++ b/.changeset/silly-flowers-cut.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': patch
+---
+
+Add `createFailedToSendTransactionError` and `createFailedToSendTransactionsError` factory helpers that create high-level `SolanaError` instances from failed or canceled transaction plan results, with unwrapped simulation errors, preflight data, and logs in the error context.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Four private "impl" packages (`@solana/crypto-impl`, `@solana/text-encoding-impl
 - **Type tests**: `src/__typetests__/` directories contain compile-time type tests using `satisfies` and `@ts-expect-error`.
 - **Lint/prettier**: Also run through Jest runners (`jest-runner-eslint`, `jest-runner-prettier`).
 - **Commands**: `pnpm test` runs all unit tests. `pnpm lint` runs lint checks. `pnpm style:fix` auto-fixes formatting.
+- **`expect.assertions`**: Only use `expect.assertions(n)` in **async** tests (where you need to guarantee the expected number of assertions ran). Synchronous tests do not need it.
 
 ## Error System
 

--- a/packages/instruction-plans/src/__tests__/transaction-plan-errors-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-errors-test.ts
@@ -1,0 +1,488 @@
+import {
+    type RpcSimulateTransactionResult,
+    SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION,
+    SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS,
+    SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+    SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+    SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE,
+    SolanaError,
+} from '@solana/errors';
+import { Signature } from '@solana/keys';
+
+import {
+    canceledSingleTransactionPlanResult,
+    createFailedToSendTransactionError,
+    createFailedToSendTransactionsError,
+    failedSingleTransactionPlanResult,
+    parallelTransactionPlanResult,
+    sequentialTransactionPlanResult,
+    successfulSingleTransactionPlanResult,
+} from '../index';
+import { createMessage } from './__setup__';
+
+const preflightContext: Omit<RpcSimulateTransactionResult, 'err'> = {
+    accounts: null,
+    loadedAccountsDataSize: null,
+    logs: ['Program log: Instruction: Transfer', 'Program failed: insufficient funds'],
+    replacementBlockhash: null,
+    returnData: null,
+    unitsConsumed: null,
+};
+
+const preflightContextWithoutLogs: Omit<RpcSimulateTransactionResult, 'err'> = {
+    accounts: null,
+    loadedAccountsDataSize: null,
+    logs: null,
+    replacementBlockhash: null,
+    returnData: null,
+    unitsConsumed: null,
+};
+
+function createPreflightError(
+    causeError: Error,
+    context: Omit<RpcSimulateTransactionResult, 'err'>,
+): SolanaError<typeof SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE> {
+    return new SolanaError(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE, {
+        ...context,
+        cause: causeError,
+    });
+}
+
+describe('createFailedToSendTransactionError', () => {
+    describe('given a failed result with a preflight error', () => {
+        it('unwraps the preflight error and sets the cause to the inner error', () => {
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const preflightError = createPreflightError(innerError, preflightContext);
+            const result = failedSingleTransactionPlanResult(createMessage('A'), preflightError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.cause).toBe(innerError);
+        });
+
+        it('sets preflightData from the preflight error context', () => {
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const preflightError = createPreflightError(innerError, preflightContext);
+            const result = failedSingleTransactionPlanResult(createMessage('A'), preflightError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.context.preflightData).toEqual(preflightContext);
+        });
+
+        it('sets logs as a shortcut to preflightData.logs', () => {
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const preflightError = createPreflightError(innerError, preflightContext);
+            const result = failedSingleTransactionPlanResult(createMessage('A'), preflightError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.context.logs).toEqual(preflightContext.logs);
+            expect(error.context.logs).toEqual(error.context.preflightData?.logs);
+        });
+
+        it('sets logs to undefined when preflight logs are null', () => {
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const preflightError = createPreflightError(innerError, preflightContextWithoutLogs);
+            const result = failedSingleTransactionPlanResult(createMessage('A'), preflightError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.context.logs).toBeUndefined();
+        });
+
+        it('includes (preflight) in the causeMessage', () => {
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const preflightError = createPreflightError(innerError, preflightContext);
+            const result = failedSingleTransactionPlanResult(createMessage('A'), preflightError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.context.causeMessage).toContain('(preflight)');
+        });
+
+        it('produces the expected error message', () => {
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const preflightError = createPreflightError(innerError, preflightContext);
+            const result = failedSingleTransactionPlanResult(createMessage('A'), preflightError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.message).toBe(`Failed to send transaction (preflight): ${innerError.message}`);
+        });
+    });
+
+    describe('given a failed result without a preflight error', () => {
+        it('uses the error directly as the cause', () => {
+            const plainError = new Error('Connection refused');
+            const result = failedSingleTransactionPlanResult(createMessage('A'), plainError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.cause).toBe(plainError);
+        });
+
+        it('sets preflightData to undefined', () => {
+            const plainError = new Error('Connection refused');
+            const result = failedSingleTransactionPlanResult(createMessage('A'), plainError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.context.preflightData).toBeUndefined();
+        });
+
+        it('sets logs to undefined', () => {
+            const plainError = new Error('Connection refused');
+            const result = failedSingleTransactionPlanResult(createMessage('A'), plainError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.context.logs).toBeUndefined();
+        });
+
+        it('produces the expected error message without an indicator', () => {
+            const plainError = new Error('Connection refused');
+            const result = failedSingleTransactionPlanResult(createMessage('A'), plainError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.message).toBe('Failed to send transaction: Connection refused');
+        });
+    });
+
+    describe('given a failed result with a signature in the context', () => {
+        it('includes the full signature in the causeMessage', () => {
+            const plainError = new Error('Transaction failed');
+            const signature =
+                '5wHu1qwD7q5ifaN5nwdcDQNbHUiCfnzJ6vaR98NLugS1CiVfCZLMGmmFaKCAVfPTFE5KPMhSaZaLo2v4xXSHVJk' as Signature;
+            const result = failedSingleTransactionPlanResult(createMessage('A'), plainError, { signature });
+            const error = createFailedToSendTransactionError(result);
+            expect(error.message).toBe(`Failed to send transaction (${signature}): Transaction failed`);
+        });
+    });
+
+    describe('given a failed result with a compute-limit simulation error', () => {
+        it('unwraps the simulation error', () => {
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const simulationError = new SolanaError(
+                SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+                { cause: innerError, unitsConsumed: 5000 },
+            );
+            const result = failedSingleTransactionPlanResult(createMessage('A'), simulationError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.cause).toBe(innerError);
+        });
+
+        // TODO(loris): The context of this error code currently only contains `{ unitsConsumed }`.
+        // Once we enrich it with the full simulation result, preflightData will be complete and
+        // logs will be available.
+        it('sets preflightData from the simulation error context', () => {
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const simulationError = new SolanaError(
+                SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+                { cause: innerError, unitsConsumed: 5000 },
+            );
+            const result = failedSingleTransactionPlanResult(createMessage('A'), simulationError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.context.preflightData).toEqual({ unitsConsumed: 5000 });
+        });
+
+        it('sets logs to undefined', () => {
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const simulationError = new SolanaError(
+                SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+                { cause: innerError, unitsConsumed: 5000 },
+            );
+            const result = failedSingleTransactionPlanResult(createMessage('A'), simulationError);
+            const error = createFailedToSendTransactionError(result);
+            expect(error.context.logs).toBeUndefined();
+        });
+    });
+
+    describe('given a canceled result with an abort reason', () => {
+        it('sets the cause to the abort reason', () => {
+            const abortReason = new Error('User canceled');
+            const result = canceledSingleTransactionPlanResult(createMessage('A'));
+            const error = createFailedToSendTransactionError(result, abortReason);
+            expect(error.cause).toBe(abortReason);
+        });
+
+        it('includes the abort reason in the causeMessage', () => {
+            const abortReason = new Error('User canceled');
+            const result = canceledSingleTransactionPlanResult(createMessage('A'));
+            const error = createFailedToSendTransactionError(result, abortReason);
+            expect(error.message).toBe('Failed to send transaction. Canceled with abort reason: Error: User canceled');
+        });
+
+        it('does not set preflightData or logs', () => {
+            const result = canceledSingleTransactionPlanResult(createMessage('A'));
+            const error = createFailedToSendTransactionError(result, new Error('abort'));
+            expect(error.context.preflightData).toBeUndefined();
+            expect(error.context.logs).toBeUndefined();
+        });
+    });
+
+    describe('given a canceled result without an abort reason', () => {
+        it('produces the expected error message', () => {
+            const result = canceledSingleTransactionPlanResult(createMessage('A'));
+            const error = createFailedToSendTransactionError(result);
+            expect(error.message).toBe('Failed to send transaction: Canceled');
+        });
+
+        it('sets the cause to undefined', () => {
+            const result = canceledSingleTransactionPlanResult(createMessage('A'));
+            const error = createFailedToSendTransactionError(result);
+            expect(error.cause).toBeUndefined();
+        });
+    });
+
+    it('sets transactionPlanResult as a non-enumerable property', () => {
+        const plainError = new Error('fail');
+        const result = failedSingleTransactionPlanResult(createMessage('A'), plainError);
+        const error = createFailedToSendTransactionError(result);
+        expect(error.context.transactionPlanResult).toBe(result);
+        expect(Object.keys(error.context)).not.toContain('transactionPlanResult');
+    });
+
+    it('has the correct error code', () => {
+        const plainError = new Error('fail');
+        const result = failedSingleTransactionPlanResult(createMessage('A'), plainError);
+        const error = createFailedToSendTransactionError(result);
+        expect(error.context.__code).toBe(SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION);
+    });
+});
+
+describe('createFailedToSendTransactionsError', () => {
+    describe('given a result with mixed failed, canceled, and successful transactions', () => {
+        it('only includes failed transactions in failedTransactions', () => {
+            const messageA = createMessage('A');
+            const messageB = createMessage('B');
+            const messageC = createMessage('C');
+            const errorB = new Error('B failed');
+            const result = sequentialTransactionPlanResult([
+                successfulSingleTransactionPlanResult(messageA, {
+                    signature: '11111111111111111111111111111111111111111111' as Signature,
+                }),
+                failedSingleTransactionPlanResult(messageB, errorB),
+                canceledSingleTransactionPlanResult(messageC),
+            ]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.context.failedTransactions).toHaveLength(1);
+        });
+
+        it('uses 0-based indices from the flattened result array', () => {
+            const messageA = createMessage('A');
+            const messageB = createMessage('B');
+            const messageC = createMessage('C');
+            const errorB = new Error('B failed');
+            const result = sequentialTransactionPlanResult([
+                successfulSingleTransactionPlanResult(messageA, {
+                    signature: '11111111111111111111111111111111111111111111' as Signature,
+                }),
+                failedSingleTransactionPlanResult(messageB, errorB),
+                canceledSingleTransactionPlanResult(messageC),
+            ]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.context.failedTransactions[0].index).toBe(1);
+        });
+
+        it('produces the expected error message', () => {
+            const messageA = createMessage('A');
+            const messageB = createMessage('B');
+            const errorA = new Error('A failed');
+            const errorB = new Error('B failed');
+            const result = sequentialTransactionPlanResult([
+                failedSingleTransactionPlanResult(messageA, errorA),
+                failedSingleTransactionPlanResult(messageB, errorB),
+            ]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.message).toBe('Failed to send transactions.\n[Tx #1] A failed\n[Tx #2] B failed');
+        });
+
+        it('sets the cause to the error when there is exactly one failure', () => {
+            const messageA = createMessage('A');
+            const messageB = createMessage('B');
+            const errorA = new Error('A failed');
+            const result = sequentialTransactionPlanResult([
+                failedSingleTransactionPlanResult(messageA, errorA),
+                canceledSingleTransactionPlanResult(messageB),
+            ]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.cause).toBe(errorA);
+        });
+
+        it('does not set the cause when there are multiple failures', () => {
+            const messageA = createMessage('A');
+            const messageB = createMessage('B');
+            const errorA = new Error('A failed');
+            const errorB = new Error('B failed');
+            const result = sequentialTransactionPlanResult([
+                failedSingleTransactionPlanResult(messageA, errorA),
+                failedSingleTransactionPlanResult(messageB, errorB),
+            ]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.cause).toBeUndefined();
+        });
+    });
+
+    describe('given failures with preflight errors', () => {
+        it('includes (preflight) indicator in causeMessages', () => {
+            const messageA = createMessage('A');
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const preflightError = createPreflightError(innerError, preflightContext);
+            const result = sequentialTransactionPlanResult([
+                failedSingleTransactionPlanResult(messageA, preflightError),
+            ]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.context.causeMessages).toContain('(preflight)');
+        });
+
+        it('unwraps the preflight error in failedTransactions entries', () => {
+            const messageA = createMessage('A');
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const preflightError = createPreflightError(innerError, preflightContext);
+            const result = sequentialTransactionPlanResult([
+                failedSingleTransactionPlanResult(messageA, preflightError),
+            ]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.context.failedTransactions[0].error).toBe(innerError);
+            expect(error.context.failedTransactions[0].preflightData).toEqual(preflightContext);
+        });
+
+        it('sets logs on failedTransactions entries', () => {
+            const messageA = createMessage('A');
+            const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
+            const preflightError = createPreflightError(innerError, preflightContext);
+            const result = sequentialTransactionPlanResult([
+                failedSingleTransactionPlanResult(messageA, preflightError),
+            ]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.context.failedTransactions[0].logs).toEqual(preflightContext.logs);
+        });
+    });
+
+    describe('given failures with signatures in the context', () => {
+        it('includes the signature in causeMessages', () => {
+            const messageA = createMessage('A');
+            const signature =
+                '5wHu1qwD7q5ifaN5nwdcDQNbHUiCfnzJ6vaR98NLugS1CiVfCZLMGmmFaKCAVfPTFE5KPMhSaZaLo2v4xXSHVJk' as Signature;
+            const plainError = new Error('Transaction failed');
+            const result = sequentialTransactionPlanResult([
+                failedSingleTransactionPlanResult(messageA, plainError, { signature }),
+            ]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.message).toBe(`Failed to send transactions.\n[Tx #1 (${signature})] Transaction failed`);
+        });
+    });
+
+    describe('given all canceled results with an abort reason', () => {
+        it('produces a single-line canceled message', () => {
+            const messageA = createMessage('A');
+            const messageB = createMessage('B');
+            const abortReason = new Error('User aborted');
+            const result = sequentialTransactionPlanResult([
+                canceledSingleTransactionPlanResult(messageA),
+                canceledSingleTransactionPlanResult(messageB),
+            ]);
+            const error = createFailedToSendTransactionsError(result, abortReason);
+            expect(error.message).toBe(
+                `Failed to send transactions. Canceled with abort reason: ${String(abortReason)}`,
+            );
+        });
+
+        it('has an empty failedTransactions array', () => {
+            const messageA = createMessage('A');
+            const result = sequentialTransactionPlanResult([canceledSingleTransactionPlanResult(messageA)]);
+            const error = createFailedToSendTransactionsError(result, new Error('abort'));
+            expect(error.context.failedTransactions).toHaveLength(0);
+        });
+
+        it('sets the cause to the abort reason', () => {
+            const messageA = createMessage('A');
+            const abortReason = new Error('User aborted');
+            const result = sequentialTransactionPlanResult([canceledSingleTransactionPlanResult(messageA)]);
+            const error = createFailedToSendTransactionsError(result, abortReason);
+            expect(error.cause).toBe(abortReason);
+        });
+    });
+
+    describe('given all canceled results without an abort reason', () => {
+        it('produces a single-line canceled message', () => {
+            const messageA = createMessage('A');
+            const result = sequentialTransactionPlanResult([canceledSingleTransactionPlanResult(messageA)]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.message).toBe('Failed to send transactions: Canceled');
+        });
+    });
+
+    describe('given a complex nested result', () => {
+        it('flattens the result tree and uses correct indices', () => {
+            const messageA = createMessage('A');
+            const messageB = createMessage('B');
+            const messageC = createMessage('C');
+            const messageD = createMessage('D');
+            const errorB = new Error('B failed');
+            const errorD = new Error('D failed');
+            const result = sequentialTransactionPlanResult([
+                parallelTransactionPlanResult([
+                    successfulSingleTransactionPlanResult(messageA, {
+                        signature: '11111111111111111111111111111111111111111111' as Signature,
+                    }),
+                    failedSingleTransactionPlanResult(messageB, errorB),
+                ]),
+                sequentialTransactionPlanResult([
+                    canceledSingleTransactionPlanResult(messageC),
+                    failedSingleTransactionPlanResult(messageD, errorD),
+                ]),
+            ]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.context.failedTransactions).toHaveLength(2);
+            // messageB is index 1 in the flattened [A, B, C, D] array
+            expect(error.context.failedTransactions[0].index).toBe(1);
+            // messageD is index 3 in the flattened [A, B, C, D] array
+            expect(error.context.failedTransactions[1].index).toBe(3);
+        });
+
+        it('produces the expected error message with varied failure indicators', () => {
+            const sigB =
+                '2RocoT4bGn3GDCCkwBmpipjYHP1RWdoSxVUvMBqRTMFCnmFi2VoSuQhRYoP69NDPH8FPr4a3gH6JkJBJGP2DX2i' as Signature;
+            const sigD =
+                '5wHu1qwD7q5ifaN5nwdcDQNbHUiCfnzJ6vaR98NLugS1CiVfCZLMGmmFaKCAVfPTFE5KPMhSaZaLo2v4xXSHVJk' as Signature;
+            // Flattened: [A(ok), B(preflight+sig), C(canceled), D(sig only), E(ok), F(preflight), G(plain), H(canceled)]
+            const result = sequentialTransactionPlanResult([
+                parallelTransactionPlanResult([
+                    successfulSingleTransactionPlanResult(createMessage('A'), {
+                        signature: '11111111111111111111111111111111111111111111' as Signature,
+                    }),
+                    // Tx #2: preflight error with signature — should show (preflight)
+                    failedSingleTransactionPlanResult(
+                        createMessage('B'),
+                        createPreflightError(new Error('B failed'), preflightContext),
+                        { signature: sigB },
+                    ),
+                ]),
+                canceledSingleTransactionPlanResult(createMessage('C')),
+                sequentialTransactionPlanResult([
+                    // Tx #4: plain error with signature — should show (signature)
+                    failedSingleTransactionPlanResult(createMessage('D'), new Error('D failed'), { signature: sigD }),
+                    successfulSingleTransactionPlanResult(createMessage('E'), {
+                        signature: '22222222222222222222222222222222222222222222' as Signature,
+                    }),
+                    // Tx #6: preflight error without signature — should show (preflight)
+                    failedSingleTransactionPlanResult(
+                        createMessage('F'),
+                        createPreflightError(new Error('F failed'), preflightContext),
+                    ),
+                    // Tx #7: plain error without signature — no indicator
+                    failedSingleTransactionPlanResult(createMessage('G'), new Error('G failed')),
+                ]),
+                canceledSingleTransactionPlanResult(createMessage('H')),
+            ]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.message).toBe(
+                'Failed to send transactions.\n' +
+                    '[Tx #2 (preflight)] B failed\n' +
+                    `[Tx #4 (${sigD})] D failed\n` +
+                    '[Tx #6 (preflight)] F failed\n' +
+                    '[Tx #7] G failed',
+            );
+        });
+    });
+
+    it('sets transactionPlanResult as a non-enumerable property', () => {
+        const messageA = createMessage('A');
+        const errorA = new Error('A failed');
+        const result = sequentialTransactionPlanResult([failedSingleTransactionPlanResult(messageA, errorA)]);
+        const error = createFailedToSendTransactionsError(result);
+        expect(error.context.transactionPlanResult).toBe(result);
+        expect(Object.keys(error.context)).not.toContain('transactionPlanResult');
+    });
+
+    it('has the correct error code', () => {
+        const messageA = createMessage('A');
+        const errorA = new Error('A failed');
+        const result = sequentialTransactionPlanResult([failedSingleTransactionPlanResult(messageA, errorA)]);
+        const error = createFailedToSendTransactionsError(result);
+        expect(error.context.__code).toBe(SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS);
+    });
+});

--- a/packages/instruction-plans/src/index.ts
+++ b/packages/instruction-plans/src/index.ts
@@ -54,6 +54,7 @@ export * from './append-instruction-plan';
 export * from './instruction-plan';
 export * from './instruction-plan-input';
 export * from './transaction-plan';
+export * from './transaction-plan-errors';
 export * from './transaction-plan-executor';
 export * from './transaction-plan-result';
 export * from './transaction-planner';

--- a/packages/instruction-plans/src/transaction-plan-errors.ts
+++ b/packages/instruction-plans/src/transaction-plan-errors.ts
@@ -1,0 +1,199 @@
+import {
+    isSolanaError,
+    type RpcSimulateTransactionResult,
+    SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION,
+    SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS,
+    SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+    SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+    SolanaError,
+    type SolanaErrorCode,
+} from '@solana/errors';
+
+import {
+    type CanceledSingleTransactionPlanResult,
+    type FailedSingleTransactionPlanResult,
+    flattenTransactionPlanResult,
+    type TransactionPlanResult,
+} from './transaction-plan-result';
+
+type PreflightData = Omit<RpcSimulateTransactionResult, 'err'>;
+
+/**
+ * Creates a {@link SolanaError} with the {@link SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION}
+ * error code from a failed or canceled {@link SingleTransactionPlanResult}.
+ *
+ * This is a high-level error designed for user-facing transaction send failures.
+ * It unwraps simulation errors (such as preflight failures) to expose the
+ * underlying transaction error as the `cause`, and extracts preflight data
+ * and logs into the error context for easy access.
+ *
+ * The error message includes an indicator showing whether the failure was a
+ * preflight error or includes the on-chain transaction signature for easy
+ * copy-pasting into block explorers.
+ *
+ * @param result - A failed or canceled single transaction plan result.
+ * @param abortReason - An optional abort reason if the transaction was canceled.
+ * @return A {@link SolanaError} with the appropriate error code, context, and cause.
+ *
+ * @example
+ * Creating an error from a failed transaction plan result.
+ * ```ts
+ * import { createFailedToSendTransactionError } from '@solana/instruction-plans';
+ *
+ * const error = createFailedToSendTransactionError(failedResult);
+ * console.log(error.message);
+ * // "Failed to send transaction (preflight): Insufficient funds for fee"
+ * console.log(error.cause);
+ * // The unwrapped transaction error
+ * console.log(error.context.logs);
+ * // Transaction logs from the preflight simulation
+ * ```
+ *
+ * @see {@link createFailedToSendTransactionsError}
+ */
+export function createFailedToSendTransactionError(
+    result: CanceledSingleTransactionPlanResult | FailedSingleTransactionPlanResult,
+    abortReason?: unknown,
+): SolanaError<typeof SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION> {
+    let causeMessage: string;
+    let cause: unknown;
+    let logs: readonly string[] | undefined;
+    let preflightData: PreflightData | undefined;
+
+    if (result.status === 'failed') {
+        const unwrapped = unwrapErrorWithPreflightData(result.error);
+        logs = unwrapped.logs;
+        preflightData = unwrapped.preflightData;
+        cause = unwrapped.unwrappedError;
+        const indicator = getFailedIndicator(!!preflightData, result.context.signature);
+        causeMessage = `${indicator}: ${(cause as Error).message}`;
+    } else {
+        cause = abortReason;
+        causeMessage = abortReason != null ? `. Canceled with abort reason: ${String(abortReason)}` : ': Canceled';
+    }
+
+    const context: Record<string, unknown> = {
+        cause,
+        causeMessage,
+        logs,
+        preflightData,
+    };
+    Object.defineProperty(context, 'transactionPlanResult', {
+        configurable: false,
+        enumerable: false,
+        value: result,
+        writable: false,
+    });
+    return new SolanaError(SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION, context);
+}
+
+/**
+ * Creates a {@link SolanaError} with the {@link SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS}
+ * error code from a {@link TransactionPlanResult}.
+ *
+ * This is a high-level error designed for user-facing transaction send failures
+ * involving multiple transactions. It walks the result tree, unwraps simulation
+ * errors from each failure, and builds a `failedTransactions` array pairing each
+ * failure with its unwrapped error, logs, and preflight data.
+ *
+ * The error message lists each failure with its position in the plan and an
+ * indicator showing whether it was a preflight error or includes the transaction
+ * signature. When all transactions were canceled, the message is a single line.
+ *
+ * @param result - The full transaction plan result tree.
+ * @param abortReason - An optional abort reason if the plan was aborted.
+ * @return A {@link SolanaError} with the appropriate error code, context, and cause.
+ *
+ * @example
+ * Creating an error from a failed transaction plan result.
+ * ```ts
+ * import { createFailedToSendTransactionsError } from '@solana/instruction-plans';
+ *
+ * const error = createFailedToSendTransactionsError(planResult);
+ * console.log(error.message);
+ * // "Failed to send transactions.
+ * // [Tx #1 (preflight)] Insufficient funds for fee
+ * // [Tx #3 (5abc...)] Custom program error: 0x1"
+ * console.log(error.context.failedTransactions);
+ * // [{ index: 0, error: ..., logs: [...], preflightData: {...} }, ...]
+ * ```
+ *
+ * @see {@link createFailedToSendTransactionError}
+ */
+export function createFailedToSendTransactionsError(
+    result: TransactionPlanResult,
+    abortReason?: unknown,
+): SolanaError<typeof SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS> {
+    const flattenedResults = flattenTransactionPlanResult(result);
+
+    const failedTransactions = flattenedResults.flatMap((singleResult, index) => {
+        if (singleResult.status !== 'failed') return [];
+        const unwrapped = unwrapErrorWithPreflightData(singleResult.error);
+        return [
+            {
+                error: unwrapped.unwrappedError as Error,
+                index,
+                logs: unwrapped.logs,
+                preflightData: unwrapped.preflightData,
+            },
+        ];
+    });
+
+    let causeMessages: string;
+    let cause: unknown;
+
+    if (failedTransactions.length > 0) {
+        cause = failedTransactions.length === 1 ? failedTransactions[0].error : undefined;
+        const failureLines = failedTransactions.map(({ error, index, preflightData }) => {
+            const indicator = getFailedIndicator(!!preflightData, flattenedResults[index].context.signature);
+            return `\n[Tx #${index + 1}${indicator}] ${error.message}`;
+        });
+        causeMessages = `.${failureLines.join('')}`;
+    } else {
+        cause = abortReason;
+        causeMessages = abortReason != null ? `. Canceled with abort reason: ${String(abortReason)}` : ': Canceled';
+    }
+
+    const context: Record<string, unknown> = {
+        cause,
+        causeMessages,
+        failedTransactions,
+    };
+    Object.defineProperty(context, 'transactionPlanResult', {
+        configurable: false,
+        enumerable: false,
+        value: result,
+        writable: false,
+    });
+    return new SolanaError(SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS, context);
+}
+
+function unwrapErrorWithPreflightData(error: Error): {
+    logs: readonly string[] | undefined;
+    preflightData: PreflightData | undefined;
+    unwrappedError: unknown;
+} {
+    const simulationCodes: SolanaErrorCode[] = [
+        SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+        SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
+    ];
+    if (isSolanaError(error) && simulationCodes.includes(error.context.__code)) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { __code, ...rest } = error.context;
+        // TODO(loris): Remove this cast once FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT
+        // is enriched with the full simulation result (logs, accounts, etc.).
+        const preflightData = rest as unknown as PreflightData;
+        return {
+            logs: preflightData.logs ?? undefined,
+            preflightData,
+            unwrappedError: error.cause ?? error,
+        };
+    }
+    return { logs: undefined, preflightData: undefined, unwrappedError: error };
+}
+
+function getFailedIndicator(isPreflight: boolean, signature: string | undefined): string {
+    if (isPreflight) return ' (preflight)';
+    if (signature) return ` (${signature})`;
+    return '';
+}


### PR DESCRIPTION
This PR adds two factory helpers to `@solana/instruction-plans` that create high-level `SolanaError` instances from transaction plan results:

- `createFailedToSendTransactionError` — for single transaction failures. Unwraps preflight and compute-limit simulation errors to expose the underlying transaction error as the `cause`, and extracts preflight data and logs into the error context. The error message includes an indicator showing whether the failure was a preflight error or includes the on-chain signature.
- `createFailedToSendTransactionsError` — for multi-transaction failures. Walks the result tree, unwraps each failure, and builds a `failedTransactions` array with per-failure error, logs, and preflight data. The error message lists each failure with its position in the plan. The `cause` is only set when there is exactly one failure or when the plan was aborted.

Both helpers handle canceled results (with or without abort reasons), attach the full `transactionPlanResult` as a non-enumerable property, and set `cause` for error chaining.