### PR TITLE
Rename ReactiveStore to ReactiveStreamStore

### DIFF
--- a/.changeset/some-views-pick.md
+++ b/.changeset/some-views-pick.md
@@ -1,0 +1,8 @@
+---
+'@solana/subscribable': minor
+'@solana/rpc-subscriptions-spec': minor
+'@solana/kit': minor
+'@solana/errors': minor
+---
+
+Rename `ReactiveStore<T>` to `ReactiveStreamStore<T>`. The old name remains exported as a deprecated alias and will be removed in a future major release.

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -675,7 +675,7 @@ export const SolanaErrorMessages: Readonly<{
     [SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED]:
         'Wallet account signers do not support signing multiple messages/transactions in a single operation',
     [SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED]:
-        'This `ReactiveStore` does not support retry. Use `createReactiveStoreFromDataPublisherFactory` ' +
+        'This `ReactiveStreamStore` does not support retry. Use `createReactiveStoreFromDataPublisherFactory` ' +
         'to construct a retryable store.',
     [SOLANA_ERROR__SUBTLE_CRYPTO__CANNOT_EXPORT_NON_EXTRACTABLE_KEY]: 'Cannot export a non-extractable key.',
     [SOLANA_ERROR__SUBTLE_CRYPTO__DIGEST_UNIMPLEMENTED]: 'No digest implementation could be found.',

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -713,7 +713,7 @@ export const SolanaErrorMessages: Readonly<{
     [SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED]:
         'Wallet account signers do not support signing multiple messages/transactions in a single operation',
     [SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED]:
-        'This `ReactiveStore` does not support retry. Use `createReactiveStoreFromDataPublisherFactory` ' +
+        'This `ReactiveStreamStore` does not support retry. Use `createReactiveStoreFromDataPublisherFactory` ' +
         'to construct a retryable store.',
     [SOLANA_ERROR__SUBTLE_CRYPTO__CANNOT_EXPORT_NON_EXTRACTABLE_KEY]: 'Cannot export a non-extractable key.',
     [SOLANA_ERROR__SUBTLE_CRYPTO__DIGEST_UNIMPLEMENTED]: 'No digest implementation could be found.',

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -40,7 +40,7 @@ await airdrop({
 
 ### `createReactiveStoreWithInitialValueAndSlotTracking(config)`
 
-Creates a `ReactiveStore` that combines an initial RPC fetch with an ongoing subscription to keep its state up to date. Uses slot-based comparison to ensure only the most recent value is kept, regardless of whether it came from the RPC response or a subscription notification.
+Creates a `ReactiveStreamStore` that combines an initial RPC fetch with an ongoing subscription to keep its state up to date. Uses slot-based comparison to ensure only the most recent value is kept, regardless of whether it came from the RPC response or a subscription notification.
 
 The returned store is compatible with React's `useSyncExternalStore`, Svelte stores, Solid's `from()`, and any other reactive primitive that expects a `{ subscribe, getState }` contract.
 

--- a/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
+++ b/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
@@ -1,7 +1,7 @@
 import type { PendingRpcRequest } from '@solana/rpc';
 import type { PendingRpcSubscriptionsRequest } from '@solana/rpc-subscriptions';
 import type { SolanaRpcResponse } from '@solana/rpc-types';
-import type { ReactiveState, ReactiveStore } from '@solana/subscribable';
+import type { ReactiveState, ReactiveStreamStore } from '@solana/subscribable';
 
 type CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscriptionValue, TItem> = Readonly<{
     /**
@@ -38,7 +38,7 @@ const LOADING_STATE: ReactiveState<never> = Object.freeze({
 });
 
 /**
- * Creates a {@link ReactiveStore} that combines an initial RPC fetch with an ongoing subscription
+ * Creates a {@link ReactiveStreamStore} that combines an initial RPC fetch with an ongoing subscription
  * to keep its state up to date.
  *
  * The store uses slot-based comparison to ensure that only the most recent value is kept,
@@ -53,7 +53,7 @@ const LOADING_STATE: ReactiveState<never> = Object.freeze({
  *   {@link SolanaRpcResponse} containing the value and the slot context at which it was observed.
  * - On error from either source, the store transitions to `status: 'error'` preserving the last
  *   known value. Only the first error per connection window is captured.
- * - Calling {@link ReactiveStore.retry | `retry()`} while in `status: 'error'` re-sends the RPC
+ * - Calling {@link ReactiveStreamStore.retry | `retry()`} while in `status: 'error'` re-sends the RPC
  *   request and re-subscribes to the subscription using a fresh inner abort signal. The store
  *   transitions through `status: 'retrying'` back to `loaded`/`error`.
  * - Triggering the caller's abort signal disconnects the store permanently; subsequent `retry()`
@@ -93,7 +93,7 @@ const LOADING_STATE: ReactiveState<never> = Object.freeze({
  * });
  * ```
  *
- * @see {@link ReactiveStore}
+ * @see {@link ReactiveStreamStore}
  */
 export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TSubscriptionValue, TItem>({
     abortSignal,
@@ -101,7 +101,7 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
     rpcValueMapper,
     rpcSubscriptionRequest,
     rpcSubscriptionValueMapper,
-}: CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscriptionValue, TItem>): ReactiveStore<
+}: CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscriptionValue, TItem>): ReactiveStreamStore<
     SolanaRpcResponse<TItem>
 > {
     let currentState: ReactiveState<SolanaRpcResponse<TItem>> = LOADING_STATE;

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions-request.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions-request.ts
@@ -1,4 +1,4 @@
-import { ReactiveStore } from '@solana/subscribable';
+import { ReactiveStreamStore } from '@solana/subscribable';
 
 /**
  * Pending subscriptions are the result of calling a supported method on a {@link RpcSubscriptions}
@@ -10,13 +10,13 @@ import { ReactiveStore } from '@solana/subscribable';
  * trigger the subscription and return a promise for an async iterable that vends `TNotifications`.
  *
  * Calling the {@link PendingRpcSubscriptionsRequest.reactiveStore | `reactiveStore(options)`}
- * method will return a {@link ReactiveStore} compatible with `useSyncExternalStore`, Svelte stores,
- * and other reactive primitives.
+ * method will return a {@link ReactiveStreamStore} compatible with `useSyncExternalStore`, Svelte
+ * stores, and other reactive primitives.
  */
 export type PendingRpcSubscriptionsRequest<TNotification> = {
     /**
-     * Triggers the subscription and returns a promise for a {@link ReactiveStore} that holds the
-     * latest notification. Compatible with `useSyncExternalStore` and other reactive primitives
+     * Triggers the subscription and returns a promise for a {@link ReactiveStreamStore} that holds
+     * the latest notification. Compatible with `useSyncExternalStore` and other reactive primitives
      * that expect a `{ subscribe, getState }` contract.
      *
      * @example
@@ -31,15 +31,15 @@ export type PendingRpcSubscriptionsRequest<TNotification> = {
      *
      * @deprecated Use {@link PendingRpcSubscriptionsRequest.reactiveStore | `reactiveStore()`}
      * instead. The synchronous variant returns a store that reconnects on
-     * {@link ReactiveStore.retry | `retry()`} after an error, whereas the store returned by
+     * {@link ReactiveStreamStore.retry | `retry()`} after an error, whereas the store returned by
      * `reactive()` cannot recover once its underlying `DataPublisher` has failed.
      */
-    reactive(options: RpcSubscribeOptions): Promise<ReactiveStore<TNotification>>;
+    reactive(options: RpcSubscribeOptions): Promise<ReactiveStreamStore<TNotification>>;
     /**
-     * Synchronously returns a {@link ReactiveStore} that subscribes in the background and holds the
-     * latest notification. Compatible with `useSyncExternalStore` and other reactive primitives
-     * that expect a `{ subscribe, getUnifiedState }` contract. The store opens a fresh subscription
-     * on construction and on every {@link ReactiveStore.retry | `retry()`}.
+     * Synchronously returns a {@link ReactiveStreamStore} that subscribes in the background and
+     * holds the latest notification. Compatible with `useSyncExternalStore` and other reactive
+     * primitives that expect a `{ subscribe, getUnifiedState }` contract. The store opens a fresh
+     * subscription on construction and on every {@link ReactiveStreamStore.retry | `retry()`}.
      *
      * @example
      * ```ts
@@ -51,7 +51,7 @@ export type PendingRpcSubscriptionsRequest<TNotification> = {
      * return <View data={state.data} />;
      * ```
      */
-    reactiveStore(options: RpcSubscribeOptions): ReactiveStore<TNotification>;
+    reactiveStore(options: RpcSubscribeOptions): ReactiveStreamStore<TNotification>;
     /**
      * Triggers the subscription and returns a promise for an async iterable of notifications.
      * Use `for await...of` to consume notifications as they arrive. Abort the signal to

--- a/packages/subscribable/README.md
+++ b/packages/subscribable/README.md
@@ -27,7 +27,7 @@ dataPublisher.on('error', e => {
 }); // OK.
 ```
 
-### `ReactiveStore<T>`
+### `ReactiveStreamStore<T>`
 
 This type represents a reactive store that holds the latest value published to a data channel. It exposes a `{ getUnifiedState, retry, subscribe }` contract compatible with `useSyncExternalStore`, Svelte stores, and other reactive primitives.
 
@@ -41,8 +41,10 @@ type ReactiveState<T> =
     | { data: T | undefined; error: undefined; status: 'retrying' };
 ```
 
+> Also exported as `ReactiveStore<T>` for backwards compatibility. That alias is deprecated and will be removed in a future major release.
+
 ```ts
-const store: ReactiveStore<AccountInfo> = /* ... */;
+const store: ReactiveStreamStore<AccountInfo> = /* ... */;
 
 // React — snapshot identity is stable between updates, so it can be passed directly.
 const state = useSyncExternalStore(store.subscribe, store.getUnifiedState);
@@ -59,7 +61,7 @@ store.subscribe(() => {
 
 `retry()` re-opens the stream after an error. When the underlying store supports restart (see [`createReactiveStoreFromDataPublisherFactory`](#createreactivestorefromdatapublisherfactory-abortsignal-createdatapublisher-datachannelname-errorchannelname-)), the store transitions to `status: 'retrying'` and reconnects. Stores that cannot be restarted throw a `SolanaError` with code `SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED` instead.
 
-The individual `getState()` and `getError()` getters on `ReactiveStore<T>` are `@deprecated` &mdash; prefer `getUnifiedState()`, which exposes the same information with a stable snapshot identity and `status` discriminator.
+The individual `getState()` and `getError()` getters on `ReactiveStreamStore<T>` are `@deprecated` &mdash; prefer `getUnifiedState()`, which exposes the same information with a stable snapshot identity and `status` discriminator.
 
 ### `TypedEventEmitter<TEventMap>`
 
@@ -119,7 +121,7 @@ Things to note:
 
 > **Deprecated.** Prefer [`createReactiveStoreFromDataPublisherFactory`](#createreactivestorefromdatapublisherfactory-abortsignal-createdatapublisher-datachannelname-errorchannelname-) &mdash; it supports `retry()`. Because this function accepts a ready-made `DataPublisher` rather than a factory, it cannot restart the underlying source, and calling `retry()` on the returned store throws a `SolanaError` with code `SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED`.
 
-Returns a `ReactiveStore` given a data publisher. The store holds the most recent message published to `dataChannelName` and notifies subscribers on each update. When a message is published to `errorChannelName`, the store transitions to `status: 'error'` preserving the last known value. Triggering the abort signal disconnects the store from the data publisher.
+Returns a `ReactiveStreamStore` given a data publisher. The store holds the most recent message published to `dataChannelName` and notifies subscribers on each update. When a message is published to `errorChannelName`, the store transitions to `status: 'error'` preserving the last known value. Triggering the abort signal disconnects the store from the data publisher.
 
 ```ts
 const store = createReactiveStoreFromDataPublisher({
@@ -141,7 +143,7 @@ Things to note:
 
 ### `createReactiveStoreFromDataPublisherFactory({ abortSignal, createDataPublisher, dataChannelName, errorChannelName })`
 
-Returns a `ReactiveStore` that wires itself to a fresh `DataPublisher` on construction and on every `retry()`. Unlike `createReactiveStoreFromDataPublisher`, this variant accepts an async factory so the store can tear down a broken stream and open a new one without losing subscribers or the last known value.
+Returns a `ReactiveStreamStore` that wires itself to a fresh `DataPublisher` on construction and on every `retry()`. Unlike `createReactiveStoreFromDataPublisher`, this variant accepts an async factory so the store can tear down a broken stream and open a new one without losing subscribers or the last known value.
 
 ```ts
 const store = createReactiveStoreFromDataPublisherFactory({

--- a/packages/subscribable/src/__tests__/reactive-stream-store-test.ts
+++ b/packages/subscribable/src/__tests__/reactive-stream-store-test.ts
@@ -1,7 +1,10 @@
 import { SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED, SolanaError } from '@solana/errors';
 
 import { DataPublisher } from '../data-publisher';
-import { createReactiveStoreFromDataPublisher, createReactiveStoreFromDataPublisherFactory } from '../reactive-store';
+import {
+    createReactiveStoreFromDataPublisher,
+    createReactiveStoreFromDataPublisherFactory,
+} from '../reactive-stream-store';
 
 jest.useFakeTimers();
 

--- a/packages/subscribable/src/index.ts
+++ b/packages/subscribable/src/index.ts
@@ -10,4 +10,4 @@ export * from './async-iterable';
 export * from './data-publisher';
 export * from './demultiplex';
 export * from './event-emitter';
-export * from './reactive-store';
+export * from './reactive-stream-store';

--- a/packages/subscribable/src/reactive-stream-store.ts
+++ b/packages/subscribable/src/reactive-stream-store.ts
@@ -28,13 +28,13 @@ type Config = Readonly<{
 type FactoryConfig = Readonly<{
     /**
      * Triggering this abort signal will cause the store to stop updating and will disconnect it from
-     * any active {@link DataPublisher}. Subsequent calls to {@link ReactiveStore.retry | `retry()`}
+     * any active {@link DataPublisher}. Subsequent calls to {@link ReactiveStreamStore.retry | `retry()`}
      * are no-ops once this signal has fired.
      */
     abortSignal: AbortSignal;
     /**
      * An async factory that produces a fresh {@link DataPublisher} each time it is invoked. Called
-     * once on construction and again on every {@link ReactiveStore.retry | `retry()`}. Rejections
+     * once on construction and again on every {@link ReactiveStreamStore.retry | `retry()`}. Rejections
      * surface as a store error.
      */
     createDataPublisher: () => Promise<DataPublisher>;
@@ -51,13 +51,13 @@ type FactoryConfig = Readonly<{
 }>;
 
 /**
- * The lifecycle state of a {@link ReactiveStore} as a single snapshot.
+ * The lifecycle state of a {@link ReactiveStreamStore} as a single snapshot.
  *
  * - `loading`: the store is waiting for its first value. `data` is `undefined`.
  * - `loaded`: a value has been received and no error is active. `data` is defined.
  * - `error`: the stream failed. `data` is the last known value (or `undefined` if no value ever
  *   arrived), and `error` holds the failure.
- * - `retrying`: a {@link ReactiveStore.retry | `retry()`} is in progress after a previous error.
+ * - `retrying`: a {@link ReactiveStreamStore.retry | `retry()`} is in progress after a previous error.
  *   `error` is cleared; `data` is preserved from before the failure if present.
  */
 export type ReactiveState<T> =
@@ -89,11 +89,11 @@ const LOADING_STATE: ReactiveState<never> = Object.freeze({
  *
  * @see {@link createReactiveStoreFromDataPublisherFactory}
  */
-export type ReactiveStore<T> = {
+export type ReactiveStreamStore<T> = {
     /**
      * Returns the error published to the error channel, or `undefined` if no error has occurred.
      *
-     * @deprecated Use {@link ReactiveStore.getUnifiedState | `getUnifiedState()`} instead. This
+     * @deprecated Use {@link ReactiveStreamStore.getUnifiedState | `getUnifiedState()`} instead. This
      * getter returns only the error field and cannot narrow the relationship between the current
      * value, error, and status.
      */
@@ -102,7 +102,7 @@ export type ReactiveStore<T> = {
      * Returns the most recent value published to the data channel, or `undefined` if no
      * notification has arrived yet. On error, continues to return the last known value.
      *
-     * @deprecated Use {@link ReactiveStore.getUnifiedState | `getUnifiedState()`} instead. This
+     * @deprecated Use {@link ReactiveStreamStore.getUnifiedState | `getUnifiedState()`} instead. This
      * getter returns only the value field and does not surface lifecycle status (e.g. `retrying`).
      */
     getState(): T | undefined;
@@ -126,7 +126,13 @@ export type ReactiveStore<T> = {
 };
 
 /**
- * Returns a {@link ReactiveStore} given a data publisher.
+ * @deprecated Use {@link ReactiveStreamStore} instead. This alias will be removed in a future
+ * major release.
+ */
+export type ReactiveStore<T> = ReactiveStreamStore<T>;
+
+/**
+ * Returns a {@link ReactiveStreamStore} given a data publisher.
  *
  * The store will update its state with each message published to `dataChannelName` and notify all
  * subscribers. When a message is published to `errorChannelName`, subscribers are notified so they
@@ -139,7 +145,7 @@ export type ReactiveStore<T> = {
  * - On error, `getUnifiedState().data` continues to return the last known value and `error` holds
  *   the failure. Only the first error is captured.
  * - The function returned by `subscribe` is idempotent — calling it multiple times is safe.
- * - Because a `DataPublisher` instance cannot be restarted, {@link ReactiveStore.retry | `retry()`}
+ * - Because a `DataPublisher` instance cannot be restarted, {@link ReactiveStreamStore.retry | `retry()`}
  *   on the returned store throws a
  *   {@link SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED | `SolanaError`}.
  *
@@ -147,14 +153,14 @@ export type ReactiveStore<T> = {
  *
  * @deprecated Use {@link createReactiveStoreFromDataPublisherFactory} instead. That variant accepts
  * a factory function for the underlying {@link DataPublisher} and can therefore support
- * {@link ReactiveStore.retry | `retry()`}.
+ * {@link ReactiveStreamStore.retry | `retry()`}.
  */
 export function createReactiveStoreFromDataPublisher<TData>({
     abortSignal,
     dataChannelName,
     dataPublisher,
     errorChannelName,
-}: Config): ReactiveStore<TData> {
+}: Config): ReactiveStreamStore<TData> {
     let currentState: ReactiveState<TData> = LOADING_STATE;
     const subscribers = new Set<() => void>();
 
@@ -207,8 +213,8 @@ export function createReactiveStoreFromDataPublisher<TData>({
 }
 
 /**
- * Returns a {@link ReactiveStore} that wires itself to a fresh {@link DataPublisher} on
- * construction and on every {@link ReactiveStore.retry | `retry()`}.
+ * Returns a {@link ReactiveStreamStore} that wires itself to a fresh {@link DataPublisher} on
+ * construction and on every {@link ReactiveStreamStore.retry | `retry()`}.
  *
  * Unlike {@link createReactiveStoreFromDataPublisher}, this variant accepts a `createDataPublisher`
  * factory rather than a ready-made publisher. That lets the store tear down a broken stream and
@@ -251,7 +257,7 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
     createDataPublisher,
     dataChannelName,
     errorChannelName,
-}: FactoryConfig): ReactiveStore<TData> {
+}: FactoryConfig): ReactiveStreamStore<TData> {
     let currentState: ReactiveState<TData> = LOADING_STATE;
     const subscribers = new Set<() => void>();
 


### PR DESCRIPTION
#### See discussion: https://github.com/anza-xyz/kit/pull/1550#issuecomment-4290107357

We decided to rename `ReactiveStore` to `ReactiveStreamStore`, to make space for an orthogonal `ReactiveActionStore`. 