### PR TITLE
feat(transactions): add reconstructEncodedTransactionFromOriginalTransaction to transactions package

### DIFF
--- a/packages/react/src/__tests__/useWalletAccountTransactionSigner-test.ts
+++ b/packages/react/src/__tests__/useWalletAccountTransactionSigner-test.ts
@@ -1,30 +1,23 @@
 import { Address } from '@solana/addresses';
-import type { VariableSizeCodec, VariableSizeDecoder } from '@solana/codecs-core';
+import type { VariableSizeCodec } from '@solana/codecs-core';
 import {
     SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED,
     SOLANA_ERROR__TRANSACTION__NONCE_ACCOUNT_CANNOT_BE_IN_LOOKUP_TABLE,
     SolanaError,
 } from '@solana/errors';
 import { SignatureBytes } from '@solana/keys';
-import { Blockhash } from '@solana/rpc-types';
 import {
-    CompiledTransactionMessage,
-    CompiledTransactionMessageWithLifetime,
-    getCompiledTransactionMessageDecoder,
-} from '@solana/transaction-messages';
-import {
-    getTransactionLifetimeConstraintFromCompiledTransactionMessage,
+    getTransactionCodec,
+    reconstructEncodedTransactionFromOriginalTransaction,
     Transaction,
     TransactionMessageBytes,
 } from '@solana/transactions';
-import { getTransactionCodec } from '@solana/transactions';
 import type { UiWalletAccount } from '@wallet-standard/ui';
 
 import { renderHook } from '../test-renderer';
 import { useSignTransaction } from '../useSignTransaction';
 import { useWalletAccountTransactionSigner } from '../useWalletAccountTransactionSigner';
 
-jest.mock('@solana/transaction-messages');
 jest.mock('@solana/transactions');
 jest.mock('../useSignTransaction');
 
@@ -32,6 +25,7 @@ describe('useWalletAccountTransactionSigner', () => {
     let mockSignTransaction: jest.Mock;
     let mockDecodeTransaction: jest.Mock;
     let mockEncodeTransaction: jest.Mock;
+    let mockReconstructEncodedTransactionFromOriginalTransaction: jest.Mock;
     let mockUiWalletAccount: {
         address: Address<'11111111111111111111111111111119'>;
         chains: ['solana:danknet'];
@@ -42,10 +36,14 @@ describe('useWalletAccountTransactionSigner', () => {
     beforeEach(() => {
         mockDecodeTransaction = jest.fn();
         mockEncodeTransaction = jest.fn();
+        mockReconstructEncodedTransactionFromOriginalTransaction = jest.fn();
         jest.mocked(getTransactionCodec).mockReturnValue({
             decode: mockDecodeTransaction,
             encode: mockEncodeTransaction,
         } as unknown as VariableSizeCodec<Transaction>);
+        jest.mocked(reconstructEncodedTransactionFromOriginalTransaction).mockImplementation(
+            mockReconstructEncodedTransactionFromOriginalTransaction,
+        );
         mockSignTransaction = jest.fn().mockResolvedValue({
             signature: new Uint8Array([1, 2, 3]),
             signedMessage: new Uint8Array([1, 2, 3]),
@@ -133,12 +131,15 @@ describe('useWalletAccountTransactionSigner', () => {
             expect(mockSignTransaction).toHaveBeenCalledWith({ transaction: mockEncodedTransaction });
         }
     });
-    it('decodes and returns the signed transaction bytes returned by `signTransactions`', async () => {
+    it('reconstructs and returns the signed transaction bytes returned by `signTransactions`', async () => {
         expect.assertions(2);
         const mockSignedTransaction = new Uint8Array([1, 2, 3, 4, 5, 6]);
-        const mockDecodedTransaction = { messageBytes: [1, 2, 3] } as unknown as Transaction;
+        const mockReconstructedTransaction = {
+            lifetimeConstraint: { blockhash: 'abc', lastValidBlockHeight: 123n },
+            messageBytes: [1, 2, 3],
+        } as unknown as Transaction;
         mockSignTransaction.mockResolvedValue({ signedTransaction: mockSignedTransaction });
-        mockDecodeTransaction.mockReturnValue(mockDecodedTransaction);
+        mockReconstructEncodedTransactionFromOriginalTransaction.mockResolvedValue(mockReconstructedTransaction);
         const { result } = renderHook(() => useWalletAccountTransactionSigner(mockUiWalletAccount, 'solana:danknet'));
         // eslint-disable-next-line jest/no-conditional-in-test
         if (result.__type === 'error' || !result.current) {
@@ -156,9 +157,12 @@ describe('useWalletAccountTransactionSigner', () => {
             const signPromise = modifyAndSignTransactions([inputTransaction]);
             await jest.runAllTimersAsync();
             // eslint-disable-next-line jest/no-conditional-expect
-            expect(mockDecodeTransaction).toHaveBeenCalledWith(mockSignedTransaction);
+            expect(mockReconstructEncodedTransactionFromOriginalTransaction).toHaveBeenCalledWith(
+                inputTransaction,
+                mockSignedTransaction,
+            );
             // eslint-disable-next-line jest/no-conditional-expect
-            await expect(signPromise).resolves.toEqual([{ ...mockDecodedTransaction, lifetimeConstraint }]);
+            await expect(signPromise).resolves.toEqual([mockReconstructedTransaction]);
         }
     });
     it('calls `signTransaction` with all options except the `abortSignal`', () => {
@@ -213,9 +217,12 @@ describe('useWalletAccountTransactionSigner', () => {
     it('returns an unchanged lifetime constraint if the signed transaction has the same one', async () => {
         expect.assertions(1);
         const mockSignedTransaction = new Uint8Array([1, 2, 3, 4, 5, 6]);
-        const mockDecodedTransaction = { messageBytes: [4, 5, 6] } as unknown as Transaction;
+        const mockReconstructedTransaction = {
+            lifetimeConstraint: { blockhash: 'abc', lastValidBlockHeight: 123n },
+            messageBytes: [4, 5, 6],
+        } as unknown as Transaction;
         mockSignTransaction.mockResolvedValue({ signedTransaction: mockSignedTransaction });
-        mockDecodeTransaction.mockReturnValue(mockDecodedTransaction);
+        mockReconstructEncodedTransactionFromOriginalTransaction.mockResolvedValue(mockReconstructedTransaction);
         const { result } = renderHook(() => useWalletAccountTransactionSigner(mockUiWalletAccount, 'solana:danknet'));
         // eslint-disable-next-line jest/no-conditional-in-test
         if (result.__type === 'error' || !result.current) {
@@ -228,23 +235,22 @@ describe('useWalletAccountTransactionSigner', () => {
                 messageBytes: new Uint8Array([1, 2, 3]) as unknown as TransactionMessageBytes,
                 signatures: {},
             };
-            jest.mocked(getCompiledTransactionMessageDecoder).mockReturnValue({
-                decode: jest.fn().mockReturnValue({
-                    lifetimeToken: 'abc',
-                }),
-            } as unknown as VariableSizeDecoder<CompiledTransactionMessage & CompiledTransactionMessageWithLifetime>);
             const signPromise = modifyAndSignTransactions([inputTransaction]);
             await jest.runAllTimersAsync();
             // eslint-disable-next-line jest/no-conditional-expect
-            await expect(signPromise).resolves.toEqual([{ ...mockDecodedTransaction, lifetimeConstraint }]);
+            await expect(signPromise).resolves.toEqual([mockReconstructedTransaction]);
         }
     });
     it('returns a new lifetime constraint if the input transaction does not have one', async () => {
         expect.assertions(1);
         const mockSignedTransaction = new Uint8Array([1, 2, 3, 4, 5, 6]);
-        const mockDecodedTransaction = { messageBytes: [4, 5, 6] } as unknown as Transaction;
+        const newLifetimeConstraint = { blockhash: 'abc', lastValidBlockHeight: 123n };
+        const mockReconstructedTransaction = {
+            lifetimeConstraint: newLifetimeConstraint,
+            messageBytes: [4, 5, 6],
+        } as unknown as Transaction;
         mockSignTransaction.mockResolvedValue({ signedTransaction: mockSignedTransaction });
-        mockDecodeTransaction.mockReturnValue(mockDecodedTransaction);
+        mockReconstructEncodedTransactionFromOriginalTransaction.mockResolvedValue(mockReconstructedTransaction);
         const { result } = renderHook(() => useWalletAccountTransactionSigner(mockUiWalletAccount, 'solana:danknet'));
         // eslint-disable-next-line jest/no-conditional-in-test
         if (result.__type === 'error' || !result.current) {
@@ -255,27 +261,22 @@ describe('useWalletAccountTransactionSigner', () => {
                 messageBytes: new Uint8Array([1, 2, 3]) as unknown as TransactionMessageBytes,
                 signatures: {},
             };
-            jest.mocked(getCompiledTransactionMessageDecoder).mockReturnValue({
-                decode: jest.fn().mockReturnValue({}),
-            } as unknown as VariableSizeDecoder<CompiledTransactionMessage & CompiledTransactionMessageWithLifetime>);
-            const newLifetimeConstraint = { blockhash: 'abc' as Blockhash, lastValidBlockHeight: 123n };
-            jest.mocked(getTransactionLifetimeConstraintFromCompiledTransactionMessage).mockResolvedValue(
-                newLifetimeConstraint,
-            );
             const signPromise = modifyAndSignTransactions([inputTransaction]);
             await jest.runAllTimersAsync();
             // eslint-disable-next-line jest/no-conditional-expect
-            await expect(signPromise).resolves.toEqual([
-                { ...mockDecodedTransaction, lifetimeConstraint: newLifetimeConstraint },
-            ]);
+            await expect(signPromise).resolves.toEqual([mockReconstructedTransaction]);
         }
     });
     it('returns a new lifetime constraint if the signed transaction has a different one', async () => {
         expect.assertions(1);
         const mockSignedTransaction = new Uint8Array([1, 2, 3, 4, 5, 6]);
-        const mockDecodedTransaction = { messageBytes: [4, 5, 6] } as unknown as Transaction;
+        const newLifetimeConstraint = { blockhash: 'def', lastValidBlockHeight: 456n };
+        const mockReconstructedTransaction = {
+            lifetimeConstraint: newLifetimeConstraint,
+            messageBytes: [4, 5, 6],
+        } as unknown as Transaction;
         mockSignTransaction.mockResolvedValue({ signedTransaction: mockSignedTransaction });
-        mockDecodeTransaction.mockReturnValue(mockDecodedTransaction);
+        mockReconstructEncodedTransactionFromOriginalTransaction.mockResolvedValue(mockReconstructedTransaction);
         const { result } = renderHook(() => useWalletAccountTransactionSigner(mockUiWalletAccount, 'solana:danknet'));
         // eslint-disable-next-line jest/no-conditional-in-test
         if (result.__type === 'error' || !result.current) {
@@ -288,29 +289,21 @@ describe('useWalletAccountTransactionSigner', () => {
                 messageBytes: new Uint8Array([1, 2, 3]) as unknown as TransactionMessageBytes,
                 signatures: {},
             };
-            jest.mocked(getCompiledTransactionMessageDecoder).mockReturnValue({
-                decode: jest.fn().mockReturnValue({
-                    lifetimeToken: 'def',
-                }),
-            } as unknown as VariableSizeDecoder<CompiledTransactionMessage & CompiledTransactionMessageWithLifetime>);
-            const newLifetimeConstraint = { blockhash: 'def' as Blockhash, lastValidBlockHeight: 456n };
-            jest.mocked(getTransactionLifetimeConstraintFromCompiledTransactionMessage).mockResolvedValue(
-                newLifetimeConstraint,
-            );
             const signPromise = modifyAndSignTransactions([inputTransaction]);
             await jest.runAllTimersAsync();
             // eslint-disable-next-line jest/no-conditional-expect
-            await expect(signPromise).resolves.toEqual([
-                { ...mockDecodedTransaction, lifetimeConstraint: newLifetimeConstraint },
-            ]);
+            await expect(signPromise).resolves.toEqual([mockReconstructedTransaction]);
         }
     });
     it('fatals when the signed transaction has a new durable nonce lifetime but the nonce account is only in a lookup table', async () => {
         expect.assertions(1);
         const mockSignedTransaction = new Uint8Array([1, 2, 3, 4, 5, 6]);
-        const mockDecodedTransaction = { messageBytes: [4, 5, 6] } as unknown as Transaction;
         mockSignTransaction.mockResolvedValue({ signedTransaction: mockSignedTransaction });
-        mockDecodeTransaction.mockReturnValue(mockDecodedTransaction);
+        mockReconstructEncodedTransactionFromOriginalTransaction.mockRejectedValue(
+            new SolanaError(SOLANA_ERROR__TRANSACTION__NONCE_ACCOUNT_CANNOT_BE_IN_LOOKUP_TABLE, {
+                nonce: 'abc',
+            }),
+        );
         const { result } = renderHook(() => useWalletAccountTransactionSigner(mockUiWalletAccount, 'solana:danknet'));
         // eslint-disable-next-line jest/no-conditional-in-test
         if (result.__type === 'error' || !result.current) {
@@ -321,14 +314,6 @@ describe('useWalletAccountTransactionSigner', () => {
                 messageBytes: new Uint8Array([1, 2, 3]) as unknown as TransactionMessageBytes,
                 signatures: {},
             };
-            jest.mocked(getCompiledTransactionMessageDecoder).mockReturnValue({
-                decode: jest.fn().mockReturnValue({}),
-            } as unknown as VariableSizeDecoder<CompiledTransactionMessage & CompiledTransactionMessageWithLifetime>);
-            jest.mocked(getTransactionLifetimeConstraintFromCompiledTransactionMessage).mockRejectedValue(
-                new SolanaError(SOLANA_ERROR__TRANSACTION__NONCE_ACCOUNT_CANNOT_BE_IN_LOOKUP_TABLE, {
-                    nonce: 'abc',
-                }),
-            );
             const signPromise = modifyAndSignTransactions([inputTransaction]);
             await jest.runAllTimersAsync();
             // eslint-disable-next-line jest/no-conditional-expect

--- a/packages/react/src/useWalletAccountTransactionSigner.ts
+++ b/packages/react/src/useWalletAccountTransactionSigner.ts
@@ -1,13 +1,10 @@
 import { address } from '@solana/addresses';
-import { bytesEqual } from '@solana/codecs-core';
 import { SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED, SolanaError } from '@solana/errors';
 import { getAbortablePromise } from '@solana/promises';
 import { TransactionModifyingSigner } from '@solana/signers';
-import { getCompiledTransactionMessageDecoder } from '@solana/transaction-messages';
 import {
-    assertIsTransactionWithinSizeLimit,
     getTransactionCodec,
-    getTransactionLifetimeConstraintFromCompiledTransactionMessage,
+    reconstructEncodedTransactionFromOriginalTransaction,
     Transaction,
     TransactionWithinSizeLimit,
     TransactionWithLifetime,
@@ -88,57 +85,11 @@ export function useWalletAccountTransactionSigner<TWalletAccount extends UiWalle
                     transaction: wireTransactionBytes as Uint8Array,
                 };
                 const { signedTransaction } = await getAbortablePromise(signTransaction(inputWithOptions), abortSignal);
-                const decodedSignedTransaction = transactionCodec.decode(
+                const reconstructedTransaction = await reconstructEncodedTransactionFromOriginalTransaction(
+                    transaction,
                     signedTransaction,
-                ) as (typeof transactions)[number];
-
-                assertIsTransactionWithinSizeLimit(decodedSignedTransaction);
-
-                const existingLifetime =
-                    'lifetimeConstraint' in transaction
-                        ? (transaction as TransactionWithLifetime).lifetimeConstraint
-                        : undefined;
-
-                if (existingLifetime) {
-                    if (bytesEqual(decodedSignedTransaction.messageBytes, transaction.messageBytes)) {
-                        // If the transaction has identical bytes, the lifetime won't have changed
-                        return Object.freeze([
-                            {
-                                ...decodedSignedTransaction,
-                                lifetimeConstraint: existingLifetime,
-                            },
-                        ]);
-                    }
-
-                    // If the transaction has changed, check the lifetime constraint field
-                    const compiledTransactionMessage = getCompiledTransactionMessageDecoder().decode(
-                        decodedSignedTransaction.messageBytes,
-                    );
-                    const currentToken =
-                        'blockhash' in existingLifetime ? existingLifetime.blockhash : existingLifetime.nonce;
-
-                    if (compiledTransactionMessage.lifetimeToken === currentToken) {
-                        return Object.freeze([
-                            {
-                                ...decodedSignedTransaction,
-                                lifetimeConstraint: existingLifetime,
-                            },
-                        ]);
-                    }
-                }
-
-                // If we get here then there is no existing lifetime, or the lifetime has changed. We need to attach a new lifetime
-                const compiledTransactionMessage = getCompiledTransactionMessageDecoder().decode(
-                    decodedSignedTransaction.messageBytes,
                 );
-                const lifetimeConstraint =
-                    await getTransactionLifetimeConstraintFromCompiledTransactionMessage(compiledTransactionMessage);
-                return Object.freeze([
-                    {
-                        ...decodedSignedTransaction,
-                        lifetimeConstraint,
-                    },
-                ]);
+                return Object.freeze([reconstructedTransaction]);
             },
         }),
         [uiWalletAccount.address, signTransaction],

--- a/packages/transactions/src/__tests__/reconstruct-encoded-transaction-from-original-transaction-test.ts
+++ b/packages/transactions/src/__tests__/reconstruct-encoded-transaction-from-original-transaction-test.ts
@@ -1,0 +1,187 @@
+import { getCompiledTransactionMessageDecoder } from '@solana/transaction-messages';
+
+import { getTransactionCodec } from '../codecs';
+import { getTransactionLifetimeConstraintFromCompiledTransactionMessage, TransactionWithLifetime } from '../lifetime';
+import { reconstructEncodedTransactionFromOriginalTransaction } from '../reconstruct-encoded-transaction-from-original-transaction';
+import { Transaction } from '../transaction';
+
+jest.mock('@solana/transaction-messages');
+jest.mock('../codecs');
+jest.mock('../lifetime');
+jest.mock('../transaction-size');
+
+describe('reconstructEncodedTransactionFromOriginalTransaction', () => {
+    const encodedTransaction = new Uint8Array([9, 8, 7]);
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('preserves the existing lifetime when message bytes are unchanged', async () => {
+        expect.assertions(2);
+        const originalLifetime = { blockhash: 'abc', lastValidBlockHeight: 123n };
+        const originalTransaction = {
+            lifetimeConstraint: originalLifetime,
+            messageBytes: new Uint8Array([1, 2, 3]),
+            signatures: {},
+        } as unknown as Transaction & TransactionWithLifetime;
+        const decodedSignedTransaction = {
+            messageBytes: new Uint8Array([1, 2, 3]),
+            signatures: {},
+        } as unknown as Transaction;
+        const decode = jest.fn().mockReturnValue(decodedSignedTransaction);
+        jest.mocked(getTransactionCodec).mockReturnValue({ decode } as unknown as ReturnType<
+            typeof getTransactionCodec
+        >);
+        const result = await reconstructEncodedTransactionFromOriginalTransaction(
+            originalTransaction,
+            encodedTransaction,
+        );
+        expect(getTransactionLifetimeConstraintFromCompiledTransactionMessage).not.toHaveBeenCalled();
+        expect(result).toEqual(Object.freeze({ ...decodedSignedTransaction, lifetimeConstraint: originalLifetime }));
+    });
+
+    it('preserves the existing lifetime when lifetime token is unchanged', async () => {
+        expect.assertions(2);
+        const originalLifetime = { blockhash: 'abc', lastValidBlockHeight: 123n };
+        const originalTransaction = {
+            lifetimeConstraint: originalLifetime,
+            messageBytes: new Uint8Array([1, 2, 3]),
+            signatures: {},
+        } as unknown as Transaction & TransactionWithLifetime;
+        const decodedSignedTransaction = {
+            messageBytes: new Uint8Array([3, 2, 1]),
+            signatures: {},
+        } as unknown as Transaction;
+        const decode = jest.fn().mockReturnValue(decodedSignedTransaction);
+        const decodeCompiledMessage = jest.fn().mockReturnValue({ lifetimeToken: 'abc' });
+        jest.mocked(getTransactionCodec).mockReturnValue({ decode } as unknown as ReturnType<
+            typeof getTransactionCodec
+        >);
+        jest.mocked(getCompiledTransactionMessageDecoder).mockReturnValue({
+            decode: decodeCompiledMessage,
+        } as unknown as ReturnType<typeof getCompiledTransactionMessageDecoder>);
+        const result = await reconstructEncodedTransactionFromOriginalTransaction(
+            originalTransaction,
+            encodedTransaction,
+        );
+        expect(getTransactionLifetimeConstraintFromCompiledTransactionMessage).not.toHaveBeenCalled();
+        expect(result).toEqual(Object.freeze({ ...decodedSignedTransaction, lifetimeConstraint: originalLifetime }));
+    });
+
+    it('recomputes lifetime when the transaction has no original lifetime', async () => {
+        expect.assertions(2);
+        const originalTransaction = {
+            messageBytes: new Uint8Array([1, 2, 3]),
+            signatures: {},
+        } as unknown as Transaction;
+        const decodedSignedTransaction = {
+            messageBytes: new Uint8Array([3, 2, 1]),
+            signatures: {},
+        } as unknown as Transaction;
+        const decode = jest.fn().mockReturnValue(decodedSignedTransaction);
+        const compiledTransactionMessage = { lifetimeToken: 'def' };
+        const decodeCompiledMessage = jest.fn().mockReturnValue(compiledTransactionMessage);
+        const newLifetime = { blockhash: 'def', lastValidBlockHeight: 456n };
+        jest.mocked(getTransactionCodec).mockReturnValue({ decode } as unknown as ReturnType<
+            typeof getTransactionCodec
+        >);
+        jest.mocked(getCompiledTransactionMessageDecoder).mockReturnValue({
+            decode: decodeCompiledMessage,
+        } as unknown as ReturnType<typeof getCompiledTransactionMessageDecoder>);
+        jest.mocked(getTransactionLifetimeConstraintFromCompiledTransactionMessage).mockResolvedValue(
+            newLifetime as Awaited<ReturnType<typeof getTransactionLifetimeConstraintFromCompiledTransactionMessage>>,
+        );
+        const result = await reconstructEncodedTransactionFromOriginalTransaction(
+            originalTransaction,
+            encodedTransaction,
+        );
+        expect(getTransactionLifetimeConstraintFromCompiledTransactionMessage).toHaveBeenCalledWith(
+            compiledTransactionMessage,
+        );
+        expect(result).toEqual(Object.freeze({ ...decodedSignedTransaction, lifetimeConstraint: newLifetime }));
+    });
+
+    it('recomputes lifetime when the existing lifetime token changed', async () => {
+        expect.assertions(2);
+        const originalTransaction = {
+            lifetimeConstraint: { blockhash: 'abc', lastValidBlockHeight: 123n },
+            messageBytes: new Uint8Array([1, 2, 3]),
+            signatures: {},
+        } as unknown as Transaction & TransactionWithLifetime;
+        const decodedSignedTransaction = {
+            messageBytes: new Uint8Array([3, 2, 1]),
+            signatures: {},
+        } as unknown as Transaction;
+        const decode = jest.fn().mockReturnValue(decodedSignedTransaction);
+        const compiledTransactionMessage = { lifetimeToken: 'def' };
+        const decodeCompiledMessage = jest.fn().mockReturnValue(compiledTransactionMessage);
+        const newLifetime = { blockhash: 'def', lastValidBlockHeight: 456n };
+        jest.mocked(getTransactionCodec).mockReturnValue({ decode } as unknown as ReturnType<
+            typeof getTransactionCodec
+        >);
+        jest.mocked(getCompiledTransactionMessageDecoder).mockReturnValue({
+            decode: decodeCompiledMessage,
+        } as unknown as ReturnType<typeof getCompiledTransactionMessageDecoder>);
+        jest.mocked(getTransactionLifetimeConstraintFromCompiledTransactionMessage).mockResolvedValue(
+            newLifetime as Awaited<ReturnType<typeof getTransactionLifetimeConstraintFromCompiledTransactionMessage>>,
+        );
+        const result = await reconstructEncodedTransactionFromOriginalTransaction(
+            originalTransaction,
+            encodedTransaction,
+        );
+        expect(getTransactionLifetimeConstraintFromCompiledTransactionMessage).toHaveBeenCalledWith(
+            compiledTransactionMessage,
+        );
+        expect(result).toEqual(Object.freeze({ ...decodedSignedTransaction, lifetimeConstraint: newLifetime }));
+    });
+
+    it('propagates errors from lifetime constraint extraction', async () => {
+        expect.assertions(1);
+        const originalTransaction = {
+            messageBytes: new Uint8Array([1, 2, 3]),
+            signatures: {},
+        } as unknown as Transaction;
+        const decodedSignedTransaction = {
+            messageBytes: new Uint8Array([4, 5, 6]),
+            signatures: {},
+        } as unknown as Transaction;
+        const decode = jest.fn().mockReturnValue(decodedSignedTransaction);
+        const compiledMessage = { lifetimeToken: 'abc' };
+        jest.mocked(getTransactionCodec).mockReturnValue({ decode } as unknown as ReturnType<
+            typeof getTransactionCodec
+        >);
+        jest.mocked(getCompiledTransactionMessageDecoder).mockReturnValue({
+            decode: jest.fn().mockReturnValue(compiledMessage),
+        } as unknown as ReturnType<typeof getCompiledTransactionMessageDecoder>);
+        const error = new Error('lifetime extraction failed');
+        jest.mocked(getTransactionLifetimeConstraintFromCompiledTransactionMessage).mockRejectedValue(error);
+        await expect(
+            reconstructEncodedTransactionFromOriginalTransaction(originalTransaction, new Uint8Array([9, 8, 7])),
+        ).rejects.toThrow(error);
+    });
+
+    it('propagates errors from compiled transaction message decoding', async () => {
+        expect.assertions(1);
+        const originalTransaction = {
+            messageBytes: new Uint8Array([1, 2, 3]),
+            signatures: {},
+        } as unknown as Transaction;
+        const decodedSignedTransaction = {
+            messageBytes: new Uint8Array([4, 5, 6]),
+            signatures: {},
+        } as unknown as Transaction;
+        const decode = jest.fn().mockReturnValue(decodedSignedTransaction);
+        const decodeCompiledMessageError = new Error('compiled message decode failed');
+        jest.mocked(getTransactionCodec).mockReturnValue({ decode } as unknown as ReturnType<
+            typeof getTransactionCodec
+        >);
+        jest.mocked(getCompiledTransactionMessageDecoder).mockReturnValue({
+            decode: jest.fn().mockImplementation(() => {
+                throw decodeCompiledMessageError;
+            }),
+        } as unknown as ReturnType<typeof getCompiledTransactionMessageDecoder>);
+        await expect(
+            reconstructEncodedTransactionFromOriginalTransaction(originalTransaction, encodedTransaction),
+        ).rejects.toThrow(decodeCompiledMessageError);
+    });
+});

--- a/packages/transactions/src/__typetests__/reconstruct-encoded-transaction-from-original-transaction-typetest.ts
+++ b/packages/transactions/src/__typetests__/reconstruct-encoded-transaction-from-original-transaction-typetest.ts
@@ -1,0 +1,67 @@
+import { TransactionWithLifetime } from '../lifetime';
+import { reconstructEncodedTransactionFromOriginalTransaction } from '../reconstruct-encoded-transaction-from-original-transaction';
+import { Transaction } from '../transaction';
+import { TransactionWithinSizeLimit } from '../transaction-size';
+
+// [DESCRIBE] reconstructEncodedTransactionFromOriginalTransaction.
+{
+    // It accepts a Transaction as the original transaction.
+    {
+        type Input = Parameters<typeof reconstructEncodedTransactionFromOriginalTransaction>[0];
+        type _acceptsTransaction = Transaction extends Exclude<Input, undefined> ? true : false;
+        const _assertAcceptsTransaction: _acceptsTransaction = true;
+        _assertAcceptsTransaction satisfies true;
+    }
+
+    // It accepts a Transaction with lifetime.
+    {
+        type Input = Parameters<typeof reconstructEncodedTransactionFromOriginalTransaction>[0];
+        type _acceptsTransactionWithLifetime =
+            Transaction & TransactionWithLifetime extends Exclude<Input, undefined> ? true : false;
+
+        const _assertAcceptsTransactionWithLifetime: _acceptsTransactionWithLifetime = true;
+        _assertAcceptsTransactionWithLifetime satisfies true;
+    }
+
+    // It accepts undefined as original transaction.
+    {
+        type Input = Parameters<typeof reconstructEncodedTransactionFromOriginalTransaction>[0];
+        type _acceptsUndefinedOriginal = undefined extends Input ? true : false;
+
+        const _assertAcceptsUndefinedOriginal: _acceptsUndefinedOriginal = true;
+        _assertAcceptsUndefinedOriginal satisfies true;
+    }
+
+    // The encoded transaction must be a Uint8Array.
+    {
+        type Params = Parameters<typeof reconstructEncodedTransactionFromOriginalTransaction>;
+        type EncodedTransaction = Params[1];
+
+        type _encodedMustBeUint8Array = EncodedTransaction extends Uint8Array ? true : false;
+
+        const _assertEncodedMustBeUint8Array: _encodedMustBeUint8Array = true;
+        _assertEncodedMustBeUint8Array satisfies true;
+    }
+
+    // It returns a Promise of Transaction that is within size limit and has a lifetime.
+    {
+        type Result = ReturnType<typeof reconstructEncodedTransactionFromOriginalTransaction>;
+        type _returnsExpectedPromise =
+            Result extends Promise<Transaction & TransactionWithinSizeLimit & TransactionWithLifetime> ? true : false;
+
+        const _assertReturnsExpectedPromise: _returnsExpectedPromise = true;
+        _assertReturnsExpectedPromise satisfies true;
+    }
+
+    // Ensure input union is correct.
+    {
+        type Input = Parameters<typeof reconstructEncodedTransactionFromOriginalTransaction>[0];
+
+        type _inputUnionCorrect = Input extends Transaction | (Transaction & TransactionWithLifetime) | undefined
+            ? true
+            : false;
+
+        const _assertInputUnionCorrect: _inputUnionCorrect = true;
+        _assertInputUnionCorrect satisfies true;
+    }
+}

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -13,6 +13,7 @@ export * from './lifetime';
 export * from './compile-transaction';
 export * from './signatures';
 export * from './wire-transaction';
+export * from './reconstruct-encoded-transaction-from-original-transaction';
 export * from './sendable-transaction';
 export * from './transaction-message-size';
 export * from './transaction-size';

--- a/packages/transactions/src/reconstruct-encoded-transaction-from-original-transaction.ts
+++ b/packages/transactions/src/reconstruct-encoded-transaction-from-original-transaction.ts
@@ -1,0 +1,72 @@
+import { bytesEqual } from '@solana/codecs-core';
+import { getCompiledTransactionMessageDecoder } from '@solana/transaction-messages';
+
+import { getTransactionCodec } from './codecs';
+import { getTransactionLifetimeConstraintFromCompiledTransactionMessage, TransactionWithLifetime } from './lifetime';
+import { Transaction } from './transaction';
+import { assertIsTransactionWithinSizeLimit, TransactionWithinSizeLimit } from './transaction-size';
+
+/**
+ * Reconstructs a signed transaction from encoded bytes using an optional original transaction.
+ *
+ * Wallets often sign raw transaction bytes and return the encoded transaction. When decoding
+ * this back into a structured `Transaction`, we may lose the original `lifetimeConstraint`.
+ *
+ * This helper attempts to preserve the existing lifetime when possible to avoid unnecessary
+ * transaction message decoding. If the transaction has changed or no lifetime exists, the
+ * lifetime constraint is recomputed from the compiled transaction message.
+ *
+ * @param originalTransaction - The original transaction before signing.
+ * @param encodedTransaction - The encoded signed transaction returned by the wallet.
+ *
+ * @returns A reconstructed transaction including size validation and lifetime constraint.
+ */
+export async function reconstructEncodedTransactionFromOriginalTransaction(
+    originalTransaction: Transaction | (Transaction & TransactionWithLifetime) | undefined,
+    encodedTransaction: Uint8Array,
+): Promise<Transaction & TransactionWithinSizeLimit & TransactionWithLifetime> {
+    const transactionCodec = getTransactionCodec();
+
+    const decodedSignedTransaction = transactionCodec.decode(encodedTransaction);
+
+    assertIsTransactionWithinSizeLimit(decodedSignedTransaction);
+
+    const existingLifetime =
+        originalTransaction && 'lifetimeConstraint' in originalTransaction
+            ? (originalTransaction as TransactionWithLifetime).lifetimeConstraint
+            : undefined;
+
+    if (existingLifetime && originalTransaction) {
+        if (bytesEqual(decodedSignedTransaction.messageBytes, originalTransaction.messageBytes)) {
+            return Object.freeze({
+                ...decodedSignedTransaction,
+                lifetimeConstraint: existingLifetime,
+            });
+        }
+
+        const compiledTransactionMessage = getCompiledTransactionMessageDecoder().decode(
+            decodedSignedTransaction.messageBytes,
+        );
+
+        const currentToken = 'blockhash' in existingLifetime ? existingLifetime.blockhash : existingLifetime.nonce;
+
+        if (compiledTransactionMessage.lifetimeToken === currentToken) {
+            return Object.freeze({
+                ...decodedSignedTransaction,
+                lifetimeConstraint: existingLifetime,
+            });
+        }
+    }
+
+    const compiledTransactionMessage = getCompiledTransactionMessageDecoder().decode(
+        decodedSignedTransaction.messageBytes,
+    );
+
+    const lifetimeConstraint =
+        await getTransactionLifetimeConstraintFromCompiledTransactionMessage(compiledTransactionMessage);
+
+    return Object.freeze({
+        ...decodedSignedTransaction,
+        lifetimeConstraint,
+    });
+}


### PR DESCRIPTION
#### Problem
The logic to determine the correct lifetime (blockhash vs durable nonce) previously existed only inside the React useWalletAccountTransactionSigner hook and was not reusable.


#### Summary of Changes
- add `reconstructEncodedTransactionFromOriginalTransaction` to the transactions package
- export the helper via the transactions package index
- refactor `useWalletAccountTransactionSigner` to use the helper
- add unit tests and typetests for the reconstructEncodedTransactionFromOriginalTransaction function
- update useWalletAccountTransactionSigner tests accordingly


Fixes #1466 