### PR TITLE
Add functions to set transaction message config values

### DIFF
--- a/packages/transaction-messages/src/__tests__/transaction-config-test.ts
+++ b/packages/transaction-messages/src/__tests__/transaction-config-test.ts
@@ -1,0 +1,505 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import {
+    setTransactionMessageComputeUnitLimit,
+    setTransactionMessageConfig,
+    setTransactionMessageHeapSize,
+    setTransactionMessageLoadedAccountsDataSizeLimit,
+    setTransactionMessagePriorityFeeLamports,
+    TransactionConfig,
+} from '../transaction-config';
+import { TransactionMessage } from '../transaction-message';
+
+const COMPUTE_UNIT_LIMIT_A = 200_000;
+const COMPUTE_UNIT_LIMIT_B = 400_000;
+
+const HEAP_SIZE_A = 30_000;
+const HEAP_SIZE_B = 50_000;
+
+const LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A = 60_000;
+const LOADED_ACCOUNTS_DATA_SIZE_LIMIT_B = 100_000;
+
+const PRIORITY_FEE_LAMPORTS_A = 5_000n;
+const PRIORITY_FEE_LAMPORTS_B = 10_000n;
+
+const baseTx: TransactionMessage & { version: 1 } = {
+    instructions: [],
+    version: 1,
+};
+
+describe('setTransactionMessageConfig', () => {
+    it('sets a complete config on the transaction', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+            heapSize: HEAP_SIZE_A,
+            loadedAccountsDataSizeLimit: LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A,
+            priorityFeeLamports: PRIORITY_FEE_LAMPORTS_A,
+        };
+        const txWithConfig = setTransactionMessageConfig(config, baseTx);
+        expect(txWithConfig).toHaveProperty('config', config);
+    });
+
+    it('sets a partial config on the transaction', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+        };
+        const txWithConfig = setTransactionMessageConfig(config, baseTx);
+        expect(txWithConfig).toHaveProperty('config', { computeUnitLimit: COMPUTE_UNIT_LIMIT_A });
+    });
+
+    it('sets multiple properties at once', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+            priorityFeeLamports: PRIORITY_FEE_LAMPORTS_A,
+        };
+        const txWithConfig = setTransactionMessageConfig(config, baseTx);
+        expect(txWithConfig.config).toMatchObject({
+            computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+            priorityFeeLamports: PRIORITY_FEE_LAMPORTS_A,
+        });
+    });
+
+    it('freezes the transaction object', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+        };
+        const txWithConfig = setTransactionMessageConfig(config, baseTx);
+        expect(txWithConfig).toBeFrozenObject();
+    });
+
+    it('freezes the config object', () => {
+        const config: TransactionConfig = {
+            computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+        };
+        const txWithConfig = setTransactionMessageConfig(config, baseTx);
+        expect(txWithConfig.config).toBeFrozenObject();
+    });
+
+    describe('empty config normalization', () => {
+        it('removes config when setting empty object', () => {
+            const txWithConfig = setTransactionMessageConfig({}, baseTx);
+            expect(txWithConfig).not.toHaveProperty('config');
+        });
+
+        it('removes config when all properties are undefined', () => {
+            const config: TransactionConfig = {
+                computeUnitLimit: undefined,
+                heapSize: undefined,
+                loadedAccountsDataSizeLimit: undefined,
+                priorityFeeLamports: undefined,
+            };
+            const txWithConfig = setTransactionMessageConfig(config, baseTx);
+            expect(txWithConfig).not.toHaveProperty('config');
+        });
+
+        it('returns same reference when config stays absent', () => {
+            const txWithEmptyConfig = setTransactionMessageConfig({}, baseTx);
+            expect(txWithEmptyConfig).toBe(baseTx);
+        });
+    });
+
+    describe('given a transaction with no existing config', () => {
+        it('sets a new config object', () => {
+            const config: TransactionConfig = {
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                heapSize: HEAP_SIZE_A,
+            };
+            const txWithConfig = setTransactionMessageConfig(config, baseTx);
+            expect(txWithConfig.config).toMatchObject(config);
+        });
+    });
+
+    describe('given a transaction with an existing config', () => {
+        const txWithConfig = {
+            ...baseTx,
+            config: {
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                heapSize: HEAP_SIZE_A,
+            },
+        };
+
+        it('merges new config properties with existing ones', () => {
+            const newConfig: TransactionConfig = {
+                priorityFeeLamports: PRIORITY_FEE_LAMPORTS_A,
+            };
+            const txWithMergedConfig = setTransactionMessageConfig(newConfig, txWithConfig);
+            expect(txWithMergedConfig.config).toMatchObject({
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                heapSize: HEAP_SIZE_A,
+                priorityFeeLamports: PRIORITY_FEE_LAMPORTS_A,
+            });
+        });
+
+        it('preserves existing config properties not being updated', () => {
+            const newConfig: TransactionConfig = {
+                loadedAccountsDataSizeLimit: LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A,
+            };
+            const txWithMergedConfig = setTransactionMessageConfig(newConfig, txWithConfig);
+            expect(txWithMergedConfig.config).toHaveProperty('computeUnitLimit', COMPUTE_UNIT_LIMIT_A);
+            expect(txWithMergedConfig.config).toHaveProperty('heapSize', HEAP_SIZE_A);
+        });
+
+        it('overwrites existing config properties with new values', () => {
+            const newConfig: TransactionConfig = {
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_B,
+            };
+            const txWithUpdatedConfig = setTransactionMessageConfig(newConfig, txWithConfig);
+            expect(txWithUpdatedConfig.config).toHaveProperty('computeUnitLimit', COMPUTE_UNIT_LIMIT_B);
+        });
+
+        it('returns the same reference when setting identical config', () => {
+            const sameConfig: TransactionConfig = {
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                heapSize: HEAP_SIZE_A,
+            };
+            const txWithSameConfig = setTransactionMessageConfig(sameConfig, txWithConfig);
+            expect(txWithSameConfig).toBe(txWithConfig);
+        });
+
+        it('returns a new reference when setting different config', () => {
+            const differentConfig: TransactionConfig = {
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_B,
+            };
+            const txWithDifferentConfig = setTransactionMessageConfig(differentConfig, txWithConfig);
+            expect(txWithDifferentConfig).not.toBe(txWithConfig);
+        });
+
+        it('removes config when overwriting all values with undefined', () => {
+            const undefinedConfig: TransactionConfig = {
+                computeUnitLimit: undefined,
+                heapSize: undefined,
+            };
+            const txWithoutConfig = setTransactionMessageConfig(undefinedConfig, txWithConfig);
+            expect(txWithoutConfig).not.toHaveProperty('config');
+        });
+    });
+
+    describe('setting undefined values', () => {
+        it('can set individual properties to undefined', () => {
+            const txWithConfig = setTransactionMessageConfig(
+                { computeUnitLimit: COMPUTE_UNIT_LIMIT_A, heapSize: HEAP_SIZE_A },
+                baseTx,
+            );
+            const txWithUndefined = setTransactionMessageConfig({ computeUnitLimit: undefined }, txWithConfig);
+            expect(txWithUndefined.config).toHaveProperty('computeUnitLimit', undefined);
+            expect(txWithUndefined.config).toHaveProperty('heapSize', HEAP_SIZE_A);
+        });
+
+        it('removes config when last property set to undefined', () => {
+            const txWithConfig = setTransactionMessageConfig({ computeUnitLimit: COMPUTE_UNIT_LIMIT_A }, baseTx);
+            const txWithoutConfig = setTransactionMessageConfig({ computeUnitLimit: undefined }, txWithConfig);
+            expect(txWithoutConfig).not.toHaveProperty('config');
+        });
+    });
+});
+
+describe('setTransactionMessageComputeUnitLimit', () => {
+    it('sets the compute unit limit on the transaction', () => {
+        const txWithLimit = setTransactionMessageComputeUnitLimit(COMPUTE_UNIT_LIMIT_A, baseTx);
+        expect(txWithLimit).toHaveProperty('config', { computeUnitLimit: COMPUTE_UNIT_LIMIT_A });
+    });
+
+    it('freezes the transaction object', () => {
+        const txWithLimit = setTransactionMessageComputeUnitLimit(COMPUTE_UNIT_LIMIT_A, baseTx);
+        expect(txWithLimit).toBeFrozenObject();
+    });
+
+    it('freezes the config object', () => {
+        const txWithLimit = setTransactionMessageComputeUnitLimit(COMPUTE_UNIT_LIMIT_A, baseTx);
+        expect(txWithLimit.config).toBeFrozenObject();
+    });
+
+    describe('given a transaction with an existing config', () => {
+        const txWithConfig = {
+            ...baseTx,
+            config: {
+                heapSize: HEAP_SIZE_A,
+                priorityFeeLamports: PRIORITY_FEE_LAMPORTS_A,
+            },
+        };
+
+        it('sets the compute unit limit while preserving other config properties', () => {
+            const txWithLimit = setTransactionMessageComputeUnitLimit(COMPUTE_UNIT_LIMIT_A, txWithConfig);
+            expect(txWithLimit.config).toMatchObject({
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                heapSize: HEAP_SIZE_A,
+                priorityFeeLamports: PRIORITY_FEE_LAMPORTS_A,
+            });
+        });
+
+        it('returns the same reference when setting the same compute unit limit', () => {
+            const txWithLimitA = setTransactionMessageComputeUnitLimit(COMPUTE_UNIT_LIMIT_A, baseTx);
+            const txWithSameLimit = setTransactionMessageComputeUnitLimit(COMPUTE_UNIT_LIMIT_A, txWithLimitA);
+            expect(txWithLimitA).toBe(txWithSameLimit);
+        });
+
+        it('returns a new reference when setting a different compute unit limit', () => {
+            const txWithLimitA = setTransactionMessageComputeUnitLimit(COMPUTE_UNIT_LIMIT_A, baseTx);
+            const txWithLimitB = setTransactionMessageComputeUnitLimit(COMPUTE_UNIT_LIMIT_B, txWithLimitA);
+            expect(txWithLimitA).not.toBe(txWithLimitB);
+            expect(txWithLimitB.config).toHaveProperty('computeUnitLimit', COMPUTE_UNIT_LIMIT_B);
+        });
+    });
+
+    describe('empty config normalization', () => {
+        it('removes config when setting to undefined as only property', () => {
+            const txWithLimit = setTransactionMessageComputeUnitLimit(COMPUTE_UNIT_LIMIT_A, baseTx);
+            const txWithoutConfig = setTransactionMessageComputeUnitLimit(undefined, txWithLimit);
+            expect(txWithoutConfig).not.toHaveProperty('config');
+        });
+
+        it('preserves config when setting to undefined with other properties present', () => {
+            const txWithConfig = {
+                ...baseTx,
+                config: {
+                    computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                    heapSize: HEAP_SIZE_A,
+                },
+            };
+            const txWithoutLimit = setTransactionMessageComputeUnitLimit(undefined, txWithConfig);
+            expect(txWithoutLimit).toHaveProperty('config', {
+                computeUnitLimit: undefined,
+                heapSize: HEAP_SIZE_A,
+            });
+        });
+    });
+});
+
+describe('setTransactionMessageHeapSize', () => {
+    it('sets the heap size on the transaction', () => {
+        const txWithHeapSize = setTransactionMessageHeapSize(HEAP_SIZE_A, baseTx);
+        expect(txWithHeapSize).toHaveProperty('config', { heapSize: HEAP_SIZE_A });
+    });
+
+    it('freezes the transaction object', () => {
+        const txWithHeapSize = setTransactionMessageHeapSize(HEAP_SIZE_A, baseTx);
+        expect(txWithHeapSize).toBeFrozenObject();
+    });
+
+    it('freezes the config object', () => {
+        const txWithHeapSize = setTransactionMessageHeapSize(HEAP_SIZE_A, baseTx);
+        expect(txWithHeapSize.config).toBeFrozenObject();
+    });
+
+    describe('given a transaction with an existing config', () => {
+        const txWithConfig = {
+            ...baseTx,
+            config: {
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                priorityFeeLamports: PRIORITY_FEE_LAMPORTS_A,
+            },
+        };
+
+        it('sets the heap size while preserving other config properties', () => {
+            const txWithHeapSize = setTransactionMessageHeapSize(HEAP_SIZE_A, txWithConfig);
+            expect(txWithHeapSize.config).toMatchObject({
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                heapSize: HEAP_SIZE_A,
+                priorityFeeLamports: PRIORITY_FEE_LAMPORTS_A,
+            });
+        });
+
+        it('returns the same reference when setting the same heap size', () => {
+            const txWithHeapSizeA = setTransactionMessageHeapSize(HEAP_SIZE_A, baseTx);
+            const txWithSameHeapSize = setTransactionMessageHeapSize(HEAP_SIZE_A, txWithHeapSizeA);
+            expect(txWithHeapSizeA).toBe(txWithSameHeapSize);
+        });
+
+        it('returns a new reference when setting a different heap size', () => {
+            const txWithHeapSizeA = setTransactionMessageHeapSize(HEAP_SIZE_A, baseTx);
+            const txWithHeapSizeB = setTransactionMessageHeapSize(HEAP_SIZE_B, txWithHeapSizeA);
+            expect(txWithHeapSizeA).not.toBe(txWithHeapSizeB);
+            expect(txWithHeapSizeB.config).toHaveProperty('heapSize', HEAP_SIZE_B);
+        });
+    });
+
+    describe('empty config normalization', () => {
+        it('removes config when setting to undefined as only property', () => {
+            const txWithHeapSize = setTransactionMessageHeapSize(HEAP_SIZE_A, baseTx);
+            const txWithoutConfig = setTransactionMessageHeapSize(undefined, txWithHeapSize);
+            expect(txWithoutConfig).not.toHaveProperty('config');
+        });
+
+        it('preserves config when setting to undefined with other properties present', () => {
+            const txWithConfig = {
+                ...baseTx,
+                config: {
+                    computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                    heapSize: HEAP_SIZE_A,
+                },
+            };
+            const txWithoutHeapSize = setTransactionMessageHeapSize(undefined, txWithConfig);
+            expect(txWithoutHeapSize).toHaveProperty('config', {
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                heapSize: undefined,
+            });
+        });
+    });
+});
+
+describe('setTransactionMessageLoadedAccountsDataSizeLimit', () => {
+    it('sets the loaded accounts data size limit on the transaction', () => {
+        const txWithLimit = setTransactionMessageLoadedAccountsDataSizeLimit(LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A, baseTx);
+        expect(txWithLimit).toHaveProperty('config', {
+            loadedAccountsDataSizeLimit: LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A,
+        });
+    });
+
+    it('freezes the transaction object', () => {
+        const txWithLimit = setTransactionMessageLoadedAccountsDataSizeLimit(LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A, baseTx);
+        expect(txWithLimit).toBeFrozenObject();
+    });
+
+    it('freezes the config object', () => {
+        const txWithLimit = setTransactionMessageLoadedAccountsDataSizeLimit(LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A, baseTx);
+        expect(txWithLimit.config).toBeFrozenObject();
+    });
+
+    describe('given a transaction with an existing config', () => {
+        const txWithConfig = {
+            ...baseTx,
+            config: {
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                heapSize: HEAP_SIZE_A,
+            },
+        };
+
+        it('sets the loaded accounts data size limit while preserving other config properties', () => {
+            const txWithLimit = setTransactionMessageLoadedAccountsDataSizeLimit(
+                LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A,
+                txWithConfig,
+            );
+            expect(txWithLimit.config).toMatchObject({
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                heapSize: HEAP_SIZE_A,
+                loadedAccountsDataSizeLimit: LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A,
+            });
+        });
+
+        it('returns the same reference when setting the same loaded accounts data size limit', () => {
+            const txWithLimitA = setTransactionMessageLoadedAccountsDataSizeLimit(
+                LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A,
+                baseTx,
+            );
+            const txWithSameLimit = setTransactionMessageLoadedAccountsDataSizeLimit(
+                LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A,
+                txWithLimitA,
+            );
+            expect(txWithLimitA).toBe(txWithSameLimit);
+        });
+
+        it('returns a new reference when setting a different loaded accounts data size limit', () => {
+            const txWithLimitA = setTransactionMessageLoadedAccountsDataSizeLimit(
+                LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A,
+                baseTx,
+            );
+            const txWithLimitB = setTransactionMessageLoadedAccountsDataSizeLimit(
+                LOADED_ACCOUNTS_DATA_SIZE_LIMIT_B,
+                txWithLimitA,
+            );
+            expect(txWithLimitA).not.toBe(txWithLimitB);
+            expect(txWithLimitB.config).toHaveProperty(
+                'loadedAccountsDataSizeLimit',
+                LOADED_ACCOUNTS_DATA_SIZE_LIMIT_B,
+            );
+        });
+    });
+
+    describe('empty config normalization', () => {
+        it('removes config when setting to undefined as only property', () => {
+            const txWithLimit = setTransactionMessageLoadedAccountsDataSizeLimit(
+                LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A,
+                baseTx,
+            );
+            const txWithoutConfig = setTransactionMessageLoadedAccountsDataSizeLimit(undefined, txWithLimit);
+            expect(txWithoutConfig).not.toHaveProperty('config');
+        });
+
+        it('preserves config when setting to undefined with other properties present', () => {
+            const txWithConfig = {
+                ...baseTx,
+                config: {
+                    computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                    loadedAccountsDataSizeLimit: LOADED_ACCOUNTS_DATA_SIZE_LIMIT_A,
+                },
+            };
+            const txWithoutLimit = setTransactionMessageLoadedAccountsDataSizeLimit(undefined, txWithConfig);
+            expect(txWithoutLimit).toHaveProperty('config', {
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                loadedAccountsDataSizeLimit: undefined,
+            });
+        });
+    });
+});
+
+describe('setTransactionMessagePriorityFeeLamports', () => {
+    it('sets the priority fee lamports on the transaction', () => {
+        const txWithFee = setTransactionMessagePriorityFeeLamports(PRIORITY_FEE_LAMPORTS_A, baseTx);
+        expect(txWithFee).toHaveProperty('config', { priorityFeeLamports: PRIORITY_FEE_LAMPORTS_A });
+    });
+
+    it('freezes the transaction object', () => {
+        const txWithFee = setTransactionMessagePriorityFeeLamports(PRIORITY_FEE_LAMPORTS_A, baseTx);
+        expect(txWithFee).toBeFrozenObject();
+    });
+
+    it('freezes the config object', () => {
+        const txWithFee = setTransactionMessagePriorityFeeLamports(PRIORITY_FEE_LAMPORTS_A, baseTx);
+        expect(txWithFee.config).toBeFrozenObject();
+    });
+
+    describe('given a transaction with an existing config', () => {
+        const txWithConfig = {
+            ...baseTx,
+            config: {
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                heapSize: HEAP_SIZE_A,
+            },
+        };
+
+        it('sets the priority fee lamports while preserving other config properties', () => {
+            const txWithFee = setTransactionMessagePriorityFeeLamports(PRIORITY_FEE_LAMPORTS_A, txWithConfig);
+            expect(txWithFee.config).toMatchObject({
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                heapSize: HEAP_SIZE_A,
+                priorityFeeLamports: PRIORITY_FEE_LAMPORTS_A,
+            });
+        });
+
+        it('returns the same reference when setting the same priority fee lamports', () => {
+            const txWithFeeA = setTransactionMessagePriorityFeeLamports(PRIORITY_FEE_LAMPORTS_A, baseTx);
+            const txWithSameFee = setTransactionMessagePriorityFeeLamports(PRIORITY_FEE_LAMPORTS_A, txWithFeeA);
+            expect(txWithFeeA).toBe(txWithSameFee);
+        });
+
+        it('returns a new reference when setting different priority fee lamports', () => {
+            const txWithFeeA = setTransactionMessagePriorityFeeLamports(PRIORITY_FEE_LAMPORTS_A, baseTx);
+            const txWithFeeB = setTransactionMessagePriorityFeeLamports(PRIORITY_FEE_LAMPORTS_B, txWithFeeA);
+            expect(txWithFeeA).not.toBe(txWithFeeB);
+            expect(txWithFeeB.config).toHaveProperty('priorityFeeLamports', PRIORITY_FEE_LAMPORTS_B);
+        });
+    });
+
+    describe('empty config normalization', () => {
+        it('removes config when setting to undefined as only property', () => {
+            const txWithFee = setTransactionMessagePriorityFeeLamports(PRIORITY_FEE_LAMPORTS_A, baseTx);
+            const txWithoutConfig = setTransactionMessagePriorityFeeLamports(undefined, txWithFee);
+            expect(txWithoutConfig).not.toHaveProperty('config');
+        });
+
+        it('preserves config when setting to undefined with other properties present', () => {
+            const txWithConfig = {
+                ...baseTx,
+                config: {
+                    computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                    priorityFeeLamports: PRIORITY_FEE_LAMPORTS_A,
+                },
+            };
+            const txWithoutFee = setTransactionMessagePriorityFeeLamports(undefined, txWithConfig);
+            expect(txWithoutFee).toHaveProperty('config', {
+                computeUnitLimit: COMPUTE_UNIT_LIMIT_A,
+                priorityFeeLamports: undefined,
+            });
+        });
+    });
+});

--- a/packages/transaction-messages/src/__typetests__/transaction-config-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/transaction-config-typetest.ts
@@ -1,0 +1,198 @@
+import {
+    setTransactionMessageComputeUnitLimit,
+    setTransactionMessageConfig,
+    setTransactionMessageHeapSize,
+    setTransactionMessageLoadedAccountsDataSizeLimit,
+    setTransactionMessagePriorityFeeLamports,
+    TransactionConfig,
+} from '../transaction-config';
+import { TransactionMessage } from '../transaction-message';
+
+type LegacyTransactionMessage = Extract<TransactionMessage, { version: 'legacy' }>;
+type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
+type V1TransactionMessage = Extract<TransactionMessage, { version: 1 }>;
+
+// [DESCRIBE] setTransactionMessageConfig
+{
+    const mockConfig = null as unknown as TransactionConfig;
+
+    // It accepts v1 messages
+    {
+        const message = null as unknown as V1TransactionMessage;
+        const result = setTransactionMessageConfig(mockConfig, message);
+        result satisfies V1TransactionMessage;
+    }
+
+    // It preserves input message type
+    {
+        const message = null as unknown as V1TransactionMessage & { some: 1 };
+        const result = setTransactionMessageConfig(mockConfig, message);
+        result satisfies V1TransactionMessage & { some: 1 };
+    }
+
+    // It rejects legacy messages
+    {
+        const message = null as unknown as LegacyTransactionMessage;
+        // @ts-expect-error Legacy transactions are not supported
+        setTransactionMessageConfig(mockConfig, message);
+    }
+
+    // It rejects v0 messages
+    {
+        const message = null as unknown as V0TransactionMessage;
+        // @ts-expect-error V0 transactions are not supported
+        setTransactionMessageConfig(mockConfig, message);
+    }
+}
+
+// [DESCRIBE] setTransactionMessageComputeUnitLimit
+{
+    // It accepts v1 messages
+    {
+        const message = null as unknown as V1TransactionMessage;
+        const result = setTransactionMessageComputeUnitLimit(200_000, message);
+        result satisfies V1TransactionMessage;
+    }
+
+    // It preserves input type
+    {
+        const message = null as unknown as V1TransactionMessage & { some: 1 };
+        const result = setTransactionMessageComputeUnitLimit(200_000, message);
+        result satisfies V1TransactionMessage & { some: 1 };
+    }
+
+    // It can set undefined value
+    {
+        const message = null as unknown as V1TransactionMessage & { some: 1 };
+        const result = setTransactionMessageComputeUnitLimit(undefined, message);
+        result satisfies V1TransactionMessage & { some: 1 };
+    }
+
+    // It rejects legacy messages
+    {
+        const message = null as unknown as LegacyTransactionMessage;
+        // @ts-expect-error Legacy transactions are not supported
+        setTransactionMessageComputeUnitLimit(200_000, message);
+    }
+
+    // It rejects v0 messages
+    {
+        const message = null as unknown as V0TransactionMessage;
+        // @ts-expect-error V0 transactions are not supported
+        setTransactionMessageComputeUnitLimit(200_000, message);
+    }
+}
+
+// [DESCRIBE] setTransactionMessageHeapSize
+{
+    // It accepts v1 messages
+    {
+        const message = null as unknown as V1TransactionMessage;
+        const result = setTransactionMessageHeapSize(32_768, message);
+        result satisfies V1TransactionMessage;
+    }
+
+    // It preserves input message type
+    {
+        const message = null as unknown as V1TransactionMessage & { some: 1 };
+        const result = setTransactionMessageHeapSize(32_768, message);
+        result satisfies V1TransactionMessage & { some: 1 };
+    }
+
+    // It can set undefined value
+    {
+        const message = null as unknown as V1TransactionMessage & { some: 1 };
+        const result = setTransactionMessageHeapSize(undefined, message);
+        result satisfies V1TransactionMessage & { some: 1 };
+    }
+
+    // It rejects legacy messages
+    {
+        const message = null as unknown as LegacyTransactionMessage;
+        // @ts-expect-error Legacy transactions are not supported
+        setTransactionMessageHeapSize(32_768, message);
+    }
+
+    // It rejects v0 messages
+    {
+        const message = null as unknown as V0TransactionMessage;
+        // @ts-expect-error V0 transactions are not supported
+        setTransactionMessageHeapSize(32_768, message);
+    }
+}
+
+// [DESCRIBE] setTransactionMessageLoadedAccountsDataSizeLimit
+{
+    // It accepts v1 messages
+    {
+        const message = null as unknown as V1TransactionMessage;
+        const result = setTransactionMessageLoadedAccountsDataSizeLimit(64_000, message);
+        result satisfies V1TransactionMessage;
+    }
+
+    // It preserves input message type
+    {
+        const message = null as unknown as V1TransactionMessage & { some: 1 };
+        const result = setTransactionMessageLoadedAccountsDataSizeLimit(64_000, message);
+        result satisfies V1TransactionMessage & { some: 1 };
+    }
+
+    // It can set undefined value
+    {
+        const message = null as unknown as V1TransactionMessage & { some: 1 };
+        const result = setTransactionMessageLoadedAccountsDataSizeLimit(undefined, message);
+        result satisfies V1TransactionMessage & { some: 1 };
+    }
+
+    // It rejects legacy messages
+    {
+        const message = null as unknown as LegacyTransactionMessage;
+        // @ts-expect-error Legacy transactions are not supported
+        setTransactionMessageLoadedAccountsDataSizeLimit(64_000, message);
+    }
+
+    // It rejects v0 messages
+    {
+        const message = null as unknown as V0TransactionMessage;
+        // @ts-expect-error V0 transactions are not supported
+        setTransactionMessageLoadedAccountsDataSizeLimit(64_000, message);
+    }
+}
+
+// [DESCRIBE] setTransactionMessagePriorityFeeLamports
+{
+    // It accepts v1 messages
+    {
+        const message = null as unknown as V1TransactionMessage;
+        const result = setTransactionMessagePriorityFeeLamports(5_000n, message);
+        result satisfies V1TransactionMessage;
+    }
+
+    // It preserves input message type
+    {
+        const message = null as unknown as V1TransactionMessage & { some: 1 };
+        const result = setTransactionMessagePriorityFeeLamports(5_000n, message);
+        result satisfies V1TransactionMessage & { some: 1 };
+    }
+
+    // It can set undefined value
+    {
+        const message = null as unknown as V1TransactionMessage & { some: 1 };
+        const result = setTransactionMessagePriorityFeeLamports(undefined, message);
+        result satisfies V1TransactionMessage & { some: 1 };
+    }
+
+    // It rejects legacy messages
+    {
+        const message = null as unknown as LegacyTransactionMessage;
+        // @ts-expect-error Legacy transactions are not supported
+        setTransactionMessagePriorityFeeLamports(5_000n, message);
+    }
+
+    // It rejects v0 messages
+    {
+        const message = null as unknown as V0TransactionMessage;
+        // @ts-expect-error V0 transactions are not supported
+        setTransactionMessagePriorityFeeLamports(5_000n, message);
+    }
+}

--- a/packages/transaction-messages/src/transaction-config.ts
+++ b/packages/transaction-messages/src/transaction-config.ts
@@ -1,6 +1,215 @@
+import { TransactionMessage, TransactionVersion } from './transaction-message';
+
+/**
+ * Configuration options for transaction messages.
+ *
+ * These options allow fine-grained control over transaction resource usage and
+ * prioritization. All fields are optional and will be encoded into the transaction
+ * when present.
+ */
 export type TransactionConfig = {
+    /**
+     * Maximum number of compute units the transaction may consume.
+     *
+     * If not specified, defaults to 200,000 CUs per instruction. The maximum
+     * allowed value is 1,400,000 CUs.
+     */
     computeUnitLimit?: number;
+    /**
+     * Requested heap frame size in bytes for the transaction's execution.
+     */
     heapSize?: number;
+    /**
+     * Maximum size in bytes for loaded account data.
+     */
     loadedAccountsDataSizeLimit?: number;
+    /**
+     * Total priority fee in lamports to pay for transaction prioritization.
+     */
     priorityFeeLamports?: bigint;
 };
+
+type SupportedTransactionVersions = Extract<TransactionVersion, 1>;
+
+function hasDefinedConfigValues(config: TransactionConfig): boolean {
+    return (
+        config.computeUnitLimit !== undefined ||
+        config.heapSize !== undefined ||
+        config.loadedAccountsDataSizeLimit !== undefined ||
+        config.priorityFeeLamports !== undefined
+    );
+}
+
+/**
+ * Sets configuration options on a transaction message.
+ *
+ * This function merges the provided configuration with any existing configuration
+ * on the transaction message. Configuration values control resource limits and
+ * transaction prioritization.
+ *
+ * @param config - The configuration options to apply.
+ * @param transactionMessage - The transaction message to configure.
+ * @typeParam TTransactionMessage - The transaction message type.
+ * @return A new transaction message with the merged configuration.
+ *
+ * @example
+ * ```ts
+ * const configuredTx = setTransactionMessageConfig(
+ *     {
+ *         computeUnitLimit: 300_000,
+ *         priorityFeeLamports: 50_000n,
+ *     },
+ *     transactionMessage,
+ * );
+ * ```
+ *
+ * @example
+ * Incrementally adding configuration values.
+ * ```ts
+ * const txMessage = pipe(
+ *     baseTransaction,
+ *     tx => setTransactionMessageConfig({ computeUnitLimit: 300_000 }, tx),
+ *     tx => setTransactionMessageConfig({ priorityFeeLamports: 50_000n }, tx),
+ * );
+ * ```
+ *
+ * @example
+ * Removing a configuration value.
+ * ```ts
+ * const txMessage = setTransactionMessageConfig({ computeUnitLimit: undefined }, tx);
+ * ```
+ *
+ * @see {@link setTransactionMessageComputeUnitLimit}
+ * @see {@link setTransactionMessagePriorityFeeLamports}
+ */
+export function setTransactionMessageConfig<
+    TTransactionMessage extends TransactionMessage & { version: SupportedTransactionVersions },
+>(config: TransactionConfig, transactionMessage: TTransactionMessage): TTransactionMessage {
+    const mergedConfig = {
+        ...transactionMessage.config,
+        ...config,
+    };
+
+    if (!hasDefinedConfigValues(mergedConfig)) {
+        // If config has no defined values, remove it entirely
+        if (!transactionMessage.config) {
+            // No config before, no config after - return same reference
+            return transactionMessage;
+        }
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { config, ...rest } = transactionMessage;
+        return Object.freeze(rest) as TTransactionMessage;
+    }
+
+    // Check if config is identical for idempotency
+    if (
+        transactionMessage.config &&
+        transactionMessage.config.computeUnitLimit === mergedConfig.computeUnitLimit &&
+        transactionMessage.config.heapSize === mergedConfig.heapSize &&
+        transactionMessage.config.loadedAccountsDataSizeLimit === mergedConfig.loadedAccountsDataSizeLimit &&
+        transactionMessage.config.priorityFeeLamports === mergedConfig.priorityFeeLamports
+    ) {
+        return transactionMessage;
+    }
+
+    return Object.freeze({
+        ...transactionMessage,
+        config: Object.freeze(mergedConfig),
+    }) as TTransactionMessage;
+}
+
+/**
+ * Sets the compute unit limit for a transaction message.
+ *
+ * @param computeUnitLimit - The maximum compute units (CUs) allowed, or `undefined` to remove the limit.
+ * @param transactionMessage - The transaction message to configure.
+ * @typeParam TTransactionMessage - The transaction message type.
+ * @return A new transaction message with the compute unit limit set.
+ *
+ * @example
+ * ```ts
+ * const txMessage = setTransactionMessageComputeUnitLimit(
+ *     400_000,
+ *     transactionMessage,
+ * );
+ * ```
+ *
+ * @see {@link setTransactionMessageConfig}
+ */
+export function setTransactionMessageComputeUnitLimit<
+    TTransactionMessage extends TransactionMessage & { version: SupportedTransactionVersions },
+>(computeUnitLimit: number | undefined, transactionMessage: TTransactionMessage): TTransactionMessage {
+    return setTransactionMessageConfig({ computeUnitLimit }, transactionMessage);
+}
+
+/**
+ * Sets the heap frame size for a transaction message.
+ *
+ * @param heapSize - The requested heap frame size in bytes, or `undefined` to remove the setting.
+ * @param transactionMessage - The transaction message to configure.
+ * @typeParam TTransactionMessage - The transaction message type.
+ * @return A new transaction message with the heap size set.
+ *
+ * @example
+ * ```ts
+ * const txMessage = setTransactionMessageHeapSize(
+ *     256_000,
+ *     transactionMessage,
+ * );
+ * ```
+ *
+ * @see {@link setTransactionMessageConfig}
+ */
+export function setTransactionMessageHeapSize<
+    TTransactionMessage extends TransactionMessage & { version: SupportedTransactionVersions },
+>(heapSize: number | undefined, transactionMessage: TTransactionMessage): TTransactionMessage {
+    return setTransactionMessageConfig({ heapSize }, transactionMessage);
+}
+
+/**
+ * Sets the loaded accounts data size limit for a transaction message.
+ *
+ * @param loadedAccountsDataSizeLimit - The maximum size in bytes for loaded account data, or `undefined` to remove the limit.
+ * @param transactionMessage - The transaction message to configure.
+ * @typeParam TTransactionMessage - The transaction message type.
+ * @return A new transaction message with the loaded accounts data size limit set.
+ *
+ * @example
+ * ```ts
+ * const txMessage = setTransactionMessageLoadedAccountsDataSizeLimit(
+ *     64_000,
+ *     transactionMessage,
+ * );
+ * ```
+ *
+ * @see {@link setTransactionMessageConfig}
+ */
+export function setTransactionMessageLoadedAccountsDataSizeLimit<
+    TTransactionMessage extends TransactionMessage & { version: SupportedTransactionVersions },
+>(loadedAccountsDataSizeLimit: number | undefined, transactionMessage: TTransactionMessage): TTransactionMessage {
+    return setTransactionMessageConfig({ loadedAccountsDataSizeLimit }, transactionMessage);
+}
+
+/**
+ * Sets the total priority fee for a transaction message.
+
+ * @param priorityFeeLamports - The priority fee amount in lamports, or `undefined` to remove the fee.
+ * @param transactionMessage - The transaction message to configure.
+ * @typeParam TTransactionMessage - The transaction message type.
+ * @return A new transaction message with the priority fee set.
+ *
+ * @example
+ * ```ts
+ * const txMessage = setTransactionMessagePriorityFeeLamports(
+ *     10_000n,
+ *     transactionMessage,
+ * );
+ * ```
+ *
+ * @see {@link setTransactionMessageConfig}
+ */
+export function setTransactionMessagePriorityFeeLamports<
+    TTransactionMessage extends TransactionMessage & { version: SupportedTransactionVersions },
+>(priorityFeeLamports: bigint | undefined, transactionMessage: TTransactionMessage): TTransactionMessage {
+    return setTransactionMessageConfig({ priorityFeeLamports }, transactionMessage);
+}


### PR DESCRIPTION
#### Summary of Changes

This PR adds functions to set the transaction message config values for v1 transactions

`setTransactionMessageConfig` can set/unset any number of config values at once. Fields can be unset by passing `undefined`, any fields not included in the input are unchanged.

There are also helper functions for each field, eg `setTransactionMessageComputeUnitLimit`. These can be used to set or unset one config value at a time. A call to one of these is the equivalent of adding a compute budget instruction to a legacy/v0 transaction message.