### PR TITLE
types: add no-arg typetest assertion for getBlockProduction

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-block-production-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-block-production-typetest.ts
@@ -1,5 +1,5 @@
 import type { Address } from '@solana/addresses';
-import type { Rpc } from '@solana/rpc-spec';
+import type { PendingRpcRequest, Rpc } from '@solana/rpc-spec';
 
 import type { GetBlockProductionApi } from '../getBlockProduction';
 
@@ -9,6 +9,13 @@ const identity = 'Joe11111111111111111111111111111' as Address<'Joe1111111111111
 void (async () => {
     // [DESCRIBE] getBlockProduction with no identity.
     {
+        // Accepts no arguments.
+        rpc.getBlockProduction() satisfies PendingRpcRequest<{
+            value: Readonly<{
+                byIdentity: Record<Address, [leaderSlots: bigint, blocksProduced: bigint]>;
+            }>;
+        }>;
+
         // Returns leader slot / blocks produced record, by validator.
         const result = await rpc.getBlockProduction().send();
         result.value.byIdentity satisfies Record<Address, [leaderSlots: bigint, blocksProduced: bigint]>;


### PR DESCRIPTION
This PR tightens type-level coverage for a no-argument RPC call in @solana/rpc-api by adding an explicit compile-time assertion for rpc.getBlockProduction() with no parameters.

## What Changed

- Updated packages/rpc-api/src/__typetests__/get-block-production-typetest.ts
- Added PendingRpcRequest import from @solana/rpc-spec
- Added a compile-time satisfies assertion for the zero-argument rpc.getBlockProduction() call

## Why

- Guards no-argument RPC call typing from regressions
- Ensures inferred request/response shape stays stable at compile time
- Keeps coverage aligned with typetest patterns already used in this package

## Scope

- Typetest-only change
- No runtime behavior change
- No production API implementation change

## Verification

- corepack pnpm install --frozen-lockfile --prod=false
- corepack pnpm --filter "@solana/rpc-api..." --if-present compile:typedefs && corepack pnpm --filter @solana/rpc-api test:typecheck

## Changeset

No changeset included because this is a typetest-only update and does not change runtime behavior. If maintainers prefer a changeset for policy reasons, I can add it.