### PR TITLE
Add ClientWithSubscribeToPayer/Identity interfaces

### DIFF
--- a/.changeset/itchy-geese-crash.md
+++ b/.changeset/itchy-geese-crash.md
@@ -1,0 +1,6 @@
+---
+'@solana/plugin-interfaces': minor
+'@solana/kit': minor
+---
+
+Add `ClientWithSubscribeToPayer` and `ClientWithSubscribeToIdentity` interfaces. These are a framework-agnostic convention for plugins that mutate `client.payer` / `client.identity` reactively — they install a sibling `subscribeToPayer` / `subscribeToIdentity` function so consumers can observe changes without naming the specific plugin that provides them.

--- a/packages/plugin-interfaces/README.md
+++ b/packages/plugin-interfaces/README.md
@@ -72,6 +72,32 @@ function nftPlugin() {
 }
 ```
 
+### `ClientWithSubscribeToPayer` / `ClientWithSubscribeToIdentity`
+
+Some plugins set `client.payer` or `client.identity` reactively — the connected wallet may change, an account may be swapped, or a signer may be cleared on disconnect. Plugins that participate in this pattern advertise it by installing a sibling `subscribeTo<Capability>` function on the client:
+
+| Type                            | Sibling function      | Advertises that…                       |
+| ------------------------------- | --------------------- | -------------------------------------- |
+| `ClientWithSubscribeToPayer`    | `subscribeToPayer`    | `client.payer` may change over time    |
+| `ClientWithSubscribeToIdentity` | `subscribeToIdentity` | `client.identity` may change over time |
+
+Reactive consumers (framework hooks, stores, effects) can then observe changes without having to know which plugin installed the capability — they duck-type on the subscribe function:
+
+```ts
+import { ClientWithPayer, ClientWithSubscribeToPayer } from '@solana/plugin-interfaces';
+
+function observePayer() {
+    return <T extends ClientWithPayer & ClientWithSubscribeToPayer>(client: T) => {
+        client.subscribeToPayer(() => {
+            console.log('payer is now', client.payer);
+        });
+        return client;
+    };
+}
+```
+
+Plugins that leave the signer fixed for the lifetime of the client do **not** need to install these hooks — there is nothing to subscribe to. The convention is meant for plugins that reassign `client.payer` / `client.identity` as the user connects, switches accounts, or disconnects.
+
 ### `ClientWithAirdrop`
 
 Represents a client that can request SOL airdrops (typically on devnet/testnet). The airdrop succeeds when the promise resolves. Some implementations (e.g., LiteSVM) update balances directly without a transaction, so no signature is returned in those cases.

--- a/packages/plugin-interfaces/src/__typetests__/subscribe-to-typetest.ts
+++ b/packages/plugin-interfaces/src/__typetests__/subscribe-to-typetest.ts
@@ -1,0 +1,45 @@
+import type { ClientWithSubscribeToIdentity, ClientWithSubscribeToPayer, SubscribeToFn } from '../subscribe-to';
+
+// [DESCRIBE] SubscribeToFn.
+{
+    // It takes a listener and returns an unsubscribe function.
+    {
+        const subscribe = null as unknown as SubscribeToFn;
+        const unsubscribe = subscribe(() => {});
+        unsubscribe satisfies () => void;
+    }
+}
+
+// [DESCRIBE] ClientWithSubscribeToPayer.
+{
+    // It exposes a readonly `subscribeToPayer` of type `SubscribeToFn`.
+    {
+        const client = null as unknown as ClientWithSubscribeToPayer;
+        client.subscribeToPayer satisfies SubscribeToFn;
+    }
+
+    // It can be combined with other interfaces via intersection.
+    {
+        type CustomClient = ClientWithSubscribeToPayer & { customMethod(): void };
+        const client = null as unknown as CustomClient;
+        client.subscribeToPayer satisfies SubscribeToFn;
+        client.customMethod satisfies () => void;
+    }
+}
+
+// [DESCRIBE] ClientWithSubscribeToIdentity.
+{
+    // It exposes a readonly `subscribeToIdentity` of type `SubscribeToFn`.
+    {
+        const client = null as unknown as ClientWithSubscribeToIdentity;
+        client.subscribeToIdentity satisfies SubscribeToFn;
+    }
+
+    // It can be combined with other interfaces via intersection.
+    {
+        type CustomClient = ClientWithSubscribeToIdentity & { customMethod(): void };
+        const client = null as unknown as CustomClient;
+        client.subscribeToIdentity satisfies SubscribeToFn;
+        client.customMethod satisfies () => void;
+    }
+}

--- a/packages/plugin-interfaces/src/index.ts
+++ b/packages/plugin-interfaces/src/index.ts
@@ -11,3 +11,4 @@ export * from './get-minimum-balance';
 export * from './identity';
 export * from './payer';
 export * from './rpc';
+export * from './subscribe-to';

--- a/packages/plugin-interfaces/src/subscribe-to.ts
+++ b/packages/plugin-interfaces/src/subscribe-to.ts
@@ -1,0 +1,100 @@
+/**
+ * Convention for advertising that a client capability is reactive.
+ *
+ * A plugin whose capability can change over time (for example, a wallet
+ * plugin whose `client.payer` is reassigned as the user connects, switches
+ * accounts, or disconnects) installs a sibling
+ * `subscribeTo<Capability>(listener): () => void` function alongside the
+ * capability itself. Reactive consumers (framework hooks, stores, effects)
+ * can then observe changes without having to name the specific plugin that
+ * installed the capability — they duck-type on the subscribe hook.
+ *
+ * The listener is invoked whenever the observable value of the capability
+ * may have changed; consumers should re-read the capability to get the
+ * current value. Over-notification is acceptable — consumers that bail on
+ * reference-equal snapshots (such as React's `useSyncExternalStore`) will
+ * filter redundant notifications out for free.
+ *
+ * Plugins whose capability is fixed for the lifetime of the client (e.g. a
+ * static `payer(signer)` plugin) do not need to install this function.
+ * Consumers that care about reactivity should fall back to a no-op subscribe
+ * and read the capability once.
+ *
+ * This module defines the convention for `client.payer` and `client.identity`.
+ * See {@link ClientWithSubscribeToPayer} and {@link ClientWithSubscribeToIdentity}.
+ */
+
+/**
+ * Registers a listener for changes to a reactive client capability. Returns
+ * an unsubscribe function.
+ *
+ * Calling the returned unsubscribe more than once is safe — it must be
+ * idempotent.
+ */
+export type SubscribeToFn = (listener: () => void) => () => void;
+
+/**
+ * Represents a client that advertises `client.payer` as reactive.
+ *
+ * A plugin that can mutate `client.payer` over time installs this sibling
+ * function so that reactive consumers can re-read the capability without
+ * having to know which plugin installed it.
+ *
+ * The listener is invoked whenever the observable value of `client.payer`
+ * may have changed; consumers should re-read `client.payer` to get the
+ * current value.
+ *
+ * @example
+ * ```ts
+ * import { type ClientWithPayer, type ClientWithSubscribeToPayer } from '@solana/plugin-interfaces';
+ *
+ * function observePayer(client: ClientWithPayer & ClientWithSubscribeToPayer) {
+ *     return client.subscribeToPayer(() => {
+ *         console.log('payer is now', client.payer);
+ *     });
+ * }
+ * ```
+ *
+ * @see {@link ClientWithPayer}
+ * @see {@link ClientWithSubscribeToIdentity}
+ */
+export type ClientWithSubscribeToPayer = {
+    /**
+     * Registers a listener to be called whenever `client.payer` may have
+     * changed. Returns an unsubscribe function.
+     */
+    readonly subscribeToPayer: SubscribeToFn;
+};
+
+/**
+ * Represents a client that advertises `client.identity` as reactive.
+ *
+ * A plugin that can mutate `client.identity` over time installs this sibling
+ * function so that reactive consumers can re-read the capability without
+ * having to know which plugin installed it.
+ *
+ * The listener is invoked whenever the observable value of `client.identity`
+ * may have changed; consumers should re-read `client.identity` to get the
+ * current value.
+ *
+ * @example
+ * ```ts
+ * import { type ClientWithIdentity, type ClientWithSubscribeToIdentity } from '@solana/plugin-interfaces';
+ *
+ * function observeIdentity(client: ClientWithIdentity & ClientWithSubscribeToIdentity) {
+ *     return client.subscribeToIdentity(() => {
+ *         console.log('identity is now', client.identity);
+ *     });
+ * }
+ * ```
+ *
+ * @see {@link ClientWithIdentity}
+ * @see {@link ClientWithSubscribeToPayer}
+ */
+export type ClientWithSubscribeToIdentity = {
+    /**
+     * Registers a listener to be called whenever `client.identity` may have
+     * changed. Returns an unsubscribe function.
+     */
+    readonly subscribeToIdentity: SubscribeToFn;
+};


### PR DESCRIPTION
This PR adds new types `ClientWithSubscribeToPayer` and `ClientWithSubscribeToIdentity` in `plugin-interfaces`. These allow a plugin (such as the wallet plugin) to notify subscribers when they modify these fields, without those consumers needing to know which plugin has made them reactive.

It's already the case that `client.payer` can be made dynamic by the wallet plugin, by using a get() function. This retains compatibility with the `payer: TransactionSigner` type. But in order to make this useful for a reactive UI that may for example render based on the current value of `client.payer`, we also need to be able to subscribe to changes.

Reactive consumers can then use `client.subscribeToPayer(() => {})` to receive these notifications.

Alternatives considered:

- Add these types to the wallet plugin only. This would work, but this would need to be duplicated by any other plugin that wants to make these fields reactive. In practice we'd be binding consumers (like a react library) to the wallet plugin's types. I think it makes more sense to define the types as plugin-interfaces and allow consumers to be agnostic to how the fields are made dynamic
- Make payer and identity actually act as a reactive store (with subscribe and getValue functions), this would be a breaking change and annoying for most uses. These types provides the same functionality only to consumers that need to react to changes to these values. This is likely only reactive UI - anything using client.payer already gets the correct updated value

Extracted from https://github.com/anza-xyz/kit-plugins/pull/200, which originally added these types to kit-plugin-signer. 