### PR TITLE
Add NO_SIGNER_CONNECTED and SIGNER_NOT_AVAILABLE wallet errors

### DIFF
--- a/.changeset/calm-swans-stay.md
+++ b/.changeset/calm-swans-stay.md
@@ -1,0 +1,5 @@
+---
+'@solana/errors': minor
+---
+
+Add `SOLANA_ERROR__WALLET__NO_SIGNER_CONNECTED` and `SOLANA_ERROR__WALLET__SIGNER_NOT_AVAILABLE` error codes for wallet-signer availability checks.

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -371,6 +371,8 @@ export const SOLANA_ERROR__PROGRAM_CLIENTS__FAILED_TO_IDENTIFY_ACCOUNT = 8500006
 // Wallet-related errors.
 // Reserve error codes in the range [8900000-8900999].
 export const SOLANA_ERROR__WALLET__NOT_CONNECTED = 8900000;
+export const SOLANA_ERROR__WALLET__NO_SIGNER_CONNECTED = 8900001;
+export const SOLANA_ERROR__WALLET__SIGNER_NOT_AVAILABLE = 8900002;
 
 // Invariant violation errors.
 // Reserve error codes in the range [9900000-9900999].
@@ -692,7 +694,9 @@ export type SolanaErrorCode =
     | typeof SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_ACCOUNT_COST_LIMIT
     | typeof SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_BLOCK_COST_LIMIT
     | typeof SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_VOTE_COST_LIMIT
-    | typeof SOLANA_ERROR__WALLET__NOT_CONNECTED;
+    | typeof SOLANA_ERROR__WALLET__NO_SIGNER_CONNECTED
+    | typeof SOLANA_ERROR__WALLET__NOT_CONNECTED
+    | typeof SOLANA_ERROR__WALLET__SIGNER_NOT_AVAILABLE;
 
 /**
  * Errors of this type are understood to have an optional {@link SolanaError} nested inside as

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -211,6 +211,7 @@ import {
     SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_RENT,
     SOLANA_ERROR__TRANSACTION_ERROR__PROGRAM_EXECUTION_TEMPORARILY_RESTRICTED,
     SOLANA_ERROR__TRANSACTION_ERROR__UNKNOWN,
+    SOLANA_ERROR__WALLET__NO_SIGNER_CONNECTED,
     SOLANA_ERROR__WALLET__NOT_CONNECTED,
     SolanaErrorCode,
 } from './codes';
@@ -873,6 +874,9 @@ export type SolanaErrorContext = ReadonlyContextValue<
             };
             [SOLANA_ERROR__WALLET__NOT_CONNECTED]: {
                 operation: string;
+            };
+            [SOLANA_ERROR__WALLET__NO_SIGNER_CONNECTED]: {
+                status: string;
             };
         }
     >

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -298,7 +298,9 @@ import {
     SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_ACCOUNT_COST_LIMIT,
     SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_BLOCK_COST_LIMIT,
     SOLANA_ERROR__TRANSACTION_ERROR__WOULD_EXCEED_MAX_VOTE_COST_LIMIT,
+    SOLANA_ERROR__WALLET__NO_SIGNER_CONNECTED,
     SOLANA_ERROR__WALLET__NOT_CONNECTED,
+    SOLANA_ERROR__WALLET__SIGNER_NOT_AVAILABLE,
     SolanaErrorCode,
 } from './codes';
 
@@ -823,4 +825,6 @@ export const SolanaErrorMessages: Readonly<{
     [SOLANA_ERROR__TRANSACTION__TOO_MANY_ACCOUNTS_IN_INSTRUCTION]:
         'The instruction at index $instructionIndex has $actualCount account references but the maximum allowed is $maxAllowed',
     [SOLANA_ERROR__WALLET__NOT_CONNECTED]: 'Cannot $operation: no wallet connected',
+    [SOLANA_ERROR__WALLET__NO_SIGNER_CONNECTED]: 'No signing wallet connected (status: $status)',
+    [SOLANA_ERROR__WALLET__SIGNER_NOT_AVAILABLE]: 'Connected wallet does not support signing',
 };


### PR DESCRIPTION
#### Summary of Changes

These are new errors that will be thrown when accessing `client.identity` or `client.payer` while those are controlled by a wallet plugin and there is not a signer for a connected wallet available.

There are 2 cases:

- `SOLANA_ERROR__WALLET__NO_SIGNER_CONNECTED` will be used when no wallet is connected. It includes a `status`, which in the wallet plugin will be one of its statuses, such as `disconnected` or `pending`. In the error definition it's just a string though.
- `SOLANA_ERROR__WALLET__SIGNER_NOT_AVAILABLE` will be used when a wallet is connected, but a signer was not created for it because of missing features. In this case as `client.identity` and `client.payer` are both signer fields, we cannot set them and will throw this error. 

Note that the first is differentiated from `SOLANA_ERROR__WALLET__NOT_CONNECTED` because we're trying to access a field controlled by the wallet, not perform an operation on the wallet. Its message `Cannot $operation: no wallet connected` doesn't work, and its context does not include `status`.

Also note that these don't specify the field that is being accessed, I think the stacktrace will provide that and it makes these error codes more reusable and less tied to precisely how plugins use them. 
