### PR TITLE
Change typescript peer dependency to >5

### DIFF
--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -82,7 +82,7 @@
         "@solana/rpc-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -81,7 +81,7 @@
         "@solana/nominal-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -77,7 +77,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -81,7 +81,7 @@
         "tinybench": "^6.0.0"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -82,7 +82,7 @@
         "@solana/codecs-strings": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -78,7 +78,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -85,7 +85,7 @@
     },
     "peerDependencies": {
         "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "fastestsmallesttextencoderdecoder": {

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -79,7 +79,7 @@
         "@solana/options": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -85,7 +85,7 @@
         "@solana/web3.js": "^1"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -79,7 +79,7 @@
         "commander": "14.0.3"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/fast-stable-stringify/package.json
+++ b/packages/fast-stable-stringify/package.json
@@ -79,7 +79,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -74,7 +74,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/instruction-plans/package.json
+++ b/packages/instruction-plans/package.json
@@ -87,7 +87,7 @@
         "@solana/functional": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -81,7 +81,7 @@
         "@solana/addresses": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -82,7 +82,7 @@
         "@solana/nominal-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -127,7 +127,7 @@
         "@solana/transactions": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/nominal-types/package.json
+++ b/packages/nominal-types/package.json
@@ -40,7 +40,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/offchain-messages/package.json
+++ b/packages/offchain-messages/package.json
@@ -84,7 +84,7 @@
         "@solana/nominal-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -81,7 +81,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -74,7 +74,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/plugin-interfaces/package.json
+++ b/packages/plugin-interfaces/package.json
@@ -49,7 +49,7 @@
         "@solana/signers": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/program-client-core/package.json
+++ b/packages/program-client-core/package.json
@@ -89,7 +89,7 @@
         "@solana/codecs-numbers": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/programs/package.json
+++ b/packages/programs/package.json
@@ -82,7 +82,7 @@
         "@solana/transaction-messages": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/promises/package.json
+++ b/packages/promises/package.json
@@ -74,7 +74,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-api/package.json
+++ b/packages/rpc-api/package.json
@@ -91,7 +91,7 @@
         "@solana/rpc-transport-http": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -87,7 +87,7 @@
         "@solana/transactions": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-parsed-types/package.json
+++ b/packages/rpc-parsed-types/package.json
@@ -76,7 +76,7 @@
         "@solana/rpc-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-spec-types/package.json
+++ b/packages/rpc-spec-types/package.json
@@ -74,7 +74,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-spec/package.json
+++ b/packages/rpc-spec/package.json
@@ -78,7 +78,7 @@
         "@solana/rpc-spec-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -86,7 +86,7 @@
         "@solana/rpc-subscriptions-channel-websocket": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-subscriptions-channel-websocket/package.json
+++ b/packages/rpc-subscriptions-channel-websocket/package.json
@@ -86,7 +86,7 @@
         "jest-websocket-mock": "^2.5.0"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-subscriptions-spec/package.json
+++ b/packages/rpc-subscriptions-spec/package.json
@@ -83,7 +83,7 @@
         "@solana/event-target-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -91,7 +91,7 @@
         "@solana/event-target-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -81,7 +81,7 @@
         "@solana/rpc-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-transport-http/package.json
+++ b/packages/rpc-transport-http/package.json
@@ -86,7 +86,7 @@
         "zx": "^8.8.5"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -82,7 +82,7 @@
         "@solana/nominal-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -88,7 +88,7 @@
         "@solana/event-target-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -89,7 +89,7 @@
         "@solana/text-encoding-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/subscribable/package.json
+++ b/packages/subscribable/package.json
@@ -80,7 +80,7 @@
         "@solana/event-target-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -89,7 +89,7 @@
         "@solana/rpc-transport-http": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -90,7 +90,7 @@
         "@solana/instructions": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/transaction-messages/package.json
+++ b/packages/transaction-messages/package.json
@@ -88,7 +88,7 @@
         "@solana/codecs-strings": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -88,7 +88,7 @@
         "@solana/transaction-messages": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/wallet-account-signer/package.json
+++ b/packages/wallet-account-signer/package.json
@@ -91,7 +91,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -77,7 +77,7 @@
         "@solana/crypto-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": "^5.0.0"
+        "typescript": ">=5.0.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,7 +339,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/addresses:
@@ -360,7 +360,7 @@ importers:
         specifier: workspace:*
         version: link:../nominal-types
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/assertions:
@@ -369,7 +369,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/build-scripts:
@@ -423,7 +423,7 @@ importers:
         specifier: workspace:*
         version: link:../options
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/codecs-core:
@@ -432,7 +432,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       tinybench:
@@ -451,7 +451,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/codecs-strings':
@@ -467,7 +467,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/codecs-strings:
@@ -485,7 +485,7 @@ importers:
         specifier: ^1.0.22
         version: 1.0.22
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/text-encoding-impl':
@@ -516,7 +516,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/web3.js':
@@ -534,7 +534,7 @@ importers:
         specifier: 14.0.3
         version: 14.0.3
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/eslint-config:
@@ -579,7 +579,7 @@ importers:
   packages/fast-stable-stringify:
     dependencies:
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@types/json-stable-stringify':
@@ -601,7 +601,7 @@ importers:
   packages/functional:
     dependencies:
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/instruction-plans:
@@ -625,7 +625,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -647,7 +647,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -672,7 +672,7 @@ importers:
         specifier: workspace:*
         version: link:../nominal-types
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       tinybench:
@@ -754,13 +754,13 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/nominal-types:
     dependencies:
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/offchain-messages:
@@ -790,7 +790,7 @@ importers:
         specifier: workspace:*
         version: link:../nominal-types
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/options:
@@ -811,13 +811,13 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/plugin-core:
     dependencies:
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/plugin-interfaces:
@@ -844,7 +844,7 @@ importers:
         specifier: workspace:*
         version: link:../signers
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/program-client-core:
@@ -877,7 +877,7 @@ importers:
         specifier: workspace:*
         version: link:../signers
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/codecs-data-structures':
@@ -896,7 +896,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/functional':
@@ -909,7 +909,7 @@ importers:
   packages/promises:
     dependencies:
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/react:
@@ -1015,7 +1015,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
@@ -1058,7 +1058,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/rpc-spec-types':
@@ -1086,7 +1086,7 @@ importers:
         specifier: ^16.13.2
         version: 16.13.2
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -1108,7 +1108,7 @@ importers:
   packages/rpc-parsed-types:
     dependencies:
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -1127,13 +1127,13 @@ importers:
         specifier: workspace:*
         version: link:../rpc-spec-types
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/rpc-spec-types:
     dependencies:
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/rpc-subscriptions:
@@ -1172,7 +1172,7 @@ importers:
         specifier: workspace:*
         version: link:../subscribable
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -1206,7 +1206,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/rpc-subscriptions-channel-websocket':
@@ -1228,7 +1228,7 @@ importers:
         specifier: workspace:*
         version: link:../subscribable
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
       ws:
         specifier: ^8.19.0
@@ -1259,7 +1259,7 @@ importers:
         specifier: workspace:*
         version: link:../subscribable
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
@@ -1284,7 +1284,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/rpc-transport-http:
@@ -1299,7 +1299,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-spec-types
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
       undici-types:
         specifier: ^8.0.0
@@ -1336,7 +1336,7 @@ importers:
         specifier: workspace:*
         version: link:../nominal-types
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/signers:
@@ -1369,7 +1369,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/rpc-types':
@@ -1385,7 +1385,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
@@ -1413,7 +1413,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -1493,7 +1493,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/codecs-core':
@@ -1536,7 +1536,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/codecs-strings':
@@ -1582,7 +1582,7 @@ importers:
         specifier: workspace:*
         version: link:../transaction-messages
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
 
   packages/tsconfig: {}
@@ -1626,7 +1626,7 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/errors':
@@ -1639,7 +1639,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typescript:
-        specifier: ^5.0.0
+        specifier: '>=5.0.0'
         version: 5.9.3
     devDependencies:
       '@solana/crypto-impl':


### PR DESCRIPTION
#### Problem

A while ago we changed our minimum typescript version to 5, but also changed it from `>=5.x.y` to `^5`. See #1187 

This means it doesn't match typescript 6.x or future versions

#### Summary of Changes

Change the version to `>=5.0.0`. This matches any version of 5.x or any future version of typescript 
