### PR TITLE
Add createAsyncGeneratorWithInitialValueAndSlotTracking

### DIFF
--- a/.changeset/long-regions-hear.md
+++ b/.changeset/long-regions-hear.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit': minor
+---
+
+Add `createAsyncGeneratorWithInitialValueAndSlotTracking`, an async generator alternative to `createReactiveStoreWithInitialValueAndSlotTracking` that yields values from both an RPC fetch and an ongoing subscription, silently dropping any value at a slot older than the last seen.

--- a/packages/kit/src/__tests__/create-async-generator-with-initial-value-and-slot-tracking-test.ts
+++ b/packages/kit/src/__tests__/create-async-generator-with-initial-value-and-slot-tracking-test.ts
@@ -104,7 +104,7 @@ function createMockSubscriptionRequest(): {
 }
 
 function rpcResponse(slot: number, value: TestValue): SolanaRpcResponse<TestValue> {
-    return { context: { slot: BigInt(slot) }, value } as SolanaRpcResponse<TestValue>;
+    return { context: { slot: BigInt(slot) }, value };
 }
 
 /** Build the expected `{ context: { slot }, value }` shape for a yielded value. */

--- a/packages/kit/src/__tests__/create-async-generator-with-initial-value-and-slot-tracking-test.ts
+++ b/packages/kit/src/__tests__/create-async-generator-with-initial-value-and-slot-tracking-test.ts
@@ -2,7 +2,7 @@ import type { PendingRpcRequest } from '@solana/rpc';
 import type { PendingRpcSubscriptionsRequest } from '@solana/rpc-subscriptions';
 import type { SolanaRpcResponse } from '@solana/rpc-types';
 
-import { createReactiveStoreWithInitialValueAndSlotTracking } from '../create-reactive-store-with-initial-value-and-slot-tracking';
+import { createAsyncGeneratorWithInitialValueAndSlotTracking } from '../create-async-generator-with-initial-value-and-slot-tracking';
 
 /** Flush all pending microtasks by waiting for a macrotask boundary. */
 const flushMicrotasks = () => new Promise(resolve => setTimeout(resolve, 0));
@@ -104,10 +104,25 @@ function createMockSubscriptionRequest(): {
 }
 
 function rpcResponse(slot: number, value: TestValue): SolanaRpcResponse<TestValue> {
+    return { context: { slot: BigInt(slot) }, value } as SolanaRpcResponse<TestValue>;
+}
+
+/** Build the expected `{ context: { slot }, value }` shape for a yielded value. */
+function expectedResponse(slot: number, value: number) {
     return { context: { slot: BigInt(slot) }, value };
 }
 
-describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
+/** Collect all values yielded by the generator until it's done (or collect `n` values). */
+async function collectValues<T>(gen: AsyncGenerator<T>, n?: number): Promise<T[]> {
+    const values: T[] = [];
+    for await (const value of gen) {
+        values.push(value);
+        if (n !== undefined && values.length >= n) break;
+    }
+    return values;
+}
+
+describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
     let abortController: AbortController;
 
     beforeEach(() => {
@@ -118,24 +133,12 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
         abortController.abort();
     });
 
-    describe('getState()', () => {
-        it('returns `undefined` before any data arrives', () => {
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            expect(store.getState()).toBeUndefined();
-        });
-        it('updates with the RPC response value', async () => {
+    describe('yielded values', () => {
+        it('yields the RPC response value', async () => {
             expect.assertions(1);
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
@@ -143,98 +146,152 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcValueMapper: v => v.count,
             });
             resolve(rpcResponse(100, { count: 42 }));
-            await flushMicrotasks();
-            expect(store.getState()).toEqual({ context: { slot: 100n }, value: 42 });
+            const values = await collectValues(gen, 1);
+            expect(values).toEqual([expectedResponse(100, 42)]);
         });
-        it('updates with a subscription notification value', async () => {
+        it('yields subscription notification values', async () => {
             expect.assertions(1);
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            // Start consuming — the generator won't yield until a value arrives.
+            const valuesPromise = collectValues(gen, 1);
             await flushMicrotasks();
             pushNotification(rpcResponse(100, { count: 99 }));
-            await flushMicrotasks();
-            expect(store.getState()).toEqual({ context: { slot: 100n }, value: 99 });
+            const values = await valuesPromise;
+            expect(values).toEqual([expectedResponse(100, 99)]);
         });
-        it('ignores the RPC response when a newer subscription notification has already arrived', async () => {
+        it('yields values from both sources in order of arrival', async () => {
             expect.assertions(1);
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            resolve(rpcResponse(100, { count: 42 }));
+            const valuesPromise = collectValues(gen, 2);
             await flushMicrotasks();
             pushNotification(rpcResponse(200, { count: 99 }));
-            await flushMicrotasks();
-            // RPC response arrives later at an older slot
-            resolve(rpcResponse(100, { count: 42 }));
-            await flushMicrotasks();
-            expect(store.getState()).toEqual({ context: { slot: 200n }, value: 99 });
+            const values = await valuesPromise;
+            expect(values).toEqual([expectedResponse(100, 42), expectedResponse(200, 99)]);
         });
-        it('ignores a subscription notification when the RPC response was at a newer slot', async () => {
+        it('silently drops the RPC response when a newer subscription notification has already arrived', async () => {
             expect.assertions(1);
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
+            const { mockRequest: rpcSubscriptionRequest, pushNotification, complete } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            const valuesPromise = collectValues(gen);
+            await flushMicrotasks();
+            // Subscription notification arrives first at slot 200
+            pushNotification(rpcResponse(200, { count: 99 }));
+            await flushMicrotasks();
+            // RPC response arrives later at older slot 100 — should be dropped
+            resolve(rpcResponse(100, { count: 42 }));
+            await flushMicrotasks();
+            complete();
+            const values = await valuesPromise;
+            expect(values).toEqual([expectedResponse(200, 99)]);
+        });
+        it('silently drops a subscription notification when the RPC response was at a newer slot', async () => {
+            expect.assertions(1);
+            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
+            const { mockRequest: rpcSubscriptionRequest, pushNotification, complete } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
+                abortSignal: abortController.signal,
+                rpcRequest,
+                rpcSubscriptionRequest,
+                rpcSubscriptionValueMapper: v => v.count,
+                rpcValueMapper: v => v.count,
+            });
+            const valuesPromise = collectValues(gen);
+            // RPC response arrives first at slot 200
             resolve(rpcResponse(200, { count: 42 }));
             await flushMicrotasks();
+            // Subscription notification at older slot — should be dropped
             pushNotification(rpcResponse(100, { count: 99 }));
             await flushMicrotasks();
-            expect(store.getState()).toEqual({ context: { slot: 200n }, value: 42 });
+            complete();
+            const values = await valuesPromise;
+            expect(values).toEqual([expectedResponse(200, 42)]);
         });
-        it('preserves the last known value after an error', async () => {
+        it('silently drops older subscription notifications while yielding newer ones', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
+            const { mockRequest: rpcRequest } = createMockRpcRequest();
+            const { mockRequest: rpcSubscriptionRequest, pushNotification, complete } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            resolve(rpcResponse(100, { count: 42 }));
+            const valuesPromise = collectValues(gen);
             await flushMicrotasks();
-            error(new Error('subscription failed'));
+            pushNotification(rpcResponse(100, { count: 1 }));
             await flushMicrotasks();
-            expect(store.getState()).toEqual({ context: { slot: 100n }, value: 42 });
+            pushNotification(rpcResponse(300, { count: 3 }));
+            await flushMicrotasks();
+            // Slot 200 is older than 300 — should be dropped
+            pushNotification(rpcResponse(200, { count: 2 }));
+            await flushMicrotasks();
+            pushNotification(rpcResponse(400, { count: 4 }));
+            await flushMicrotasks();
+            complete();
+            const values = await valuesPromise;
+            expect(values).toEqual([expectedResponse(100, 1), expectedResponse(300, 3), expectedResponse(400, 4)]);
+        });
+        it('buffers values that arrive while the consumer has not yet called next, then yields them', async () => {
+            expect.assertions(4);
+            const { mockRequest: rpcRequest } = createMockRpcRequest();
+            const { mockRequest: rpcSubscriptionRequest, pushNotification, complete } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
+                abortSignal: abortController.signal,
+                rpcRequest,
+                rpcSubscriptionRequest,
+                rpcSubscriptionValueMapper: v => v.count,
+                rpcValueMapper: v => v.count,
+            });
+            // Start the generator — it enters the await.
+            const firstNext = gen.next();
+            await flushMicrotasks();
+            // First notification resolves the waiting promise; the generator yields it.
+            pushNotification(rpcResponse(100, { count: 1 }));
+            await expect(firstNext).resolves.toEqual({ done: false, value: expectedResponse(100, 1) });
+            // Generator is now suspended at the yield. Push more values — these
+            // buffer into the internal queue because the consumer hasn't called next().
+            pushNotification(rpcResponse(200, { count: 2 }));
+            pushNotification(rpcResponse(300, { count: 3 }));
+            await flushMicrotasks();
+            // Consume — values should drain from the queue.
+            await expect(gen.next()).resolves.toEqual({ done: false, value: expectedResponse(200, 2) });
+            await expect(gen.next()).resolves.toEqual({ done: false, value: expectedResponse(300, 3) });
+            complete();
+            await expect(gen.next()).resolves.toEqual({ done: true, value: undefined });
         });
     });
 
-    describe('getError()', () => {
-        it('returns `undefined` before any error', () => {
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            expect(store.getError()).toBeUndefined();
-        });
-        it('captures an error from the RPC request', async () => {
+    describe('error handling', () => {
+        it('throws when the RPC request fails', async () => {
             expect.assertions(1);
             const { mockRequest: rpcRequest, reject } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
@@ -243,297 +300,213 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             });
             const error = new Error('rpc failed');
             reject(error);
-            await flushMicrotasks();
-            expect(store.getError()).toBe(error);
+            await expect(collectValues(gen)).rejects.toBe(error);
         });
-        it('captures an error from the subscription', async () => {
+        it('throws when the subscription fails', async () => {
             expect.assertions(1);
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            const valuesPromise = collectValues(gen);
             await flushMicrotasks();
             const subscriptionError = new Error('subscription failed');
             error(subscriptionError);
-            await flushMicrotasks();
-            expect(store.getError()).toBe(subscriptionError);
+            await expect(valuesPromise).rejects.toBe(subscriptionError);
         });
-        it('only captures the first error when RPC fails then subscription fails', async () => {
-            expect.assertions(1);
-            const { mockRequest: rpcRequest, reject: rejectRpc } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, error: errorSubscription } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
+        it('throws the error even after yielding values', async () => {
+            expect.assertions(2);
+            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
+            const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            resolve(rpcResponse(100, { count: 42 }));
+            // Collect one value, then wait for the next (which will be an error).
+            const firstResult = await gen.next();
+            expect(firstResult).toEqual({ done: false, value: expectedResponse(100, 42) });
             await flushMicrotasks();
-            rejectRpc(new Error('rpc error'));
-            await flushMicrotasks();
-            errorSubscription(new Error('subscription error'));
-            await flushMicrotasks();
-            expect(store.getError()).toEqual(new Error('rpc error'));
-        });
-        it('only captures the first error when subscription fails then RPC fails', async () => {
-            expect.assertions(1);
-            const { mockRequest: rpcRequest, reject: rejectRpc } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, error: errorSubscription } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            await flushMicrotasks();
-            errorSubscription(new Error('subscription error'));
-            await flushMicrotasks();
-            rejectRpc(new Error('rpc error'));
-            await flushMicrotasks();
-            expect(store.getError()).toEqual(new Error('subscription error'));
+            error(new Error('subscription failed'));
+            await expect(gen.next()).rejects.toEqual(new Error('subscription failed'));
         });
     });
 
-    describe('subscribe()', () => {
-        it('calls the subscriber when the RPC response arrives', async () => {
+    describe('completion', () => {
+        it('completes when the subscription ends', async () => {
             expect.assertions(1);
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
+            const { mockRequest: rpcSubscriptionRequest, complete } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
             resolve(rpcResponse(100, { count: 42 }));
+            const valuesPromise = collectValues(gen);
             await flushMicrotasks();
-            expect(subscriber).toHaveBeenCalledTimes(1);
+            complete();
+            const values = await valuesPromise;
+            expect(values).toEqual([expectedResponse(100, 42)]);
         });
-        it('calls the subscriber when a subscription notification arrives', async () => {
+        it('completes when the subscription ends while the consumer has not yet called next', async () => {
+            expect.assertions(3);
+            const { mockRequest: rpcRequest } = createMockRpcRequest();
+            const { mockRequest: rpcSubscriptionRequest, pushNotification, complete } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
+                abortSignal: abortController.signal,
+                rpcRequest,
+                rpcSubscriptionRequest,
+                rpcSubscriptionValueMapper: v => v.count,
+                rpcValueMapper: v => v.count,
+            });
+            // Start the generator — it enters the await.
+            const firstNext = gen.next();
+            await flushMicrotasks();
+            pushNotification(rpcResponse(100, { count: 1 }));
+            await expect(firstNext).resolves.toEqual({ done: false, value: expectedResponse(100, 1) });
+            // Generator is now suspended at the yield. Complete the subscription.
+            complete();
+            await flushMicrotasks();
+            // Next call should see done=true and return.
+            await expect(gen.next()).resolves.toEqual({ done: true, value: undefined });
+            // Subsequent calls also return done.
+            await expect(gen.next()).resolves.toEqual({ done: true, value: undefined });
+        });
+        it('returns immediately if the abort signal is already aborted', async () => {
             expect.assertions(1);
             const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            await flushMicrotasks();
-            pushNotification(rpcResponse(100, { count: 99 }));
-            await flushMicrotasks();
-            expect(subscriber).toHaveBeenCalledTimes(1);
-        });
-        it('does not call the subscriber when an out-of-order notification is skipped', async () => {
-            expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            resolve(rpcResponse(200, { count: 42 }));
-            await flushMicrotasks();
-            subscriber.mockClear();
-            await flushMicrotasks();
-            // This notification is at an older slot and should be skipped
-            pushNotification(rpcResponse(100, { count: 99 }));
-            await flushMicrotasks();
-            expect(subscriber).not.toHaveBeenCalled();
-        });
-        it('calls the subscriber when an error occurs', async () => {
-            expect.assertions(1);
-            const { mockRequest: rpcRequest, reject } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
+                abortSignal: AbortSignal.abort(),
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            reject(new Error('fail'));
-            await flushMicrotasks();
-            expect(subscriber).toHaveBeenCalledTimes(1);
-        });
-        it('calls the subscriber when a subscription error occurs', async () => {
-            expect.assertions(1);
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            await flushMicrotasks();
-            error(new Error('fail'));
-            await flushMicrotasks();
-            expect(subscriber).toHaveBeenCalledTimes(1);
-        });
-        it('stops calling the subscriber after unsubscribe', async () => {
-            expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            const subscriber = jest.fn();
-            const unsubscribe = store.subscribe(subscriber);
-            unsubscribe();
-            resolve(rpcResponse(100, { count: 42 }));
-            await flushMicrotasks();
-            expect(subscriber).not.toHaveBeenCalled();
-        });
-        it('the unsubscribe function is idempotent', () => {
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            const unsubscribe = store.subscribe(jest.fn());
-            expect(() => {
-                unsubscribe();
-                unsubscribe();
-            }).not.toThrow();
+            const values = await collectValues(gen);
+            expect(values).toEqual([]);
         });
     });
 
     describe('abort signal', () => {
-        it('aborts the signal passed to the RPC request when the caller aborts', () => {
+        it('completes without error when the abort signal fires', async () => {
+            expect.assertions(1);
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            createReactiveStoreWithInitialValueAndSlotTracking({
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            const valuesPromise = collectValues(gen);
+            await flushMicrotasks();
+            abortController.abort();
+            const values = await valuesPromise;
+            expect(values).toEqual([]);
+        });
+        it('yields values received before abort, then completes', async () => {
+            expect.assertions(1);
+            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
+            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
+                abortSignal: abortController.signal,
+                rpcRequest,
+                rpcSubscriptionRequest,
+                rpcSubscriptionValueMapper: v => v.count,
+                rpcValueMapper: v => v.count,
+            });
+            resolve(rpcResponse(100, { count: 42 }));
+            // Collect the first value.
+            const firstResult = await gen.next();
+            expect(firstResult).toEqual({ done: false, value: expectedResponse(100, 42) });
+            abortController.abort();
+        });
+        it('does not yield values that arrive after abort', async () => {
+            expect.assertions(1);
+            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
+            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
+                abortSignal: abortController.signal,
+                rpcRequest,
+                rpcSubscriptionRequest,
+                rpcSubscriptionValueMapper: v => v.count,
+                rpcValueMapper: v => v.count,
+            });
+            const valuesPromise = collectValues(gen);
+            await flushMicrotasks();
+            abortController.abort();
+            // RPC resolves after abort.
+            resolve(rpcResponse(100, { count: 42 }));
+            const values = await valuesPromise;
+            expect(values).toEqual([]);
+        });
+        it('aborts the signal passed to the RPC request', async () => {
+            expect.assertions(2);
+            const { mockRequest: rpcRequest } = createMockRpcRequest();
+            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
+                abortSignal: abortController.signal,
+                rpcRequest,
+                rpcSubscriptionRequest,
+                rpcSubscriptionValueMapper: v => v.count,
+                rpcValueMapper: v => v.count,
+            });
+            const nextPromise = gen.next();
             const rpcSignal = (rpcRequest.send as jest.Mock).mock.calls[0][0].abortSignal;
             expect(rpcSignal.aborted).toBe(false);
             abortController.abort('test reason');
             expect(rpcSignal.aborted).toBe(true);
-            expect(rpcSignal.reason).toBe('test reason');
+            await nextPromise;
         });
-        it('aborts the signal passed to the subscription request when the caller aborts', () => {
+        it('aborts the signal passed to the subscription request', async () => {
+            expect.assertions(2);
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            createReactiveStoreWithInitialValueAndSlotTracking({
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            const nextPromise = gen.next();
+            await flushMicrotasks();
             const subscriptionSignal = (rpcSubscriptionRequest.subscribe as jest.Mock).mock.calls[0][0].abortSignal;
             expect(subscriptionSignal.aborted).toBe(false);
             abortController.abort('test reason');
             expect(subscriptionSignal.aborted).toBe(true);
-            expect(subscriptionSignal.reason).toBe('test reason');
+            await nextPromise;
         });
-        it('swallows errors from the RPC request when the caller aborts', async () => {
+        it('cleans up when the consumer breaks out of the loop', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, reject } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            abortController.abort();
-            reject(new Error('aborted'));
-            await flushMicrotasks();
-            expect(store.getError()).toBeUndefined();
-        });
-        it('swallows errors from the subscription when the caller aborts', async () => {
-            expect.assertions(1);
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            await flushMicrotasks();
-            abortController.abort();
-            error(new Error('aborted'));
-            await flushMicrotasks();
-            expect(store.getError()).toBeUndefined();
-        });
-        it('does not update state when the RPC response arrives after abort', async () => {
-            expect.assertions(2);
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            abortController.abort();
             resolve(rpcResponse(100, { count: 42 }));
+            // Collect only 1 value (simulates breaking out of the loop).
+            await collectValues(gen, 1);
             await flushMicrotasks();
-            expect(store.getState()).toBeUndefined();
-            expect(subscriber).not.toHaveBeenCalled();
-        });
-        it('does not update state when a subscription notification arrives after abort', async () => {
-            expect.assertions(2);
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            await flushMicrotasks();
-            abortController.abort();
-            pushNotification(rpcResponse(100, { count: 99 }));
-            await flushMicrotasks();
-            expect(store.getState()).toBeUndefined();
-            expect(subscriber).not.toHaveBeenCalled();
+            const rpcSignal = (rpcRequest.send as jest.Mock).mock.calls[0][0].abortSignal;
+            expect(rpcSignal.aborted).toBe(true);
         });
     });
 });

--- a/packages/kit/src/__tests__/create-async-generator-with-initial-value-and-slot-tracking-test.ts
+++ b/packages/kit/src/__tests__/create-async-generator-with-initial-value-and-slot-tracking-test.ts
@@ -232,7 +232,7 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
         });
         it('silently drops older subscription notifications while yielding newer ones', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
+            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, pushNotification, complete } = createMockSubscriptionRequest();
             const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
@@ -252,13 +252,16 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             await flushMicrotasks();
             pushNotification(rpcResponse(400, { count: 4 }));
             await flushMicrotasks();
+            // Resolve RPC at old slot (dropped) so the generator can complete.
+            resolve(rpcResponse(0, { count: 0 }));
+            await flushMicrotasks();
             complete();
             const values = await valuesPromise;
             expect(values).toEqual([expectedResponse(100, 1), expectedResponse(300, 3), expectedResponse(400, 4)]);
         });
         it('buffers values that arrive while the consumer has not yet called next, then yields them', async () => {
             expect.assertions(4);
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
+            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, pushNotification, complete } = createMockSubscriptionRequest();
             const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
@@ -281,6 +284,9 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             // Consume — values should drain from the queue.
             await expect(gen.next()).resolves.toEqual({ done: false, value: expectedResponse(200, 2) });
             await expect(gen.next()).resolves.toEqual({ done: false, value: expectedResponse(300, 3) });
+            // Resolve RPC at old slot (dropped) and complete subscription.
+            resolve(rpcResponse(0, { count: 0 }));
+            await flushMicrotasks();
             complete();
             await expect(gen.next()).resolves.toEqual({ done: true, value: undefined });
         });
@@ -359,9 +365,9 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             const values = await valuesPromise;
             expect(values).toEqual([expectedResponse(100, 42)]);
         });
-        it('completes when the subscription ends while the consumer has not yet called next', async () => {
+        it('completes when both the subscription and RPC end while the consumer has not yet called next', async () => {
             expect.assertions(3);
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
+            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, pushNotification, complete } = createMockSubscriptionRequest();
             const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
@@ -375,13 +381,58 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             await flushMicrotasks();
             pushNotification(rpcResponse(100, { count: 1 }));
             await expect(firstNext).resolves.toEqual({ done: false, value: expectedResponse(100, 1) });
-            // Generator is now suspended at the yield. Complete the subscription.
+            // Resolve RPC at older slot (will be dropped) and complete the subscription.
+            resolve(rpcResponse(50, { count: 0 }));
+            await flushMicrotasks();
             complete();
             await flushMicrotasks();
             // Next call should see done=true and return.
             await expect(gen.next()).resolves.toEqual({ done: true, value: undefined });
             // Subsequent calls also return done.
             await expect(gen.next()).resolves.toEqual({ done: true, value: undefined });
+        });
+        it('yields the RPC response when the subscription ends before the RPC resolves', async () => {
+            expect.assertions(1);
+            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
+            const { mockRequest: rpcSubscriptionRequest, complete } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
+                abortSignal: abortController.signal,
+                rpcRequest,
+                rpcSubscriptionRequest,
+                rpcSubscriptionValueMapper: v => v.count,
+                rpcValueMapper: v => v.count,
+            });
+            const valuesPromise = collectValues(gen);
+            await flushMicrotasks();
+            // Subscription ends before the RPC responds.
+            complete();
+            await flushMicrotasks();
+            // RPC resolves after the subscription is already done.
+            resolve(rpcResponse(100, { count: 42 }));
+            const values = await valuesPromise;
+            expect(values).toEqual([expectedResponse(100, 42)]);
+        });
+        it('does not complete until both the RPC and subscription have completed', async () => {
+            expect.assertions(2);
+            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
+            const { mockRequest: rpcSubscriptionRequest, pushNotification, complete } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
+                abortSignal: abortController.signal,
+                rpcRequest,
+                rpcSubscriptionRequest,
+                rpcSubscriptionValueMapper: v => v.count,
+                rpcValueMapper: v => v.count,
+            });
+            const firstNext = gen.next();
+            await flushMicrotasks();
+            pushNotification(rpcResponse(100, { count: 1 }));
+            await expect(firstNext).resolves.toEqual({ done: false, value: expectedResponse(100, 1) });
+            // Complete the subscription — generator should NOT be done because RPC is pending.
+            complete();
+            await flushMicrotasks();
+            // Resolve the RPC at a newer slot — should be yielded, then generator completes.
+            resolve(rpcResponse(200, { count: 42 }));
+            await expect(gen.next()).resolves.toEqual({ done: false, value: expectedResponse(200, 42) });
         });
         it('returns immediately if the abort signal is already aborted', async () => {
             expect.assertions(1);

--- a/packages/kit/src/__tests__/create-async-generator-with-initial-value-and-slot-tracking-test.ts
+++ b/packages/kit/src/__tests__/create-async-generator-with-initial-value-and-slot-tracking-test.ts
@@ -4,9 +4,6 @@ import type { SolanaRpcResponse } from '@solana/rpc-types';
 
 import { createAsyncGeneratorWithInitialValueAndSlotTracking } from '../create-async-generator-with-initial-value-and-slot-tracking';
 
-/** Flush all pending microtasks by waiting for a macrotask boundary. */
-const flushMicrotasks = () => new Promise(resolve => setTimeout(resolve, 0));
-
 type TestValue = { count: number };
 
 function createMockRpcRequest(): {
@@ -14,12 +11,7 @@ function createMockRpcRequest(): {
     reject(error: unknown): void;
     resolve(response: SolanaRpcResponse<TestValue>): void;
 } {
-    let resolve!: (response: SolanaRpcResponse<TestValue>) => void;
-    let reject!: (error: unknown) => void;
-    const promise = new Promise<SolanaRpcResponse<TestValue>>((res, rej) => {
-        resolve = res;
-        reject = rej;
-    });
+    const { promise, resolve, reject } = Promise.withResolvers<SolanaRpcResponse<TestValue>>();
     return {
         mockRequest: { send: jest.fn().mockReturnValue(promise) },
         reject,
@@ -122,6 +114,8 @@ async function collectValues<T>(gen: AsyncGenerator<T>, n?: number): Promise<T[]
     return values;
 }
 
+jest.useFakeTimers();
+
 describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
     let abortController: AbortController;
 
@@ -162,7 +156,8 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             });
             // Start consuming — the generator won't yield until a value arrives.
             const valuesPromise = collectValues(gen, 1);
-            await flushMicrotasks();
+            // await jest.runAllTimersAsync();
+            await jest.runAllTimersAsync();
             pushNotification(rpcResponse(100, { count: 99 }));
             const values = await valuesPromise;
             expect(values).toEqual([expectedResponse(100, 99)]);
@@ -180,7 +175,8 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             });
             resolve(rpcResponse(100, { count: 42 }));
             const valuesPromise = collectValues(gen, 2);
-            await flushMicrotasks();
+            // await jest.runAllTimersAsync()
+            await jest.runAllTimersAsync();
             pushNotification(rpcResponse(200, { count: 99 }));
             const values = await valuesPromise;
             expect(values).toEqual([expectedResponse(100, 42), expectedResponse(200, 99)]);
@@ -197,13 +193,13 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
                 rpcValueMapper: v => v.count,
             });
             const valuesPromise = collectValues(gen);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // Subscription notification arrives first at slot 200
             pushNotification(rpcResponse(200, { count: 99 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // RPC response arrives later at older slot 100 — should be dropped
             resolve(rpcResponse(100, { count: 42 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             complete();
             const values = await valuesPromise;
             expect(values).toEqual([expectedResponse(200, 99)]);
@@ -222,10 +218,10 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             const valuesPromise = collectValues(gen);
             // RPC response arrives first at slot 200
             resolve(rpcResponse(200, { count: 42 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // Subscription notification at older slot — should be dropped
             pushNotification(rpcResponse(100, { count: 99 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             complete();
             const values = await valuesPromise;
             expect(values).toEqual([expectedResponse(200, 42)]);
@@ -242,19 +238,19 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
                 rpcValueMapper: v => v.count,
             });
             const valuesPromise = collectValues(gen);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             pushNotification(rpcResponse(100, { count: 1 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             pushNotification(rpcResponse(300, { count: 3 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // Slot 200 is older than 300 — should be dropped
             pushNotification(rpcResponse(200, { count: 2 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             pushNotification(rpcResponse(400, { count: 4 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // Resolve RPC at old slot (dropped) so the generator can complete.
             resolve(rpcResponse(0, { count: 0 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             complete();
             const values = await valuesPromise;
             expect(values).toEqual([expectedResponse(100, 1), expectedResponse(300, 3), expectedResponse(400, 4)]);
@@ -272,7 +268,7 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             });
             // Start the generator — it enters the await.
             const firstNext = gen.next();
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // First notification resolves the waiting promise; the generator yields it.
             pushNotification(rpcResponse(100, { count: 1 }));
             await expect(firstNext).resolves.toEqual({ done: false, value: expectedResponse(100, 1) });
@@ -280,13 +276,13 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             // buffer into the internal queue because the consumer hasn't called next().
             pushNotification(rpcResponse(200, { count: 2 }));
             pushNotification(rpcResponse(300, { count: 3 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // Consume — values should drain from the queue.
             await expect(gen.next()).resolves.toEqual({ done: false, value: expectedResponse(200, 2) });
             await expect(gen.next()).resolves.toEqual({ done: false, value: expectedResponse(300, 3) });
             // Resolve RPC at old slot (dropped) and complete subscription.
             resolve(rpcResponse(0, { count: 0 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             complete();
             await expect(gen.next()).resolves.toEqual({ done: true, value: undefined });
         });
@@ -320,7 +316,7 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
                 rpcValueMapper: v => v.count,
             });
             const valuesPromise = collectValues(gen);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             const subscriptionError = new Error('subscription failed');
             error(subscriptionError);
             await expect(valuesPromise).rejects.toBe(subscriptionError);
@@ -340,7 +336,7 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             // Collect one value, then wait for the next (which will be an error).
             const firstResult = await gen.next();
             expect(firstResult).toEqual({ done: false, value: expectedResponse(100, 42) });
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             error(new Error('subscription failed'));
             await expect(gen.next()).rejects.toEqual(new Error('subscription failed'));
         });
@@ -360,7 +356,7 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             });
             resolve(rpcResponse(100, { count: 42 }));
             const valuesPromise = collectValues(gen);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             complete();
             const values = await valuesPromise;
             expect(values).toEqual([expectedResponse(100, 42)]);
@@ -378,14 +374,14 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             });
             // Start the generator — it enters the await.
             const firstNext = gen.next();
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             pushNotification(rpcResponse(100, { count: 1 }));
             await expect(firstNext).resolves.toEqual({ done: false, value: expectedResponse(100, 1) });
             // Resolve RPC at older slot (will be dropped) and complete the subscription.
             resolve(rpcResponse(50, { count: 0 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             complete();
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // Next call should see done=true and return.
             await expect(gen.next()).resolves.toEqual({ done: true, value: undefined });
             // Subsequent calls also return done.
@@ -403,10 +399,10 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
                 rpcValueMapper: v => v.count,
             });
             const valuesPromise = collectValues(gen);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // Subscription ends before the RPC responds.
             complete();
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // RPC resolves after the subscription is already done.
             resolve(rpcResponse(100, { count: 42 }));
             const values = await valuesPromise;
@@ -424,12 +420,12 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
                 rpcValueMapper: v => v.count,
             });
             const firstNext = gen.next();
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             pushNotification(rpcResponse(100, { count: 1 }));
             await expect(firstNext).resolves.toEqual({ done: false, value: expectedResponse(100, 1) });
             // Complete the subscription — generator should NOT be done because RPC is pending.
             complete();
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // Resolve the RPC at a newer slot — should be yielded, then generator completes.
             resolve(rpcResponse(200, { count: 42 }));
             await expect(gen.next()).resolves.toEqual({ done: false, value: expectedResponse(200, 42) });
@@ -463,7 +459,7 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
                 rpcValueMapper: v => v.count,
             });
             const valuesPromise = collectValues(gen);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             abortController.abort();
             const values = await valuesPromise;
             expect(values).toEqual([]);
@@ -498,7 +494,7 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             });
             // Pull the first value — generator enters the await.
             const firstNext = gen.next();
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // Push three notifications at once. The first resolves the generator's
             // waiting promise; the other two are buffered in the mock.
             pushNotification(rpcResponse(100, { count: 1 }));
@@ -507,7 +503,7 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             // Flush so the for-await loop processes all three notifications.
             // The generator yields slot 100 (via waitingResolve) and the loop
             // enqueues slots 200 and 300 into the internal queue.
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             await firstNext;
             // Abort while slots 200 and 300 are sitting in the queue.
             abortController.abort();
@@ -529,7 +525,7 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
                 rpcValueMapper: v => v.count,
             });
             const valuesPromise = collectValues(gen);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             abortController.abort();
             // RPC resolves after abort.
             resolve(rpcResponse(100, { count: 42 }));
@@ -566,7 +562,7 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
                 rpcValueMapper: v => v.count,
             });
             const nextPromise = gen.next();
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             const subscriptionSignal = (rpcSubscriptionRequest.subscribe as jest.Mock).mock.calls[0][0].abortSignal;
             expect(subscriptionSignal.aborted).toBe(false);
             abortController.abort('test reason');
@@ -587,7 +583,7 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             resolve(rpcResponse(100, { count: 42 }));
             // Collect only 1 value (simulates breaking out of the loop).
             await collectValues(gen, 1);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             const rpcSignal = (rpcRequest.send as jest.Mock).mock.calls[0][0].abortSignal;
             expect(rpcSignal.aborted).toBe(true);
         });

--- a/packages/kit/src/__tests__/create-async-generator-with-initial-value-and-slot-tracking-test.ts
+++ b/packages/kit/src/__tests__/create-async-generator-with-initial-value-and-slot-tracking-test.ts
@@ -485,6 +485,38 @@ describe('createAsyncGeneratorWithInitialValueAndSlotTracking', () => {
             expect(firstResult).toEqual({ done: false, value: expectedResponse(100, 42) });
             abortController.abort();
         });
+        it('drains buffered values after abort before completing', async () => {
+            expect.assertions(3);
+            const { mockRequest: rpcRequest } = createMockRpcRequest();
+            const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
+            const gen = createAsyncGeneratorWithInitialValueAndSlotTracking({
+                abortSignal: abortController.signal,
+                rpcRequest,
+                rpcSubscriptionRequest,
+                rpcSubscriptionValueMapper: v => v.count,
+                rpcValueMapper: v => v.count,
+            });
+            // Pull the first value — generator enters the await.
+            const firstNext = gen.next();
+            await flushMicrotasks();
+            // Push three notifications at once. The first resolves the generator's
+            // waiting promise; the other two are buffered in the mock.
+            pushNotification(rpcResponse(100, { count: 1 }));
+            pushNotification(rpcResponse(200, { count: 2 }));
+            pushNotification(rpcResponse(300, { count: 3 }));
+            // Flush so the for-await loop processes all three notifications.
+            // The generator yields slot 100 (via waitingResolve) and the loop
+            // enqueues slots 200 and 300 into the internal queue.
+            await flushMicrotasks();
+            await firstNext;
+            // Abort while slots 200 and 300 are sitting in the queue.
+            abortController.abort();
+            // Buffered values should still be yielded.
+            await expect(gen.next()).resolves.toEqual({ done: false, value: expectedResponse(200, 2) });
+            await expect(gen.next()).resolves.toEqual({ done: false, value: expectedResponse(300, 3) });
+            // Then the generator completes.
+            await expect(gen.next()).resolves.toEqual({ done: true, value: undefined });
+        });
         it('does not yield values that arrive after abort', async () => {
             expect.assertions(1);
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();

--- a/packages/kit/src/__tests__/create-reactive-store-with-initial-value-and-slot-tracking-test.ts
+++ b/packages/kit/src/__tests__/create-reactive-store-with-initial-value-and-slot-tracking-test.ts
@@ -4,9 +4,6 @@ import type { SolanaRpcResponse } from '@solana/rpc-types';
 
 import { createReactiveStoreWithInitialValueAndSlotTracking } from '../create-reactive-store-with-initial-value-and-slot-tracking';
 
-/** Flush all pending microtasks by waiting for a macrotask boundary. */
-const flushMicrotasks = () => new Promise(resolve => setTimeout(resolve, 0));
-
 type TestValue = { count: number };
 
 function createMockRpcRequest(): {
@@ -14,12 +11,7 @@ function createMockRpcRequest(): {
     reject(error: unknown): void;
     resolve(response: SolanaRpcResponse<TestValue>): void;
 } {
-    let resolve!: (response: SolanaRpcResponse<TestValue>) => void;
-    let reject!: (error: unknown) => void;
-    const promise = new Promise<SolanaRpcResponse<TestValue>>((res, rej) => {
-        resolve = res;
-        reject = rej;
-    });
+    const { promise, resolve, reject } = Promise.withResolvers<SolanaRpcResponse<TestValue>>();
     return {
         mockRequest: { send: jest.fn().mockReturnValue(promise) },
         reject,
@@ -107,6 +99,8 @@ function rpcResponse(slot: number, value: TestValue): SolanaRpcResponse<TestValu
     return { context: { slot: BigInt(slot) }, value };
 }
 
+jest.useFakeTimers();
+
 describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
     let abortController: AbortController;
 
@@ -143,7 +137,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcValueMapper: v => v.count,
             });
             resolve(rpcResponse(100, { count: 42 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getState()).toEqual({ context: { slot: 100n }, value: 42 });
         });
         it('updates with a subscription notification value', async () => {
@@ -157,9 +151,9 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             pushNotification(rpcResponse(100, { count: 99 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getState()).toEqual({ context: { slot: 100n }, value: 99 });
         });
         it('ignores the RPC response when a newer subscription notification has already arrived', async () => {
@@ -173,12 +167,12 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             pushNotification(rpcResponse(200, { count: 99 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // RPC response arrives later at an older slot
             resolve(rpcResponse(100, { count: 42 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getState()).toEqual({ context: { slot: 200n }, value: 99 });
         });
         it('ignores a subscription notification when the RPC response was at a newer slot', async () => {
@@ -193,9 +187,9 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcValueMapper: v => v.count,
             });
             resolve(rpcResponse(200, { count: 42 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             pushNotification(rpcResponse(100, { count: 99 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getState()).toEqual({ context: { slot: 200n }, value: 42 });
         });
         it('preserves the last known value after an error', async () => {
@@ -210,9 +204,9 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcValueMapper: v => v.count,
             });
             resolve(rpcResponse(100, { count: 42 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             error(new Error('subscription failed'));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getState()).toEqual({ context: { slot: 100n }, value: 42 });
         });
     });
@@ -243,7 +237,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             });
             const error = new Error('rpc failed');
             reject(error);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getError()).toBe(error);
         });
         it('captures an error from the subscription', async () => {
@@ -257,10 +251,10 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             const subscriptionError = new Error('subscription failed');
             error(subscriptionError);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getError()).toBe(subscriptionError);
         });
         it('only captures the first error when RPC fails then subscription fails', async () => {
@@ -274,11 +268,11 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             rejectRpc(new Error('rpc error'));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             errorSubscription(new Error('subscription error'));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getError()).toEqual(new Error('rpc error'));
         });
         it('only captures the first error when subscription fails then RPC fails', async () => {
@@ -292,11 +286,11 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             errorSubscription(new Error('subscription error'));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             rejectRpc(new Error('rpc error'));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getError()).toEqual(new Error('subscription error'));
         });
     });
@@ -316,7 +310,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const subscriber = jest.fn();
             store.subscribe(subscriber);
             resolve(rpcResponse(100, { count: 42 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(subscriber).toHaveBeenCalledTimes(1);
         });
         it('calls the subscriber when a subscription notification arrives', async () => {
@@ -332,9 +326,9 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             });
             const subscriber = jest.fn();
             store.subscribe(subscriber);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             pushNotification(rpcResponse(100, { count: 99 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(subscriber).toHaveBeenCalledTimes(1);
         });
         it('does not call the subscriber when an out-of-order notification is skipped', async () => {
@@ -351,12 +345,12 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const subscriber = jest.fn();
             store.subscribe(subscriber);
             resolve(rpcResponse(200, { count: 42 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             subscriber.mockClear();
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             // This notification is at an older slot and should be skipped
             pushNotification(rpcResponse(100, { count: 99 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(subscriber).not.toHaveBeenCalled();
         });
         it('calls the subscriber when an error occurs', async () => {
@@ -373,7 +367,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const subscriber = jest.fn();
             store.subscribe(subscriber);
             reject(new Error('fail'));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(subscriber).toHaveBeenCalledTimes(1);
         });
         it('calls the subscriber when a subscription error occurs', async () => {
@@ -389,9 +383,9 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             });
             const subscriber = jest.fn();
             store.subscribe(subscriber);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             error(new Error('fail'));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(subscriber).toHaveBeenCalledTimes(1);
         });
         it('stops calling the subscriber after unsubscribe', async () => {
@@ -409,7 +403,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const unsubscribe = store.subscribe(subscriber);
             unsubscribe();
             resolve(rpcResponse(100, { count: 42 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(subscriber).not.toHaveBeenCalled();
         });
         it('the unsubscribe function is idempotent', () => {
@@ -476,7 +470,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             });
             abortController.abort();
             reject(new Error('aborted'));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getError()).toBeUndefined();
         });
         it('swallows errors from the subscription when the caller aborts', async () => {
@@ -490,10 +484,10 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             abortController.abort();
             error(new Error('aborted'));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getError()).toBeUndefined();
         });
         it('does not update state when the RPC response arrives after abort', async () => {
@@ -511,7 +505,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             store.subscribe(subscriber);
             abortController.abort();
             resolve(rpcResponse(100, { count: 42 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getState()).toBeUndefined();
             expect(subscriber).not.toHaveBeenCalled();
         });
@@ -528,10 +522,10 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             });
             const subscriber = jest.fn();
             store.subscribe(subscriber);
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             abortController.abort();
             pushNotification(rpcResponse(100, { count: 99 }));
-            await flushMicrotasks();
+            await jest.runAllTimersAsync();
             expect(store.getState()).toBeUndefined();
             expect(subscriber).not.toHaveBeenCalled();
         });

--- a/packages/kit/src/create-async-generator-with-initial-value-and-slot-tracking.ts
+++ b/packages/kit/src/create-async-generator-with-initial-value-and-slot-tracking.ts
@@ -1,0 +1,199 @@
+import type { PendingRpcRequest } from '@solana/rpc';
+import type { PendingRpcSubscriptionsRequest } from '@solana/rpc-subscriptions';
+import type { SolanaRpcResponse } from '@solana/rpc-types';
+
+type CreateAsyncGeneratorWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscriptionValue, TItem> = Readonly<{
+    /**
+     * Triggering this abort signal will cancel the pending RPC request and subscription, and
+     * cause the async generator to return (complete without error).
+     */
+    abortSignal: AbortSignal;
+    /**
+     * A pending RPC request whose response will be yielded as the generator's first value
+     * (unless a subscription notification with a newer slot arrives first).
+     * The response must be a {@link SolanaRpcResponse} so that its slot can be compared with
+     * subscription notifications.
+     */
+    rpcRequest: PendingRpcRequest<SolanaRpcResponse<TRpcValue>>;
+    /**
+     * A pending RPC subscription request whose notifications will be yielded as they arrive.
+     * Each notification must be a {@link SolanaRpcResponse} so that its slot can be compared
+     * with the initial RPC response and other notifications.
+     */
+    rpcSubscriptionRequest: PendingRpcSubscriptionsRequest<SolanaRpcResponse<TSubscriptionValue>>;
+    /**
+     * Maps the value from a subscription notification to the item type yielded by the generator.
+     */
+    rpcSubscriptionValueMapper: (value: TSubscriptionValue) => TItem;
+    /**
+     * Maps the value from the RPC response to the item type yielded by the generator.
+     */
+    rpcValueMapper: (value: TRpcValue) => TItem;
+}>;
+
+/**
+ * Creates an async generator that combines an initial RPC fetch with an ongoing subscription,
+ * yielding values as they arrive from either source.
+ *
+ * The generator uses slot-based comparison to ensure that only the most recent values are yielded.
+ * Any value at a slot older than a previously yielded value is silently dropped.
+ * This prevents stale data from appearing when the RPC response and subscription notifications
+ * arrive out of order.
+ *
+ * Things to note:
+ *
+ * - The generator yields {@link SolanaRpcResponse} values from both the RPC response and
+ *   subscription notifications, each containing the slot context and the mapped value.
+ * - Out-of-order values (by slot) are silently dropped — they are never yielded.
+ * - On error from either source, the generator throws the error.
+ * - Triggering the caller's abort signal causes the generator to return (complete without error).
+ * - The generator completes when the subscription ends, an error occurs, or the abort signal fires.
+ *
+ * @param config
+ *
+ * @example
+ * ```ts
+ * import {
+ *     address,
+ *     createAsyncGeneratorWithInitialValueAndSlotTracking,
+ *     createSolanaRpc,
+ *     createSolanaRpcSubscriptions,
+ * } from '@solana/kit';
+ *
+ * const rpc = createSolanaRpc('http://127.0.0.1:8899');
+ * const rpcSubscriptions = createSolanaRpcSubscriptions('ws://127.0.0.1:8900');
+ * const myAddress = address('FnHyam9w4NZoWR6mKN1CuGBritdsEWZQa4Z4oawLZGxa');
+ *
+ * const abortController = new AbortController();
+ * for await (const balance of createAsyncGeneratorWithInitialValueAndSlotTracking({
+ *     abortSignal: abortController.signal,
+ *     rpcRequest: rpc.getBalance(myAddress, { commitment: 'confirmed' }),
+ *     rpcValueMapper: lamports => lamports,
+ *     rpcSubscriptionRequest: rpcSubscriptions.accountNotifications(myAddress),
+ *     rpcSubscriptionValueMapper: ({ lamports }) => lamports,
+ * })) {
+ *     console.log(`Balance at slot ${balance.context.slot}:`, balance.value);
+ * }
+ * ```
+ */
+export async function* createAsyncGeneratorWithInitialValueAndSlotTracking<TRpcValue, TSubscriptionValue, TItem>({
+    abortSignal,
+    rpcRequest,
+    rpcValueMapper,
+    rpcSubscriptionRequest,
+    rpcSubscriptionValueMapper,
+}: CreateAsyncGeneratorWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscriptionValue, TItem>): AsyncGenerator<
+    SolanaRpcResponse<TItem>
+> {
+    if (abortSignal.aborted) return;
+
+    let lastUpdateSlot = -1n;
+
+    // Shared queue for merging values from the RPC response and subscription notifications.
+    const queue: SolanaRpcResponse<TItem>[] = [];
+    let waitingResolve: ((value: IteratorResult<SolanaRpcResponse<TItem>>) => void) | null = null;
+    let waitingReject: ((reason: unknown) => void) | null = null;
+    let done = false;
+    let pendingError: unknown;
+
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+
+    function onAbort() {
+        done = true;
+        abortController.abort(abortSignal.reason);
+        if (waitingResolve) {
+            const resolve = waitingResolve;
+            waitingResolve = null;
+            waitingReject = null;
+            resolve({ done: true, value: undefined });
+        }
+    }
+    abortSignal.addEventListener('abort', onAbort);
+
+    function enqueue(item: SolanaRpcResponse<TItem>) {
+        if (done || signal.aborted) return;
+        if (waitingResolve) {
+            // generator is waiting for a value, so resolve immediately
+            const resolve = waitingResolve;
+            waitingResolve = null;
+            waitingReject = null;
+            resolve({ done: false, value: item });
+        } else {
+            // No pending generator pull, so enqueue the item for future delivery
+            queue.push(item);
+        }
+    }
+
+    function handleError(err: unknown) {
+        if (signal.aborted) return;
+        done = true;
+        pendingError = err;
+        abortController.abort(err);
+        if (waitingReject) {
+            // generator is waiting for a value, so reject immediately
+            const reject = waitingReject;
+            waitingResolve = null;
+            waitingReject = null;
+            reject(err);
+        }
+    }
+
+    // Start both sources concurrently.
+    rpcRequest
+        .send({ abortSignal: signal })
+        .then(({ context: { slot }, value }) => {
+            if (signal.aborted) return;
+            if (slot < lastUpdateSlot) return;
+            lastUpdateSlot = slot;
+            enqueue({ context: { slot }, value: rpcValueMapper(value) });
+        })
+        .catch(handleError);
+
+    rpcSubscriptionRequest
+        .subscribe({ abortSignal: signal })
+        .then(async notifications => {
+            for await (const {
+                context: { slot },
+                value,
+            } of notifications) {
+                if (signal.aborted) return;
+                if (slot < lastUpdateSlot) continue;
+                lastUpdateSlot = slot;
+                enqueue({ context: { slot }, value: rpcSubscriptionValueMapper(value) });
+            }
+            // Subscription completed normally.
+            done = true;
+            if (waitingResolve) {
+                const resolve = waitingResolve;
+                waitingResolve = null;
+                resolve({ done: true, value: undefined });
+            }
+        })
+        .catch(handleError);
+
+    try {
+        while (true) {
+            if (pendingError) throw pendingError;
+            if (queue.length > 0) {
+                yield queue.shift()!;
+            } else if (done) {
+                if (pendingError) throw pendingError;
+                return;
+            } else {
+                // if no value queued or error, wait for the next value or error
+                const result: IteratorResult<SolanaRpcResponse<TItem>> = await new Promise((resolve, reject) => {
+                    waitingResolve = resolve;
+                    waitingReject = reject;
+                });
+                if (result.done) return;
+                yield result.value;
+            }
+        }
+    } finally {
+        abortSignal.removeEventListener('abort', onAbort);
+        if (!signal.aborted) {
+            abortController.abort();
+        }
+    }
+}

--- a/packages/kit/src/create-async-generator-with-initial-value-and-slot-tracking.ts
+++ b/packages/kit/src/create-async-generator-with-initial-value-and-slot-tracking.ts
@@ -93,8 +93,19 @@ export async function* createAsyncGeneratorWithInitialValueAndSlotTracking<TRpcV
     const queue: SolanaRpcResponse<TItem>[] = [];
     let waitingResolve: ((value: IteratorResult<SolanaRpcResponse<TItem>>) => void) | null = null;
     let waitingReject: ((reason: unknown) => void) | null = null;
+    let rpcDone = false;
+    let subscriptionDone = false;
     let done = false;
     let pendingError: unknown;
+
+    function markSourcesDone() {
+        done = true;
+        if (waitingResolve) {
+            const resolve = waitingResolve;
+            waitingResolve = null;
+            resolve({ done: true, value: undefined });
+        }
+    }
 
     const abortController = new AbortController();
     const signal = abortController.signal;
@@ -148,6 +159,10 @@ export async function* createAsyncGeneratorWithInitialValueAndSlotTracking<TRpcV
             lastUpdateSlot = slot;
             enqueue({ context: { slot }, value: rpcValueMapper(value) });
         })
+        .then(() => {
+            rpcDone = true;
+            if (subscriptionDone) markSourcesDone();
+        })
         .catch(handleError);
 
     rpcSubscriptionRequest
@@ -163,12 +178,8 @@ export async function* createAsyncGeneratorWithInitialValueAndSlotTracking<TRpcV
                 enqueue({ context: { slot }, value: rpcSubscriptionValueMapper(value) });
             }
             // Subscription completed normally.
-            done = true;
-            if (waitingResolve) {
-                const resolve = waitingResolve;
-                waitingResolve = null;
-                resolve({ done: true, value: undefined });
-            }
+            subscriptionDone = true;
+            if (rpcDone) markSourcesDone();
         })
         .catch(handleError);
 
@@ -178,7 +189,6 @@ export async function* createAsyncGeneratorWithInitialValueAndSlotTracking<TRpcV
             if (queue.length > 0) {
                 yield queue.shift()!;
             } else if (done) {
-                if (pendingError) throw pendingError;
                 return;
             } else {
                 // if no value queued or error, wait for the next value or error

--- a/packages/kit/src/create-async-generator-with-initial-value-and-slot-tracking.ts
+++ b/packages/kit/src/create-async-generator-with-initial-value-and-slot-tracking.ts
@@ -103,6 +103,7 @@ export async function* createAsyncGeneratorWithInitialValueAndSlotTracking<TRpcV
         if (waitingResolve) {
             const resolve = waitingResolve;
             waitingResolve = null;
+            waitingReject = null;
             resolve({ done: true, value: undefined });
         }
     }

--- a/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
+++ b/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
@@ -124,7 +124,7 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
             if (signal.aborted) return;
             if (slot < lastUpdateSlot) return;
             lastUpdateSlot = slot;
-            currentState = { context: { slot }, value: rpcValueMapper(value) } as SolanaRpcResponse<TItem>;
+            currentState = { context: { slot }, value: rpcValueMapper(value) };
             notifySubscribers();
         })
         .catch(handleError);
@@ -142,7 +142,7 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
                 currentState = {
                     context: { slot },
                     value: rpcSubscriptionValueMapper(value),
-                } as SolanaRpcResponse<TItem>;
+                };
                 notifySubscribers();
             }
         })

--- a/packages/kit/tsconfig.json
+++ b/packages/kit/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
     "compilerOptions": {
-        "lib": ["DOM", "ES2020", "ES2022.Error"]
+        "lib": ["DOM", "ES2020", "ES2022.Error", "ES2024"]
     },
     "display": "@solana/kit",
     "extends": "../tsconfig/base.json",


### PR DESCRIPTION
#### Summary of Changes

This PR adds `createAsyncGeneratorWithInitialValueAndSlotTracking`. Same idea as the reactive store version, but presented as an async generator API.

It allows you to take any RPC request and subscription with a `SolanaRpcResponse` shape and that can map to the same value, and iterate over them while silently dropping any information from an older slot than has already been received.

While the store only needs to provide the most recent data, this requires us to queue all responses received (from either source) in order, where the slot is not older than the previous last seen slot.

Note that avoiding race conditions is mostly implicit on the JS single threaded runtime, and the fact that Promise `then` blocks are synchronous.