### PR TITLE
Make typescript a devDependency

### DIFF
--- a/.changeset/clean-ants-end.md
+++ b/.changeset/clean-ants-end.md
@@ -1,0 +1,50 @@
+---
+'@solana/accounts': patch
+'@solana/addresses': patch
+'@solana/assertions': patch
+'@solana/codecs': patch
+'@solana/codecs-core': patch
+'@solana/codecs-data-structures': patch
+'@solana/codecs-numbers': patch
+'@solana/codecs-strings': patch
+'@solana/compat': patch
+'@solana/errors': patch
+'@solana/fast-stable-stringify': patch
+'@solana/functional': patch
+'@solana/instruction-plans': patch
+'@solana/instructions': patch
+'@solana/keys': patch
+'@solana/kit': patch
+'@solana/nominal-types': patch
+'@solana/offchain-messages': patch
+'@solana/options': patch
+'@solana/plugin-core': patch
+'@solana/plugin-interfaces': patch
+'@solana/program-client-core': patch
+'@solana/programs': patch
+'@solana/promises': patch
+'@solana/react': patch
+'@solana/rpc': patch
+'@solana/rpc-api': patch
+'@solana/rpc-graphql': patch
+'@solana/rpc-parsed-types': patch
+'@solana/rpc-spec': patch
+'@solana/rpc-spec-types': patch
+'@solana/rpc-subscriptions': patch
+'@solana/rpc-subscriptions-api': patch
+'@solana/rpc-subscriptions-channel-websocket': patch
+'@solana/rpc-subscriptions-spec': patch
+'@solana/rpc-transformers': patch
+'@solana/rpc-transport-http': patch
+'@solana/rpc-types': patch
+'@solana/signers': patch
+'@solana/subscribable': patch
+'@solana/sysvars': patch
+'@solana/transaction-confirmation': patch
+'@solana/transaction-messages': patch
+'@solana/transactions': patch
+'@solana/wallet-account-signer': patch
+'@solana/webcrypto-ed25519-polyfill': patch
+---
+
+Remove typescript as a peer dependency

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -81,15 +81,10 @@
         "@solana/rpc-spec": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -80,15 +80,10 @@
         "@solana/errors": "workspace:*",
         "@solana/nominal-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -76,15 +76,10 @@
     "dependencies": {
         "@solana/errors": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -78,15 +78,8 @@
         "@solana/errors": "workspace:*"
     },
     "devDependencies": {
-        "tinybench": "^6.0.0"
-    },
-    "peerDependencies": {
+        "tinybench": "^6.0.0",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -79,15 +79,8 @@
         "@solana/errors": "workspace:*"
     },
     "devDependencies": {
-        "@solana/codecs-strings": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/codecs-strings": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -77,15 +77,10 @@
         "@solana/codecs-core": "workspace:*",
         "@solana/errors": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -81,17 +81,14 @@
     },
     "devDependencies": {
         "@solana/text-encoding-impl": "workspace:*",
-        "tinybench": "^6.0.0"
+        "tinybench": "^6.0.0",
+        "typescript": "^5.0.0"
     },
     "peerDependencies": {
-        "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "typescript": "^5.0.0"
+        "fastestsmallesttextencoderdecoder": "^1.0.22"
     },
     "peerDependenciesMeta": {
         "fastestsmallesttextencoderdecoder": {
-            "optional": true
-        },
-        "typescript": {
             "optional": true
         }
     },

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -78,15 +78,10 @@
         "@solana/codecs-strings": "workspace:*",
         "@solana/options": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -82,15 +82,8 @@
         "@solana/transactions": "workspace:*"
     },
     "devDependencies": {
-        "@solana/web3.js": "^1"
-    },
-    "peerDependencies": {
+        "@solana/web3.js": "^1",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -78,15 +78,10 @@
         "chalk": "5.6.2",
         "commander": "14.0.3"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/fast-stable-stringify/package.json
+++ b/packages/fast-stable-stringify/package.json
@@ -63,7 +63,8 @@
     },
     "devDependencies": {
         "@types/json-stable-stringify": "^1.2.0",
-        "json-stable-stringify": "^1.3.0"
+        "json-stable-stringify": "^1.3.0",
+        "typescript": "^5.0.0"
     },
     "author": "Solana Labs Maintainers <maintainers@solanalabs.com>",
     "license": "MIT",
@@ -78,14 +79,6 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
     }

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -73,15 +73,10 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/instruction-plans/package.json
+++ b/packages/instruction-plans/package.json
@@ -84,15 +84,8 @@
     "devDependencies": {
         "@solana/addresses": "workspace:*",
         "@solana/codecs": "workspace:*",
-        "@solana/functional": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/functional": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -78,15 +78,8 @@
         "@solana/errors": "workspace:*"
     },
     "devDependencies": {
-        "@solana/addresses": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/addresses": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -81,16 +81,9 @@
         "@solana/errors": "workspace:*",
         "@solana/nominal-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "devDependencies": {
-        "tinybench": "^6.0.0"
+        "tinybench": "^6.0.0",
+        "typescript": "^5.0.0"
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -126,15 +126,10 @@
         "@solana/transaction-messages": "workspace:*",
         "@solana/transactions": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/nominal-types/package.json
+++ b/packages/nominal-types/package.json
@@ -39,15 +39,10 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/offchain-messages/package.json
+++ b/packages/offchain-messages/package.json
@@ -83,15 +83,10 @@
         "@solana/keys": "workspace:*",
         "@solana/nominal-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -80,15 +80,10 @@
         "@solana/codecs-strings": "workspace:*",
         "@solana/errors": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -73,15 +73,10 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/plugin-interfaces/package.json
+++ b/packages/plugin-interfaces/package.json
@@ -48,15 +48,10 @@
         "@solana/rpc-types": "workspace:*",
         "@solana/signers": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/program-client-core/package.json
+++ b/packages/program-client-core/package.json
@@ -86,15 +86,8 @@
     },
     "devDependencies": {
         "@solana/codecs-data-structures": "workspace:*",
-        "@solana/codecs-numbers": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/codecs-numbers": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/programs/package.json
+++ b/packages/programs/package.json
@@ -79,15 +79,8 @@
     },
     "devDependencies": {
         "@solana/functional": "workspace:*",
-        "@solana/transaction-messages": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/transaction-messages": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/promises/package.json
+++ b/packages/promises/package.json
@@ -73,15 +73,10 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/rpc-api/package.json
+++ b/packages/rpc-api/package.json
@@ -88,15 +88,8 @@
     },
     "devDependencies": {
         "@solana/rpc-spec-types": "workspace:*",
-        "@solana/rpc-transport-http": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/rpc-transport-http": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -84,15 +84,8 @@
         "@solana/keys": "workspace:*",
         "@solana/rpc": "workspace:*",
         "@solana/rpc-types": "workspace:*",
-        "@solana/transactions": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/transactions": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-parsed-types/package.json
+++ b/packages/rpc-parsed-types/package.json
@@ -73,15 +73,8 @@
     ],
     "devDependencies": {
         "@solana/addresses": "workspace:*",
-        "@solana/rpc-types": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/rpc-types": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-spec-types/package.json
+++ b/packages/rpc-spec-types/package.json
@@ -73,15 +73,10 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/rpc-spec/package.json
+++ b/packages/rpc-spec/package.json
@@ -77,15 +77,10 @@
         "@solana/errors": "workspace:*",
         "@solana/rpc-spec-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -83,15 +83,8 @@
         "@solana/transactions": "workspace:*"
     },
     "devDependencies": {
-        "@solana/rpc-subscriptions-channel-websocket": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/rpc-subscriptions-channel-websocket": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-subscriptions-channel-websocket/package.json
+++ b/packages/rpc-subscriptions-channel-websocket/package.json
@@ -83,15 +83,8 @@
     "devDependencies": {
         "@solana/event-target-impl": "workspace:*",
         "@solana/ws-impl": "workspace:*",
-        "jest-websocket-mock": "^2.5.0"
-    },
-    "peerDependencies": {
+        "jest-websocket-mock": "^2.5.0",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-subscriptions-spec/package.json
+++ b/packages/rpc-subscriptions-spec/package.json
@@ -80,15 +80,8 @@
         "@solana/subscribable": "workspace:*"
     },
     "devDependencies": {
-        "@solana/event-target-impl": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/event-target-impl": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -88,15 +88,8 @@
     },
     "devDependencies": {
         "@solana/addresses": "workspace:*",
-        "@solana/event-target-impl": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/event-target-impl": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -80,15 +80,10 @@
         "@solana/rpc-spec-types": "workspace:*",
         "@solana/rpc-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/rpc-transport-http/package.json
+++ b/packages/rpc-transport-http/package.json
@@ -82,16 +82,9 @@
     },
     "devDependencies": {
         "tinybench": "^6.0.0",
+        "typescript": "^5.0.0",
         "undici": "^8.0.0",
         "zx": "^8.8.5"
-    },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -81,15 +81,10 @@
         "@solana/errors": "workspace:*",
         "@solana/nominal-types": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -85,15 +85,8 @@
         "@solana/rpc-types": "workspace:*"
     },
     "devDependencies": {
-        "@solana/event-target-impl": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/event-target-impl": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -86,15 +86,8 @@
     },
     "devDependencies": {
         "@solana/rpc-types": "workspace:*",
-        "@solana/text-encoding-impl": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/text-encoding-impl": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/subscribable/package.json
+++ b/packages/subscribable/package.json
@@ -77,15 +77,8 @@
         "@solana/errors": "workspace:*"
     },
     "devDependencies": {
-        "@solana/event-target-impl": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/event-target-impl": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -86,15 +86,8 @@
         "@solana/rpc-api": "workspace:*",
         "@solana/rpc-parsed-types": "workspace:*",
         "@solana/rpc-spec": "workspace:*",
-        "@solana/rpc-transport-http": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/rpc-transport-http": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -87,15 +87,8 @@
     "devDependencies": {
         "@solana/codecs-core": "workspace:*",
         "@solana/event-target-impl": "workspace:*",
-        "@solana/instructions": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/instructions": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/transaction-messages/package.json
+++ b/packages/transaction-messages/package.json
@@ -85,15 +85,8 @@
         "@solana/rpc-types": "workspace:*"
     },
     "devDependencies": {
-        "@solana/codecs-strings": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/codecs-strings": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -87,15 +87,10 @@
         "@solana/rpc-types": "workspace:*",
         "@solana/transaction-messages": "workspace:*"
     },
-    "peerDependencies": {
-        "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
-    },
     "engines": {
         "node": ">=20.18.0"
+    },
+    "devDependencies": {
+        "typescript": "^5.0.0"
     }
 }

--- a/packages/wallet-account-signer/package.json
+++ b/packages/wallet-account-signer/package.json
@@ -88,15 +88,8 @@
         "@wallet-standard/ui-registry": "^1.0.1"
     },
     "devDependencies": {
-        "@solana/errors": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/errors": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -74,15 +74,8 @@
         "@noble/ed25519": "^3.0.0"
     },
     "devDependencies": {
-        "@solana/crypto-impl": "workspace:*"
-    },
-    "peerDependencies": {
+        "@solana/crypto-impl": "workspace:*",
         "typescript": "^5.0.0"
-    },
-    "peerDependenciesMeta": {
-        "typescript": {
-            "optional": true
-        }
     },
     "engines": {
         "node": ">=20.18.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,7 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -359,6 +360,7 @@ importers:
       '@solana/nominal-types':
         specifier: workspace:*
         version: link:../nominal-types
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -368,6 +370,7 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -422,6 +425,7 @@ importers:
       '@solana/options':
         specifier: workspace:*
         version: link:../options
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -431,13 +435,13 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       tinybench:
         specifier: ^6.0.0
         version: 6.0.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/codecs-data-structures:
     dependencies:
@@ -450,13 +454,13 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/codecs-strings':
         specifier: workspace:*
         version: link:../codecs-strings
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/codecs-numbers:
     dependencies:
@@ -466,6 +470,7 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -484,9 +489,6 @@ importers:
       fastestsmallesttextencoderdecoder:
         specifier: ^1.0.22
         version: 1.0.22
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/text-encoding-impl':
         specifier: workspace:*
@@ -494,6 +496,9 @@ importers:
       tinybench:
         specifier: ^6.0.0
         version: 6.0.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/compat:
     dependencies:
@@ -515,13 +520,13 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/web3.js':
         specifier: ^1
         version: 1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/crypto-impl: {}
 
@@ -533,6 +538,7 @@ importers:
       commander:
         specifier: 14.0.3
         version: 14.0.3
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -577,10 +583,6 @@ importers:
   packages/event-target-impl: {}
 
   packages/fast-stable-stringify:
-    dependencies:
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@types/json-stable-stringify':
         specifier: ^1.2.0
@@ -588,6 +590,9 @@ importers:
       json-stable-stringify:
         specifier: ^1.3.0
         version: 1.3.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/fetch-impl:
     devDependencies:
@@ -599,7 +604,7 @@ importers:
         version: 8.0.0
 
   packages/functional:
-    dependencies:
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -624,9 +629,6 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -637,6 +639,9 @@ importers:
       '@solana/functional':
         specifier: workspace:*
         version: link:../functional
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/instructions:
     dependencies:
@@ -646,13 +651,13 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/keys:
     dependencies:
@@ -671,13 +676,13 @@ importers:
       '@solana/nominal-types':
         specifier: workspace:*
         version: link:../nominal-types
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       tinybench:
         specifier: ^6.0.0
         version: 6.0.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/kit:
     dependencies:
@@ -753,12 +758,13 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
 
   packages/nominal-types:
-    dependencies:
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -789,6 +795,7 @@ importers:
       '@solana/nominal-types':
         specifier: workspace:*
         version: link:../nominal-types
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -810,12 +817,13 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
 
   packages/plugin-core:
-    dependencies:
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -843,6 +851,7 @@ importers:
       '@solana/signers':
         specifier: workspace:*
         version: link:../signers
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -876,9 +885,6 @@ importers:
       '@solana/signers':
         specifier: workspace:*
         version: link:../signers
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/codecs-data-structures':
         specifier: workspace:*
@@ -886,6 +892,9 @@ importers:
       '@solana/codecs-numbers':
         specifier: workspace:*
         version: link:../codecs-numbers
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/programs:
     dependencies:
@@ -895,9 +904,6 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/functional':
         specifier: workspace:*
@@ -905,9 +911,12 @@ importers:
       '@solana/transaction-messages':
         specifier: workspace:*
         version: link:../transaction-messages
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/promises:
-    dependencies:
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -1014,13 +1023,13 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
         specifier: workspace:*
         version: link:../event-target-impl
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/rpc-api:
     dependencies:
@@ -1057,9 +1066,6 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/rpc-spec-types':
         specifier: workspace:*
@@ -1067,6 +1073,9 @@ importers:
       '@solana/rpc-transport-http':
         specifier: workspace:*
         version: link:../rpc-transport-http
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/rpc-graphql:
     dependencies:
@@ -1085,9 +1094,6 @@ importers:
       graphql:
         specifier: ^16.13.2
         version: 16.13.2
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -1104,12 +1110,11 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-
-  packages/rpc-parsed-types:
-    dependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
+
+  packages/rpc-parsed-types:
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -1117,6 +1122,9 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/rpc-spec:
     dependencies:
@@ -1126,12 +1134,13 @@ importers:
       '@solana/rpc-spec-types':
         specifier: workspace:*
         version: link:../rpc-spec-types
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
 
   packages/rpc-spec-types:
-    dependencies:
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -1171,9 +1180,6 @@ importers:
       '@solana/subscribable':
         specifier: workspace:*
         version: link:../subscribable
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -1181,6 +1187,9 @@ importers:
       '@solana/event-target-impl':
         specifier: workspace:*
         version: link:../event-target-impl
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/rpc-subscriptions-api:
     dependencies:
@@ -1205,13 +1214,13 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/rpc-subscriptions-channel-websocket':
         specifier: workspace:*
         version: link:../rpc-subscriptions-channel-websocket
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/rpc-subscriptions-channel-websocket:
     dependencies:
@@ -1227,9 +1236,6 @@ importers:
       '@solana/subscribable':
         specifier: workspace:*
         version: link:../subscribable
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
       ws:
         specifier: ^8.19.0
         version: 8.19.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -1243,6 +1249,9 @@ importers:
       jest-websocket-mock:
         specifier: ^2.5.0
         version: 2.5.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/rpc-subscriptions-spec:
     dependencies:
@@ -1258,13 +1267,13 @@ importers:
       '@solana/subscribable':
         specifier: workspace:*
         version: link:../subscribable
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
         specifier: workspace:*
         version: link:../event-target-impl
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/rpc-transformers:
     dependencies:
@@ -1283,6 +1292,7 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -1298,9 +1308,6 @@ importers:
       '@solana/rpc-spec-types':
         specifier: workspace:*
         version: link:../rpc-spec-types
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
       undici-types:
         specifier: ^8.0.0
         version: 8.0.0
@@ -1308,6 +1315,9 @@ importers:
       tinybench:
         specifier: ^6.0.0
         version: 6.0.0
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
       undici:
         specifier: ^8.0.0
         version: 8.0.0
@@ -1335,6 +1345,7 @@ importers:
       '@solana/nominal-types':
         specifier: workspace:*
         version: link:../nominal-types
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -1368,9 +1379,6 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/rpc-types':
         specifier: workspace:*
@@ -1378,19 +1386,22 @@ importers:
       '@solana/text-encoding-impl':
         specifier: workspace:*
         version: link:../text-encoding-impl
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/subscribable:
     dependencies:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
         specifier: workspace:*
         version: link:../event-target-impl
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/sysvars:
     dependencies:
@@ -1412,9 +1423,6 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/addresses':
         specifier: workspace:*
@@ -1431,6 +1439,9 @@ importers:
       '@solana/rpc-transport-http':
         specifier: workspace:*
         version: link:../rpc-transport-http
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/test-config:
     dependencies:
@@ -1492,9 +1503,6 @@ importers:
       '@solana/transactions':
         specifier: workspace:*
         version: link:../transactions
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/codecs-core':
         specifier: workspace:*
@@ -1505,6 +1513,9 @@ importers:
       '@solana/instructions':
         specifier: workspace:*
         version: link:../instructions
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/transaction-messages:
     dependencies:
@@ -1535,13 +1546,13 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/codecs-strings':
         specifier: workspace:*
         version: link:../codecs-strings
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/transactions:
     dependencies:
@@ -1581,6 +1592,7 @@ importers:
       '@solana/transaction-messages':
         specifier: workspace:*
         version: link:../transaction-messages
+    devDependencies:
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -1625,26 +1637,26 @@ importers:
       '@wallet-standard/ui-registry':
         specifier: ^1.0.1
         version: 1.0.1
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/webcrypto-ed25519-polyfill:
     dependencies:
       '@noble/ed25519':
         specifier: ^3.0.0
         version: 3.0.0
-      typescript:
-        specifier: ^5.0.0
-        version: 5.9.3
     devDependencies:
       '@solana/crypto-impl':
         specifier: workspace:*
         version: link:../crypto-impl
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
 
   packages/ws-impl:
     dependencies:


### PR DESCRIPTION
#### Problem

Listing typescript as a peer dependency prevents consumers from using their own version of typescript (e.g. typescript 6). This change marks typescript as a `devDependency` so that consumers are unconstrained.

Fixes #1511