### PR TITLE
fix(codecs): Correct return types for predicate and pattern-match codec overloads

### DIFF
--- a/packages/codecs-data-structures/src/__typetests__/pattern-match-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/pattern-match-typetest.ts
@@ -31,7 +31,7 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
         getPatternMatchEncoder([
             [numberValuePredicate, {} as FixedSizeEncoder<number>],
             [numberValuePredicate, {} as FixedSizeEncoder<number>],
-        ]) satisfies FixedSizeEncoder<number>;
+        ]) satisfies Encoder<number>;
 
         // It maintains the size if all encoders are FixedSizeEncoder with the same size
         getPatternMatchEncoder([
@@ -115,7 +115,7 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
     getPatternMatchDecoder([
         [bytesPredicate, {} as FixedSizeDecoder<number>],
         [bytesPredicate, {} as FixedSizeDecoder<number>],
-    ]) satisfies FixedSizeDecoder<number>;
+    ]) satisfies Decoder<number>;
 
     // It maintains the size if all decoders are FixedSizeDecoder with the same size
     getPatternMatchDecoder([
@@ -157,7 +157,7 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
         getPatternMatchCodec([
             [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
             [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
-        ]) satisfies FixedSizeCodec<number>;
+        ]) satisfies Codec<number>;
 
         // It maintains the size if all codecs are FixedSizeCodec with the same size
         getPatternMatchCodec([

--- a/packages/codecs-data-structures/src/__typetests__/predicate-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/predicate-typetest.ts
@@ -24,7 +24,7 @@ const predicate = null as unknown as () => boolean;
         predicate,
         {} as FixedSizeEncoder<number>,
         {} as FixedSizeEncoder<number>,
-    ) satisfies FixedSizeEncoder<number>;
+    ) satisfies Encoder<number>;
 
     // It maintains the size if both encoders are FixedSizeEncoder with the same size
     getPredicateEncoder(
@@ -76,7 +76,7 @@ const predicate = null as unknown as () => boolean;
         predicate,
         {} as FixedSizeDecoder<number>,
         {} as FixedSizeDecoder<number>,
-    ) satisfies FixedSizeDecoder<number>;
+    ) satisfies Decoder<number>;
 
     // It maintains the size if both decoders are FixedSizeDecoder with the same size
     getPredicateDecoder(
@@ -129,7 +129,7 @@ const predicate = null as unknown as () => boolean;
         predicate,
         {} as FixedSizeCodec<number>,
         {} as FixedSizeCodec<number>,
-    ) satisfies FixedSizeCodec<number>;
+    ) satisfies Codec<number>;
 
     // It maintains the size if both codecs are FixedSizeCodec with the same size
     getPredicateCodec(

--- a/packages/codecs-data-structures/src/pattern-match.ts
+++ b/packages/codecs-data-structures/src/pattern-match.ts
@@ -94,7 +94,7 @@ export function getPatternMatchEncoder<TFrom, TSize extends number>(
 ): FixedSizeEncoder<TFrom, TSize>;
 export function getPatternMatchEncoder<TFrom>(
     patterns: FixedSizePatternMatchEncoderEntry<TFrom>[],
-): FixedSizeEncoder<TFrom>;
+): Encoder<TFrom>;
 export function getPatternMatchEncoder<TFrom>(
     patterns: VariableSizePatternMatchEncoderEntry<TFrom>[],
 ): VariableSizeEncoder<TFrom>;
@@ -151,7 +151,7 @@ export function getPatternMatchDecoder<TTo, TSize extends number>(
 ): FixedSizeDecoder<TTo, TSize>;
 export function getPatternMatchDecoder<TTo>(
     patterns: [(value: ReadonlyUint8Array) => boolean, FixedSizeDecoder<TTo>][],
-): FixedSizeDecoder<TTo>;
+): Decoder<TTo>;
 export function getPatternMatchDecoder<TTo>(
     patterns: [(value: ReadonlyUint8Array) => boolean, VariableSizeDecoder<TTo>][],
 ): VariableSizeDecoder<TTo>;
@@ -293,7 +293,7 @@ export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom, TSize ext
 ): FixedSizeCodec<TFrom, TTo, TSize>;
 export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom>(
     patterns: FixedSizePatternMatchCodecEntry<TFrom, TFrom, TTo>[],
-): FixedSizeCodec<TFrom, TTo>;
+): Codec<TFrom, TTo>;
 export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom>(
     patterns: VariableSizePatternMatchCodecEntry<TFrom, TFrom, TTo>[],
 ): VariableSizeCodec<TFrom, TTo>;

--- a/packages/codecs-data-structures/src/predicate.ts
+++ b/packages/codecs-data-structures/src/predicate.ts
@@ -56,7 +56,7 @@ export function getPredicateEncoder<TFrom>(
     predicate: (value: TFrom) => boolean,
     ifTrue: FixedSizeEncoder<TFrom>,
     ifFalse: FixedSizeEncoder<TFrom>,
-): FixedSizeEncoder<TFrom>;
+): Encoder<TFrom>;
 export function getPredicateEncoder<TFrom>(
     predicate: (value: TFrom) => boolean,
     ifTrue: VariableSizeEncoder<TFrom>,
@@ -116,7 +116,7 @@ export function getPredicateDecoder<TTo>(
     predicate: (value: ReadonlyUint8Array) => boolean,
     ifTrue: FixedSizeDecoder<TTo>,
     ifFalse: FixedSizeDecoder<TTo>,
-): FixedSizeDecoder<TTo>;
+): Decoder<TTo>;
 export function getPredicateDecoder<TTo>(
     predicate: (value: ReadonlyUint8Array) => boolean,
     ifTrue: VariableSizeDecoder<TTo>,
@@ -187,7 +187,7 @@ export function getPredicateCodec<TFrom, TTo extends TFrom>(
     decodePredicate: (value: ReadonlyUint8Array) => boolean,
     ifTrue: FixedSizeCodec<TFrom, TTo>,
     ifFalse: FixedSizeCodec<TFrom, TTo>,
-): FixedSizeCodec<TFrom, TTo>;
+): Codec<TFrom, TTo>;
 export function getPredicateCodec<TFrom, TTo extends TFrom>(
     encodePredicate: (value: TFrom) => boolean,
     decodePredicate: (value: ReadonlyUint8Array) => boolean,


### PR DESCRIPTION
## Problem

Fixes #1443

Both `getPredicateEncoder/Decoder/Codec` and `getPatternMatchEncoder/Decoder/Codec` wrap the union codec internally. The union codec has runtime behavior where it returns a `VariableSize` codec when all inputs are `FixedSize` but have **different sizes** (see `getUnionFixedSize` in `union.ts`).

However, overload #2 in both predicate and pattern-match incorrectly promised `FixedSize` returns when both inputs are `FixedSize` without constraining them to the same size.

## Example of the bug

```ts
const encoder = getPredicateEncoder(
  (n: number) => n < 256,
  getU8Encoder(),   // FixedSize<1>
  getU32Encoder(),  // FixedSize<4>
);
// TypeScript says: FixedSizeEncoder<number>
// Runtime says: VariableSizeEncoder
```

## Changes

Changed overload #2 return types to match runtime behavior. 4 files, 12 lines changed.

- `predicate.ts` — Encoder/Decoder/Codec overload #2: FixedSize → Encoder/Decoder/Codec
- `pattern-match.ts` — Encoder/Decoder/Codec overload #2: FixedSize → Encoder/Decoder/Codec  
- Typetests updated accordingly

Overload #1 (same TSize) still correctly returns FixedSize with preserved size.