### PR TITLE
Add reactive() for pending subscriptions, that returns a reactive store for the subscription

### DIFF
--- a/.changeset/many-pandas-beg.md
+++ b/.changeset/many-pandas-beg.md
@@ -1,0 +1,6 @@
+---
+'@solana/subscribable': minor
+'@solana/rpc-subscriptions-spec': minor
+---
+
+Add `ReactiveStore` type and `createReactiveStoreFromDataPublisher()` to `@solana/subscribable`, and a `reactive()` method to pending subscriptions in `@solana/rpc-subscriptions-spec` that returns a reactive store compatible with `useSyncExternalStore`, Svelte stores, and other reactive primitives.

--- a/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-reactive-test.ts
+++ b/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-reactive-test.ts
@@ -1,0 +1,76 @@
+import { DataPublisher } from '@solana/subscribable';
+
+import { createSubscriptionRpc, type RpcSubscriptions } from '../rpc-subscriptions';
+import { RpcSubscriptionsTransport } from '../rpc-subscriptions-transport';
+
+interface TestRpcSubscriptionNotifications {
+    thingNotifications(...args: unknown[]): { value: number };
+}
+
+describe('PendingRpcSubscriptionsRequest.reactive()', () => {
+    let mockTransport: jest.MockedFunction<RpcSubscriptionsTransport>;
+    let mockOn: jest.Mock;
+    let mockDataPublisher: DataPublisher;
+    let rpcSubscriptions: RpcSubscriptions<TestRpcSubscriptionNotifications>;
+    function publish(type: string, payload: unknown) {
+        mockOn.mock.calls.filter(([actualType]) => actualType === type).forEach(([_, listener]) => listener(payload));
+    }
+    beforeEach(() => {
+        mockOn = jest.fn().mockReturnValue(function unsubscribe() {});
+        mockDataPublisher = { on: mockOn };
+        mockTransport = jest.fn().mockResolvedValue(mockDataPublisher);
+        rpcSubscriptions = createSubscriptionRpc<TestRpcSubscriptionNotifications>({
+            api: {
+                thingNotifications(...args: unknown[]) {
+                    return {
+                        execute: jest.fn().mockResolvedValue(mockDataPublisher),
+                        request: { methodName: 'thingNotifications', params: args },
+                    };
+                },
+            },
+            transport: mockTransport,
+        });
+    });
+
+    it('passes the abort signal to the transport', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        await rpcSubscriptions.thingNotifications().reactive({ abortSignal: abortController.signal });
+        expect(mockTransport).toHaveBeenCalledWith(expect.objectContaining({ signal: abortController.signal }));
+    });
+    it('returns a store whose getState() starts as undefined', async () => {
+        expect.assertions(1);
+        const store = await rpcSubscriptions
+            .thingNotifications()
+            .reactive({ abortSignal: new AbortController().signal });
+        expect(store.getState()).toBeUndefined();
+    });
+    it('returns a store whose getState() reflects incoming notifications', async () => {
+        expect.assertions(1);
+        const store = await rpcSubscriptions
+            .thingNotifications()
+            .reactive({ abortSignal: new AbortController().signal });
+        publish('notification', { value: 42 });
+        expect(store.getState()).toStrictEqual({ value: 42 });
+    });
+    it('calls store subscribers when a notification arrives', async () => {
+        expect.assertions(1);
+        const store = await rpcSubscriptions
+            .thingNotifications()
+            .reactive({ abortSignal: new AbortController().signal });
+        const subscriber = jest.fn();
+        store.subscribe(subscriber);
+        publish('notification', { value: 42 });
+        expect(subscriber).toHaveBeenCalledTimes(1);
+    });
+    it('surfaces errors via getError()', async () => {
+        expect.assertions(2);
+        const store = await rpcSubscriptions
+            .thingNotifications()
+            .reactive({ abortSignal: new AbortController().signal });
+        expect(store.getError()).toBeUndefined();
+        const error = new Error('o no');
+        publish('error', error);
+        expect(store.getError()).toBe(error);
+    });
+});

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions-request.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions-request.ts
@@ -1,3 +1,5 @@
+import { ReactiveStore } from '@solana/subscribable';
+
 /**
  * Pending subscriptions are the result of calling a supported method on a {@link RpcSubscriptions}
  * object. They encapsulate all of the information necessary to make the subscription without
@@ -6,8 +8,41 @@
  * Calling the {@link PendingRpcSubscriptionsRequest.subscribe | `subscribe(options)`} method on a
  * {@link PendingRpcSubscriptionsRequest | PendingRpcSubscriptionsRequest<TNotification>} will
  * trigger the subscription and return a promise for an async iterable that vends `TNotifications`.
+ *
+ * Calling the {@link PendingRpcSubscriptionsRequest.reactive | `reactive(options)`} method will
+ * trigger the subscription and return a promise for a {@link ReactiveStore} compatible with
+ * `useSyncExternalStore`, Svelte stores, and other reactive primitives.
  */
 export type PendingRpcSubscriptionsRequest<TNotification> = {
+    /**
+     * Triggers the subscription and returns a promise for a {@link ReactiveStore} that holds the
+     * latest notification. Compatible with `useSyncExternalStore` and other reactive primitives
+     * that expect a `{ subscribe, getState }` contract.
+     *
+     * @example
+     * ```ts
+     * const store = await rpc.accountNotifications(address).reactive({ abortSignal });
+     * // React — throw error from snapshot to surface via Error Boundary
+     * const state = useSyncExternalStore(store.subscribe, () => {
+     *     if (store.getError()) throw store.getError();
+     *     return store.getState();
+     * });
+     * ```
+     */
+    reactive(options: RpcSubscribeOptions): Promise<ReactiveStore<TNotification>>;
+    /**
+     * Triggers the subscription and returns a promise for an async iterable of notifications.
+     * Use `for await...of` to consume notifications as they arrive. Abort the signal to
+     * unsubscribe.
+     *
+     * @example
+     * ```ts
+     * const notifications = await rpc.accountNotifications(address).subscribe({ abortSignal });
+     * for await (const notification of notifications) {
+     *     console.log('Account changed:', notification);
+     * }
+     * ```
+     */
     subscribe(options: RpcSubscribeOptions): Promise<AsyncIterable<TNotification>>;
 };
 

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
@@ -1,6 +1,6 @@
 import { SOLANA_ERROR__RPC_SUBSCRIPTIONS__CANNOT_CREATE_SUBSCRIPTION_PLAN, SolanaError } from '@solana/errors';
 import { Callable, Flatten, OverloadImplementations, UnionToIntersection } from '@solana/rpc-spec-types';
-import { createAsyncIterableFromDataPublisher } from '@solana/subscribable';
+import { createAsyncIterableFromDataPublisher, createReactiveStoreFromDataPublisher } from '@solana/subscribable';
 
 import { RpcSubscriptionsApi, RpcSubscriptionsPlan } from './rpc-subscriptions-api';
 import { PendingRpcSubscriptionsRequest, RpcSubscribeOptions } from './rpc-subscriptions-request';
@@ -79,6 +79,18 @@ function createPendingRpcSubscription<TNotification>(
     subscriptionsPlan: RpcSubscriptionsPlan<TNotification>,
 ): PendingRpcSubscriptionsRequest<TNotification> {
     return {
+        async reactive({ abortSignal }: RpcSubscribeOptions) {
+            const notificationsDataPublisher = await transport({
+                signal: abortSignal,
+                ...subscriptionsPlan,
+            });
+            return createReactiveStoreFromDataPublisher<TNotification>({
+                abortSignal,
+                dataChannelName: 'notification',
+                dataPublisher: notificationsDataPublisher,
+                errorChannelName: 'error',
+            });
+        },
         async subscribe({ abortSignal }: RpcSubscribeOptions): Promise<AsyncIterable<TNotification>> {
             const notificationsDataPublisher = await transport({
                 signal: abortSignal,

--- a/packages/subscribable/README.md
+++ b/packages/subscribable/README.md
@@ -27,6 +27,28 @@ dataPublisher.on('error', e => {
 }); // OK.
 ```
 
+### `ReactiveStore<T>`
+
+This type represents a reactive store that holds the latest value published to a data channel. It exposes a `{ getState, getError, subscribe }` contract compatible with `useSyncExternalStore`, Svelte stores, and other reactive primitives.
+
+```ts
+const store: ReactiveStore<AccountInfo> = /* ... */;
+
+// React
+const state = useSyncExternalStore(store.subscribe, () => {
+    if (store.getError()) throw store.getError();
+    return store.getState();
+});
+
+// Vue
+const data = shallowRef(store.getState());
+const error = shallowRef(store.getError());
+store.subscribe(() => {
+    data.value = store.getState();
+    error.value = store.getError();
+});
+```
+
 ### `TypedEventEmitter<TEventMap>`
 
 This type allows you to type `addEventListener` and `removeEventListener` so that the call signature of the listener matches the event type given.
@@ -80,6 +102,28 @@ Things to note:
 - If there are messages in the queue and an error occurs, all queued messages will be vended to the iterator before the error is thrown.
 - If there are messages in the queue and the abort signal fires, all queued messages will be vended to the iterator after which it will return.
 - Any new iterators created after the first error is encountered will reject with that error when polled.
+
+### `createReactiveStoreFromDataPublisher({ abortSignal, dataChannelName, dataPublisher, errorChannelName })`
+
+Returns a `ReactiveStore` given a data publisher. The store holds the most recent message published to `dataChannelName` and notifies subscribers on each update. When a message is published to `errorChannelName`, the error is captured in `getError()` and subscribers are notified. Triggering the abort signal disconnects the store from the data publisher.
+
+```ts
+const store = createReactiveStoreFromDataPublisher({
+    abortSignal: AbortSignal.timeout(10_000),
+    dataChannelName: 'notification',
+    dataPublisher,
+    errorChannelName: 'error',
+});
+const unsubscribe = store.subscribe(() => {
+    console.log('State updated:', store.getState());
+});
+```
+
+Things to note:
+
+- `getState()` returns `undefined` until the first notification arrives.
+- On error, `getState()` continues to return the last known value and `getError()` returns the error. Only the first error is captured.
+- The function returned by `subscribe` is idempotent &mdash; calling it multiple times is safe.
 
 ### `demultiplexDataPublisher(publisher, sourceChannelName, messageTransformer)`
 

--- a/packages/subscribable/src/__tests__/reactive-store-test.ts
+++ b/packages/subscribable/src/__tests__/reactive-store-test.ts
@@ -1,0 +1,269 @@
+import { DataPublisher } from '../data-publisher';
+import { createReactiveStoreFromDataPublisher } from '../reactive-store';
+
+describe('createReactiveStoreFromDataPublisher', () => {
+    let mockDataPublisher: DataPublisher;
+    let mockOn: jest.Mock;
+    function publish(type: string, payload: unknown) {
+        mockOn.mock.calls.filter(([actualType]) => actualType === type).forEach(([_, listener]) => listener(payload));
+    }
+    beforeEach(() => {
+        mockOn = jest.fn().mockReturnValue(function unsubscribe() {});
+        mockDataPublisher = {
+            on: mockOn,
+        };
+    });
+
+    describe('getState()', () => {
+        it('returns `undefined` before any notification arrives', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            expect(store.getState()).toBeUndefined();
+        });
+        it('returns the latest notification after one arrives', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            publish('data', { value: 42 });
+            expect(store.getState()).toStrictEqual({ value: 42 });
+        });
+        it('returns the most recent notification when multiple arrive', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            publish('data', { value: 1 });
+            publish('data', { value: 2 });
+            publish('data', { value: 3 });
+            expect(store.getState()).toStrictEqual({ value: 3 });
+        });
+        it('preserves the last known value after an error', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            publish('data', { value: 42 });
+            publish('error', new Error('o no'));
+            expect(store.getState()).toStrictEqual({ value: 42 });
+        });
+        it('returns `undefined` after an error when no notification has arrived', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            publish('error', new Error('o no'));
+            expect(store.getState()).toBeUndefined();
+        });
+    });
+
+    describe('getError()', () => {
+        it('returns `undefined` before any error', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            expect(store.getError()).toBeUndefined();
+        });
+        it('returns the error after one arrives', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            const error = new Error('o no');
+            publish('error', error);
+            expect(store.getError()).toBe(error);
+        });
+        it('preserves the first error when multiple errors arrive', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            const firstError = new Error('first');
+            const secondError = new Error('second');
+            publish('error', firstError);
+            publish('error', secondError);
+            expect(store.getError()).toBe(firstError);
+        });
+        it('remains `undefined` when only data notifications arrive', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            publish('data', { value: 1 });
+            publish('data', { value: 2 });
+            expect(store.getError()).toBeUndefined();
+        });
+    });
+
+    describe('subscribe()', () => {
+        it('calls the subscriber when a notification arrives', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            const subscriber = jest.fn();
+            store.subscribe(subscriber);
+            publish('data', { value: 1 });
+            expect(subscriber).toHaveBeenCalledTimes(1);
+        });
+        it('calls the subscriber on each new notification', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            const subscriber = jest.fn();
+            store.subscribe(subscriber);
+            publish('data', { value: 1 });
+            publish('data', { value: 2 });
+            publish('data', { value: 3 });
+            expect(subscriber).toHaveBeenCalledTimes(3);
+        });
+        it('calls the subscriber when an error arrives', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            const subscriber = jest.fn();
+            store.subscribe(subscriber);
+            publish('error', new Error('o no'));
+            expect(subscriber).toHaveBeenCalledTimes(1);
+        });
+        it('does not notify subscribers on subsequent errors', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            const subscriber = jest.fn();
+            store.subscribe(subscriber);
+            publish('error', new Error('first'));
+            publish('error', new Error('second'));
+            expect(subscriber).toHaveBeenCalledTimes(1);
+        });
+        it('calls multiple concurrent subscribers on each notification', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            const subscriberA = jest.fn();
+            const subscriberB = jest.fn();
+            store.subscribe(subscriberA);
+            store.subscribe(subscriberB);
+            publish('data', { value: 1 });
+            expect(subscriberA).toHaveBeenCalledTimes(1);
+            expect(subscriberB).toHaveBeenCalledTimes(1);
+        });
+        it('stops calling the subscriber after the returned unsubscribe is called', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            const subscriber = jest.fn();
+            const unsubscribe = store.subscribe(subscriber);
+            unsubscribe();
+            publish('data', { value: 1 });
+            expect(subscriber).not.toHaveBeenCalled();
+        });
+        it('only unsubscribes the subscriber whose unsubscribe function was called', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            const subscriberA = jest.fn();
+            const subscriberB = jest.fn();
+            const unsubscribeA = store.subscribe(subscriberA);
+            store.subscribe(subscriberB);
+            unsubscribeA();
+            publish('data', { value: 1 });
+            expect(subscriberA).not.toHaveBeenCalled();
+            expect(subscriberB).toHaveBeenCalledTimes(1);
+        });
+        it('the unsubscribe function is idempotent', () => {
+            const store = createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            const unsubscribe = store.subscribe(jest.fn());
+            expect(() => {
+                unsubscribe();
+                unsubscribe();
+            }).not.toThrow();
+        });
+    });
+
+    describe('abort signal', () => {
+        it('aborts the signals forwarded to dataPublisher.on() when the caller aborts', () => {
+            const abortController = new AbortController();
+            createReactiveStoreFromDataPublisher({
+                abortSignal: abortController.signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            const dataChannelSignal = mockOn.mock.calls.find(([type]: [string]) => type === 'data')![2].signal;
+            const errorChannelSignal = mockOn.mock.calls.find(([type]: [string]) => type === 'error')![2].signal;
+            expect(dataChannelSignal.aborted).toBe(false);
+            expect(errorChannelSignal.aborted).toBe(false);
+            const reason = new Error('go away');
+            abortController.abort(reason);
+            expect(dataChannelSignal.aborted).toBe(true);
+            expect(dataChannelSignal.reason).toBe(reason);
+            expect(errorChannelSignal.aborted).toBe(true);
+            expect(errorChannelSignal.reason).toBe(reason);
+        });
+        it('aborts the signals forwarded to dataPublisher.on() when an error arrives', () => {
+            createReactiveStoreFromDataPublisher({
+                abortSignal: new AbortController().signal,
+                dataChannelName: 'data',
+                dataPublisher: mockDataPublisher,
+                errorChannelName: 'error',
+            });
+            const dataChannelSignal = mockOn.mock.calls.find(([type]: [string]) => type === 'data')![2].signal;
+            const errorChannelSignal = mockOn.mock.calls.find(([type]: [string]) => type === 'error')![2].signal;
+            expect(dataChannelSignal.aborted).toBe(false);
+            expect(errorChannelSignal.aborted).toBe(false);
+            const error = new Error('o no');
+            publish('error', error);
+            expect(dataChannelSignal.aborted).toBe(true);
+            expect(dataChannelSignal.reason).toBe(error);
+            expect(errorChannelSignal.aborted).toBe(true);
+            expect(errorChannelSignal.reason).toBe(error);
+        });
+    });
+});

--- a/packages/subscribable/src/index.ts
+++ b/packages/subscribable/src/index.ts
@@ -10,3 +10,4 @@ export * from './async-iterable';
 export * from './data-publisher';
 export * from './demultiplex';
 export * from './event-emitter';
+export * from './reactive-store';

--- a/packages/subscribable/src/reactive-store.ts
+++ b/packages/subscribable/src/reactive-store.ts
@@ -1,0 +1,146 @@
+import { AbortController } from '@solana/event-target-impl';
+
+import { DataPublisher } from './data-publisher';
+
+type Config = Readonly<{
+    /**
+     * Triggering this abort signal will cause the store to stop updating and will disconnect it from
+     * the underlying data publisher.
+     */
+    abortSignal: AbortSignal;
+    /**
+     * Messages from this channel of `dataPublisher` will be used to update the store's state.
+     */
+    dataChannelName: string;
+    // FIXME: It would be nice to be able to constrain the type of `dataPublisher` to one that
+    //        definitely supports the `dataChannelName` and `errorChannelName` channels, and
+    //        furthermore publishes `TData` on the `dataChannelName` channel. This is more difficult
+    //        than it should be: https://tsplay.dev/NlZelW
+    dataPublisher: DataPublisher;
+    /**
+     * Messages from this channel of `dataPublisher` will cause subscribers to be notified without
+     * updating the state, so that they can respond to the error condition.
+     */
+    errorChannelName: string;
+}>;
+
+/**
+ * A reactive store that holds the latest value published to a data channel and allows external
+ * systems to subscribe to changes. Compatible with `useSyncExternalStore`, Svelte stores, Solid's
+ * `from()`, and other reactive primitives that expect a `{ subscribe, getState }` contract.
+ *
+ * @example
+ * ```ts
+ * // React — throw error from snapshot function to surface via Error Boundary
+ * const state = useSyncExternalStore(store.subscribe, () => {
+ *     if (store.getError()) throw store.getError();
+ *     return store.getState();
+ * });
+ *
+ * // Vue — check error reactively in a composable
+ * const data = shallowRef(store.getState());
+ * const error = shallowRef(store.getError());
+ * store.subscribe(() => {
+ *     data.value = store.getState();
+ *     error.value = store.getError();
+ * });
+ * ```
+ *
+ * @see {@link createReactiveStoreFromDataPublisher}
+ */
+export type ReactiveStore<T> = {
+    /**
+     * Returns the error published to the error channel, or `undefined` if no error has occurred.
+     * Once set, the error is preserved — subsequent errors do not overwrite it.
+     */
+    getError(): unknown;
+    /**
+     * Returns the most recent value published to the data channel, or `undefined` if no
+     * notification has arrived yet. On error, continues to return the last known value.
+     */
+    getState(): T | undefined;
+    /**
+     * Registers a callback to be called whenever the state changes or an error is received.
+     * Returns an unsubscribe function. Safe to call multiple times.
+     */
+    subscribe(callback: () => void): () => void;
+};
+
+/**
+ * Returns a {@link ReactiveStore} given a data publisher.
+ *
+ * The store will update its state with each message published to `dataChannelName` and notify all
+ * subscribers. When a message is published to `errorChannelName`, subscribers are notified so they
+ * can react to the error condition, but the last-known state is preserved. Triggering the abort
+ * signal disconnects the store from the data publisher.
+ *
+ * Things to note:
+ *
+ * - `getState()` returns `undefined` until the first notification arrives.
+ * - On error, `getState()` continues to return the last known value and `getError()` returns the
+ *   error. Only the first error is captured.
+ * - The function returned by `subscribe` is idempotent — calling it multiple times is safe.
+ *
+ * @param config
+ *
+ * @example
+ * ```ts
+ * const store = createReactiveStoreFromDataPublisher({
+ *     abortSignal: AbortSignal.timeout(10_000),
+ *     dataChannelName: 'notification',
+ *     dataPublisher,
+ *     errorChannelName: 'error',
+ * });
+ * const unsubscribe = store.subscribe(() => {
+ *     console.log('State updated:', store.getState());
+ * });
+ * ```
+ */
+export function createReactiveStoreFromDataPublisher<TData>({
+    abortSignal,
+    dataChannelName,
+    dataPublisher,
+    errorChannelName,
+}: Config): ReactiveStore<TData> {
+    let currentState: TData | undefined;
+    let currentError: unknown;
+    const subscribers = new Set<() => void>();
+
+    const abortController = new AbortController();
+    abortSignal.addEventListener('abort', () => abortController.abort(abortSignal.reason));
+
+    dataPublisher.on(
+        dataChannelName,
+        data => {
+            currentState = data as TData;
+            subscribers.forEach(cb => cb());
+        },
+        { signal: abortController.signal },
+    );
+    dataPublisher.on(
+        errorChannelName,
+        err => {
+            if (currentError !== undefined) return;
+            currentError = err;
+            // Abort the signal passed to dataPublisher, which stops the subscriptions
+            abortController.abort(err);
+            subscribers.forEach(cb => cb());
+        },
+        { signal: abortController.signal },
+    );
+
+    return {
+        getError(): unknown {
+            return currentError;
+        },
+        getState(): TData | undefined {
+            return currentState;
+        },
+        subscribe(callback: () => void): () => void {
+            subscribers.add(callback);
+            return () => {
+                subscribers.delete(callback);
+            };
+        },
+    };
+}

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-blockheight-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-blockheight-test.ts
@@ -27,6 +27,7 @@ describe('createBlockHeightExceedencePromiseFactory', () => {
         });
         const rpcSubscriptions = {
             slotNotifications: () => ({
+                reactive: jest.fn(),
                 subscribe: createSubscriptionIterable,
             }),
         };

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-nonce-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-nonce-test.ts
@@ -44,7 +44,9 @@ describe('createNonceInvalidationPromiseFactory', () => {
         createSubscriptionIterable = jest.fn().mockResolvedValue({
             [Symbol.asyncIterator]: accountNotificationGenerator,
         });
-        createPendingSubscription = jest.fn().mockReturnValue({ subscribe: createSubscriptionIterable });
+        createPendingSubscription = jest
+            .fn()
+            .mockReturnValue({ reactive: jest.fn(), subscribe: createSubscriptionIterable });
         const rpcSubscriptions = {
             accountNotifications: createPendingSubscription,
         };

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-signature-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-signature-test.ts
@@ -27,7 +27,9 @@ describe('createSignatureConfirmationPromiseFactory', () => {
         createSubscriptionIterable = jest.fn().mockResolvedValue({
             [Symbol.asyncIterator]: signatureNotificationGenerator,
         });
-        createPendingSubscription = jest.fn().mockReturnValue({ subscribe: createSubscriptionIterable });
+        createPendingSubscription = jest
+            .fn()
+            .mockReturnValue({ reactive: jest.fn(), subscribe: createSubscriptionIterable });
         const rpcSubscriptions = {
             signatureNotifications: createPendingSubscription,
         };


### PR DESCRIPTION
#### Summary of Changes

This PR adds an alternative API for RPC subscriptions:

```typescript
const store = rpcSubscriptions.slotNotifications().reactive({ abortSignal: abortController.signal })
```

This returns an object with fields `getState()`, `getError()` and `subscribe()`

- `getState()` returns the latest published value from the subscription, or `undefined` until a value is published
- `getError()` returns the first error from the subscription, or `undefined` if there has not been any error
- `subscribe(listener)`registers a function to be called if either data or an error occurs

Together they enable reactive frameworks to consume subscriptions:, eg react with an error boundary

```typescript
const slot = useSyncExternalStore(store.subscribe, () => {
  if (store.getError()) throw store.getError();
  return store.getState();
});
```

Or without error boundaries:

```typescript
const slot = useSyncExternalStore(store.subscribe, store.getState)
const error = useSyncExternalStore(store.subscribe, store.getError)
```

And svelte:

```typescript
let slot = $state(store.getState());
let error = $state(store.getError());
$effect(() => store.subscribe(() => {
    slot = store.getState();
    error = store.getError();
}));
```

Vanilla JS:

```typescript
store.subscribe(() => {
    if (store.getError()) console.error(store.getError());
    else el.textContent = store.getState().slot;
});
```

It's also compatible with libraries like SWR subscriptions:

```typescript
useSWRSubscription('slot', (key, { next }) => {
    const abortController = new AbortController();
    rpcSubscriptions
        .slotNotifications()
        .reactive({ abortSignal: abortController.signal })
        .then(store => {
            store.subscribe(() => {
                const error = store.getError();
                if (error) next(error);
                else next(null, store.getState());
            });
        });
    return () => abortController.abort();
});
```

Note that we intentionally separate error handling, and `getState()` never throws. This gives consumers maximum flexibility and allows access to the stale latest value while recovering from an error.

This change is purely additive to the existing async generator API for subscriptions, and architecturally lives alongside it as an alternative interface to the `DataPublisher` abstraction. It's intended to make subscriptions easier to use in reactive UIs.