### PR TITLE
Update docs for remainder size, since it is not limited to fixed-size items

### DIFF
--- a/packages/codecs-data-structures/src/array.ts
+++ b/packages/codecs-data-structures/src/array.ts
@@ -26,7 +26,6 @@ import { getFixedSize, getMaxSize } from './utils';
  * - A {@link NumberCodec}, {@link NumberDecoder}, or {@link NumberEncoder} to store a size prefix.
  * - A fixed `number` of items, enforcing an exact length.
  * - The string `"remainder"`, which infers the number of items by consuming the rest of the available bytes.
- *   This option is only available when encoding fixed-size items.
  *
  * @typeParam TPrefix - A number codec, decoder, or encoder used for size prefixing.
  */


### PR DESCRIPTION
#### Problem

One of the reasons I used custom codecs in the v1 codec functions was because the v1 transaction format encodes arrays without a size prefix, relying on the size/structure to be encoded elsewhere in the encoded message.

The way to do this with the array codec is using the config `{ size: 'remainder' }` or `{size: Number}`, ie set a fixed known length of the input array or use 'remainder' to infer it. Remainder is currently documented as only available for fixed-size items. This leads to using a custom encoder in order to be able to include a { size: Number }` config instead.

In fact, we can use `remainder` in these cases, and the documentation is more restrictive than it needs to be here.

#### Summary of Changes

This PR changes the documentation to remove this restriction. The tests already demonstrate that it can also be used for variable-size items. 

Note that there is an asymmetry here where we can use `remainder` to encode an arbitrary array, but may not be able to decode it using `remainder` if it should not actually consume the rest of the byte array. But this is not affected by whether items are fixed or variable size. 