### PR TITLE
Add `withAsyncCleanup` function to `@solana/plugin-core`

### DIFF
--- a/.changeset/floppy-memes-try.md
+++ b/.changeset/floppy-memes-try.md
@@ -1,0 +1,5 @@
+---
+'@solana/plugin-core': minor
+---
+
+Add `withAsyncCleanup` function to `@solana/plugin-core`. Plugin authors can use it to register asynchronous teardown logic on a client, making it `AsyncDisposable`. If the client already implements `Symbol.asyncDispose`, it is awaited after the new cleanup; if only `Symbol.dispose` is present, it is called synchronously as a fallback.

--- a/.changeset/loose-feet-like.md
+++ b/.changeset/loose-feet-like.md
@@ -1,0 +1,5 @@
+---
+'@solana/plugin-core': minor
+---
+
+Add `withCleanup` function to `@solana/plugin-core`. Plugin authors can use it to register teardown logic (e.g. closing connections or clearing timers) on a client, making it `Disposable`. If the client already implements `Symbol.dispose`, the new cleanup function is chained so both run on disposal.

--- a/packages/plugin-core/src/__tests__/client-test.ts
+++ b/packages/plugin-core/src/__tests__/client-test.ts
@@ -1,6 +1,6 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
-import { createEmptyClient, extendClient } from '../client';
+import { createEmptyClient, extendClient, withCleanup } from '../client';
 
 describe('createEmptyClient', () => {
     it('creates an empty object with a use function', () => {
@@ -259,5 +259,61 @@ describe('extendClient', () => {
 
     it('returns a frozen object', () => {
         expect(extendClient({ fruit: 'apple' as const }, { vegetable: 'carrot' as const })).toBeFrozenObject();
+    });
+});
+
+describe('withCleanup', () => {
+    it('calls the cleanup function when disposed', () => {
+        const cleanup = jest.fn();
+        const result = withCleanup({}, cleanup);
+        result[Symbol.dispose]();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('disposes using the `using` syntax', () => {
+        const cleanup = jest.fn();
+        {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            using _ = withCleanup({}, cleanup);
+        }
+        expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call the cleanup function before dispose is invoked', () => {
+        const cleanup = jest.fn();
+        withCleanup({}, cleanup);
+        expect(cleanup).not.toHaveBeenCalled();
+    });
+
+    it('chains parent Symbol.dispose when client already has one', () => {
+        const callOrder: string[] = [];
+        const parentDispose = jest.fn(() => callOrder.push('parent'));
+        const cleanup = jest.fn(() => callOrder.push('cleanup'));
+        const client = { [Symbol.dispose]: parentDispose };
+        const result = withCleanup(client, cleanup);
+        result[Symbol.dispose]();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+        expect(parentDispose).toHaveBeenCalledTimes(1);
+        expect(callOrder).toStrictEqual(['cleanup', 'parent']);
+    });
+
+    it('does not throw when client has no Symbol.dispose', () => {
+        const cleanup = jest.fn();
+        const result = withCleanup({}, cleanup);
+        expect(() => result[Symbol.dispose]()).not.toThrow();
+    });
+
+    it('preserves existing client properties', () => {
+        const result = withCleanup({ fruit: 'apple' as const }, () => {});
+        expect(result.fruit).toBe('apple');
+    });
+
+    it('symbol.dispose is a function on the result', () => {
+        const result = withCleanup({}, () => {});
+        expect(typeof result[Symbol.dispose]).toBe('function');
+    });
+
+    it('returns a frozen object', () => {
+        expect(withCleanup({ fruit: 'apple' as const }, () => {})).toBeFrozenObject();
     });
 });

--- a/packages/plugin-core/src/__tests__/client-test.ts
+++ b/packages/plugin-core/src/__tests__/client-test.ts
@@ -1,6 +1,6 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
-import { createEmptyClient, extendClient, withCleanup } from '../client';
+import { createEmptyClient, extendClient, withAsyncCleanup, withCleanup } from '../client';
 
 describe('createEmptyClient', () => {
     it('creates an empty object with a use function', () => {
@@ -346,5 +346,96 @@ describe('withCleanup', () => {
         const result = withCleanup(client, cleanup2);
         result[Symbol.dispose]();
         expect(callOrder).toStrictEqual(['cleanup2', 'cleanup1', 'parent']);
+    });
+
+    it('preserves async dispose when client already has Symbol.asyncDispose', () => {
+        const asyncDispose = jest.fn();
+        const client = { [Symbol.asyncDispose]: asyncDispose };
+        const result = withCleanup(client, () => {});
+        expect(result[Symbol.asyncDispose]).toBe(asyncDispose);
+    });
+});
+
+describe('withAsyncCleanup', () => {
+    it('calls the cleanup function when async-disposed', async () => {
+        expect.assertions(1);
+        const cleanup = jest.fn().mockResolvedValue(undefined);
+        const result = withAsyncCleanup({}, cleanup);
+        await result[Symbol.asyncDispose]();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('disposes using the `await using` syntax', async () => {
+        expect.assertions(1);
+        const cleanup = jest.fn().mockResolvedValue(undefined);
+        {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            await using _ = withAsyncCleanup({}, cleanup);
+        }
+        expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call the cleanup function before dispose is invoked', () => {
+        const cleanup = jest.fn().mockResolvedValue(undefined);
+        withAsyncCleanup({}, cleanup);
+        expect(cleanup).not.toHaveBeenCalled();
+    });
+
+    it('chains parent Symbol.asyncDispose when client already has one', async () => {
+        expect.assertions(3);
+        const callOrder: string[] = [];
+        // eslint-disable-next-line @typescript-eslint/require-await
+        const parentAsyncDispose = jest.fn().mockImplementation(async () => {
+            callOrder.push('parent');
+        });
+        // eslint-disable-next-line @typescript-eslint/require-await
+        const cleanup = jest.fn().mockImplementation(async () => {
+            callOrder.push('cleanup');
+        });
+        const client = { [Symbol.asyncDispose]: parentAsyncDispose };
+        const result = withAsyncCleanup(client, cleanup);
+        await result[Symbol.asyncDispose]();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+        expect(parentAsyncDispose).toHaveBeenCalledTimes(1);
+        expect(callOrder).toStrictEqual(['cleanup', 'parent']);
+    });
+
+    it('falls back to parent Symbol.dispose when no Symbol.asyncDispose', async () => {
+        expect.assertions(3);
+        const callOrder: string[] = [];
+        const parentDispose = jest.fn(() => {
+            callOrder.push('parent');
+        });
+        // eslint-disable-next-line @typescript-eslint/require-await
+        const cleanup = jest.fn(async () => {
+            callOrder.push('cleanup');
+        });
+        const client = { [Symbol.dispose]: parentDispose };
+        const result = withAsyncCleanup(client, cleanup);
+        await result[Symbol.asyncDispose]();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+        expect(parentDispose).toHaveBeenCalledTimes(1);
+        expect(callOrder).toStrictEqual(['cleanup', 'parent']);
+    });
+
+    it('does not throw when client has neither Symbol.dispose nor Symbol.asyncDispose', async () => {
+        expect.assertions(1);
+        const cleanup = jest.fn().mockResolvedValue(undefined);
+        const result = withAsyncCleanup({}, cleanup);
+        await expect(result[Symbol.asyncDispose]()).resolves.toBeUndefined();
+    });
+
+    it('preserves existing client properties', () => {
+        const result = withAsyncCleanup({ fruit: 'apple' as const }, async () => {});
+        expect(result.fruit).toBe('apple');
+    });
+
+    it('symbol.asyncDispose is a function on the result', () => {
+        const result = withAsyncCleanup({}, async () => {});
+        expect(typeof result[Symbol.asyncDispose]).toBe('function');
+    });
+
+    it('returns a frozen object', () => {
+        expect(withAsyncCleanup({ fruit: 'apple' as const }, async () => {})).toBeFrozenObject();
     });
 });

--- a/packages/plugin-core/src/__tests__/client-test.ts
+++ b/packages/plugin-core/src/__tests__/client-test.ts
@@ -316,4 +316,35 @@ describe('withCleanup', () => {
     it('returns a frozen object', () => {
         expect(withCleanup({ fruit: 'apple' as const }, () => {})).toBeFrozenObject();
     });
+
+    it('calls all cleanup functions when withCleanup is called multiple times', () => {
+        const cleanup1 = jest.fn();
+        const cleanup2 = jest.fn();
+        const client = withCleanup({}, cleanup1);
+        const result = withCleanup(client, cleanup2);
+        result[Symbol.dispose]();
+        expect(cleanup1).toHaveBeenCalledTimes(1);
+        expect(cleanup2).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls multiple cleanups in LIFO order', () => {
+        const callOrder: string[] = [];
+        const cleanup1 = jest.fn(() => callOrder.push('cleanup1'));
+        const cleanup2 = jest.fn(() => callOrder.push('cleanup2'));
+        const client = withCleanup({}, cleanup1);
+        const result = withCleanup(client, cleanup2);
+        result[Symbol.dispose]();
+        expect(callOrder).toStrictEqual(['cleanup2', 'cleanup1']);
+    });
+
+    it('calls multiple cleanups and existing parent dispose in the correct order', () => {
+        const callOrder: string[] = [];
+        const parentDispose = jest.fn(() => callOrder.push('parent'));
+        const cleanup1 = jest.fn(() => callOrder.push('cleanup1'));
+        const cleanup2 = jest.fn(() => callOrder.push('cleanup2'));
+        const client = withCleanup({ [Symbol.dispose]: parentDispose }, cleanup1);
+        const result = withCleanup(client, cleanup2);
+        result[Symbol.dispose]();
+        expect(callOrder).toStrictEqual(['cleanup2', 'cleanup1', 'parent']);
+    });
 });

--- a/packages/plugin-core/src/__typetests__/client-typetest.ts
+++ b/packages/plugin-core/src/__typetests__/client-typetest.ts
@@ -5,6 +5,7 @@ import {
     type ClientPlugin,
     createEmptyClient,
     extendClient,
+    withAsyncCleanup,
     withCleanup,
 } from '../client';
 
@@ -249,6 +250,13 @@ const EMPTY_ASYNC_CLIENT = null as unknown as AsyncClient<object>;
         withCleanup(client, () => {}) satisfies Client<object> & Disposable;
     }
 
+    // It can be used with the `using` syntax
+    {
+        const client = null as unknown as Client<object>;
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        using _ = withCleanup(client, () => {});
+    }
+
     // It accepts an already Disposable client
     {
         const client = null as unknown as Client<object> & Disposable;
@@ -259,5 +267,69 @@ const EMPTY_ASYNC_CLIENT = null as unknown as AsyncClient<object>;
     {
         const client = null as unknown as AsyncClient<object>;
         withCleanup(client, () => {}) satisfies AsyncClient<object> & Disposable;
+    }
+
+    // It preserves an AsyncDisposable client
+    {
+        const client = null as unknown as AsyncDisposable & Client<object>;
+        withCleanup(client, () => {}) satisfies AsyncDisposable & Client<object>;
+    }
+
+    // It does not make an AsyncDisposable client Disposable
+    {
+        const client = null as unknown as AsyncDisposable & Client<object>;
+        // @ts-expect-error - client is not Disposable.
+        withCleanup(client, () => {}) satisfies Client<object> & Disposable;
+    }
+}
+
+// [Describe] withAsyncCleanup
+{
+    // It returns an AsyncDisposable client
+    {
+        const client = null as unknown as Client<object>;
+        withAsyncCleanup(client, async () => {}) satisfies AsyncDisposable & Client<object>;
+    }
+
+    // It cannot be used with the `using` syntax
+    {
+        const client = null as unknown as Client<object>;
+        // @ts-expect-error - withAsyncCleanup returns an AsyncDisposable, which cannot be used with `using`.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        using _ = withAsyncCleanup(client, async () => {});
+    }
+
+    // It can be used with the `await using` syntax
+    {
+        const client = null as unknown as AsyncDisposable & Client<object>;
+        void (async () => {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            await using _ = withCleanup(client, () => {});
+        })();
+    }
+
+    // It accepts an already AsyncDisposable client
+    {
+        const client = null as unknown as AsyncDisposable & Client<object>;
+        withAsyncCleanup(client, async () => {}) satisfies AsyncDisposable & Client<object>;
+    }
+
+    // It accepts a Disposable (sync-only) client
+    {
+        const client = null as unknown as Client<object> & Disposable;
+        withAsyncCleanup(client, async () => {}) satisfies AsyncDisposable & Client<object>;
+    }
+
+    // It strips Disposable from a Disposable client
+    {
+        const client = null as unknown as Client<object> & Disposable;
+        // @ts-expect-error - returned client is not Disposable.
+        withAsyncCleanup(client, async () => {}) satisfies Client<object> & Disposable;
+    }
+
+    // It accepts an AsyncClient
+    {
+        const client = null as unknown as AsyncClient<object>;
+        withAsyncCleanup(client, async () => {}) satisfies AsyncClient<object> & AsyncDisposable;
     }
 }

--- a/packages/plugin-core/src/__typetests__/client-typetest.ts
+++ b/packages/plugin-core/src/__typetests__/client-typetest.ts
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import { type AsyncClient, type Client, type ClientPlugin, createEmptyClient, extendClient } from '../client';
+import {
+    type AsyncClient,
+    type Client,
+    type ClientPlugin,
+    createEmptyClient,
+    extendClient,
+    withCleanup,
+} from '../client';
 
 const EMPTY_CLIENT = null as unknown as Client<object>;
 const EMPTY_ASYNC_CLIENT = null as unknown as AsyncClient<object>;
@@ -231,5 +238,26 @@ const EMPTY_ASYNC_CLIENT = null as unknown as AsyncClient<object>;
     {
         // @ts-expect-error - additions is not an object.
         extendClient({}, 'hello');
+    }
+}
+
+// [Describe] withCleanup
+{
+    // It returns a Disposable client
+    {
+        const client = null as unknown as Client<object>;
+        withCleanup(client, () => {}) satisfies Client<object> & Disposable;
+    }
+
+    // It accepts an already Disposable client
+    {
+        const client = null as unknown as Client<object> & Disposable;
+        withCleanup(client, () => {}) satisfies Client<object> & Disposable;
+    }
+
+    // It accepts an AsyncClient
+    {
+        const client = null as unknown as AsyncClient<object>;
+        withCleanup(client, () => {}) satisfies AsyncClient<object> & Disposable;
     }
 }

--- a/packages/plugin-core/src/client.ts
+++ b/packages/plugin-core/src/client.ts
@@ -277,13 +277,50 @@ export function extendClient<TClient extends object, TAdditions extends object>(
  * @see {@link extendClient}
  */
 export function withCleanup<TClient extends object>(client: TClient, cleanup: () => void): Disposable & TClient {
-    const parentDispose: (() => void) | undefined =
-        Symbol.dispose in client ? (client as Disposable)[Symbol.dispose] : undefined;
-    const additions: Disposable = {
+    if (DISPOSABLE_STACK_PROPERTY in client) {
+        return addCleanupToClientWithExistingStack(
+            client as Record<typeof DISPOSABLE_STACK_PROPERTY, DisposableStack> & TClient,
+            cleanup,
+        );
+    } else {
+        return addCleanupToClientWithoutExistingStack(client, cleanup);
+    }
+}
+
+const DISPOSABLE_STACK_PROPERTY = '__PRIVATE__DISPOSABLE_STACK' as const;
+
+function addCleanupToClientWithExistingStack<TClient extends Record<typeof DISPOSABLE_STACK_PROPERTY, DisposableStack>>(
+    client: TClient,
+    cleanup: () => void,
+): Disposable & TClient {
+    // If we already have the stack, add the new cleanup to it
+    client[DISPOSABLE_STACK_PROPERTY].defer(cleanup);
+    // We assume we already added a dispose method when we added the stack
+    return client as Disposable & TClient;
+}
+
+function addCleanupToClientWithoutExistingStack<TClient extends object>(
+    client: TClient,
+    cleanup: () => void,
+): Disposable & TClient {
+    const stack = new DisposableStack();
+
+    // If the client has an existing dispose method but not our stack, we maintain this existing cleanup by deferring it to the new stack
+    if (Symbol.dispose in client) {
+        const existingDispose = (client as Disposable)[Symbol.dispose];
+        stack.defer(() => existingDispose.call(client));
+    }
+
+    // Add the new cleanup to the stack
+    stack.defer(cleanup);
+
+    // We add our stack to the client, and replace any existing dispose method with our stack dispose
+    const additions = {
+        [DISPOSABLE_STACK_PROPERTY]: stack,
         [Symbol.dispose]() {
-            cleanup();
-            parentDispose?.call(client);
+            stack[Symbol.dispose]();
         },
     };
-    return extendClient(client, additions) as Disposable & TClient;
+
+    return extendClient(client, additions) as unknown as Disposable & TClient;
 }

--- a/packages/plugin-core/src/client.ts
+++ b/packages/plugin-core/src/client.ts
@@ -242,3 +242,48 @@ export function extendClient<TClient extends object, TAdditions extends object>(
     Object.defineProperties(result, Object.getOwnPropertyDescriptors(additions));
     return Object.freeze(result) as Omit<TClient, keyof TAdditions> & TAdditions;
 }
+
+/**
+ * Wraps a client with a cleanup function, making it {@link Disposable}.
+ *
+ * Plugin authors can use this to register teardown logic (e.g. closing
+ * connections or clearing timers) that runs when the client is disposed.
+ * If the client already implements `Symbol.dispose`, the existing dispose
+ * logic is chained so that it runs after the new `cleanup` function.
+ *
+ * @typeParam TClient - The type of the original client.
+ * @param client - The client to wrap.
+ * @param cleanup - The cleanup function to run when the client is disposed.
+ * @return A new client that extends `TClient` and implements `Disposable`.
+ *
+ * @example
+ * Register a cleanup function in a plugin that opens a WebSocket connection.
+ * ```ts
+ * function myPlugin() {
+ *     return <T extends object>(client: T) => {
+ *         const socket = new WebSocket('wss://api.example.com');
+ *         return withCleanup(
+ *             extendClient(client, { socket }),
+ *             () => socket.close(),
+ *         );
+ *     };
+ * }
+ *
+ * // Later, when the client is no longer needed:
+ * using client = createEmptyClient().use(myPlugin();
+ * // `socket.close()` is called automatically when `client` goes out of scope.
+ * ```
+ *
+ * @see {@link extendClient}
+ */
+export function withCleanup<TClient extends object>(client: TClient, cleanup: () => void): Disposable & TClient {
+    const parentDispose: (() => void) | undefined =
+        Symbol.dispose in client ? (client as Disposable)[Symbol.dispose] : undefined;
+    const additions: Disposable = {
+        [Symbol.dispose]() {
+            cleanup();
+            parentDispose?.call(client);
+        },
+    };
+    return extendClient(client, additions) as Disposable & TClient;
+}

--- a/packages/plugin-core/src/client.ts
+++ b/packages/plugin-core/src/client.ts
@@ -276,6 +276,8 @@ export function extendClient<TClient extends object, TAdditions extends object>(
  *
  * @see {@link extendClient}
  */
+export function withCleanup<TClient extends AsyncDisposable>(client: TClient, cleanup: () => void): TClient;
+export function withCleanup<TClient extends object>(client: TClient, cleanup: () => void): Disposable & TClient;
 export function withCleanup<TClient extends object>(client: TClient, cleanup: () => void): Disposable & TClient {
     if (DISPOSABLE_STACK_PROPERTY in client) {
         return addCleanupToClientWithExistingStack(
@@ -323,4 +325,60 @@ function addCleanupToClientWithoutExistingStack<TClient extends object>(
     };
 
     return extendClient(client, additions) as unknown as Disposable & TClient;
+}
+
+/**
+ * Wraps a client with an async cleanup function, making it {@link AsyncDisposable}.
+ *
+ * Plugin authors can use this to register asynchronous teardown logic (e.g.
+ * flushing buffers, closing connections) that runs when the client is disposed.
+ * If the client already implements `Symbol.asyncDispose`, it is awaited after
+ * the new cleanup. If only `Symbol.dispose` is present, it is called
+ * synchronously as a fallback.
+ *
+ * @typeParam TClient - The type of the original client.
+ * @param client - The client to wrap.
+ * @param cleanup - The async cleanup function to run when the client is disposed.
+ * @return A new client that extends `TClient` and implements `AsyncDisposable`.
+ *
+ * @example
+ * Register an async cleanup function in a plugin that opens a database connection.
+ * ```ts
+ * function myPlugin() {
+ *     return <T extends object>(client: T) => {
+ *         const db = await openDatabase();
+ *         return withAsyncCleanup(
+ *             extendClient(client, { db }),
+ *             () => db.close(),
+ *         );
+ *     };
+ * }
+ *
+ * // Later, when the client is no longer needed:
+ * await using client = createEmptyClient().use(myPlugin();
+ * // `db.close()` is awaited automatically when `client` goes out of scope.
+ * ```
+ *
+ * @see {@link withCleanup}
+ * @see {@link extendClient}
+ */
+export function withAsyncCleanup<TClient extends object>(
+    client: TClient,
+    cleanup: () => Promise<void>,
+): AsyncDisposable & Omit<TClient, keyof Disposable> {
+    const parentDispose: (() => void) | undefined =
+        Symbol.dispose in client ? (client as Disposable)[Symbol.dispose] : undefined;
+    const parentAsyncDispose: (() => PromiseLike<void>) | undefined =
+        Symbol.asyncDispose in client ? (client as AsyncDisposable)[Symbol.asyncDispose] : undefined;
+    const additions: AsyncDisposable = {
+        async [Symbol.asyncDispose]() {
+            await cleanup();
+            if (parentAsyncDispose) {
+                await parentAsyncDispose.call(client);
+            } else {
+                parentDispose?.call(client);
+            }
+        },
+    };
+    return extendClient(client, additions) as AsyncDisposable & TClient;
 }


### PR DESCRIPTION
This PR follows up the previous one by adding `withAsyncCleanup` to enable async cleanup functions and the `await using` syntax. 

For async cleanup, we first await the given cleanup function. We then call the parent `AsyncDispose` if there is one, falling back to a parent `Dispose` if there is one. This means that on async cleanup we call the parent cleanup function, even if it is not async.

This PR also uses types to try to force consumers to use async disposal if any plugin in the chain uses `withAsyncCleanup`:

- If the input client to `withAsyncCleanup` is `Disposable`, this is stripped and only `AsyncDisposable` is returned
- If the input client to `withCleanup` is `AsyncDisposable`, then it is returned with its type unchanged, ie it is `AsyncDisposable` and not `Disposable`. This means that if you chain a plugin with sync disposal after one with async disposal, the returned client is `AsyncDisposable` only. 

Note: We could decide not to ship this until we/someone else have an async use case, I think our wallet plugin will only need sync. But async is part of the same spec, and not having it would limit some future use cases. 