### PR TITLE
Add withCleanup function to @solana/plugin-core

### DIFF
--- a/.changeset/loose-feet-like.md
+++ b/.changeset/loose-feet-like.md
@@ -1,0 +1,5 @@
+---
+'@solana/plugin-core': minor
+---
+
+Add `withCleanup` function to `@solana/plugin-core`. Plugin authors can use it to register teardown logic (e.g. closing connections or clearing timers) on a client, making it `Disposable`. If the client already implements `Symbol.dispose`, the new cleanup function is chained so both run on disposal.

--- a/packages/plugin-core/src/__tests__/client-test.ts
+++ b/packages/plugin-core/src/__tests__/client-test.ts
@@ -1,6 +1,6 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
-import { createEmptyClient, extendClient } from '../client';
+import { createEmptyClient, extendClient, withCleanup } from '../client';
 
 describe('createEmptyClient', () => {
     it('creates an empty object with a use function', () => {
@@ -259,5 +259,61 @@ describe('extendClient', () => {
 
     it('returns a frozen object', () => {
         expect(extendClient({ fruit: 'apple' as const }, { vegetable: 'carrot' as const })).toBeFrozenObject();
+    });
+});
+
+describe('withCleanup', () => {
+    it('calls the cleanup function when disposed', () => {
+        const cleanup = jest.fn();
+        const result = withCleanup({}, cleanup);
+        result[Symbol.dispose]();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('disposes using the `using` syntax', () => {
+        const cleanup = jest.fn();
+        {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            using _ = withCleanup({}, cleanup);
+        }
+        expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call the cleanup function before dispose is invoked', () => {
+        const cleanup = jest.fn();
+        withCleanup({}, cleanup);
+        expect(cleanup).not.toHaveBeenCalled();
+    });
+
+    it('chains parent Symbol.dispose when client already has one', () => {
+        const callOrder: string[] = [];
+        const parentDispose = jest.fn(() => callOrder.push('parent'));
+        const cleanup = jest.fn(() => callOrder.push('cleanup'));
+        const client = { [Symbol.dispose]: parentDispose };
+        const result = withCleanup(client, cleanup);
+        result[Symbol.dispose]();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+        expect(parentDispose).toHaveBeenCalledTimes(1);
+        expect(callOrder).toStrictEqual(['cleanup', 'parent']);
+    });
+
+    it('does not throw when client has no Symbol.dispose', () => {
+        const cleanup = jest.fn();
+        const result = withCleanup({}, cleanup);
+        expect(() => result[Symbol.dispose]()).not.toThrow();
+    });
+
+    it('preserves existing client properties', () => {
+        const result = withCleanup({ fruit: 'apple' as const }, () => {});
+        expect(result.fruit).toBe('apple');
+    });
+
+    it('symbol.dispose is a function on the result', () => {
+        const result = withCleanup({}, () => {});
+        expect(typeof result[Symbol.dispose]).toBe('function');
+    });
+
+    it('returns a frozen object', () => {
+        expect(withCleanup({ fruit: 'apple' as const }, () => {})).toBeFrozenObject();
     });
 });

--- a/packages/plugin-core/src/__tests__/client-test.ts
+++ b/packages/plugin-core/src/__tests__/client-test.ts
@@ -316,4 +316,35 @@ describe('withCleanup', () => {
     it('returns a frozen object', () => {
         expect(withCleanup({ fruit: 'apple' as const }, () => {})).toBeFrozenObject();
     });
+
+    it('calls all cleanup functions when withCleanup is called multiple times', () => {
+        const cleanup1 = jest.fn();
+        const cleanup2 = jest.fn();
+        const client = withCleanup({}, cleanup1);
+        const result = withCleanup(client, cleanup2);
+        result[Symbol.dispose]();
+        expect(cleanup1).toHaveBeenCalledTimes(1);
+        expect(cleanup2).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls multiple cleanups in LIFO order', () => {
+        const callOrder: string[] = [];
+        const cleanup1 = jest.fn(() => callOrder.push('cleanup1'));
+        const cleanup2 = jest.fn(() => callOrder.push('cleanup2'));
+        const client = withCleanup({}, cleanup1);
+        const result = withCleanup(client, cleanup2);
+        result[Symbol.dispose]();
+        expect(callOrder).toStrictEqual(['cleanup2', 'cleanup1']);
+    });
+
+    it('calls multiple cleanups and existing parent dispose in the correct order', () => {
+        const callOrder: string[] = [];
+        const parentDispose = jest.fn(() => callOrder.push('parent'));
+        const cleanup1 = jest.fn(() => callOrder.push('cleanup1'));
+        const cleanup2 = jest.fn(() => callOrder.push('cleanup2'));
+        const client = withCleanup({ [Symbol.dispose]: parentDispose }, cleanup1);
+        const result = withCleanup(client, cleanup2);
+        result[Symbol.dispose]();
+        expect(callOrder).toStrictEqual(['cleanup2', 'cleanup1', 'parent']);
+    });
 });

--- a/packages/plugin-core/src/__typetests__/client-typetest.ts
+++ b/packages/plugin-core/src/__typetests__/client-typetest.ts
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import { type AsyncClient, type Client, type ClientPlugin, createEmptyClient, extendClient } from '../client';
+import {
+    type AsyncClient,
+    type Client,
+    type ClientPlugin,
+    createEmptyClient,
+    extendClient,
+    withCleanup,
+} from '../client';
 
 const EMPTY_CLIENT = null as unknown as Client<object>;
 const EMPTY_ASYNC_CLIENT = null as unknown as AsyncClient<object>;
@@ -231,5 +238,26 @@ const EMPTY_ASYNC_CLIENT = null as unknown as AsyncClient<object>;
     {
         // @ts-expect-error - additions is not an object.
         extendClient({}, 'hello');
+    }
+}
+
+// [Describe] withCleanup
+{
+    // It returns a Disposable client
+    {
+        const client = null as unknown as Client<object>;
+        withCleanup(client, () => {}) satisfies Client<object> & Disposable;
+    }
+
+    // It accepts an already Disposable client
+    {
+        const client = null as unknown as Client<object> & Disposable;
+        withCleanup(client, () => {}) satisfies Client<object> & Disposable;
+    }
+
+    // It accepts an AsyncClient
+    {
+        const client = null as unknown as AsyncClient<object>;
+        withCleanup(client, () => {}) satisfies AsyncClient<object> & Disposable;
     }
 }

--- a/packages/plugin-core/src/client.ts
+++ b/packages/plugin-core/src/client.ts
@@ -277,13 +277,50 @@ export function extendClient<TClient extends object, TAdditions extends object>(
  * @see {@link extendClient}
  */
 export function withCleanup<TClient extends object>(client: TClient, cleanup: () => void): Disposable & TClient {
-    const parentDispose: (() => void) | undefined =
-        Symbol.dispose in client ? (client as Disposable)[Symbol.dispose] : undefined;
-    const additions: Disposable = {
+    if (DISPOSABLE_STACK_PROPERTY in client) {
+        return addCleanupToClientWithExistingStack(
+            client as Record<typeof DISPOSABLE_STACK_PROPERTY, DisposableStack> & TClient,
+            cleanup,
+        );
+    } else {
+        return addCleanupToClientWithoutExistingStack(client, cleanup);
+    }
+}
+
+const DISPOSABLE_STACK_PROPERTY = '__PRIVATE__DISPOSABLE_STACK' as const;
+
+function addCleanupToClientWithExistingStack<TClient extends Record<typeof DISPOSABLE_STACK_PROPERTY, DisposableStack>>(
+    client: TClient,
+    cleanup: () => void,
+): Disposable & TClient {
+    // If we already have the stack, add the new cleanup to it
+    client[DISPOSABLE_STACK_PROPERTY].defer(cleanup);
+    // We assume we already added a dispose method when we added the stack
+    return client as Disposable & TClient;
+}
+
+function addCleanupToClientWithoutExistingStack<TClient extends object>(
+    client: TClient,
+    cleanup: () => void,
+): Disposable & TClient {
+    const stack = new DisposableStack();
+
+    // If the client has an existing dispose method but not our stack, we maintain this existing cleanup by deferring it to the new stack
+    if (Symbol.dispose in client) {
+        const existingDispose = (client as Disposable)[Symbol.dispose];
+        stack.defer(() => existingDispose.call(client));
+    }
+
+    // Add the new cleanup to the stack
+    stack.defer(cleanup);
+
+    // We add our stack to the client, and replace any existing dispose method with our stack dispose
+    const additions = {
+        [DISPOSABLE_STACK_PROPERTY]: stack,
         [Symbol.dispose]() {
-            cleanup();
-            parentDispose?.call(client);
+            stack[Symbol.dispose]();
         },
     };
-    return extendClient(client, additions) as Disposable & TClient;
+
+    return extendClient(client, additions) as unknown as Disposable & TClient;
 }

--- a/packages/plugin-core/src/client.ts
+++ b/packages/plugin-core/src/client.ts
@@ -242,3 +242,48 @@ export function extendClient<TClient extends object, TAdditions extends object>(
     Object.defineProperties(result, Object.getOwnPropertyDescriptors(additions));
     return Object.freeze(result) as Omit<TClient, keyof TAdditions> & TAdditions;
 }
+
+/**
+ * Wraps a client with a cleanup function, making it {@link Disposable}.
+ *
+ * Plugin authors can use this to register teardown logic (e.g. closing
+ * connections or clearing timers) that runs when the client is disposed.
+ * If the client already implements `Symbol.dispose`, the existing dispose
+ * logic is chained so that it runs after the new `cleanup` function.
+ *
+ * @typeParam TClient - The type of the original client.
+ * @param client - The client to wrap.
+ * @param cleanup - The cleanup function to run when the client is disposed.
+ * @return A new client that extends `TClient` and implements `Disposable`.
+ *
+ * @example
+ * Register a cleanup function in a plugin that opens a WebSocket connection.
+ * ```ts
+ * function myPlugin() {
+ *     return <T extends object>(client: T) => {
+ *         const socket = new WebSocket('wss://api.example.com');
+ *         return withCleanup(
+ *             extendClient(client, { socket }),
+ *             () => socket.close(),
+ *         );
+ *     };
+ * }
+ *
+ * // Later, when the client is no longer needed:
+ * using client = createEmptyClient().use(myPlugin();
+ * // `socket.close()` is called automatically when `client` goes out of scope.
+ * ```
+ *
+ * @see {@link extendClient}
+ */
+export function withCleanup<TClient extends object>(client: TClient, cleanup: () => void): Disposable & TClient {
+    const parentDispose: (() => void) | undefined =
+        Symbol.dispose in client ? (client as Disposable)[Symbol.dispose] : undefined;
+    const additions: Disposable = {
+        [Symbol.dispose]() {
+            cleanup();
+            parentDispose?.call(client);
+        },
+    };
+    return extendClient(client, additions) as Disposable & TClient;
+}


### PR DESCRIPTION
Adds a `withCleanup` function that extends any client with a synchronous `Symbol.dispose` method, enabling the TC39 `using` declaration pattern. Note that only synchronous cleanup is supported for now — async teardown (`Symbol.asyncDispose`) is not yet handled. If the client already has a `Symbol.dispose`, the new cleanup is chained so both run when the client is disposed. Includes unit tests and a type test.

```ts
function myPlugin() {
    return <T extends object>(client: T) => {
        const socket = new WebSocket('wss://api.example.com');
        return withCleanup(
            extendClient(client, { socket }),
            () => socket.close(),
        );
    };
}

// `socket.close()` is called automatically when `client` goes out of scope:
using client = createClient(myPlugin());
```