### PR TITLE
Add `createFailedToExecuteTransactionPlanError` helper

### DIFF
--- a/.changeset/dull-rice-film.md
+++ b/.changeset/dull-rice-film.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': patch
+---
+
+Add `createFailedToExecuteTransactionPlanError` factory helper for custom transaction plan executor authors and refactor the built-in executor to use it.

--- a/packages/instruction-plans/src/__tests__/transaction-plan-errors-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-errors-test.ts
@@ -2,6 +2,7 @@ import {
     type RpcSimulateTransactionResult,
     SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION,
     SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS,
+    SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
     SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
     SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE,
@@ -11,6 +12,7 @@ import { Signature } from '@solana/keys';
 
 import {
     canceledSingleTransactionPlanResult,
+    createFailedToExecuteTransactionPlanError,
     createFailedToSendTransactionError,
     createFailedToSendTransactionsError,
     failedSingleTransactionPlanResult,
@@ -484,5 +486,39 @@ describe('createFailedToSendTransactionsError', () => {
         const result = sequentialTransactionPlanResult([failedSingleTransactionPlanResult(messageA, errorA)]);
         const error = createFailedToSendTransactionsError(result);
         expect(error.context.__code).toBe(SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS);
+    });
+});
+
+describe('createFailedToExecuteTransactionPlanError', () => {
+    it('has the correct error code', () => {
+        const result = sequentialTransactionPlanResult([
+            failedSingleTransactionPlanResult(createMessage('A'), new Error('A failed')),
+        ]);
+        const error = createFailedToExecuteTransactionPlanError(result);
+        expect(error.context.__code).toBe(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN);
+    });
+
+    it('sets transactionPlanResult as a non-enumerable property', () => {
+        const result = sequentialTransactionPlanResult([
+            failedSingleTransactionPlanResult(createMessage('A'), new Error('A failed')),
+        ]);
+        const error = createFailedToExecuteTransactionPlanError(result);
+        expect(error.context.transactionPlanResult).toBe(result);
+        expect(Object.keys(error.context)).not.toContain('transactionPlanResult');
+    });
+
+    it('sets abortReason in the context when provided', () => {
+        const abortReason = new Error('User canceled');
+        const result = sequentialTransactionPlanResult([canceledSingleTransactionPlanResult(createMessage('A'))]);
+        const error = createFailedToExecuteTransactionPlanError(result, abortReason);
+        expect(error.context.abortReason).toBe(abortReason);
+    });
+
+    it('sets abortReason to undefined when not provided', () => {
+        const result = sequentialTransactionPlanResult([
+            failedSingleTransactionPlanResult(createMessage('A'), new Error('A failed')),
+        ]);
+        const error = createFailedToExecuteTransactionPlanError(result);
+        expect(error.context.abortReason).toBeUndefined();
     });
 });

--- a/packages/instruction-plans/src/transaction-plan-errors.ts
+++ b/packages/instruction-plans/src/transaction-plan-errors.ts
@@ -3,6 +3,7 @@ import {
     type RpcSimulateTransactionResult,
     SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION,
     SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS,
+    SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
     SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
     SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
     SolanaError,
@@ -168,6 +169,49 @@ export function createFailedToSendTransactionsError(
     return new SolanaError(SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS, context);
 }
 
+/**
+ * Creates a {@link SolanaError} with the
+ * {@link SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN}
+ * error code from a {@link TransactionPlanResult}.
+ *
+ * This is a low-level error intended for custom transaction plan executor
+ * authors. It attaches the full `transactionPlanResult` as a non-enumerable
+ * property so that callers can inspect execution details without the result
+ * being serialized with the error.
+ *
+ * @param result - The full transaction plan result tree.
+ * @param abortReason - An optional abort reason if the plan was aborted.
+ * @return A {@link SolanaError} with the appropriate error code and context.
+ *
+ * @example
+ * Throwing a failed-to-execute error from a custom executor.
+ * ```ts
+ * import { createFailedToExecuteTransactionPlanError } from '@solana/instruction-plans';
+ *
+ * throw createFailedToExecuteTransactionPlanError(transactionPlanResult, abortSignal?.reason);
+ * ```
+ *
+ * @see {@link createFailedToSendTransactionError}
+ * @see {@link createFailedToSendTransactionsError}
+ */
+export function createFailedToExecuteTransactionPlanError(
+    result: TransactionPlanResult,
+    abortReason?: unknown,
+): SolanaError<typeof SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN> {
+    const context: Record<string, unknown> = {
+        abortReason,
+        // Deprecated: will be removed in a future version.
+        cause: findErrorFromTransactionPlanResult(result) ?? abortReason,
+    };
+    Object.defineProperty(context, 'transactionPlanResult', {
+        configurable: false,
+        enumerable: false,
+        value: result,
+        writable: false,
+    });
+    return new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, context);
+}
+
 function unwrapErrorWithPreflightData(error: Error): {
     logs: readonly string[] | undefined;
     preflightData: PreflightData | undefined;
@@ -190,6 +234,18 @@ function unwrapErrorWithPreflightData(error: Error): {
         };
     }
     return { logs: undefined, preflightData: undefined, unwrappedError: error };
+}
+
+function findErrorFromTransactionPlanResult(result: TransactionPlanResult): Error | undefined {
+    if (result.kind === 'single') {
+        return result.status === 'failed' ? result.error : undefined;
+    }
+    for (const plan of result.plans) {
+        const error = findErrorFromTransactionPlanResult(plan);
+        if (error) {
+            return error;
+        }
+    }
 }
 
 function getFailedIndicator(isPreflight: boolean, signature: string | undefined): string {

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -16,6 +16,7 @@ import type {
     SingleTransactionPlan,
     TransactionPlan,
 } from './transaction-plan';
+import { createFailedToExecuteTransactionPlanError } from './transaction-plan-errors';
 import {
     BaseTransactionPlanResultContext,
     canceledSingleTransactionPlanResult,
@@ -140,20 +141,7 @@ export function createTransactionPlanExecutor<
 
         if (traverseConfig.canceled) {
             const abortReason = abortSignal?.aborted ? abortSignal.reason : undefined;
-            const context = {
-                abortReason,
-                cause: findErrorFromTransactionPlanResult(transactionPlanResult) ?? abortReason,
-            };
-            // Here we want the `transactionPlanResult` to be available in the error context
-            // so applications can create recovery plans but we don't want this object to be
-            // serialized with the error. This is why we set it as a non-enumerable property.
-            Object.defineProperty(context, 'transactionPlanResult', {
-                configurable: false,
-                enumerable: false,
-                value: transactionPlanResult,
-                writable: false,
-            });
-            throw new SolanaError(SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN, context);
+            throw createFailedToExecuteTransactionPlanError(transactionPlanResult, abortReason);
         }
 
         return transactionPlanResult;
@@ -235,18 +223,6 @@ async function traverseSingle<TContext extends TransactionPlanResultContext>(
                 ? { ...context, signature: getSignatureFromTransaction(context.transaction) }
                 : context;
         return failedSingleTransactionPlanResult(transactionPlan.message, error as Error, contextWithSignature);
-    }
-}
-
-function findErrorFromTransactionPlanResult(result: TransactionPlanResult): Error | undefined {
-    if (result.kind === 'single') {
-        return result.status === 'failed' ? result.error : undefined;
-    }
-    for (const plan of result.plans) {
-        const error = findErrorFromTransactionPlanResult(plan);
-        if (error) {
-            return error;
-        }
     }
 }
 


### PR DESCRIPTION
This PR extracts the `SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN` error creation logic from the built-in transaction plan executor into a new `createFailedToExecuteTransactionPlanError` factory helper in `transaction-plan-errors.ts`. This allows custom executor authors to throw the same error type with consistent structure.

The helper accepts a `TransactionPlanResult` and an optional `abortReason`, attaches the result as a non-enumerable `transactionPlanResult` property, and still sets the deprecated `cause` property for backwards compatibility. The built-in executor is refactored to call this helper, and `findErrorFromTransactionPlanResult` is moved to `transaction-plan-errors.ts` as an internal helper.