### PR TITLE
docs(wallet-account-signer): update README with correct title, badges, and API docs

### DIFF
--- a/packages/wallet-account-signer/README.md
+++ b/packages/wallet-account-signer/README.md
@@ -12,6 +12,7 @@
 # @solana/wallet-account-signer
 
 This package bridges [Wallet Standard](https://github.com/wallet-standard/wallet-standard) accounts to Kit [`@solana/signers`](https://github.com/anza-xyz/kit/tree/main/packages/signers) interfaces. It converts a `UiWalletAccount` into the appropriate Kit signer depending on which Wallet Standard features the wallet supports.
+
 ## Installation
 
 ```shell

--- a/packages/wallet-account-signer/README.md
+++ b/packages/wallet-account-signer/README.md
@@ -1,4 +1,4 @@
-![npm][npm-image]][npm-url]
+[![npm][npm-image]][npm-url]
 [![npm-downloads][npm-downloads-image]][npm-url]
 <br />
 [![code-style-prettier][code-style-prettier-image]][code-style-prettier-url]
@@ -9,8 +9,75 @@
 [npm-image]: https://img.shields.io/npm/v/@solana/wallet-account-signer?style=flat
 [npm-url]: https://www.npmjs.com/package/@solana/wallet-account-signer
 
-# @solana/program-client-core
+# @solana/wallet-account-signer
 
-This package contains functions for converting from [Wallet Standard](https://github.com/wallet-standard/wallet-standard) accounts on Solana chains, to Kit Signer objects.
+This package bridges [Wallet Standard](https://github.com/wallet-standard/wallet-standard) accounts to Kit [`@solana/signers`](https://github.com/anza-xyz/kit/tree/main/packages/signers) interfaces. It converts a `UiWalletAccount` into the appropriate Kit signer depending on which Wallet Standard features the wallet supports.
+## Installation
 
-Note that this package has dependencies on Wallet Standard packages.
+```shell
+pnpm add @solana/wallet-account-signer
+```
+
+## Chains
+
+Several functions in this package require a `chain` parameter of type `SolanaChain` from `@solana/wallet-standard-chains`. Valid values are:
+
+- `'solana:mainnet'`
+- `'solana:devnet'`
+- `'solana:testnet'`
+- `'solana:localnet'`
+
+## Usage
+
+### `createSignerFromWalletAccount(uiWalletAccount, chain)`
+
+Creates a signer that exposes every signing capability the wallet account supports. Inspects the account's features at call time and returns a frozen object with the applicable methods:
+
+- `modifyAndSignTransactions` — when `solana:signTransaction` is available.
+- `signAndSendTransactions` — when `solana:signAndSendTransaction` is available.
+- `modifyAndSignMessages` — when `solana:signMessage` is available.
+
+At least one transaction-signing feature must be present or an error is thrown.
+
+```ts
+import { createSignerFromWalletAccount } from '@solana/wallet-account-signer';
+
+const signer = createSignerFromWalletAccount(walletAccount, 'solana:mainnet');
+```
+
+### `createTransactionSignerFromWalletAccount(uiWalletAccount, chain)`
+
+Creates a `TransactionModifyingSigner` from a wallet account that supports the `solana:signTransaction` feature.
+
+```ts
+import { createTransactionSignerFromWalletAccount } from '@solana/wallet-account-signer';
+
+const signer = createTransactionSignerFromWalletAccount(walletAccount, 'solana:devnet');
+const [signedTransaction] = await signer.modifyAndSignTransactions([transaction]);
+```
+
+### `createTransactionSendingSignerFromWalletAccount(uiWalletAccount, chain)`
+
+Creates a `TransactionSendingSigner` from a wallet account that supports the `solana:signAndSendTransaction` feature.
+
+```ts
+import { createTransactionSendingSignerFromWalletAccount } from '@solana/wallet-account-signer';
+
+const signer = createTransactionSendingSignerFromWalletAccount(walletAccount, 'solana:devnet');
+const [signature] = await signer.signAndSendTransactions([transaction]);
+```
+
+### `createMessageSignerFromWalletAccount(uiWalletAccount)`
+
+Creates a `MessageModifyingSigner` from a wallet account that supports the `solana:signMessage` feature. Unlike the transaction signers, this function does not require a `chain` parameter.
+
+```ts
+import { createMessageSignerFromWalletAccount } from '@solana/wallet-account-signer';
+import { createSignableMessage } from '@solana/signers';
+
+const signer = createMessageSignerFromWalletAccount(walletAccount);
+const message = createSignableMessage('Hello, world!');
+const [signedMessage] = await signer.modifyAndSignMessages([message]);
+```
+
+To learn more about the different signer types, see the [Signers](https://www.solanakit.com/docs/concepts/signers) documentation.


### PR DESCRIPTION
## Summary
- Fix broken npm badge markdown (missing `[`) and incorrect package title (`@solana/program-client-core` → `@solana/wallet-account-signer`)
- Add API documentation for all four exported functions with usage examples
- Add `SolanaChain` reference section and link to signers docs