### PR TITLE
Refactor `createReactiveStoreWithInitialValueAndSlotTracking` to return slot as well as value

### DIFF
--- a/.changeset/giant-falcons-invite.md
+++ b/.changeset/giant-falcons-invite.md
@@ -2,4 +2,4 @@
 '@solana/kit': minor
 ---
 
-Add `createReactiveStoreWithInitialValueAndSlotTracking()`, a helper that combines an initial RPC fetch with an ongoing subscription into a single `ReactiveStore`. Uses slot-based comparison to ensure only the most recent value is kept, regardless of arrival order. Compatible with `useSyncExternalStore`, Svelte stores, and other reactive primitives.
+Add `createReactiveStoreWithInitialValueAndSlotTracking()`, a helper that combines an initial RPC fetch with an ongoing subscription into a single `ReactiveStore`. Uses slot-based comparison to ensure only the most recent value is kept, regardless of arrival order. The store state is a `SolanaRpcResponse<TItem>`. Compatible with `useSyncExternalStore`, Svelte stores, and other reactive primitives.

--- a/examples/react-app/src/functions/balance.ts
+++ b/examples/react-app/src/functions/balance.ts
@@ -36,7 +36,7 @@ export function balanceSubscribe(
         if (error) {
             next(error as Error);
         } else {
-            next(null, store.getState());
+            next(null, store.getState()?.value);
         }
     });
     return () => {

--- a/packages/kit/src/__tests__/create-reactive-store-with-initial-value-and-slot-tracking-test.ts
+++ b/packages/kit/src/__tests__/create-reactive-store-with-initial-value-and-slot-tracking-test.ts
@@ -144,7 +144,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             });
             resolve(rpcResponse(100, { count: 42 }));
             await flushMicrotasks();
-            expect(store.getState()).toBe(42);
+            expect(store.getState()).toEqual({ context: { slot: 100n }, value: 42 });
         });
         it('updates with a subscription notification value', async () => {
             expect.assertions(1);
@@ -160,7 +160,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             await flushMicrotasks();
             pushNotification(rpcResponse(100, { count: 99 }));
             await flushMicrotasks();
-            expect(store.getState()).toBe(99);
+            expect(store.getState()).toEqual({ context: { slot: 100n }, value: 99 });
         });
         it('ignores the RPC response when a newer subscription notification has already arrived', async () => {
             expect.assertions(1);
@@ -179,7 +179,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             // RPC response arrives later at an older slot
             resolve(rpcResponse(100, { count: 42 }));
             await flushMicrotasks();
-            expect(store.getState()).toBe(99);
+            expect(store.getState()).toEqual({ context: { slot: 200n }, value: 99 });
         });
         it('ignores a subscription notification when the RPC response was at a newer slot', async () => {
             expect.assertions(1);
@@ -196,7 +196,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             await flushMicrotasks();
             pushNotification(rpcResponse(100, { count: 99 }));
             await flushMicrotasks();
-            expect(store.getState()).toBe(42);
+            expect(store.getState()).toEqual({ context: { slot: 200n }, value: 42 });
         });
         it('preserves the last known value after an error', async () => {
             expect.assertions(1);
@@ -213,7 +213,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             await flushMicrotasks();
             error(new Error('subscription failed'));
             await flushMicrotasks();
-            expect(store.getState()).toBe(42);
+            expect(store.getState()).toEqual({ context: { slot: 100n }, value: 42 });
         });
     });
 

--- a/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
+++ b/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
@@ -42,7 +42,9 @@ type CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscr
  *
  * Things to note:
  *
- * - `getState()` returns `undefined` until the first response or notification arrives.
+ * - `getState()` returns `undefined` until the first response or notification arrives. Once
+ *   data arrives, it returns a {@link SolanaRpcResponse} containing the value and the slot
+ *   context at which it was observed.
  * - On error from either source, `getState()` continues to return the last known value and
  *   `getError()` returns the error. Only the first error is captured.
  * - When an error occurs, the abort signal is triggered, cancelling both the RPC request and
@@ -75,7 +77,10 @@ type CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscr
  * const unsubscribe = balanceStore.subscribe(() => {
  *     const error = balanceStore.getError();
  *     if (error) console.error('Error:', error);
- *     else console.log('Balance:', balanceStore.getState());
+ *     else {
+ *         const state = balanceStore.getState();
+ *         if (state) console.log(`Balance at slot ${state.context.slot}:`, state.value);
+ *     }
  * });
  * ```
  *
@@ -87,12 +92,10 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
     rpcValueMapper,
     rpcSubscriptionRequest,
     rpcSubscriptionValueMapper,
-}: CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<
-    TRpcValue,
-    TSubscriptionValue,
-    TItem
->): ReactiveStore<TItem> {
-    let currentState: TItem | undefined;
+}: CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscriptionValue, TItem>): ReactiveStore<
+    SolanaRpcResponse<TItem>
+> {
+    let currentState: SolanaRpcResponse<TItem> | undefined;
     let currentError: unknown;
     let lastUpdateSlot = -1n;
     const subscribers = new Set<() => void>();
@@ -121,7 +124,7 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
             if (signal.aborted) return;
             if (slot < lastUpdateSlot) return;
             lastUpdateSlot = slot;
-            currentState = rpcValueMapper(value);
+            currentState = { context: { slot }, value: rpcValueMapper(value) } as SolanaRpcResponse<TItem>;
             notifySubscribers();
         })
         .catch(handleError);
@@ -136,7 +139,10 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
                 if (signal.aborted) return;
                 if (slot < lastUpdateSlot) continue;
                 lastUpdateSlot = slot;
-                currentState = rpcSubscriptionValueMapper(value);
+                currentState = {
+                    context: { slot },
+                    value: rpcSubscriptionValueMapper(value),
+                } as SolanaRpcResponse<TItem>;
                 notifySubscribers();
             }
         })
@@ -146,7 +152,7 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
         getError(): unknown {
             return currentError;
         },
-        getState(): TItem | undefined {
+        getState(): SolanaRpcResponse<TItem> | undefined {
             return currentState;
         },
         subscribe(callback: () => void): () => void {


### PR DESCRIPTION
#### Summary of Changes

Just rethinking this API a little before we ship

The stored value is now `SolanaRpcResponse<TItem>` instead of just `TItem`, ie the app also has access to the slot that the value comes from. This means that if you use the identity function as the mapper for the subscription, code consuming this store would be identical to if it was just calling `reactive()` on the subscription. 

This enables use cases like displaying the freshness of data, acting conditionally on which slot data is from, etc. 

Note that since this hasn't shipped I've just updated the existing changeset. 
