### PR TITLE
Allow any `IdentifierString` as the `chain` for wallet account signers

### DIFF
--- a/.changeset/pink-pets-buy.md
+++ b/.changeset/pink-pets-buy.md
@@ -1,0 +1,5 @@
+---
+'@solana/wallet-account-signer': patch
+---
+
+Widen the `chain` parameter on `createSignerFromWalletAccount`, `createTransactionSignerFromWalletAccount`, and `createTransactionSendingSignerFromWalletAccount` from `SolanaChain` to `SolanaChain | (IdentifierString & {})`. The known Solana chain identifiers continue to autocomplete, but any Wallet Standard `${namespace}:${reference}` value is now also accepted, matching the underlying `solana:signTransaction` and `solana:signAndSendTransaction` feature inputs.

--- a/packages/wallet-account-signer/README.md
+++ b/packages/wallet-account-signer/README.md
@@ -21,12 +21,14 @@ pnpm add @solana/wallet-account-signer
 
 ## Chains
 
-Several functions in this package require a `chain` parameter of type `SolanaChain` from `@solana/wallet-standard-chains`. Valid values are:
+Several functions in this package require a `chain` parameter. The known Solana chains from `@solana/wallet-standard-chains` are autocompleted:
 
 - `'solana:mainnet'`
 - `'solana:devnet'`
 - `'solana:testnet'`
 - `'solana:localnet'`
+
+Any other Wallet Standard `IdentifierString` (i.e. any `${namespace}:${reference}` value) is also accepted to support wallets that advertise non-standard chains.
 
 ## Usage
 

--- a/packages/wallet-account-signer/package.json
+++ b/packages/wallet-account-signer/package.json
@@ -83,6 +83,7 @@
         "@solana/transactions": "workspace:*",
         "@solana/wallet-standard-chains": "^1.1.1",
         "@solana/wallet-standard-features": "^1.3.0",
+        "@wallet-standard/base": "^1.1.0",
         "@wallet-standard/errors": "^0.1.1",
         "@wallet-standard/ui": "^1.0.1",
         "@wallet-standard/ui-registry": "^1.0.1"

--- a/packages/wallet-account-signer/src/__typetests__/wallet-account-transaction-sending-signer-typetest.ts
+++ b/packages/wallet-account-signer/src/__typetests__/wallet-account-transaction-sending-signer-typetest.ts
@@ -27,3 +27,8 @@ const mockAccount = {
     createTransactionSendingSignerFromWalletAccount(mockAccount, 'solana:devnet');
     createTransactionSendingSignerFromWalletAccount(mockAccount, 'solana:testnet');
 }
+
+{
+    // [createSendingSignerFromWalletAccount]: It accepts any non-Solana chain identifier.
+    createTransactionSendingSignerFromWalletAccount(mockAccount, 'l2:mainnet');
+}

--- a/packages/wallet-account-signer/src/__typetests__/wallet-account-transaction-signer-typetest.ts
+++ b/packages/wallet-account-signer/src/__typetests__/wallet-account-transaction-signer-typetest.ts
@@ -27,3 +27,8 @@ const mockAccount = {
     createTransactionSignerFromWalletAccount(mockAccount, 'solana:devnet');
     createTransactionSignerFromWalletAccount(mockAccount, 'solana:testnet');
 }
+
+{
+    // [createSignerFromWalletAccount]: It accepts any non-Solana chain identifier.
+    createTransactionSignerFromWalletAccount(mockAccount, 'l2:mainnet');
+}

--- a/packages/wallet-account-signer/src/wallet-account-signer.ts
+++ b/packages/wallet-account-signer/src/wallet-account-signer.ts
@@ -7,6 +7,7 @@ import {
     SolanaSignMessage,
     SolanaSignTransaction,
 } from '@solana/wallet-standard-features';
+import { IdentifierString } from '@wallet-standard/base';
 import {
     WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED,
     WalletStandardError,
@@ -67,7 +68,7 @@ import { createTransactionSignerFromWalletAccount } from './wallet-account-trans
  */
 export function createSignerFromWalletAccount<TWalletAccount extends UiWalletAccount>(
     uiWalletAccount: TWalletAccount,
-    chain: SolanaChain,
+    chain: SolanaChain | (IdentifierString & {}),
 ):
     | TransactionSigner<TWalletAccount['address']>
     | (MessageSigner<TWalletAccount['address']> & TransactionSigner<TWalletAccount['address']>) {

--- a/packages/wallet-account-signer/src/wallet-account-transaction-sending-signer.ts
+++ b/packages/wallet-account-signer/src/wallet-account-transaction-sending-signer.ts
@@ -5,6 +5,7 @@ import { TransactionSendingSigner } from '@solana/signers';
 import { getTransactionEncoder } from '@solana/transactions';
 import { SolanaChain } from '@solana/wallet-standard-chains';
 import { SolanaSignAndSendTransaction, SolanaSignAndSendTransactionFeature } from '@solana/wallet-standard-features';
+import { IdentifierString } from '@wallet-standard/base';
 import {
     WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED,
     WalletStandardError,
@@ -38,7 +39,7 @@ import { getWalletAccountForUiWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } fr
  */
 export function createTransactionSendingSignerFromWalletAccount<TWalletAccount extends UiWalletAccount>(
     uiWalletAccount: TWalletAccount,
-    chain: SolanaChain,
+    chain: SolanaChain | (IdentifierString & {}),
 ): TransactionSendingSigner<TWalletAccount['address']> {
     if (!uiWalletAccount.chains.includes(chain)) {
         throw new WalletStandardError(WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED, {

--- a/packages/wallet-account-signer/src/wallet-account-transaction-signer.ts
+++ b/packages/wallet-account-signer/src/wallet-account-transaction-signer.ts
@@ -13,6 +13,7 @@ import {
 } from '@solana/transactions';
 import { SolanaChain } from '@solana/wallet-standard-chains';
 import { SolanaSignTransaction, SolanaSignTransactionFeature } from '@solana/wallet-standard-features';
+import { IdentifierString } from '@wallet-standard/base';
 import {
     WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED,
     WalletStandardError,
@@ -46,7 +47,7 @@ import { getWalletAccountForUiWalletAccount_DO_NOT_USE_OR_YOU_WILL_BE_FIRED } fr
  */
 export function createTransactionSignerFromWalletAccount<TWalletAccount extends UiWalletAccount>(
     uiWalletAccount: TWalletAccount,
-    chain: SolanaChain,
+    chain: SolanaChain | (IdentifierString & {}),
 ): TransactionModifyingSigner<TWalletAccount['address']> {
     if (!uiWalletAccount.chains.includes(chain)) {
         throw new WalletStandardError(WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -391,7 +391,7 @@ importers:
         version: 2.1.1(browserslist@4.28.2)
       jscodeshift:
         specifier: ^17.3.0
-        version: 17.3.0(@babel/preset-env@7.25.0(@babel/core@7.28.5))
+        version: 17.3.0(@babel/preset-env@7.25.0(@babel/core@7.26.10))
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
@@ -1631,6 +1631,9 @@ importers:
       '@solana/wallet-standard-features':
         specifier: ^1.3.0
         version: 1.3.0
+      '@wallet-standard/base':
+        specifier: ^1.1.0
+        version: 1.1.0
       '@wallet-standard/errors':
         specifier: ^0.1.1
         version: 0.1.1
@@ -9385,13 +9388,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.28.5)':
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.28.5)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.26.10)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.29.0
       semver: 6.3.1
@@ -9399,17 +9402,17 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.28.5)':
+  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
       regexpu-core: 6.4.0
       semver: 6.3.1
     optional: true
 
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.28.5)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       debug: 4.4.3
@@ -9459,6 +9462,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.26.10)':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   '@babel/helper-module-transforms@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -9483,9 +9496,9 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.28.5)':
+  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.6
       '@babel/traverse': 7.29.0
@@ -9502,9 +9515,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.28.5)':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.29.0
@@ -9572,49 +9585,49 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.28.5)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)':
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
     optional: true
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.26.10)':
@@ -9647,20 +9660,26 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.10)':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -9669,9 +9688,9 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -9680,9 +9699,9 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -9781,6 +9800,12 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.26.5
 
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.10)':
+    dependencies:
+      '@babel/core': 7.26.10
+      '@babel/helper-plugin-utils': 7.27.1
+    optional: true
+
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -9811,48 +9836,48 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.5)':
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.28.5)':
+  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.26.10)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-block-scoped-functions@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -9864,88 +9889,88 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.28.5)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.26.10)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/template': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.28.5)':
+  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.28.5)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -9955,18 +9980,18 @@ snapshots:
       '@babel/helper-plugin-utils': 7.26.5
       '@babel/plugin-syntax-flow': 7.26.0(@babel/core@7.26.10)
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
@@ -9974,34 +9999,34 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -10015,19 +10040,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.28.5)':
+  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
@@ -10035,25 +10060,25 @@ snapshots:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.28.5)':
+  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -10062,42 +10087,42 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.26.10)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.26.10)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-object-super@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.28.5)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -10109,18 +10134,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.28.5)':
+  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -10132,73 +10157,73 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.5)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-property-literals@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.28.5)':
+  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-template-literals@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
@@ -10213,117 +10238,117 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.26.10)
       '@babel/helper-plugin-utils': 7.28.6
     optional: true
 
-  '@babel/preset-env@7.25.0(@babel/core@7.28.5)':
+  '@babel/preset-env@7.25.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.5)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.5)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.5)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.5)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.5)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.5)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.28.5)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.28.5)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.28.5)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.28.5)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.28.5)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.28.5)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.28.5)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.28.5)
-      babel-plugin-polyfill-corejs3: 0.10.6(@babel/core@7.28.5)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.28.5)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.26.10)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.26.10)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.26.10)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.26.10)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.26.10)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.26.10)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.26.10)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.26.10)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.26.10)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.26.10)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.26.10)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.26.10)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.26.10)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.26.10)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.26.10)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.10)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.10)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.26.10)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.26.10)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.26.10)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.26.10)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.26.10)
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.26.10)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.26.10)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.26.10)
+      babel-plugin-polyfill-corejs3: 0.10.6(@babel/core@7.26.10)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.26.10)
       core-js-compat: 3.49.0
       semver: 6.3.1
     transitivePeerDependencies:
@@ -10337,9 +10362,9 @@ snapshots:
       '@babel/helper-validator-option': 7.25.9
       '@babel/plugin-transform-flow-strip-types': 7.26.5(@babel/core@7.26.10)
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.5)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.26.10)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.0
       esutils: 2.0.3
@@ -14088,29 +14113,29 @@ snapshots:
     dependencies:
       '@types/babel__core': 7.20.5
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.28.5):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.26.10):
     dependencies:
       '@babel/compat-data': 7.29.0
-      '@babel/core': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.26.10)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  babel-plugin-polyfill-corejs3@0.10.6(@babel/core@7.28.5):
+  babel-plugin-polyfill-corejs3@0.10.6(@babel/core@7.26.10):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.26.10)
       core-js-compat: 3.49.0
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.28.5):
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.26.10):
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.28.5)
+      '@babel/core': 7.26.10
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -16725,7 +16750,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jscodeshift@17.3.0(@babel/preset-env@7.25.0(@babel/core@7.28.5)):
+  jscodeshift@17.3.0(@babel/preset-env@7.25.0(@babel/core@7.26.10)):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/parser': 7.27.0
@@ -16746,7 +16771,7 @@ snapshots:
       tmp: 0.2.5
       write-file-atomic: 5.0.1
     optionalDependencies:
-      '@babel/preset-env': 7.25.0(@babel/core@7.28.5)
+      '@babel/preset-env': 7.25.0(@babel/core@7.26.10)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
#### Summary of Changes

Widen the `chain` parameter on `createSignerFromWalletAccount`, `createTransactionSignerFromWalletAccount`, and `createTransactionSendingSignerFromWalletAccount` from `SolanaChain` to `SolanaChain | (IdentifierString & {})`.

The known Solana chain identifiers continue to autocomplete, but any Wallet Standard `${namespace}:${reference}` value is now also accepted, matching the underlying `solana:signTransaction` and `solana:signAndSendTransaction` feature inputs.

This makes the types more flexible and properly matches wallet-standard. All of wallet-standard, including the solana-specific sign methods, allow chain to be `IdentifierString`. `SolanaChain` is just a convenience union of the known Solana chains. 