### PR TITLE
Add WALLET_NOT_CONNECTED error

### DIFF
--- a/.changeset/proud-results-cheat.md
+++ b/.changeset/proud-results-cheat.md
@@ -1,0 +1,5 @@
+---
+'@solana/errors': minor
+---
+
+Add `SOLANA_ERROR__WALLET__NOT_CONNECTED` error code for when a wallet operation is attempted without a connected wallet.

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -362,6 +362,10 @@ export const SOLANA_ERROR__PROGRAM_CLIENTS__RESOLVED_INSTRUCTION_INPUT_MUST_BE_N
 export const SOLANA_ERROR__PROGRAM_CLIENTS__UNRECOGNIZED_ACCOUNT_TYPE = 8500005;
 export const SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT = 8500006;
 
+// Wallet-related errors.
+// Reserve error codes in the range [8900000-8900999].
+export const SOLANA_ERROR__WALLET__NOT_CONNECTED = 8900000;
+
 // Invariant violation errors.
 // Reserve error codes in the range [9900000-9900999].
 // These errors should only be thrown when there is a bug with the
@@ -678,7 +682,8 @@ export type SolanaErrorCode =
     | typeof SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_ACCOUNT_DATA_TOTAL_LIMIT
     | typeof SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_ACCOUNT_COST_LIMIT
     | typeof SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_BLOCK_COST_LIMIT
-    | typeof SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_VOTE_COST_LIMIT;
+    | typeof SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_VOTE_COST_LIMIT
+    | typeof SOLANA_ERROR__WALLET__NOT_CONNECTED;
 
 /**
  * Errors of this type are understood to have an optional {@link SolanaError} nested inside as

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -209,6 +209,7 @@ import {
     SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_RENT,
     SOLANA_ERROR__TRANSACTION_ERROR__PROGRAM_EXECUTION_TEMPORARILY_RESTRICTED,
     SOLANA_ERROR__TRANSACTION_ERROR__UNKNOWN,
+    SOLANA_ERROR__WALLET__NOT_CONNECTED,
     SolanaErrorCode,
 } from './codes';
 import { RpcSimulateTransactionResult } from './json-rpc-error';
@@ -860,6 +861,9 @@ export type SolanaErrorContext = ReadonlyContextValue<
             [SOLANA_ERROR__TRANSACTION__VERSION_ZERO_MUST_BE_ENCODED_WITH_SIGNATURES_FIRST]: {
                 firstByte: number;
                 transactionBytes: ReadonlyUint8Array;
+            };
+            [SOLANA_ERROR__WALLET__NOT_CONNECTED]: {
+                operation: string;
             };
         }
     >

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -295,6 +295,7 @@ import {
     SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_ACCOUNT_COST_LIMIT,
     SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_BLOCK_COST_LIMIT,
     SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_VOTE_COST_LIMIT,
+    SOLANA_ERROR__WALLET__NOT_CONNECTED,
     SolanaErrorCode,
 } from './codes';
 
@@ -812,4 +813,5 @@ export const SolanaErrorMessages: Readonly<{
         'Transaction has $actualCount instructions but the maximum allowed is $maxAllowed',
     [SOLANA_ERROR__TRANSACTION__TOO_MANY_ACCOUNTS_IN_INSTRUCTION]:
         'The instruction at index $instructionIndex has $actualCount account references but the maximum allowed is $maxAllowed',
+    [SOLANA_ERROR__WALLET__NOT_CONNECTED]: 'Cannot $operation: no wallet connected',
 };


### PR DESCRIPTION
This error is being added so that we can use it for our wallet plugin. I think it's reasonable to have in Kit because it would be useful for any wallet API built on Kit

See also https://github.com/anza-xyz/kit-plugins/pull/173 