### PR TITLE
Bump TypeScript minimum version to 5.4

### DIFF
--- a/.changeset/thin-tigers-wish.md
+++ b/.changeset/thin-tigers-wish.md
@@ -1,0 +1,50 @@
+---
+'@solana/accounts': minor
+'@solana/addresses': minor
+'@solana/assertions': minor
+'@solana/codecs-core': minor
+'@solana/codecs-data-structures': minor
+'@solana/codecs-numbers': minor
+'@solana/codecs-strings': minor
+'@solana/codecs': minor
+'@solana/compat': minor
+'@solana/errors': minor
+'@solana/fast-stable-stringify': minor
+'@solana/fixed-points': minor
+'@solana/functional': minor
+'@solana/instruction-plans': minor
+'@solana/instructions': minor
+'@solana/keys': minor
+'@solana/kit': minor
+'@solana/nominal-types': minor
+'@solana/offchain-messages': minor
+'@solana/options': minor
+'@solana/plugin-core': minor
+'@solana/plugin-interfaces': minor
+'@solana/program-client-core': minor
+'@solana/programs': minor
+'@solana/promises': minor
+'@solana/rpc-api': minor
+'@solana/rpc-graphql': minor
+'@solana/rpc-parsed-types': minor
+'@solana/rpc-spec-types': minor
+'@solana/rpc-spec': minor
+'@solana/rpc-subscriptions-api': minor
+'@solana/rpc-subscriptions-channel-websocket': minor
+'@solana/rpc-subscriptions-spec': minor
+'@solana/rpc-subscriptions': minor
+'@solana/rpc-transformers': minor
+'@solana/rpc-transport-http': minor
+'@solana/rpc-types': minor
+'@solana/rpc': minor
+'@solana/signers': minor
+'@solana/subscribable': minor
+'@solana/sysvars': minor
+'@solana/transaction-confirmation': minor
+'@solana/transaction-messages': minor
+'@solana/transactions': minor
+'@solana/wallet-account-signer': minor
+'@solana/webcrypto-ed25519-polyfill': minor
+---
+
+Bump the TypeScript peer dependency floor from `>=5.0.0` to `>=5.4.0`.

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -82,7 +82,7 @@
         "@solana/rpc-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/addresses/package.json
+++ b/packages/addresses/package.json
@@ -81,7 +81,7 @@
         "@solana/nominal-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/assertions/package.json
+++ b/packages/assertions/package.json
@@ -77,7 +77,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/codecs-core/package.json
+++ b/packages/codecs-core/package.json
@@ -81,7 +81,7 @@
         "tinybench": "^6.0.0"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/codecs-data-structures/package.json
+++ b/packages/codecs-data-structures/package.json
@@ -82,7 +82,7 @@
         "@solana/codecs-strings": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/codecs-numbers/package.json
+++ b/packages/codecs-numbers/package.json
@@ -78,7 +78,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/codecs-strings/package.json
+++ b/packages/codecs-strings/package.json
@@ -85,7 +85,7 @@
     },
     "peerDependencies": {
         "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "fastestsmallesttextencoderdecoder": {

--- a/packages/codecs/package.json
+++ b/packages/codecs/package.json
@@ -80,7 +80,7 @@
         "@solana/options": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/compat/package.json
+++ b/packages/compat/package.json
@@ -85,7 +85,7 @@
         "@solana/web3.js": "^1"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -79,7 +79,7 @@
         "commander": "14.0.3"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/fast-stable-stringify/package.json
+++ b/packages/fast-stable-stringify/package.json
@@ -79,7 +79,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/fixed-points/package.json
+++ b/packages/fixed-points/package.json
@@ -77,7 +77,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/functional/package.json
+++ b/packages/functional/package.json
@@ -74,7 +74,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/instruction-plans/package.json
+++ b/packages/instruction-plans/package.json
@@ -87,7 +87,7 @@
         "@solana/functional": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/instructions/package.json
+++ b/packages/instructions/package.json
@@ -81,7 +81,7 @@
         "@solana/addresses": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/keys/package.json
+++ b/packages/keys/package.json
@@ -83,7 +83,7 @@
         "@solana/promises": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -128,7 +128,7 @@
         "@solana/transactions": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/nominal-types/package.json
+++ b/packages/nominal-types/package.json
@@ -40,7 +40,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/offchain-messages/package.json
+++ b/packages/offchain-messages/package.json
@@ -84,7 +84,7 @@
         "@solana/nominal-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/options/package.json
+++ b/packages/options/package.json
@@ -81,7 +81,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/plugin-core/package.json
+++ b/packages/plugin-core/package.json
@@ -74,7 +74,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/plugin-interfaces/package.json
+++ b/packages/plugin-interfaces/package.json
@@ -49,7 +49,7 @@
         "@solana/signers": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/program-client-core/package.json
+++ b/packages/program-client-core/package.json
@@ -89,7 +89,7 @@
         "@solana/codecs-numbers": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/programs/package.json
+++ b/packages/programs/package.json
@@ -82,7 +82,7 @@
         "@solana/transaction-messages": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/promises/package.json
+++ b/packages/promises/package.json
@@ -74,7 +74,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-api/package.json
+++ b/packages/rpc-api/package.json
@@ -91,7 +91,7 @@
         "@solana/rpc-transport-http": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-graphql/package.json
+++ b/packages/rpc-graphql/package.json
@@ -87,7 +87,7 @@
         "@solana/transactions": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-parsed-types/package.json
+++ b/packages/rpc-parsed-types/package.json
@@ -76,7 +76,7 @@
         "@solana/rpc-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-spec-types/package.json
+++ b/packages/rpc-spec-types/package.json
@@ -74,7 +74,7 @@
         "maintained node versions"
     ],
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-spec/package.json
+++ b/packages/rpc-spec/package.json
@@ -78,7 +78,7 @@
         "@solana/rpc-spec-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-subscriptions-api/package.json
+++ b/packages/rpc-subscriptions-api/package.json
@@ -86,7 +86,7 @@
         "@solana/rpc-subscriptions-channel-websocket": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-subscriptions-channel-websocket/package.json
+++ b/packages/rpc-subscriptions-channel-websocket/package.json
@@ -86,7 +86,7 @@
         "jest-websocket-mock": "^2.5.0"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-subscriptions-spec/package.json
+++ b/packages/rpc-subscriptions-spec/package.json
@@ -83,7 +83,7 @@
         "@solana/event-target-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -91,7 +91,7 @@
         "@solana/event-target-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-transformers/package.json
+++ b/packages/rpc-transformers/package.json
@@ -81,7 +81,7 @@
         "@solana/rpc-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-transport-http/package.json
+++ b/packages/rpc-transport-http/package.json
@@ -86,7 +86,7 @@
         "zx": "^8.8.5"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -82,7 +82,7 @@
         "@solana/nominal-types": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -88,7 +88,7 @@
         "@solana/event-target-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -89,7 +89,7 @@
         "@solana/text-encoding-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/subscribable/package.json
+++ b/packages/subscribable/package.json
@@ -80,7 +80,7 @@
         "@solana/event-target-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/sysvars/package.json
+++ b/packages/sysvars/package.json
@@ -89,7 +89,7 @@
         "@solana/rpc-transport-http": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/transaction-confirmation/package.json
+++ b/packages/transaction-confirmation/package.json
@@ -90,7 +90,7 @@
         "@solana/instructions": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/transaction-messages/package.json
+++ b/packages/transaction-messages/package.json
@@ -88,7 +88,7 @@
         "@solana/codecs-strings": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -88,7 +88,7 @@
         "@solana/transaction-messages": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/wallet-account-signer/package.json
+++ b/packages/wallet-account-signer/package.json
@@ -92,7 +92,7 @@
         "@solana/errors": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/packages/webcrypto-ed25519-polyfill/package.json
+++ b/packages/webcrypto-ed25519-polyfill/package.json
@@ -77,7 +77,7 @@
         "@solana/crypto-impl": "workspace:*"
     },
     "peerDependencies": {
-        "typescript": ">=5.0.0"
+        "typescript": ">=5.4.0"
     },
     "peerDependenciesMeta": {
         "typescript": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,7 +339,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/addresses:
@@ -360,7 +360,7 @@ importers:
         specifier: workspace:*
         version: link:../nominal-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/assertions:
@@ -369,7 +369,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/build-scripts:
@@ -426,7 +426,7 @@ importers:
         specifier: workspace:*
         version: link:../options
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/codecs-core:
@@ -435,7 +435,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       tinybench:
@@ -454,7 +454,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/codecs-strings':
@@ -470,7 +470,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/codecs-strings:
@@ -488,7 +488,7 @@ importers:
         specifier: ^1.0.22
         version: 1.0.22
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/text-encoding-impl':
@@ -519,7 +519,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/web3.js':
@@ -537,7 +537,7 @@ importers:
         specifier: 14.0.3
         version: 14.0.3
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/eslint-config:
@@ -582,7 +582,7 @@ importers:
   packages/fast-stable-stringify:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@types/json-stable-stringify':
@@ -607,7 +607,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/fs-impl:
@@ -619,7 +619,7 @@ importers:
   packages/functional:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/instruction-plans:
@@ -643,7 +643,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -665,7 +665,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -693,7 +693,7 @@ importers:
         specifier: workspace:*
         version: link:../promises
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/fs-impl':
@@ -781,13 +781,13 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/nominal-types:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/offchain-messages:
@@ -817,7 +817,7 @@ importers:
         specifier: workspace:*
         version: link:../nominal-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/options:
@@ -838,13 +838,13 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/plugin-core:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/plugin-interfaces:
@@ -871,7 +871,7 @@ importers:
         specifier: workspace:*
         version: link:../signers
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/program-client-core:
@@ -904,7 +904,7 @@ importers:
         specifier: workspace:*
         version: link:../signers
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/codecs-data-structures':
@@ -923,7 +923,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/functional':
@@ -936,7 +936,7 @@ importers:
   packages/promises:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/react:
@@ -1042,7 +1042,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
@@ -1085,7 +1085,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/rpc-spec-types':
@@ -1113,7 +1113,7 @@ importers:
         specifier: ^16.13.2
         version: 16.13.2
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -1135,7 +1135,7 @@ importers:
   packages/rpc-parsed-types:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -1154,13 +1154,13 @@ importers:
         specifier: workspace:*
         version: link:../rpc-spec-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/rpc-spec-types:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/rpc-subscriptions:
@@ -1199,7 +1199,7 @@ importers:
         specifier: workspace:*
         version: link:../subscribable
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -1233,7 +1233,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/rpc-subscriptions-channel-websocket':
@@ -1255,7 +1255,7 @@ importers:
         specifier: workspace:*
         version: link:../subscribable
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
       ws:
         specifier: ^8.19.0
@@ -1286,7 +1286,7 @@ importers:
         specifier: workspace:*
         version: link:../subscribable
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
@@ -1311,7 +1311,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/rpc-transport-http:
@@ -1326,7 +1326,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-spec-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
       undici-types:
         specifier: ^8.0.0
@@ -1363,7 +1363,7 @@ importers:
         specifier: workspace:*
         version: link:../nominal-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/signers:
@@ -1396,7 +1396,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/rpc-types':
@@ -1412,7 +1412,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
@@ -1440,7 +1440,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -1520,7 +1520,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/codecs-core':
@@ -1563,7 +1563,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/codecs-strings':
@@ -1609,7 +1609,7 @@ importers:
         specifier: workspace:*
         version: link:../transaction-messages
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/tsconfig: {}
@@ -1656,7 +1656,7 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/errors':
@@ -1669,7 +1669,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/crypto-impl':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,7 +339,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/addresses:
@@ -360,7 +360,7 @@ importers:
         specifier: workspace:*
         version: link:../nominal-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/assertions:
@@ -369,7 +369,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/build-scripts:
@@ -426,7 +426,7 @@ importers:
         specifier: workspace:*
         version: link:../options
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/codecs-core:
@@ -435,7 +435,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       tinybench:
@@ -454,7 +454,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/codecs-strings':
@@ -470,7 +470,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/codecs-strings:
@@ -488,7 +488,7 @@ importers:
         specifier: ^1.0.22
         version: 1.0.22
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/text-encoding-impl':
@@ -519,7 +519,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/web3.js':
@@ -537,7 +537,7 @@ importers:
         specifier: 14.0.3
         version: 14.0.3
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/eslint-config:
@@ -582,7 +582,7 @@ importers:
   packages/fast-stable-stringify:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@types/json-stable-stringify':
@@ -607,7 +607,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/fs-impl:
@@ -619,7 +619,7 @@ importers:
   packages/functional:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/instruction-plans:
@@ -643,7 +643,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -665,7 +665,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -693,7 +693,7 @@ importers:
         specifier: workspace:*
         version: link:../promises
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/fs-impl':
@@ -781,13 +781,13 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/nominal-types:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/offchain-messages:
@@ -817,7 +817,7 @@ importers:
         specifier: workspace:*
         version: link:../nominal-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/options:
@@ -838,13 +838,13 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/plugin-core:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/plugin-interfaces:
@@ -871,7 +871,7 @@ importers:
         specifier: workspace:*
         version: link:../signers
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/program-client-core:
@@ -904,7 +904,7 @@ importers:
         specifier: workspace:*
         version: link:../signers
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/codecs-data-structures':
@@ -923,7 +923,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/functional':
@@ -936,7 +936,7 @@ importers:
   packages/promises:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/react:
@@ -1042,7 +1042,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
@@ -1085,7 +1085,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/rpc-spec-types':
@@ -1113,7 +1113,7 @@ importers:
         specifier: ^16.13.2
         version: 16.13.2
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -1135,7 +1135,7 @@ importers:
   packages/rpc-parsed-types:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -1154,13 +1154,13 @@ importers:
         specifier: workspace:*
         version: link:../rpc-spec-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/rpc-spec-types:
     dependencies:
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/rpc-subscriptions:
@@ -1199,7 +1199,7 @@ importers:
         specifier: workspace:*
         version: link:../subscribable
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -1233,7 +1233,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/rpc-subscriptions-channel-websocket':
@@ -1255,7 +1255,7 @@ importers:
         specifier: workspace:*
         version: link:../subscribable
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
       ws:
         specifier: ^8.19.0
@@ -1286,7 +1286,7 @@ importers:
         specifier: workspace:*
         version: link:../subscribable
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
@@ -1311,7 +1311,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/rpc-transport-http:
@@ -1326,7 +1326,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-spec-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
       undici-types:
         specifier: ^8.2.0
@@ -1363,7 +1363,7 @@ importers:
         specifier: workspace:*
         version: link:../nominal-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/signers:
@@ -1396,7 +1396,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/rpc-types':
@@ -1412,7 +1412,7 @@ importers:
         specifier: workspace:*
         version: link:../errors
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/event-target-impl':
@@ -1440,7 +1440,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/addresses':
@@ -1520,7 +1520,7 @@ importers:
         specifier: workspace:*
         version: link:../transactions
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/codecs-core':
@@ -1563,7 +1563,7 @@ importers:
         specifier: workspace:*
         version: link:../rpc-types
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/codecs-strings':
@@ -1609,7 +1609,7 @@ importers:
         specifier: workspace:*
         version: link:../transaction-messages
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
 
   packages/tsconfig: {}
@@ -1656,7 +1656,7 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/errors':
@@ -1669,7 +1669,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       typescript:
-        specifier: '>=5.0.0'
+        specifier: '>=5.4.0'
         version: 5.9.3
     devDependencies:
       '@solana/crypto-impl':


### PR DESCRIPTION
Bumps the declared TypeScript peer dependency floor from `>=5.0.0` to `>=5.4.0` across all 46 publishable packages. TypeScript 5.4 was released in March 2024 and introduces the `NoInfer` utility type, which Kit starts relying on in `@solana/fixed-points`. Consumers still on TypeScript 5.0–5.3 will see an optional peer dependency warning at install time.