### PR TITLE
Rename `createEmptyClient` to `createClient` and accept an optional initial value

### DIFF
--- a/.changeset/frank-flowers-kick.md
+++ b/.changeset/frank-flowers-kick.md
@@ -1,0 +1,5 @@
+---
+'@solana/plugin-core': minor
+---
+
+Add `createClient` function that replaces `createEmptyClient` and accepts an optional initial value. The old `createEmptyClient` is preserved as a deprecated re-export.

--- a/packages/plugin-core/src/__tests__/client-test.ts
+++ b/packages/plugin-core/src/__tests__/client-test.ts
@@ -1,19 +1,28 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
-import { createEmptyClient, extendClient, withCleanup } from '../client';
+import { createClient, extendClient, withCleanup } from '../client';
 
-describe('createEmptyClient', () => {
+describe('createClient', () => {
     it('creates an empty object with a use function', () => {
-        const emptyClient = createEmptyClient();
+        const emptyClient = createClient();
         expect(typeof emptyClient).toBe('object');
         const attributes = Object.getOwnPropertyNames(emptyClient);
         expect(attributes).toStrictEqual(['use']);
         expect(typeof emptyClient.use).toBe('function');
     });
 
+    it('creates an client from an existing object', () => {
+        const client = createClient({ fruit: 'banana' as const });
+        expect(typeof client).toBe('object');
+        const attributes = Object.getOwnPropertyNames(client);
+        expect(attributes).toStrictEqual(['fruit', 'use']);
+        expect(typeof client.use).toBe('function');
+        expect(client.fruit).toBe('banana');
+    });
+
     it('evolves when using plugins', () => {
         expect(
-            createEmptyClient()
+            createClient()
                 .use(c => ({ ...c, fruit: 'apple' as const }))
                 .use(c => ({ ...c, vegetable: 'carrot' as const })),
         ).toStrictEqual({
@@ -25,7 +34,7 @@ describe('createEmptyClient', () => {
 
     it('can be overriden by subsequent plugins', () => {
         expect(
-            createEmptyClient()
+            createClient()
                 .use(() => ({ fruit: 'apple' as const }))
                 .use(() => ({ vegetable: 'carrot' as const })),
         ).toStrictEqual({
@@ -36,7 +45,7 @@ describe('createEmptyClient', () => {
 
     it('allows plugins to enforce input type constraints', () => {
         expect(
-            createEmptyClient()
+            createClient()
                 .use(c => ({ ...c, fruit: 'apple' as const }))
                 .use(<T extends { fruit: 'apple' }>(c: T) => ({ ...c, dessert: 'apple cake' as const })),
         ).toStrictEqual({
@@ -47,7 +56,7 @@ describe('createEmptyClient', () => {
     });
 
     it('preserves getter properties from plugins', () => {
-        const client = createEmptyClient()
+        const client = createClient()
             // Make fruit a get() property
             .use(c => {
                 const result = { ...c };
@@ -69,7 +78,7 @@ describe('createEmptyClient', () => {
     it('preserves symbol-keyed properties from plugins', () => {
         const sym = Symbol('fruit');
 
-        const client = createEmptyClient()
+        const client = createClient()
             // Add the fruit symbol property
             .use(c => ({ ...c, [sym]: 'apple' }))
             // Add dessert as a normal property
@@ -86,7 +95,7 @@ describe('createEmptyClient', () => {
     it('supports asynchronous plugins', async () => {
         expect.assertions(1);
         await expect(
-            createEmptyClient()
+            createClient()
                 .use(c => Promise.resolve({ ...c, fruit: 'apple' as const }))
                 .use(c => Promise.resolve({ ...c, vegetable: 'carrot' as const })),
         ).resolves.toStrictEqual({
@@ -99,7 +108,7 @@ describe('createEmptyClient', () => {
     it('supports a mixture of synchronous and asynchronous plugins', async () => {
         expect.assertions(1);
         await expect(
-            createEmptyClient()
+            createClient()
                 .use(c => ({ ...c, fruit: 'apple' as const }))
                 .use(c => Promise.resolve({ ...c, vegetable: 'carrot' as const }))
                 .use(c => ({ ...c, grain: 'rice' as const }))
@@ -115,7 +124,7 @@ describe('createEmptyClient', () => {
 
     it('can catch synchronous errors', () => {
         expect(() =>
-            createEmptyClient().use(() => {
+            createClient().use(() => {
                 throw new Error('Missing fruit');
             }),
         ).toThrow('Missing fruit');
@@ -124,7 +133,7 @@ describe('createEmptyClient', () => {
     it('can catch asynchronous errors', async () => {
         expect.assertions(1);
         await expect(
-            createEmptyClient().use(() => {
+            createClient().use(() => {
                 return Promise.reject(new Error('Missing fruit'));
             }),
         ).rejects.toThrow('Missing fruit');
@@ -133,7 +142,7 @@ describe('createEmptyClient', () => {
     it('can chain the then function on the async client', async () => {
         expect.assertions(1);
         const thenFn = jest.fn();
-        await createEmptyClient()
+        await createClient()
             .use(() => Promise.resolve({ fruit: 'apple' as const }))
             .then(thenFn);
         expect(thenFn).toHaveBeenNthCalledWith(1, expect.objectContaining({ fruit: 'apple' }));
@@ -142,7 +151,7 @@ describe('createEmptyClient', () => {
     it('can chain the catch function on the async client', async () => {
         expect.assertions(1);
         const catchFn = jest.fn();
-        await createEmptyClient()
+        await createClient()
             .use(() => Promise.reject(new Error('Missing fruit')))
             .catch(catchFn);
         expect(catchFn).toHaveBeenNthCalledWith(1, expect.objectContaining({ message: 'Missing fruit' }));
@@ -151,7 +160,7 @@ describe('createEmptyClient', () => {
     it('can chain the finally function on the async client when successful', async () => {
         expect.assertions(1);
         const finallyFn = jest.fn();
-        await createEmptyClient()
+        await createClient()
             .use(() => Promise.resolve({ fruit: 'apple' as const }))
             .finally(finallyFn);
         expect(finallyFn).toHaveBeenCalledTimes(1);
@@ -160,7 +169,7 @@ describe('createEmptyClient', () => {
     it('can chain the finally function on the async client when unsuccessful', async () => {
         expect.assertions(1);
         const finallyFn = jest.fn();
-        await createEmptyClient()
+        await createClient()
             .use(() => Promise.reject(new Error('Missing fruit')))
             .finally(finallyFn)
             .catch(() => {});
@@ -170,23 +179,38 @@ describe('createEmptyClient', () => {
     it('does not resolve subsequent asynchronous plugins after an error', async () => {
         expect.assertions(1);
         const subsequentPlugin = jest.fn();
-        await createEmptyClient()
+        await createClient()
             .use(() => Promise.reject(new Error('Missing fruit')))
             .use(subsequentPlugin)
             .catch(() => {});
         expect(subsequentPlugin).not.toHaveBeenCalled();
     });
 
+    it('allows plugins to use createClient internally to offer plugin bundles', () => {
+        const fruitPlugin = <T extends object>(c: T) => ({ ...c, fruit: 'apple' as const });
+        const vegetablePlugin = <T extends object>(c: T) => ({ ...c, vegetable: 'carrot' as const });
+        const proteinPlugin = <T extends object>(c: T) => ({ ...c, protein: 'tofu' as const });
+        const foodPlugin = <T extends object>(c: T) =>
+            createClient(c).use(fruitPlugin).use(vegetablePlugin).use(proteinPlugin);
+
+        expect(createClient().use(foodPlugin)).toStrictEqual({
+            fruit: 'apple',
+            protein: 'tofu',
+            use: expect.any(Function),
+            vegetable: 'carrot',
+        });
+    });
+
     it('returns a frozen object when empty', () => {
-        expect(createEmptyClient()).toBeFrozenObject();
+        expect(createClient()).toBeFrozenObject();
     });
 
     it('returns a frozen object when extended by a plugin', () => {
-        expect(createEmptyClient().use(() => ({ fruit: 'apple' as const }))).toBeFrozenObject();
+        expect(createClient().use(() => ({ fruit: 'apple' as const }))).toBeFrozenObject();
     });
 
     it('returns a frozen object when extended by an asynchronous plugin', () => {
-        expect(createEmptyClient().use(() => Promise.resolve({ fruit: 'apple' as const }))).toBeFrozenObject();
+        expect(createClient().use(() => Promise.resolve({ fruit: 'apple' as const }))).toBeFrozenObject();
     });
 });
 

--- a/packages/plugin-core/src/__typetests__/client-typetest.ts
+++ b/packages/plugin-core/src/__typetests__/client-typetest.ts
@@ -1,12 +1,5 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import {
-    type AsyncClient,
-    type Client,
-    type ClientPlugin,
-    createEmptyClient,
-    extendClient,
-    withCleanup,
-} from '../client';
+import { type AsyncClient, type Client, type ClientPlugin, createClient, extendClient, withCleanup } from '../client';
 
 const EMPTY_CLIENT = null as unknown as Client<object>;
 const EMPTY_ASYNC_CLIENT = null as unknown as AsyncClient<object>;
@@ -204,11 +197,16 @@ const EMPTY_ASYNC_CLIENT = null as unknown as AsyncClient<object>;
     }
 }
 
-// [DESCRIBE] createEmptyClient
+// [DESCRIBE] createClient
 {
     // It returns an empty Client (See typetests above).
     {
-        createEmptyClient() satisfies typeof EMPTY_CLIENT;
+        createClient() satisfies typeof EMPTY_CLIENT;
+    }
+
+    // It creates a Client from an existing object.
+    {
+        createClient({ fruit: 'banana' as const }) satisfies Client<{ fruit: 'banana' }>;
     }
 }
 

--- a/packages/plugin-core/src/client.ts
+++ b/packages/plugin-core/src/client.ts
@@ -9,7 +9,7 @@
  * and asynchronous transformations and extensions of the client.
  *
  * Plugins are usually applied using the `use` method on a {@link Client} or {@link AsyncClient}
- * instance, which {@link createEmptyClient} provides as a starting point.
+ * instance, which {@link createClient} provides as a starting point.
  *
  * @typeParam TInput - The input client object type that this plugin accepts.
  * @typeParam TOutput - The output type. Either a new client object or a promise resolving to one.
@@ -18,7 +18,7 @@
  * Given an RPC endpoint, this plugin adds an `rpc` property to the client.
  *
  * ```ts
- * import { createEmptyClient, createSolanaRpc } from '@solana/kit';
+ * import { createClient, createSolanaRpc } from '@solana/kit';
  *
  * // Define a simple RPC plugin.
  * function rpcPlugin(endpoint: string) {
@@ -26,7 +26,7 @@
  * }
  *
  * // Use the plugin.
- * const client = createEmptyClient().use(rpcPlugin('https://api.mainnet-beta.solana.com'));
+ * const client = createClient().use(rpcPlugin('https://api.mainnet-beta.solana.com'));
  * await client.rpc.getLatestBlockhash().send();
  * ```
  *
@@ -34,7 +34,7 @@
  * The following plugin shows how to create an asynchronous plugin that generates a new keypair signer.
  *
  * ```ts
- * import { createEmptyClient, generateKeypairSigner } from '@solana/kit';
+ * import { createClient, generateKeypairSigner } from '@solana/kit';
  *
  * // Define a plugin that generates a new keypair signer.
  * function generatedPayerPlugin() {
@@ -42,7 +42,7 @@
  * }
  *
  * // Use the plugin.
- * const client = await createEmptyClient().use(generatedPayerPlugin());
+ * const client = await createClient().use(generatedPayerPlugin());
  * console.log(client.payer.address);
  * ```
  *
@@ -51,7 +51,7 @@
  * client to already have a `payer` signer attached to the client in order to perform an airdrop.
  *
  * ```ts
- * import { createEmptyClient, TransactionSigner, Lamports, lamports } from '@solana/kit';
+ * import { createClient, TransactionSigner, Lamports, lamports } from '@solana/kit';
  *
  * // Define a plugin that airdrops lamports to the payer set on the client.
  * function airdropPayerPlugin(lamports: Lamports) {
@@ -62,7 +62,7 @@
  * }
  *
  * // Use the plugins.
- * const client = await createEmptyClient()
+ * const client = await createClient()
  *     .use(generatedPayerPlugin()) // This is required before using the airdrop plugin.
  *     .use(airdropPayerPlugin(lamports(1_000_000_000n)));
  * ```
@@ -74,7 +74,7 @@
  * This is because the `use` method on `AsyncClient` returns another `AsyncClient`, allowing for seamless chaining.
  *
  * ```ts
- * import { createEmptyClient, createSolanaRpc, createSolanaRpcSubscriptions, generateKeypairSigner } from '@solana/kit';
+ * import { createClient, createSolanaRpc, createSolanaRpcSubscriptions, generateKeypairSigner } from '@solana/kit';
  *
  * // Define multiple plugins.
  * function rpcPlugin(endpoint: string) {
@@ -91,7 +91,7 @@
  * }
  *
  * // Chain plugins together.
- * const client = await createEmptyClient()
+ * const client = await createClient()
  *     .use(rpcPlugin('https://api.mainnet-beta.solana.com'))
  *     .use(rpcSubscriptionsPlugin('wss://api.mainnet-beta.solana.com'))
  *     .use(generatedPayerPlugin())
@@ -146,7 +146,8 @@ export type AsyncClient<TSelf extends object> = Promise<Client<TSelf>> & {
     ) => AsyncClient<TOutput extends Promise<infer U> ? (U extends object ? U : never) : TOutput>;
 };
 
-// TODO(loris): Add examples in this docblock using real plugins once they have been published.
+/** @deprecated This function has been renamed. Use `createClient` instead. It behaves identically. */
+export const createEmptyClient = () => createClient();
 
 /**
  * Creates a new empty client that can be extended with plugins.
@@ -162,15 +163,17 @@ export type AsyncClient<TSelf extends object> = Promise<Client<TSelf>> & {
  *
  * @example Basic client setup
  * ```ts
- * import { createEmptyClient } from '@solana/client';
+ * import { createClient } from '@solana/client';
+ * import { generatedPayer } from '@solana/kit-plugin-payer';
+ * import { rpc } from '@solana/kit-plugin-rpc';
  *
- * const client = createEmptyClient()
- *     .use(myRpcPlugin('https://api.mainnet-beta.solana.com'))
- *     .use(myWalletPlugin());
+ * const client = await createClient()
+ *     .use(generatedPayer())
+ *     .use(rpc('https://api.mainnet-beta.solana.com'));
  * ```
  */
-export function createEmptyClient(): Client<object> {
-    return addUse({});
+export function createClient<TSelf extends object = object>(value?: TSelf): Client<TSelf> {
+    return addUse(value ?? ({} as TSelf));
 }
 
 function addUse<TSelf extends object>(value: TSelf): Client<TSelf> {
@@ -270,7 +273,7 @@ export function extendClient<TClient extends object, TAdditions extends object>(
  * }
  *
  * // Later, when the client is no longer needed:
- * using client = createEmptyClient().use(myPlugin();
+ * using client = createClient().use(myPlugin();
  * // `socket.close()` is called automatically when `client` goes out of scope.
  * ```
  *


### PR DESCRIPTION
This PR renames `createEmptyClient` to `createClient` in `@solana/plugin-core`, making the API name more general-purpose. The new `createClient` function also accepts an optional initial object, allowing callers to seed a client with existing properties before applying plugins. This is useful for creating plugin bundles that compose multiple plugins on top of an existing client.

The old `createEmptyClient` function is preserved as a deprecated re-export so existing consumers can migrate at their own pace.

All tests and type tests have been updated accordingly, including new test cases for creating a client from an existing object and for using `createClient` internally within a plugin to offer plugin bundles.