### PR TITLE
Remove stale `$encodedData` from `BORSH_IO_ERROR` message

### DIFF
--- a/.changeset/neat-rivers-dance.md
+++ b/.changeset/neat-rivers-dance.md
@@ -1,0 +1,5 @@
+---
+'@solana/errors': patch
+---
+
+Remove stale `$encodedData` interpolation from the `BORSH_IO_ERROR` message. The `encodedData` context property was removed in v5.0.0 but the message template was not updated, causing the literal `$encodedData` to appear in the rendered error message.

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -393,7 +393,7 @@ export const SolanaErrorMessages: Readonly<{
     [SOLANA_ERROR__INSTRUCTION_ERROR__ACCOUNT_NOT_RENT_EXEMPT]:
         'An account does not have enough lamports to be rent-exempt',
     [SOLANA_ERROR__INSTRUCTION_ERROR__ARITHMETIC_OVERFLOW]: 'Program arithmetic overflowed',
-    [SOLANA_ERROR__INSTRUCTION_ERROR__BORSH_IO_ERROR]: 'Failed to serialize or deserialize account data: $encodedData',
+    [SOLANA_ERROR__INSTRUCTION_ERROR__BORSH_IO_ERROR]: 'Failed to serialize or deserialize account data',
     [SOLANA_ERROR__INSTRUCTION_ERROR__BUILTIN_PROGRAMS_MUST_CONSUME_COMPUTE_UNITS]:
         'Builtin programs must consume compute units',
     [SOLANA_ERROR__INSTRUCTION_ERROR__CALL_DEPTH]: 'Cross-program invocation call depth too deep',


### PR DESCRIPTION
This PR removes the stale `$encodedData` interpolation variable from the `BORSH_IO_ERROR` error message. The `encodedData` context property was intentionally removed in v5.0.0 (PR https://github.com/anza-xyz/kit/pull/974) when the Solana SDK 3.0 changed `BorshIoError(String)` to a fieldless unit variant, but the message template was not updated at the time. This caused the literal string `$encodedData` to appear in the rendered error message.