### PR TITLE
Smid 0194 depricate rent exemption threshold

### DIFF
--- a/.changeset/tangy-wolves-move.md
+++ b/.changeset/tangy-wolves-move.md
@@ -1,0 +1,8 @@
+---
+'@solana/sysvars': minor
+'@solana/kit': minor
+'@solana/rpc-graphql': minor
+'@solana/rpc-parsed-types': minor
+---
+
+Deprecate `exemptionThreshold` and `burnPercent` fields on `SysvarRent` per SIMD-0194. Update `lamportsPerByte` documentation to reflect that rent is no longer time-based. Simplify `getMinimumBalanceForRentExemption` constants to use `DEFAULT_LAMPORTS_PER_BYTE: 6960n` directly.

--- a/packages/kit/src/__tests__/get-minimum-balance-for-rent-exemption-test.ts
+++ b/packages/kit/src/__tests__/get-minimum-balance-for-rent-exemption-test.ts
@@ -6,10 +6,24 @@ describe('getMinimumBalanceForRentExemption', () => {
     it.each`
         space     | lamports
         ${0n}     | ${890_880n}
-        ${100n}   | ${890_880n + 100n * 3_480n * 2n}
-        ${1_024n} | ${890_880n + 1_024n * 3_480n * 2n}
+        ${100n}   | ${890_880n + 100n * 6_960n}
+        ${1_024n} | ${890_880n + 1_024n * 6_960n}
     `('calculates the correct rent for an account with $space bytes of space allocated', ({ space, lamports }) => {
         expect.assertions(1);
         expect(getMinimumBalanceForRentExemption(space)).toBe(lamports as unknown as Lamports);
+    });
+    it('produces 890,880 lamports for a zero-data account (128 * 6960)', () => {
+        expect(getMinimumBalanceForRentExemption(0n)).toBe(890_880n as unknown as Lamports);
+    });
+    it('produces the same result as the old formula: (128 + space) * 3480 * 2', () => {
+        const space = 200n;
+        const oldFormula = (128n + space) * 3_480n * 2n;
+        const newResult = getMinimumBalanceForRentExemption(space);
+        expect(newResult).toBe(oldFormula as unknown as Lamports);
+    });
+    it('uses DEFAULT_LAMPORTS_PER_BYTE of 6960 (doubled from 3480 per SIMD-0194)', () => {
+        const space = 1n;
+        // (128 + 1) * 6960 = 129 * 6960 = 897_840
+        expect(getMinimumBalanceForRentExemption(space)).toBe(897_840n as unknown as Lamports);
     });
 });

--- a/packages/kit/src/get-minimum-balance-for-rent-exemption.ts
+++ b/packages/kit/src/get-minimum-balance-for-rent-exemption.ts
@@ -24,12 +24,10 @@ import type { Lamports } from '@solana/rpc-types';
 export function getMinimumBalanceForRentExemption(space: bigint): Lamports {
     const RENT = {
         ACCOUNT_STORAGE_OVERHEAD: 128n,
-        DEFAULT_EXEMPTION_THRESHOLD: 2n,
-        DEFAULT_LAMPORTS_PER_BYTE_YEAR: 3_480n,
+        DEFAULT_LAMPORTS_PER_BYTE: 6_960n,
     } as const;
     const requiredLamports =
         (RENT.ACCOUNT_STORAGE_OVERHEAD + space) *
-        RENT.DEFAULT_LAMPORTS_PER_BYTE_YEAR *
-        RENT.DEFAULT_EXEMPTION_THRESHOLD;
+        RENT.DEFAULT_LAMPORTS_PER_BYTE;
     return requiredLamports as Lamports;
 }

--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -1059,6 +1059,8 @@ describe('account', () => {
                 const variableValues = {
                     address: 'SysvarRent111111111111111111111111111111111',
                 };
+                // Validators return `lamportsPerByteYear` in JSON-parsed responses
+                // even after SIMD-0194 (the binary value changed but the field name didn't).
                 const source = /* GraphQL */ `
                     query testQuery($address: Address!) {
                         account(address: $address) {

--- a/packages/rpc-graphql/src/schema/type-defs/account.ts
+++ b/packages/rpc-graphql/src/schema/type-defs/account.ts
@@ -508,7 +508,8 @@ export const accountTypeDefs = /* GraphQL */ `
         space: BigInt
         burnPercent: Int
         exemptionThreshold: Int
-        lamportsPerByteYear: Lamports
+        lamportsPerByte: Lamports
+        lamportsPerByteYear: Lamports @deprecated(reason: "Use lamportsPerByte instead (SIMD-0194)")
     }
 
     type SlotHashEntry {

--- a/packages/rpc-parsed-types/src/__typetests__/sysvar-accounts-typetest.ts
+++ b/packages/rpc-parsed-types/src/__typetests__/sysvar-accounts-typetest.ts
@@ -101,7 +101,7 @@ import { JsonParsedSysvarAccount } from '../sysvar-accounts';
         info: {
             burnPercent: 50,
             exemptionThreshold: 2.0,
-            lamportsPerByteYear: '3480' as StringifiedBigInt,
+            lamportsPerByte: '3480' as StringifiedBigInt,
         },
         type: 'rent' as const,
     };
@@ -112,7 +112,22 @@ import { JsonParsedSysvarAccount } from '../sysvar-accounts';
     const account = {} as unknown as JsonParsedSysvarAccount;
     if (account.type === 'rent') {
         account.info.burnPercent satisfies number;
+        account.info.lamportsPerByte satisfies StringifiedBigInt;
     }
+}
+
+// rent account with deprecated lamportsPerByteYear alias (SIMD-0194)
+{
+    const account = {
+        info: {
+            burnPercent: 50,
+            exemptionThreshold: 1.0,
+            lamportsPerByte: '6960' as StringifiedBigInt,
+            lamportsPerByteYear: '6960' as StringifiedBigInt,
+        },
+        type: 'rent' as const,
+    };
+    account satisfies JsonParsedSysvarAccount;
 }
 
 // slot hashes account

--- a/packages/rpc-parsed-types/src/sysvar-accounts.ts
+++ b/packages/rpc-parsed-types/src/sysvar-accounts.ts
@@ -34,7 +34,9 @@ type JsonParsedRecentBlockhashesAccount_DEPRECATED = Readonly<{
 type JsonParsedRentAccount = Readonly<{
     burnPercent: number;
     exemptionThreshold: number;
-    lamportsPerByteYear: StringifiedBigInt;
+    lamportsPerByte: StringifiedBigInt;
+    /** @deprecated Use `lamportsPerByte` instead (SIMD-0194) */
+    lamportsPerByteYear?: StringifiedBigInt;
 }>;
 
 type JsonParsedSlotHashesAccount = Readonly<{

--- a/packages/sysvars/src/__tests__/rent-test.ts
+++ b/packages/sysvars/src/__tests__/rent-test.ts
@@ -1,5 +1,6 @@
 import type { GetAccountInfoApi } from '@solana/rpc-api';
 import type { Rpc } from '@solana/rpc-spec';
+import type { Lamports } from '@solana/rpc-types';
 
 import { fetchSysvarRent, getSysvarRentCodec } from '../rent';
 import { createLocalhostSolanaRpc } from './__setup__';
@@ -22,12 +23,59 @@ describe('rent', () => {
             lamportsPerByteYear: 100_000_000n,
         });
     });
+    it('maintains backward compatibility by aliasing lamportsPerByteYear', () => {
+        const rentState = new Uint8Array([
+            0, 225, 245, 5, 0, 0, 0, 0, // lamportsPerByte
+            0, 0, 0, 0, 0, 0, 0, 0,     // exemptionThreshold (ignored)
+            0,                          // burnPercent (ignored)
+        ]);
+        const decoded = getSysvarRentCodec().decode(rentState);
+        expect(decoded.lamportsPerByteYear).toBeDefined();
+        expect(decoded.lamportsPerByteYear).toStrictEqual(decoded.lamportsPerByte);
+    });
+    it('encode and decode roundtrip produces consistent data', () => {
+        const rent = {
+            burnPercent: 50,
+            exemptionThreshold: 1.0,
+            lamportsPerByte: 6_960n as Lamports,
+        };
+        const codec = getSysvarRentCodec();
+        const encoded = codec.encode(rent);
+        const decoded = codec.decode(encoded);
+        expect(decoded.lamportsPerByte).toBe(6_960n);
+        expect(decoded.exemptionThreshold).toBe(1.0);
+        expect(decoded.burnPercent).toBe(50);
+        expect(decoded.lamportsPerByteYear).toBe(decoded.lamportsPerByte);
+    });
+    it('binary layout is exactly 17 bytes (u64 + f64 + u8)', () => {
+        const rent = {
+            burnPercent: 0,
+            exemptionThreshold: 1.0,
+            lamportsPerByte: 6_960n as Lamports,
+        };
+        const encoded = getSysvarRentCodec().encode(rent);
+        expect(encoded.byteLength).toBe(17);
+    });
+    it('decodes post-SIMD-0194 mainnet values (lamportsPerByte=6960, exemptionThreshold=1.0)', () => {
+        // prettier-ignore
+        const postSimd194State = new Uint8Array([
+            48, 27, 0, 0, 0, 0, 0, 0,       // lamportsPerByte = 6960 (little-endian u64)
+            0, 0, 0, 0, 0, 0, 240, 63,      // exemptionThreshold = 1.0 (IEEE 754 f64)
+            50,                              // burnPercent = 50
+        ]);
+        const decoded = getSysvarRentCodec().decode(postSimd194State);
+        expect(decoded.lamportsPerByte).toBe(6_960n);
+        expect(decoded.exemptionThreshold).toBe(1.0);
+        expect(decoded.burnPercent).toBe(50);
+        expect(decoded.lamportsPerByteYear).toBe(6_960n);
+    });
     it('fetch', async () => {
         expect.assertions(1);
         const rent = await fetchSysvarRent(rpc);
         expect(rent).toMatchObject({
             burnPercent: expect.any(Number),
             exemptionThreshold: expect.any(Number),
+            lamportsPerByte: expect.any(BigInt),
             lamportsPerByteYear: expect.any(BigInt),
         });
     });

--- a/packages/sysvars/src/__tests__/sysvar-test.ts
+++ b/packages/sysvars/src/__tests__/sysvar-test.ts
@@ -117,6 +117,8 @@ describe('sysvar account', () => {
         });
         it('fetch JSON-parsed', async () => {
             expect.assertions(3);
+            // Validators return `lamportsPerByteYear` in JSON-parsed responses
+            // even after SIMD-0194 (the binary value changed but the field name didn't).
             await assertValidJsonParsedSysvarAccount(SYSVAR_RENT_ADDRESS, {
                 data: {
                     burnPercent: expect.any(Number),

--- a/packages/sysvars/src/rent.ts
+++ b/packages/sysvars/src/rent.ts
@@ -1,5 +1,5 @@
 import { assertAccountExists, decodeAccount, type FetchAccountConfig } from '@solana/accounts';
-import { combineCodec, type FixedSizeCodec, type FixedSizeDecoder, type FixedSizeEncoder } from '@solana/codecs-core';
+import { combineCodec, type FixedSizeCodec, type FixedSizeDecoder, type FixedSizeEncoder, transformDecoder } from '@solana/codecs-core';
 import { getStructDecoder, getStructEncoder } from '@solana/codecs-data-structures';
 import { getF64Decoder, getF64Encoder, getU8Decoder, getU8Encoder } from '@solana/codecs-numbers';
 import type { GetAccountInfoApi } from '@solana/rpc-api';
@@ -24,12 +24,23 @@ export type SysvarRent = Readonly<{
      *
      * Valid values are in the range [0, 100]. The remaining percentage is distributed to
      * validators.
+     *
+     * @deprecated Rent no longer exists (SIMD-0194).
      */
     burnPercent: number;
-    /** Amount of time (in years) a balance must include rent for the account to be rent exempt */
+    /**
+     * Formerly, the amount of time (in years) a balance must include rent for the account to be rent exempt.
+     * Now deprecated — use {@link SysvarRent.lamportsPerByte | lamportsPerByte} directly to calculate the minimum balance.
+     *
+     * @deprecated Use {@link SysvarRent.lamportsPerByte | lamportsPerByte} directly (SIMD-0194).
+     */
     exemptionThreshold: F64UnsafeSeeDocumentation;
-    /** Rental rate in {@link Lamports}/byte-year. */
-    lamportsPerByteYear: Lamports;
+    /** Rental rate in {@link Lamports} per byte of account storage. */
+    lamportsPerByte: Lamports;
+    /**
+     * @deprecated Use {@link SysvarRent.lamportsPerByte | lamportsPerByte} instead (SIMD-0194).
+     */
+    lamportsPerByteYear?: Lamports;
 }>;
 
 /**
@@ -38,7 +49,7 @@ export type SysvarRent = Readonly<{
  */
 export function getSysvarRentEncoder(): FixedSizeEncoder<SysvarRent, SysvarRentSize> {
     return getStructEncoder([
-        ['lamportsPerByteYear', getDefaultLamportsEncoder()],
+        ['lamportsPerByte', getDefaultLamportsEncoder()],
         ['exemptionThreshold', getF64Encoder()],
         ['burnPercent', getU8Encoder()],
     ]) as FixedSizeEncoder<SysvarRent, SysvarRentSize>;
@@ -49,11 +60,17 @@ export function getSysvarRentEncoder(): FixedSizeEncoder<SysvarRent, SysvarRentS
  * account data to a {@link SysvarRent}.
  */
 export function getSysvarRentDecoder(): FixedSizeDecoder<SysvarRent, SysvarRentSize> {
-    return getStructDecoder([
-        ['lamportsPerByteYear', getDefaultLamportsDecoder()],
-        ['exemptionThreshold', getF64Decoder()],
-        ['burnPercent', getU8Decoder()],
-    ]) as FixedSizeDecoder<SysvarRent, SysvarRentSize>;
+    return transformDecoder(
+        getStructDecoder([
+            ['lamportsPerByte', getDefaultLamportsDecoder()],
+            ['exemptionThreshold', getF64Decoder()],
+            ['burnPercent', getU8Decoder()],
+        ]),
+        value => ({
+            ...value,
+            lamportsPerByteYear: value.lamportsPerByte,
+        })
+    ) as FixedSizeDecoder<SysvarRent, SysvarRentSize>;
 }
 
 /**


### PR DESCRIPTION
#### Summary of Changes

- Deprecate `lamportsPerByteYear` in favor of `lamportsPerByte` on `SysvarRent`.
- Deprecate `exemptionThreshold` and `burnPercent` fields.
- Update `getMinimumBalanceForRentExemption` to use `DEFAULT_LAMPORTS_PER_BYTE: 6960n` directly.

Fixes #1490