### PR TITLE
Enrich `FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT` error with full simulation result

### DIFF
--- a/.changeset/young-deer-occur.md
+++ b/.changeset/young-deer-occur.md
@@ -1,0 +1,6 @@
+---
+'@solana/errors': minor
+'@solana/instruction-plans': minor
+---
+
+Enrich the `SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT` error context with the full simulation result (`Omit<RpcSimulateTransactionResult, 'err'>`) and add it to `SolanaErrorCodeWithCause`, aligning it with the `SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE` error.

--- a/packages/errors/src/__tests__/simulation-errors-test.ts
+++ b/packages/errors/src/__tests__/simulation-errors-test.ts
@@ -40,8 +40,8 @@ describe('unwrapSimulationError', () => {
         it('returns the cause of the error', () => {
             const cause = new Error('underlying error');
             const error = new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT, {
+                ...rpcSimulationError,
                 cause,
-                unitsConsumed: 5000,
             });
             expect(unwrapSimulationError(error)).toBe(cause);
         });
@@ -50,7 +50,7 @@ describe('unwrapSimulationError', () => {
     describe('given a simulation compute limit estimation failure error without a cause', () => {
         it('returns the original error unchanged', () => {
             const error = new SolanaError(SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT, {
-                unitsConsumed: 5000,
+                ...rpcSimulationError,
             });
             expect(unwrapSimulationError(error)).toBe(error);
         });

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -668,7 +668,9 @@ export type SolanaErrorCode =
  * Errors of this type are understood to have an optional {@link SolanaError} nested inside as
  * `cause`.
  */
-export type SolanaErrorCodeWithCause = typeof SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE;
+export type SolanaErrorCodeWithCause =
+    | typeof SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE
+    | typeof SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT;
 
 /**
  * Errors of this type have a deprecated `cause` property. Consumers should use the error's

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -776,9 +776,10 @@ export type SolanaErrorContext = ReadonlyContextValue<
             [SOLANA_ERROR__TRANSACTION__FAILED_TO_DECOMPILE_INSTRUCTION_PROGRAM_ADDRESS_NOT_FOUND]: {
                 index: number;
             };
-            [SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT]: {
-                unitsConsumed: number;
-            };
+            [SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT]: Omit<
+                RpcSimulateTransactionResult,
+                'err'
+            >;
             [SOLANA_ERROR__TRANSACTION__INVALID_CONFIG_MASK_PRIORITY_FEE_BITS]: {
                 mask: number;
             };

--- a/packages/instruction-plans/src/__tests__/transaction-plan-errors-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-errors-test.ts
@@ -148,36 +148,33 @@ describe('createFailedToSendTransactionError', () => {
             const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
             const simulationError = new SolanaError(
                 SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
-                { cause: innerError, unitsConsumed: 5000 },
+                { ...preflightContext, cause: innerError },
             );
             const result = failedSingleTransactionPlanResult(createMessage('A'), simulationError);
             const error = createFailedToSendTransactionError(result);
             expect(error.cause).toBe(innerError);
         });
 
-        // TODO(loris): The context of this error code currently only contains `{ unitsConsumed }`.
-        // Once we enrich it with the full simulation result, preflightData will be complete and
-        // logs will be available.
         it('sets preflightData from the simulation error context', () => {
             const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
             const simulationError = new SolanaError(
                 SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
-                { cause: innerError, unitsConsumed: 5000 },
+                { ...preflightContext, cause: innerError },
             );
             const result = failedSingleTransactionPlanResult(createMessage('A'), simulationError);
             const error = createFailedToSendTransactionError(result);
-            expect(error.context.preflightData).toEqual({ unitsConsumed: 5000 });
+            expect(error.context.preflightData).toEqual(preflightContext);
         });
 
-        it('sets logs to undefined', () => {
+        it('sets logs from the simulation error context', () => {
             const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
             const simulationError = new SolanaError(
                 SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT,
-                { cause: innerError, unitsConsumed: 5000 },
+                { ...preflightContext, cause: innerError },
             );
             const result = failedSingleTransactionPlanResult(createMessage('A'), simulationError);
             const error = createFailedToSendTransactionError(result);
-            expect(error.context.logs).toBeUndefined();
+            expect(error.context.logs).toEqual(preflightContext.logs);
         });
     });
 

--- a/packages/instruction-plans/src/transaction-plan-errors.ts
+++ b/packages/instruction-plans/src/transaction-plan-errors.ts
@@ -223,13 +223,10 @@ function unwrapErrorWithPreflightData(error: Error): {
     ];
     if (isSolanaError(error) && simulationCodes.includes(error.context.__code)) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { __code, ...rest } = error.context;
-        // TODO(loris): Remove this cast once FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT
-        // is enriched with the full simulation result (logs, accounts, etc.).
-        const preflightData = rest as unknown as PreflightData;
+        const { __code, ...preflightData } = error.context;
         return {
-            logs: preflightData.logs ?? undefined,
-            preflightData,
+            logs: (preflightData as PreflightData).logs ?? undefined,
+            preflightData: preflightData as PreflightData,
             unwrappedError: error.cause ?? error,
         };
     }


### PR DESCRIPTION
#### Problem

The `SOLANA_ERROR__TRANSACTION__FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT` error only carried `{ unitsConsumed: number }` as context, hiding away most of the simulation data (logs, accounts, return data, etc.). This made it impossible for that data to flow through to the `SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION` and `SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS` error codes, which extract preflight data from simulation errors.

#### Summary of Changes

This PR aligns the two simulation error codes so they carry the exact same context and cause typing:

- Change the context of `FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT` from `{ unitsConsumed: number }` to `Omit<RpcSimulateTransactionResult, 'err'>`.
- Add `FAILED_WHEN_SIMULATING_TO_ESTIMATE_COMPUTE_LIMIT` to the `SolanaErrorCodeWithCause` union so its `cause` is typed as `SolanaError | undefined`.
- Remove the TODO comment and unsafe double-cast in `unwrapErrorWithPreflightData` since the context now natively matches `PreflightData`.
- Update tests in both packages to pass the full simulation context and assert on the newly available fields.