### PR TITLE
Regenerate .source files using fumadocs-mdx in build-api-docs script

### DIFF
--- a/docs/build-api-docs.sh
+++ b/docs/build-api-docs.sh
@@ -20,3 +20,8 @@ done
 # Generate API index.
 echo "📝 Generating API index page from TypeDoc JSON..."
 node docs/build-api-index.js
+
+# Regenerate .source to pick up the new index.mdx
+echo "♻️  Regenerating .source files..."
+cd docs
+pnpm fumadocs-mdx


### PR DESCRIPTION
We saw a 404 on solanakit.com/api, which was caused by [this CI job](https://github.com/anza-xyz/kit/actions/runs/22682647624/job/65757034529) (note: not the fault of the code in that commit)

In the logs we see the generated nextjs app:

```
Route (app)
┌ ○ /
├ ○ /_not-found
├ ● /api/[[...slug]]
├ ● /docs/[[...slug]]
│ ├ /docs/compatible-clients
│ ├ /docs
│ ├ /docs/upgrade-guide
│ └ [+17 more paths]
├ ○ /llms-full.txt
├ ● /llms.mdx/api/[[...slug]]
└ ● /llms.mdx/docs/[[...slug]]
  ├ /llms.mdx/docs/compatible-clients
  ├ /llms.mdx/docs
  ├ /llms.mdx/docs/upgrade-guide
  └ [+17 more paths]
```

Compare with [a more recent CI job](https://github.com/anza-xyz/kit/actions/runs/22709576718/job/65844098775), which produced the current docs which do not 404 on /api

```
Route (app)
┌ ○ /
├ ○ /_not-found
├ ● /api/[[...slug]]
│ ├ /api
│ ├ /api/classes/SolanaError
│ ├ /api/enumerations/AccountRole
│ └ [+1369 more paths]
├ ● /docs/[[...slug]]
│ ├ /docs/compatible-clients
│ ├ /docs
│ ├ /docs/upgrade-guide
│ └ [+17 more paths]
├ ○ /llms-full.txt
├ ● /llms.mdx/api/[[...slug]]
│ ├ /llms.mdx/api
│ ├ /llms.mdx/api/classes/SolanaError
│ ├ /llms.mdx/api/enumerations/AccountRole
│ └ [+1369 more paths]
└ ● /llms.mdx/docs/[[...slug]]
  ├ /llms.mdx/docs/compatible-clients
  ├ /llms.mdx/docs
  ├ /llms.mdx/docs/upgrade-guide
  └ [+17 more paths]
```

TLDR: Vercel didn't produce the API routes

----

My hypothesis is that this is caused by a race condition when we build the docs.

In prebuild we call `build-api-docs.sh` which generates `index.mdx` but does not regenerate `.source`.

During the `next build` it calls `generateStaticParams()` on all routes, and generates the current routes from `.source`

Also during the Next build, it calls `withMDX()` from `next.config.mjs`, which runs `fumadocs-mdx` and updates `.source`. This triggers the `[MDX] updated map file` line in the logs

This is a race - Next generates static pages for whatever is in `.source` at the right time. It seems this usually ends up being timed in a way that works, but in this build it was not.

----

The fix in this PR is to run `fumadocs-mdx` as part of the prebuild, before Next does anything. This should update `.source` before `generateStaticParams` is called, regardless of how things are timed within the Next build.