### PR TITLE
Add instruction index suffix to instruction error messages

### DIFF
--- a/.changeset/cruel-tires-win.md
+++ b/.changeset/cruel-tires-win.md
@@ -1,0 +1,5 @@
+---
+'@solana/errors': patch
+---
+
+Append the instruction index to all instruction error messages (e.g. `(instruction #1)`) and add a human-readable message for unknown instruction errors.

--- a/packages/errors/src/__tests__/message-formatter-test.ts
+++ b/packages/errors/src/__tests__/message-formatter-test.ts
@@ -1,4 +1,4 @@
-import { SolanaErrorCode } from '../codes';
+import { SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN, SolanaErrorCode } from '../codes';
 import { encodeContextObject } from '../context';
 import { getErrorMessage } from '../message-formatter';
 import * as MessagesModule from '../messages';
@@ -171,6 +171,51 @@ describe('getErrorMessage', () => {
                 { variable: undefined },
             );
             expect(message).toBe('Here is a variable: undefined');
+        });
+        it('appends the instruction number to instruction error messages', () => {
+            const messagesSpy = jest.spyOn(MessagesModule, 'SolanaErrorMessages', 'get');
+            // @ts-expect-error Mock error config doesn't conform to exported config.
+            messagesSpy.mockReturnValue({
+                [SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN]: 'Some instruction error',
+            });
+            const message = getErrorMessage(SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN, { index: 0 });
+            expect(message).toBe('Some instruction error (instruction #1)');
+        });
+        it('uses one-based instruction numbering', () => {
+            const messagesSpy = jest.spyOn(MessagesModule, 'SolanaErrorMessages', 'get');
+            // @ts-expect-error Mock error config doesn't conform to exported config.
+            messagesSpy.mockReturnValue({
+                [SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN]: 'Some instruction error',
+            });
+            const message = getErrorMessage(SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN, { index: 5 });
+            expect(message).toBe('Some instruction error (instruction #6)');
+        });
+        it('appends the instruction number to error codes at the end of the instruction error range', () => {
+            const lastInstructionErrorCode = SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN + 999;
+            const messagesSpy = jest.spyOn(MessagesModule, 'SolanaErrorMessages', 'get');
+            // @ts-expect-error Mock error config doesn't conform to exported config.
+            messagesSpy.mockReturnValue({
+                [lastInstructionErrorCode]: 'Some instruction error',
+            });
+            const message = getErrorMessage(
+                // @ts-expect-error Mock error code doesn't conform to exported config.
+                lastInstructionErrorCode,
+                { index: 2 },
+            );
+            expect(message).toBe('Some instruction error (instruction #3)');
+        });
+        it('does not append the instruction number to non-instruction error messages', () => {
+            const messagesSpy = jest.spyOn(MessagesModule, 'SolanaErrorMessages', 'get');
+            messagesSpy.mockReturnValue({
+                // @ts-expect-error Mock error config doesn't conform to exported config.
+                123: 'some other error',
+            });
+            const message = getErrorMessage(
+                // @ts-expect-error Mock error context doesn't conform to exported context.
+                123,
+                { index: 0 },
+            );
+            expect(message).toBe('some other error');
         });
     });
 });

--- a/packages/errors/src/message-formatter.ts
+++ b/packages/errors/src/message-formatter.ts
@@ -1,6 +1,8 @@
-import { SolanaErrorCode } from './codes';
+import { SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN, SolanaErrorCode } from './codes';
 import { encodeContextObject } from './context';
 import { SolanaErrorMessages } from './messages';
+
+const INSTRUCTION_ERROR_RANGE_SIZE = 1000;
 
 const enum StateType {
     EscapeSequence,
@@ -81,7 +83,15 @@ export function getHumanReadableErrorMessage<TErrorCode extends SolanaErrorCode>
         }
     });
     commitStateUpTo();
-    return fragments.join('');
+    let message = fragments.join('');
+    if (
+        code >= SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN &&
+        code < SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN + INSTRUCTION_ERROR_RANGE_SIZE &&
+        'index' in context
+    ) {
+        message += ` (instruction #${(context as { index: number }).index + 1})`;
+    }
+    return message;
 }
 
 export function getErrorMessage<TErrorCode extends SolanaErrorCode>(

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -450,7 +450,7 @@ export const SolanaErrorMessages: Readonly<{
     [SOLANA_ERROR__INSTRUCTION_ERROR__UNBALANCED_INSTRUCTION]:
         'sum of account balances before and after instruction do not match',
     [SOLANA_ERROR__INSTRUCTION_ERROR__UNINITIALIZED_ACCOUNT]: 'instruction requires an initialized account',
-    [SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN]: '',
+    [SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN]: 'The instruction failed with the error: $errorName',
     [SOLANA_ERROR__INSTRUCTION_ERROR__UNSUPPORTED_PROGRAM_ID]: 'Unsupported program id',
     [SOLANA_ERROR__INSTRUCTION_ERROR__UNSUPPORTED_SYSVAR]: 'Unsupported sysvar',
     [SOLANA_ERROR__INVARIANT_VIOLATION__INVALID_INSTRUCTION_PLAN_KIND]: 'Invalid instruction plan kind: $kind.',


### PR DESCRIPTION
This PR appends a one-based instruction index suffix like `(instruction https://github.com/anza-xyz/kit/pull/1)` to all `INSTRUCTION_ERROR__*` error messages, making it immediately clear which instruction in a transaction caused the error. It also fills in the previously empty `SOLANA_ERROR__INSTRUCTION_ERROR__UNKNOWN` message with `'The instruction failed with the error: $errorName'` so that unrecognized instruction error names from the RPC are surfaced to the user.