### PR TITLE
Add fixed-point arithmetic

### DIFF
--- a/packages/fixed-points/src/__tests__/binary-arithmetics-test.ts
+++ b/packages/fixed-points/src/__tests__/binary-arithmetics-test.ts
@@ -1,0 +1,347 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import {
+    SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW,
+    SOLANA_ERROR__FIXED_POINTS__DIVISION_BY_ZERO,
+    SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH,
+    SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS,
+    SolanaError,
+} from '@solana/errors';
+
+import {
+    absoluteBinaryFixedPoint,
+    addBinaryFixedPoint,
+    binaryFixedPoint,
+    divideBinaryFixedPoint,
+    multiplyBinaryFixedPoint,
+    negateBinaryFixedPoint,
+    rawBinaryFixedPoint,
+    subtractBinaryFixedPoint,
+} from '../binary';
+
+describe('addBinaryFixedPoint', () => {
+    it('adds two values of the same shape', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(addBinaryFixedPoint(q1_15('0.25'), q1_15('0.5')).raw).toBe(2n ** 13n + 2n ** 14n);
+    });
+
+    it('returns a frozen value', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(addBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBeFrozenObject();
+    });
+
+    it('throws SHAPE_MISMATCH when the operands have different shapes', () => {
+        const q1_15 = rawBinaryFixedPoint('signed', 16, 15);
+        const q8_8 = rawBinaryFixedPoint('signed', 16, 8);
+        expect(() =>
+            // @ts-expect-error Operands must share the same shape.
+            addBinaryFixedPoint(q1_15(1n), q8_8(1n)),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'binaryFixedPoint',
+                actualScale: 8,
+                actualScaleLabel: 'fractional bits',
+                actualSignedness: 'signed',
+                actualTotalBits: 16,
+                expectedKind: 'binaryFixedPoint',
+                expectedScale: 15,
+                expectedScaleLabel: 'fractional bits',
+                expectedSignedness: 'signed',
+                expectedTotalBits: 16,
+                operation: 'addBinaryFixedPoint',
+            }),
+        );
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when the sum exceeds the upper bound', () => {
+        const factory = rawBinaryFixedPoint('signed', 8, 0);
+        expect(() => addBinaryFixedPoint(factory(100n), factory(50n))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'binaryFixedPoint',
+                max: 127n,
+                min: -128n,
+                operation: 'add',
+                result: 150n,
+                signedness: 'signed',
+                totalBits: 8,
+            }),
+        );
+    });
+});
+
+describe('subtractBinaryFixedPoint', () => {
+    it('subtracts two values of the same shape', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(subtractBinaryFixedPoint(q1_15('0.75'), q1_15('0.5')).raw).toBe(2n ** 13n);
+    });
+
+    it('returns a frozen value', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(subtractBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBeFrozenObject();
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when the difference is below the lower bound', () => {
+        const factory = rawBinaryFixedPoint('unsigned', 8, 0);
+        expect(() => subtractBinaryFixedPoint(factory(1n), factory(2n))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'binaryFixedPoint',
+                max: 255n,
+                min: 0n,
+                operation: 'subtract',
+                result: -1n,
+                signedness: 'unsigned',
+                totalBits: 8,
+            }),
+        );
+    });
+});
+
+describe('multiplyBinaryFixedPoint', () => {
+    it('multiplies two values of the same shape', () => {
+        // 0.5 × 0.5 = 0.25 at Q1.15 → raw = 2^13
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(multiplyBinaryFixedPoint(q1_15('0.5'), q1_15('0.5')).raw).toBe(2n ** 13n);
+    });
+
+    it('multiplies by a fixed-point operand with a different totalBits and fractionalBits', () => {
+        // 0.5 (raw 16384 at 15 fractional bits) × 0.25 (raw 4 at 4 fractional bits)
+        // rescales back to 15 fractional bits: (16384 × 4) / 2^4 = 65536 / 16 = 4096 = 2^12.
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        const q4_4 = rawBinaryFixedPoint('signed', 8, 4);
+        expect(multiplyBinaryFixedPoint(q1_15('0.5'), q4_4(4n)).raw).toBe(2n ** 12n);
+    });
+
+    it('multiplies by a bigint scalar', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(multiplyBinaryFixedPoint(q1_15('0.25'), 2n).raw).toBe(2n ** 14n);
+        expect(multiplyBinaryFixedPoint(q1_15('0.25'), -2n).raw).toBe(-(2n ** 14n));
+    });
+
+    it('returns a frozen value', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(multiplyBinaryFixedPoint(q1_15('0.25'), 2n)).toBeFrozenObject();
+    });
+
+    it('throws STRICT_MODE_PRECISION_LOSS under the default rounding when the product is inexact', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        // 1/3 × 1/3 in Q1.15 requires rounding.
+        expect(() => multiplyBinaryFixedPoint(q1_15('0.25'), rawBinaryFixedPoint('signed', 16, 15)(1n))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS, {
+                kind: 'binaryFixedPoint',
+                operation: 'multiply',
+            }),
+        );
+    });
+
+    it('rounds an inexact product when a non-strict rounding mode is supplied', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        const tiny = rawBinaryFixedPoint('signed', 16, 15)(1n);
+        expect(multiplyBinaryFixedPoint(q1_15('0.25'), tiny, 'floor').raw).toBe(0n);
+        expect(multiplyBinaryFixedPoint(q1_15('0.25'), tiny, 'ceil').raw).toBe(1n);
+    });
+
+    it('throws SHAPE_MISMATCH when the fixed-point operand has a different signedness', () => {
+        const signed = binaryFixedPoint('signed', 16, 15);
+        const unsigned = rawBinaryFixedPoint('unsigned', 16, 15);
+        expect(() =>
+            // @ts-expect-error Second operand must share the first operand's signedness.
+            multiplyBinaryFixedPoint(signed('0.25'), unsigned(1n)),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'binaryFixedPoint',
+                actualScale: 15,
+                actualScaleLabel: 'fractional bits',
+                actualSignedness: 'unsigned',
+                actualTotalBits: 16,
+                expectedKind: 'binaryFixedPoint',
+                expectedScale: 15,
+                expectedScaleLabel: 'fractional bits',
+                expectedSignedness: 'signed',
+                expectedTotalBits: 16,
+                operation: 'multiplyBinaryFixedPoint',
+            }),
+        );
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when the product does not fit the target shape', () => {
+        const int8 = rawBinaryFixedPoint('signed', 8, 0);
+        expect(() => multiplyBinaryFixedPoint(int8(100n), 2n)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'binaryFixedPoint',
+                max: 127n,
+                min: -128n,
+                operation: 'multiply',
+                result: 200n,
+                signedness: 'signed',
+                totalBits: 8,
+            }),
+        );
+    });
+});
+
+describe('divideBinaryFixedPoint', () => {
+    it('divides by a fixed-point operand of the same shape', () => {
+        // 0.5 ÷ 0.25 = 2.0; 3 integer bits provide enough headroom for the result.
+        const q3_13 = binaryFixedPoint('signed', 16, 13);
+        expect(divideBinaryFixedPoint(q3_13('0.5'), q3_13('0.25')).raw).toBe(2n ** 14n);
+    });
+
+    it('divides by a fixed-point operand with a different totalBits and fractionalBits', () => {
+        // 0.5 (raw 4096 at 13 fractional bits) ÷ 0.25 (raw 4 at 4 fractional bits)
+        // rescales back to 13 fractional bits: (4096 × 2^4) / 4 = 65536 / 4 = 16384.
+        const q3_13 = binaryFixedPoint('signed', 16, 13);
+        const q4_4 = rawBinaryFixedPoint('signed', 8, 4);
+        expect(divideBinaryFixedPoint(q3_13('0.5'), q4_4(4n)).raw).toBe(2n ** 14n);
+    });
+
+    it('divides by a bigint scalar', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(divideBinaryFixedPoint(q1_15('0.5'), 2n).raw).toBe(2n ** 13n);
+    });
+
+    it('returns a frozen value', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(divideBinaryFixedPoint(q1_15('0.5'), 2n)).toBeFrozenObject();
+    });
+
+    it('throws STRICT_MODE_PRECISION_LOSS under the default rounding when the division is inexact', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(() => divideBinaryFixedPoint(q1_15('0.5'), 3n)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS, {
+                kind: 'binaryFixedPoint',
+                operation: 'divide',
+            }),
+        );
+    });
+
+    it('rounds an inexact division when a non-strict rounding mode is supplied', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        // 16384 / 3 = 5461.33…
+        expect(divideBinaryFixedPoint(q1_15('0.5'), 3n, 'floor').raw).toBe(5461n);
+        expect(divideBinaryFixedPoint(q1_15('0.5'), 3n, 'ceil').raw).toBe(5462n);
+    });
+
+    it('throws DIVISION_BY_ZERO when dividing by a bigint zero', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(() => divideBinaryFixedPoint(q1_15('0.5'), 0n)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__DIVISION_BY_ZERO, {
+                kind: 'binaryFixedPoint',
+                signedness: 'signed',
+                totalBits: 16,
+            }),
+        );
+    });
+
+    it('throws DIVISION_BY_ZERO when dividing by a fixed-point zero', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(() => divideBinaryFixedPoint(q1_15('0.5'), q1_15('0'))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__DIVISION_BY_ZERO, {
+                kind: 'binaryFixedPoint',
+                signedness: 'signed',
+                totalBits: 16,
+            }),
+        );
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when the quotient does not fit the target shape', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(() => divideBinaryFixedPoint(q1_15('0.5'), q1_15('0.25'))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'binaryFixedPoint',
+                max: 32767n,
+                min: -32768n,
+                operation: 'divide',
+                result: 65536n,
+                signedness: 'signed',
+                totalBits: 16,
+            }),
+        );
+    });
+});
+
+describe('negateBinaryFixedPoint', () => {
+    it('negates a signed value', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(negateBinaryFixedPoint(q1_15('0.5')).raw).toBe(-(2n ** 14n));
+        expect(negateBinaryFixedPoint(q1_15('-0.5')).raw).toBe(2n ** 14n);
+    });
+
+    it('returns a frozen value', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(negateBinaryFixedPoint(q1_15('0.5'))).toBeFrozenObject();
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when negating the minimum signed value', () => {
+        const factory = rawBinaryFixedPoint('signed', 8, 0);
+        expect(() => negateBinaryFixedPoint(factory(-128n))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'binaryFixedPoint',
+                max: 127n,
+                min: -128n,
+                operation: 'negate',
+                result: 128n,
+                signedness: 'signed',
+                totalBits: 8,
+            }),
+        );
+    });
+
+    it('throws SHAPE_MISMATCH when called on an unsigned value at runtime', () => {
+        const unsigned = rawBinaryFixedPoint('unsigned', 16, 15)(1n);
+        expect(() =>
+            // @ts-expect-error Only signed values can be negated.
+            negateBinaryFixedPoint(unsigned),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'binaryFixedPoint',
+                actualScale: 15,
+                actualScaleLabel: 'fractional bits',
+                actualSignedness: 'unsigned',
+                actualTotalBits: 16,
+                expectedKind: 'binaryFixedPoint',
+                expectedScale: 15,
+                expectedScaleLabel: 'fractional bits',
+                expectedSignedness: 'signed',
+                expectedTotalBits: 16,
+                operation: 'negateBinaryFixedPoint',
+            }),
+        );
+    });
+});
+
+describe('absoluteBinaryFixedPoint', () => {
+    it('returns the absolute value of a signed negative', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(absoluteBinaryFixedPoint(q1_15('-0.5')).raw).toBe(2n ** 14n);
+    });
+
+    it('returns the signed positive unchanged', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(absoluteBinaryFixedPoint(q1_15('0.5')).raw).toBe(2n ** 14n);
+    });
+
+    it('returns the unsigned input unchanged', () => {
+        const unsigned = binaryFixedPoint('unsigned', 16, 15);
+        expect(absoluteBinaryFixedPoint(unsigned('0.5')).raw).toBe(2n ** 14n);
+    });
+
+    it('returns a frozen value', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(absoluteBinaryFixedPoint(q1_15('-0.5'))).toBeFrozenObject();
+    });
+
+    it('throws ARITHMETIC_OVERFLOW on the minimum signed value', () => {
+        const factory = rawBinaryFixedPoint('signed', 8, 0);
+        expect(() => absoluteBinaryFixedPoint(factory(-128n))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'binaryFixedPoint',
+                max: 127n,
+                min: -128n,
+                operation: 'absolute',
+                result: 128n,
+                signedness: 'signed',
+                totalBits: 8,
+            }),
+        );
+    });
+});

--- a/packages/fixed-points/src/__tests__/decimal-arithmetics-test.ts
+++ b/packages/fixed-points/src/__tests__/decimal-arithmetics-test.ts
@@ -1,0 +1,348 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import {
+    SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW,
+    SOLANA_ERROR__FIXED_POINTS__DIVISION_BY_ZERO,
+    SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH,
+    SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS,
+    SolanaError,
+} from '@solana/errors';
+
+import {
+    absoluteDecimalFixedPoint,
+    addDecimalFixedPoint,
+    decimalFixedPoint,
+    divideDecimalFixedPoint,
+    multiplyDecimalFixedPoint,
+    negateDecimalFixedPoint,
+    rawDecimalFixedPoint,
+    subtractDecimalFixedPoint,
+} from '../decimal';
+
+describe('addDecimalFixedPoint', () => {
+    it('adds two values of the same shape', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(addDecimalFixedPoint(usd('1.50'), usd('2.25')).raw).toBe(375n);
+    });
+
+    it('returns a frozen value', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(addDecimalFixedPoint(usd('1.50'), usd('2.25'))).toBeFrozenObject();
+    });
+
+    it('throws SHAPE_MISMATCH when the operands have different decimals', () => {
+        const usd = rawDecimalFixedPoint('unsigned', 64, 2);
+        const rate = rawDecimalFixedPoint('unsigned', 64, 4);
+        expect(() =>
+            // @ts-expect-error Operands must share the same shape.
+            addDecimalFixedPoint(usd(1n), rate(1n)),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'decimalFixedPoint',
+                actualScale: 4,
+                actualScaleLabel: 'decimals',
+                actualSignedness: 'unsigned',
+                actualTotalBits: 64,
+                expectedKind: 'decimalFixedPoint',
+                expectedScale: 2,
+                expectedScaleLabel: 'decimals',
+                expectedSignedness: 'unsigned',
+                expectedTotalBits: 64,
+                operation: 'addDecimalFixedPoint',
+            }),
+        );
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when the sum exceeds the upper bound', () => {
+        const factory = rawDecimalFixedPoint('unsigned', 8, 0);
+        expect(() => addDecimalFixedPoint(factory(200n), factory(100n))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'decimalFixedPoint',
+                max: 255n,
+                min: 0n,
+                operation: 'add',
+                result: 300n,
+                signedness: 'unsigned',
+                totalBits: 8,
+            }),
+        );
+    });
+});
+
+describe('subtractDecimalFixedPoint', () => {
+    it('subtracts two values of the same shape', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(subtractDecimalFixedPoint(usd('10'), usd('3.5')).raw).toBe(650n);
+    });
+
+    it('returns a frozen value', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(subtractDecimalFixedPoint(usd('10'), usd('3.5'))).toBeFrozenObject();
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when the difference is below the lower bound', () => {
+        const factory = rawDecimalFixedPoint('unsigned', 8, 0);
+        expect(() => subtractDecimalFixedPoint(factory(1n), factory(2n))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'decimalFixedPoint',
+                max: 255n,
+                min: 0n,
+                operation: 'subtract',
+                result: -1n,
+                signedness: 'unsigned',
+                totalBits: 8,
+            }),
+        );
+    });
+});
+
+describe('multiplyDecimalFixedPoint', () => {
+    it('multiplies two values of the same shape', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        // 1.50 × 2.00 = 3.00 → raw 300n
+        expect(multiplyDecimalFixedPoint(usd('1.50'), usd('2.00')).raw).toBe(300n);
+    });
+
+    it('multiplies by a fixed-point operand with a different totalBits and decimals', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        const rate = decimalFixedPoint('unsigned', 32, 4);
+        // 100.00 × 0.0025 = 0.25 → raw 25n at 2 decimals
+        expect(multiplyDecimalFixedPoint(usd('100'), rate('0.0025')).raw).toBe(25n);
+    });
+
+    it('multiplies by a bigint scalar', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(multiplyDecimalFixedPoint(usd('1.50'), 3n).raw).toBe(450n);
+    });
+
+    it('returns a frozen value', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(multiplyDecimalFixedPoint(usd('1.50'), 3n)).toBeFrozenObject();
+    });
+
+    it('throws STRICT_MODE_PRECISION_LOSS under the default rounding when the product is inexact', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        const rate = rawDecimalFixedPoint('unsigned', 64, 4);
+        // 100n × 1n / 10000 = 0.01 at 2 decimals is inexact (0.0001 precision lost).
+        expect(() => multiplyDecimalFixedPoint(usd('1'), rate(1n))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS, {
+                kind: 'decimalFixedPoint',
+                operation: 'multiply',
+            }),
+        );
+    });
+
+    it('rounds an inexact product when a non-strict rounding mode is supplied', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        const rate = rawDecimalFixedPoint('unsigned', 64, 4);
+        // 100n × 1n / 10000 = 0.01, floor → 0
+        expect(multiplyDecimalFixedPoint(usd('1'), rate(1n), 'floor').raw).toBe(0n);
+        expect(multiplyDecimalFixedPoint(usd('1'), rate(1n), 'ceil').raw).toBe(1n);
+    });
+
+    it('throws SHAPE_MISMATCH when the fixed-point operand has a different signedness', () => {
+        const signed = decimalFixedPoint('signed', 64, 2);
+        const unsigned = rawDecimalFixedPoint('unsigned', 64, 2);
+        expect(() =>
+            // @ts-expect-error Second operand must share the first operand's signedness.
+            multiplyDecimalFixedPoint(signed('1'), unsigned(1n)),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'decimalFixedPoint',
+                actualScale: 2,
+                actualScaleLabel: 'decimals',
+                actualSignedness: 'unsigned',
+                actualTotalBits: 64,
+                expectedKind: 'decimalFixedPoint',
+                expectedScale: 2,
+                expectedScaleLabel: 'decimals',
+                expectedSignedness: 'signed',
+                expectedTotalBits: 64,
+                operation: 'multiplyDecimalFixedPoint',
+            }),
+        );
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when the product does not fit the target shape', () => {
+        const tiny = rawDecimalFixedPoint('unsigned', 8, 0);
+        expect(() => multiplyDecimalFixedPoint(tiny(100n), 3n)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'decimalFixedPoint',
+                max: 255n,
+                min: 0n,
+                operation: 'multiply',
+                result: 300n,
+                signedness: 'unsigned',
+                totalBits: 8,
+            }),
+        );
+    });
+});
+
+describe('divideDecimalFixedPoint', () => {
+    it('divides by a fixed-point operand of the same shape', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        // 10.00 ÷ 5.00 = 2.00 → raw 200n
+        expect(divideDecimalFixedPoint(usd('10'), usd('5')).raw).toBe(200n);
+    });
+
+    it('divides by a fixed-point operand with a different totalBits and decimals', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        const rate = decimalFixedPoint('unsigned', 32, 4);
+        // 10.00 ÷ 0.05 = 200.00 → raw 20000n at 2 decimals
+        expect(divideDecimalFixedPoint(usd('10'), rate('0.05')).raw).toBe(20000n);
+    });
+
+    it('divides by a bigint scalar', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(divideDecimalFixedPoint(usd('10.50'), 3n, 'round').raw).toBe(350n);
+    });
+
+    it('returns a frozen value', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(divideDecimalFixedPoint(usd('10'), 2n)).toBeFrozenObject();
+    });
+
+    it('throws STRICT_MODE_PRECISION_LOSS under the default rounding when the division is inexact', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(() => divideDecimalFixedPoint(usd('10'), 3n)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS, {
+                kind: 'decimalFixedPoint',
+                operation: 'divide',
+            }),
+        );
+    });
+
+    it('rounds an inexact division when a non-strict rounding mode is supplied', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        // 1000 / 3 = 333.33…
+        expect(divideDecimalFixedPoint(usd('10'), 3n, 'floor').raw).toBe(333n);
+        expect(divideDecimalFixedPoint(usd('10'), 3n, 'ceil').raw).toBe(334n);
+        expect(divideDecimalFixedPoint(usd('10'), 3n, 'round').raw).toBe(333n);
+    });
+
+    it('throws DIVISION_BY_ZERO when dividing by a bigint zero', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(() => divideDecimalFixedPoint(usd('10'), 0n)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__DIVISION_BY_ZERO, {
+                kind: 'decimalFixedPoint',
+                signedness: 'unsigned',
+                totalBits: 64,
+            }),
+        );
+    });
+
+    it('throws DIVISION_BY_ZERO when dividing by a fixed-point zero', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(() => divideDecimalFixedPoint(usd('10'), usd('0'))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__DIVISION_BY_ZERO, {
+                kind: 'decimalFixedPoint',
+                signedness: 'unsigned',
+                totalBits: 64,
+            }),
+        );
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when the quotient does not fit the target shape', () => {
+        const tiny = rawDecimalFixedPoint('unsigned', 8, 0);
+        const rate = decimalFixedPoint('unsigned', 64, 4);
+        expect(() => divideDecimalFixedPoint(tiny(100n), rate('0.1'))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'decimalFixedPoint',
+                max: 255n,
+                min: 0n,
+                operation: 'divide',
+                result: 1000n,
+                signedness: 'unsigned',
+                totalBits: 8,
+            }),
+        );
+    });
+});
+
+describe('negateDecimalFixedPoint', () => {
+    it('negates a signed value', () => {
+        const signed = decimalFixedPoint('signed', 32, 2);
+        expect(negateDecimalFixedPoint(signed('1.5')).raw).toBe(-150n);
+        expect(negateDecimalFixedPoint(signed('-1.5')).raw).toBe(150n);
+    });
+
+    it('returns a frozen value', () => {
+        const signed = decimalFixedPoint('signed', 32, 2);
+        expect(negateDecimalFixedPoint(signed('1.5'))).toBeFrozenObject();
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when negating the minimum signed value', () => {
+        const factory = rawDecimalFixedPoint('signed', 8, 0);
+        expect(() => negateDecimalFixedPoint(factory(-128n))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'decimalFixedPoint',
+                max: 127n,
+                min: -128n,
+                operation: 'negate',
+                result: 128n,
+                signedness: 'signed',
+                totalBits: 8,
+            }),
+        );
+    });
+
+    it('throws SHAPE_MISMATCH when called on an unsigned value at runtime', () => {
+        const unsigned = rawDecimalFixedPoint('unsigned', 64, 6)(1n);
+        expect(() =>
+            // @ts-expect-error Only signed values can be negated.
+            negateDecimalFixedPoint(unsigned),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'decimalFixedPoint',
+                actualScale: 6,
+                actualScaleLabel: 'decimals',
+                actualSignedness: 'unsigned',
+                actualTotalBits: 64,
+                expectedKind: 'decimalFixedPoint',
+                expectedScale: 6,
+                expectedScaleLabel: 'decimals',
+                expectedSignedness: 'signed',
+                expectedTotalBits: 64,
+                operation: 'negateDecimalFixedPoint',
+            }),
+        );
+    });
+});
+
+describe('absoluteDecimalFixedPoint', () => {
+    it('returns the absolute value of a signed negative', () => {
+        const signed = decimalFixedPoint('signed', 32, 2);
+        expect(absoluteDecimalFixedPoint(signed('-1.5')).raw).toBe(150n);
+    });
+
+    it('returns the signed positive unchanged', () => {
+        const signed = decimalFixedPoint('signed', 32, 2);
+        expect(absoluteDecimalFixedPoint(signed('1.5')).raw).toBe(150n);
+    });
+
+    it('returns the unsigned input unchanged', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(absoluteDecimalFixedPoint(usd('1.5')).raw).toBe(150n);
+    });
+
+    it('returns a frozen value', () => {
+        const signed = decimalFixedPoint('signed', 32, 2);
+        expect(absoluteDecimalFixedPoint(signed('-1.5'))).toBeFrozenObject();
+    });
+
+    it('throws ARITHMETIC_OVERFLOW on the minimum signed value', () => {
+        const factory = rawDecimalFixedPoint('signed', 8, 0);
+        expect(() => absoluteDecimalFixedPoint(factory(-128n))).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'decimalFixedPoint',
+                max: 127n,
+                min: -128n,
+                operation: 'absolute',
+                result: 128n,
+                signedness: 'signed',
+                totalBits: 8,
+            }),
+        );
+    });
+});

--- a/packages/fixed-points/src/__typetests__/binary-arithmetics-typetest.ts
+++ b/packages/fixed-points/src/__typetests__/binary-arithmetics-typetest.ts
@@ -1,0 +1,119 @@
+import {
+    absoluteBinaryFixedPoint,
+    addBinaryFixedPoint,
+    type BinaryFixedPoint,
+    divideBinaryFixedPoint,
+    multiplyBinaryFixedPoint,
+    negateBinaryFixedPoint,
+    subtractBinaryFixedPoint,
+} from '../binary';
+
+// [DESCRIBE] addBinaryFixedPoint.
+{
+    // It preserves the full shape of both operands.
+    {
+        const a = {} as BinaryFixedPoint<'signed', 16, 15>;
+        const b = {} as BinaryFixedPoint<'signed', 16, 15>;
+        addBinaryFixedPoint(a, b) satisfies BinaryFixedPoint<'signed', 16, 15>;
+    }
+
+    // It rejects operands whose shapes differ at the type level.
+    {
+        const a = {} as BinaryFixedPoint<'signed', 16, 15>;
+        const b = {} as BinaryFixedPoint<'signed', 16, 8>;
+        // @ts-expect-error Operands must share the same shape.
+        addBinaryFixedPoint(a, b);
+    }
+}
+
+// [DESCRIBE] subtractBinaryFixedPoint.
+{
+    // It preserves the full shape of both operands.
+    {
+        const a = {} as BinaryFixedPoint<'unsigned', 32, 16>;
+        const b = {} as BinaryFixedPoint<'unsigned', 32, 16>;
+        subtractBinaryFixedPoint(a, b) satisfies BinaryFixedPoint<'unsigned', 32, 16>;
+    }
+
+    // It rejects operands whose shapes differ at the type level.
+    {
+        const a = {} as BinaryFixedPoint<'unsigned', 32, 16>;
+        const b = {} as BinaryFixedPoint<'unsigned', 32, 8>;
+        // @ts-expect-error Operands must share the same shape.
+        subtractBinaryFixedPoint(a, b);
+    }
+}
+
+// [DESCRIBE] multiplyBinaryFixedPoint.
+{
+    // It returns the shape of the first operand, regardless of the second.
+    {
+        const a = {} as BinaryFixedPoint<'signed', 16, 15>;
+        const sameShape = {} as BinaryFixedPoint<'signed', 16, 15>;
+        multiplyBinaryFixedPoint(a, sameShape) satisfies BinaryFixedPoint<'signed', 16, 15>;
+    }
+    {
+        const a = {} as BinaryFixedPoint<'signed', 16, 15>;
+        const differentShape = {} as BinaryFixedPoint<'signed', 32, 8>;
+        multiplyBinaryFixedPoint(a, differentShape) satisfies BinaryFixedPoint<'signed', 16, 15>;
+    }
+
+    // It accepts a bigint as the second operand.
+    {
+        const a = {} as BinaryFixedPoint<'signed', 16, 15>;
+        multiplyBinaryFixedPoint(a, 3n) satisfies BinaryFixedPoint<'signed', 16, 15>;
+    }
+
+    // It rejects a plain `number` as the second operand.
+    {
+        const a = {} as BinaryFixedPoint<'signed', 16, 15>;
+        // @ts-expect-error Second operand must be a BinaryFixedPoint or bigint, not a number.
+        multiplyBinaryFixedPoint(a, 3);
+    }
+
+    // It rejects a second operand whose signedness differs.
+    {
+        const a = {} as BinaryFixedPoint<'signed', 16, 15>;
+        const wrongSignedness = {} as BinaryFixedPoint<'unsigned', 16, 15>;
+        // @ts-expect-error Second operand must share the first operand's signedness.
+        multiplyBinaryFixedPoint(a, wrongSignedness);
+    }
+}
+
+// [DESCRIBE] divideBinaryFixedPoint.
+{
+    // It behaves like multiply for the return-type shape and second-operand rules.
+    {
+        const a = {} as BinaryFixedPoint<'signed', 16, 15>;
+        const different = {} as BinaryFixedPoint<'signed', 32, 8>;
+        divideBinaryFixedPoint(a, different) satisfies BinaryFixedPoint<'signed', 16, 15>;
+        divideBinaryFixedPoint(a, 3n) satisfies BinaryFixedPoint<'signed', 16, 15>;
+    }
+}
+
+// [DESCRIBE] negateBinaryFixedPoint.
+{
+    // It accepts a signed operand.
+    {
+        const a = {} as BinaryFixedPoint<'signed', 16, 15>;
+        negateBinaryFixedPoint(a) satisfies BinaryFixedPoint<'signed', 16, 15>;
+    }
+
+    // It rejects an unsigned operand at the type level.
+    {
+        const a = {} as BinaryFixedPoint<'unsigned', 16, 15>;
+        // @ts-expect-error Only signed values can be negated.
+        negateBinaryFixedPoint(a);
+    }
+}
+
+// [DESCRIBE] absoluteBinaryFixedPoint.
+{
+    // It accepts both signednesses and preserves the shape.
+    {
+        const signed = {} as BinaryFixedPoint<'signed', 16, 15>;
+        absoluteBinaryFixedPoint(signed) satisfies BinaryFixedPoint<'signed', 16, 15>;
+        const unsigned = {} as BinaryFixedPoint<'unsigned', 16, 15>;
+        absoluteBinaryFixedPoint(unsigned) satisfies BinaryFixedPoint<'unsigned', 16, 15>;
+    }
+}

--- a/packages/fixed-points/src/__typetests__/decimal-arithmetics-typetest.ts
+++ b/packages/fixed-points/src/__typetests__/decimal-arithmetics-typetest.ts
@@ -1,0 +1,119 @@
+import {
+    absoluteDecimalFixedPoint,
+    addDecimalFixedPoint,
+    type DecimalFixedPoint,
+    divideDecimalFixedPoint,
+    multiplyDecimalFixedPoint,
+    negateDecimalFixedPoint,
+    subtractDecimalFixedPoint,
+} from '../decimal';
+
+// [DESCRIBE] addDecimalFixedPoint.
+{
+    // It preserves the full shape of both operands.
+    {
+        const a = {} as DecimalFixedPoint<'unsigned', 64, 6>;
+        const b = {} as DecimalFixedPoint<'unsigned', 64, 6>;
+        addDecimalFixedPoint(a, b) satisfies DecimalFixedPoint<'unsigned', 64, 6>;
+    }
+
+    // It rejects operands whose shapes differ at the type level.
+    {
+        const a = {} as DecimalFixedPoint<'unsigned', 64, 6>;
+        const b = {} as DecimalFixedPoint<'unsigned', 64, 2>;
+        // @ts-expect-error Operands must share the same shape.
+        addDecimalFixedPoint(a, b);
+    }
+}
+
+// [DESCRIBE] subtractDecimalFixedPoint.
+{
+    // It preserves the full shape of both operands.
+    {
+        const a = {} as DecimalFixedPoint<'signed', 32, 4>;
+        const b = {} as DecimalFixedPoint<'signed', 32, 4>;
+        subtractDecimalFixedPoint(a, b) satisfies DecimalFixedPoint<'signed', 32, 4>;
+    }
+
+    // It rejects operands whose shapes differ at the type level.
+    {
+        const a = {} as DecimalFixedPoint<'signed', 32, 4>;
+        const b = {} as DecimalFixedPoint<'signed', 32, 2>;
+        // @ts-expect-error Operands must share the same shape.
+        subtractDecimalFixedPoint(a, b);
+    }
+}
+
+// [DESCRIBE] multiplyDecimalFixedPoint.
+{
+    // It returns the shape of the first operand, regardless of the second.
+    {
+        const a = {} as DecimalFixedPoint<'unsigned', 64, 2>;
+        const sameShape = {} as DecimalFixedPoint<'unsigned', 64, 2>;
+        multiplyDecimalFixedPoint(a, sameShape) satisfies DecimalFixedPoint<'unsigned', 64, 2>;
+    }
+    {
+        const a = {} as DecimalFixedPoint<'unsigned', 64, 2>;
+        const differentShape = {} as DecimalFixedPoint<'unsigned', 128, 4>;
+        multiplyDecimalFixedPoint(a, differentShape) satisfies DecimalFixedPoint<'unsigned', 64, 2>;
+    }
+
+    // It accepts a bigint as the second operand.
+    {
+        const a = {} as DecimalFixedPoint<'unsigned', 64, 2>;
+        multiplyDecimalFixedPoint(a, 3n) satisfies DecimalFixedPoint<'unsigned', 64, 2>;
+    }
+
+    // It rejects a plain `number` as the second operand.
+    {
+        const a = {} as DecimalFixedPoint<'unsigned', 64, 2>;
+        // @ts-expect-error Second operand must be a DecimalFixedPoint or bigint, not a number.
+        multiplyDecimalFixedPoint(a, 3);
+    }
+
+    // It rejects a second operand whose signedness differs.
+    {
+        const a = {} as DecimalFixedPoint<'signed', 64, 2>;
+        const wrongSignedness = {} as DecimalFixedPoint<'unsigned', 64, 2>;
+        // @ts-expect-error Second operand must share the first operand's signedness.
+        multiplyDecimalFixedPoint(a, wrongSignedness);
+    }
+}
+
+// [DESCRIBE] divideDecimalFixedPoint.
+{
+    // It behaves like multiply for the return-type shape and second-operand rules.
+    {
+        const a = {} as DecimalFixedPoint<'unsigned', 64, 2>;
+        const different = {} as DecimalFixedPoint<'unsigned', 128, 4>;
+        divideDecimalFixedPoint(a, different) satisfies DecimalFixedPoint<'unsigned', 64, 2>;
+        divideDecimalFixedPoint(a, 3n) satisfies DecimalFixedPoint<'unsigned', 64, 2>;
+    }
+}
+
+// [DESCRIBE] negateDecimalFixedPoint.
+{
+    // It accepts a signed operand.
+    {
+        const a = {} as DecimalFixedPoint<'signed', 32, 4>;
+        negateDecimalFixedPoint(a) satisfies DecimalFixedPoint<'signed', 32, 4>;
+    }
+
+    // It rejects an unsigned operand at the type level.
+    {
+        const a = {} as DecimalFixedPoint<'unsigned', 64, 6>;
+        // @ts-expect-error Only signed values can be negated.
+        negateDecimalFixedPoint(a);
+    }
+}
+
+// [DESCRIBE] absoluteDecimalFixedPoint.
+{
+    // It accepts both signednesses and preserves the shape.
+    {
+        const signed = {} as DecimalFixedPoint<'signed', 32, 4>;
+        absoluteDecimalFixedPoint(signed) satisfies DecimalFixedPoint<'signed', 32, 4>;
+        const unsigned = {} as DecimalFixedPoint<'unsigned', 64, 6>;
+        absoluteDecimalFixedPoint(unsigned) satisfies DecimalFixedPoint<'unsigned', 64, 6>;
+    }
+}

--- a/packages/fixed-points/src/assertions.ts
+++ b/packages/fixed-points/src/assertions.ts
@@ -1,4 +1,6 @@
 import {
+    SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW,
+    SOLANA_ERROR__FIXED_POINTS__DIVISION_BY_ZERO,
     SOLANA_ERROR__FIXED_POINTS__FRACTIONAL_BITS_EXCEED_TOTAL_BITS,
     SOLANA_ERROR__FIXED_POINTS__INVALID_DECIMALS,
     SOLANA_ERROR__FIXED_POINTS__INVALID_FRACTIONAL_BITS,
@@ -236,6 +238,56 @@ export function assertRawIsBigint(kind: FixedPointKind, value: unknown): asserts
         throw new SolanaError(SOLANA_ERROR__FIXED_POINTS__MALFORMED_RAW_VALUE, {
             kind,
             raw,
+        });
+    }
+}
+
+/**
+ * Asserts that a bigint `result` produced by an arithmetic operation fits
+ * the range claimed by the given signedness and total bits. Throws
+ * `SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW` otherwise, carrying
+ * the operation name so the error message can identify which op overflowed.
+ *
+ * @internal
+ */
+export function assertNoArithmeticOverflow(
+    kind: FixedPointKind,
+    operation: string,
+    signedness: Signedness,
+    totalBits: number,
+    result: bigint,
+): void {
+    const { max, min } = getRawRange(signedness, totalBits);
+    if (result < min || result > max) {
+        throw new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+            kind,
+            max,
+            min,
+            operation,
+            result,
+            signedness,
+            totalBits,
+        });
+    }
+}
+
+/**
+ * Asserts that a divisor is non-zero. Throws
+ * `SOLANA_ERROR__FIXED_POINTS__DIVISION_BY_ZERO` otherwise.
+ *
+ * @internal
+ */
+export function assertNoDivisionByZero(
+    kind: FixedPointKind,
+    signedness: Signedness,
+    totalBits: number,
+    denominator: bigint,
+): void {
+    if (denominator === 0n) {
+        throw new SolanaError(SOLANA_ERROR__FIXED_POINTS__DIVISION_BY_ZERO, {
+            kind,
+            signedness,
+            totalBits,
         });
     }
 }

--- a/packages/fixed-points/src/binary/arithmetics.ts
+++ b/packages/fixed-points/src/binary/arithmetics.ts
@@ -1,0 +1,209 @@
+import { assertNoArithmeticOverflow, assertNoDivisionByZero, assertShapeMatches, describeShape } from '../assertions';
+import { roundDivision, type RoundingMode } from '../rounding';
+import type { Signedness } from '../signedness';
+import type { BinaryFixedPoint } from './core';
+
+/**
+ * Adds two {@link BinaryFixedPoint} values of the same shape and returns
+ * the result at the same shape.
+ *
+ * Throws `SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH` if the two operands
+ * differ in signedness, total bits, or fractional bits, and
+ * `SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW` if the sum does not
+ * fit the target shape.
+ *
+ * @example
+ * ```ts
+ * const usd = binaryFixedPoint('signed', 32, 16);
+ * addBinaryFixedPoint(usd('1.5'), usd('2.25')); // represents 3.75
+ * ```
+ *
+ * @see {@link subtractBinaryFixedPoint}
+ */
+export function addBinaryFixedPoint<
+    TSignedness extends Signedness,
+    TTotalBits extends number,
+    TFractionalBits extends number,
+>(
+    a: BinaryFixedPoint<TSignedness, TTotalBits, TFractionalBits>,
+    b: NoInfer<BinaryFixedPoint<TSignedness, TTotalBits, TFractionalBits>>,
+): BinaryFixedPoint<TSignedness, TTotalBits, TFractionalBits> {
+    assertShapeMatches('addBinaryFixedPoint', describeShape(b), {
+        kind: a.kind,
+        scale: a.fractionalBits,
+        scaleLabel: 'fractional bits',
+        signedness: a.signedness,
+        totalBits: a.totalBits,
+    });
+    const result = a.raw + b.raw;
+    assertNoArithmeticOverflow(a.kind, 'add', a.signedness, a.totalBits, result);
+    return Object.freeze({ ...a, raw: result });
+}
+
+/**
+ * Subtracts `b` from `a` where both are {@link BinaryFixedPoint} values of
+ * the same shape, and returns the result at the same shape.
+ *
+ * Throws `SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH` if the two operands
+ * differ in shape, and `SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW`
+ * if the difference does not fit the target shape.
+ *
+ * @see {@link addBinaryFixedPoint}
+ */
+export function subtractBinaryFixedPoint<
+    TSignedness extends Signedness,
+    TTotalBits extends number,
+    TFractionalBits extends number,
+>(
+    a: BinaryFixedPoint<TSignedness, TTotalBits, TFractionalBits>,
+    b: NoInfer<BinaryFixedPoint<TSignedness, TTotalBits, TFractionalBits>>,
+): BinaryFixedPoint<TSignedness, TTotalBits, TFractionalBits> {
+    assertShapeMatches('subtractBinaryFixedPoint', describeShape(b), {
+        kind: a.kind,
+        scale: a.fractionalBits,
+        scaleLabel: 'fractional bits',
+        signedness: a.signedness,
+        totalBits: a.totalBits,
+    });
+    const result = a.raw - b.raw;
+    assertNoArithmeticOverflow(a.kind, 'subtract', a.signedness, a.totalBits, result);
+    return Object.freeze({ ...a, raw: result });
+}
+
+/**
+ * Multiplies a {@link BinaryFixedPoint} by a scalar.
+ *
+ * The second operand may be another {@link BinaryFixedPoint} with the same
+ * signedness (any total bits or fractional bits) or a bare `bigint`. The
+ * result always has `a`'s shape.
+ *
+ * Multiplication by a same-kind fixed-point rescales the product back to
+ * `a`'s scale. When that rescaling is not exact, the optional
+ * {@link RoundingMode} is consulted; it defaults to `'strict'` and throws
+ * `SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS` in that case.
+ *
+ * @example
+ * ```ts
+ * const audioSample = binaryFixedPoint('signed', 16, 15);
+ * multiplyBinaryFixedPoint(audioSample('0.6'), audioSample('0.8')); // represents 0.48
+ * multiplyBinaryFixedPoint(audioSample('0.5'), 2n);                 // represents 1.0 (overflows Q1.15)
+ * ```
+ *
+ * @see {@link divideBinaryFixedPoint}
+ */
+export function multiplyBinaryFixedPoint<
+    TSignedness extends Signedness,
+    TTotalBits extends number,
+    TFractionalBits extends number,
+>(
+    a: BinaryFixedPoint<TSignedness, TTotalBits, TFractionalBits>,
+    b: BinaryFixedPoint<NoInfer<TSignedness>, number, number> | bigint,
+    rounding: RoundingMode = 'strict',
+): BinaryFixedPoint<TSignedness, TTotalBits, TFractionalBits> {
+    let result: bigint;
+    if (typeof b === 'bigint') {
+        result = a.raw * b;
+    } else {
+        assertShapeMatches('multiplyBinaryFixedPoint', describeShape(b), {
+            kind: a.kind,
+            scaleLabel: 'fractional bits',
+            signedness: a.signedness,
+        });
+        result = roundDivision(a.kind, 'multiply', a.raw * b.raw, 1n << BigInt(b.fractionalBits), rounding);
+    }
+    assertNoArithmeticOverflow(a.kind, 'multiply', a.signedness, a.totalBits, result);
+    return Object.freeze({ ...a, raw: result });
+}
+
+/**
+ * Divides a {@link BinaryFixedPoint} by a scalar.
+ *
+ * The second operand may be another {@link BinaryFixedPoint} with the same
+ * signedness (any total bits or fractional bits) or a bare `bigint`. The
+ * result always has `a`'s shape.
+ *
+ * The optional {@link RoundingMode} is consulted whenever the division is
+ * inexact; it defaults to `'strict'` and throws
+ * `SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS` in that case.
+ * A zero divisor always throws
+ * `SOLANA_ERROR__FIXED_POINTS__DIVISION_BY_ZERO`.
+ *
+ * @example
+ * ```ts
+ * const q1_15 = binaryFixedPoint('signed', 16, 15);
+ * divideBinaryFixedPoint(q1_15('0.5'), q1_15('0.25')); // represents 2.0 (overflows)
+ * divideBinaryFixedPoint(q1_15('0.5'), 2n);            // represents 0.25
+ * ```
+ *
+ * @see {@link multiplyBinaryFixedPoint}
+ */
+export function divideBinaryFixedPoint<
+    TSignedness extends Signedness,
+    TTotalBits extends number,
+    TFractionalBits extends number,
+>(
+    a: BinaryFixedPoint<TSignedness, TTotalBits, TFractionalBits>,
+    b: BinaryFixedPoint<NoInfer<TSignedness>, number, number> | bigint,
+    rounding: RoundingMode = 'strict',
+): BinaryFixedPoint<TSignedness, TTotalBits, TFractionalBits> {
+    let result: bigint;
+    if (typeof b === 'bigint') {
+        assertNoDivisionByZero(a.kind, a.signedness, a.totalBits, b);
+        result = roundDivision(a.kind, 'divide', a.raw, b, rounding);
+    } else {
+        assertShapeMatches('divideBinaryFixedPoint', describeShape(b), {
+            kind: a.kind,
+            scaleLabel: 'fractional bits',
+            signedness: a.signedness,
+        });
+        assertNoDivisionByZero(a.kind, a.signedness, a.totalBits, b.raw);
+        result = roundDivision(a.kind, 'divide', a.raw * (1n << BigInt(b.fractionalBits)), b.raw, rounding);
+    }
+    assertNoArithmeticOverflow(a.kind, 'divide', a.signedness, a.totalBits, result);
+    return Object.freeze({ ...a, raw: result });
+}
+
+/**
+ * Returns the additive inverse of a signed {@link BinaryFixedPoint}.
+ *
+ * Unsigned values are rejected at the type level; they are also rejected
+ * at runtime with `SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH` in case the
+ * type safety is bypassed. Negating the minimum representable value
+ * overflows and throws `SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW`.
+ *
+ * @see {@link absoluteBinaryFixedPoint}
+ */
+export function negateBinaryFixedPoint<TTotalBits extends number, TFractionalBits extends number>(
+    a: BinaryFixedPoint<'signed', TTotalBits, TFractionalBits>,
+): BinaryFixedPoint<'signed', TTotalBits, TFractionalBits> {
+    assertShapeMatches('negateBinaryFixedPoint', describeShape(a), {
+        kind: a.kind,
+        scaleLabel: 'fractional bits',
+        signedness: 'signed',
+    });
+    const result = -a.raw;
+    assertNoArithmeticOverflow(a.kind, 'negate', a.signedness, a.totalBits, result);
+    return Object.freeze({ ...a, raw: result });
+}
+
+/**
+ * Returns the absolute value of a {@link BinaryFixedPoint}. Unsigned
+ * inputs are returned unchanged.
+ *
+ * Throws `SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW` when taking the
+ * absolute value of the minimum representable signed value, which has no
+ * positive counterpart in two's-complement.
+ *
+ * @see {@link negateBinaryFixedPoint}
+ */
+export function absoluteBinaryFixedPoint<
+    TSignedness extends Signedness,
+    TTotalBits extends number,
+    TFractionalBits extends number,
+>(
+    a: BinaryFixedPoint<TSignedness, TTotalBits, TFractionalBits>,
+): BinaryFixedPoint<TSignedness, TTotalBits, TFractionalBits> {
+    const result = a.raw < 0n ? -a.raw : a.raw;
+    assertNoArithmeticOverflow(a.kind, 'absolute', a.signedness, a.totalBits, result);
+    return Object.freeze({ ...a, raw: result });
+}

--- a/packages/fixed-points/src/binary/index.ts
+++ b/packages/fixed-points/src/binary/index.ts
@@ -1,2 +1,3 @@
+export * from './arithmetics';
 export * from './core';
 export * from './guards';

--- a/packages/fixed-points/src/decimal/arithmetics.ts
+++ b/packages/fixed-points/src/decimal/arithmetics.ts
@@ -1,0 +1,209 @@
+import { assertNoArithmeticOverflow, assertNoDivisionByZero, assertShapeMatches, describeShape } from '../assertions';
+import { roundDivision, type RoundingMode } from '../rounding';
+import type { Signedness } from '../signedness';
+import type { DecimalFixedPoint } from './core';
+
+/**
+ * Adds two {@link DecimalFixedPoint} values of the same shape and returns
+ * the result at the same shape.
+ *
+ * Throws `SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH` if the two operands
+ * differ in signedness, total bits, or decimals, and
+ * `SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW` if the sum does not
+ * fit the target shape.
+ *
+ * @example
+ * ```ts
+ * const usd = decimalFixedPoint('unsigned', 64, 2);
+ * addDecimalFixedPoint(usd('1.50'), usd('2.25')); // represents 3.75
+ * ```
+ *
+ * @see {@link subtractDecimalFixedPoint}
+ */
+export function addDecimalFixedPoint<
+    TSignedness extends Signedness,
+    TTotalBits extends number,
+    TDecimals extends number,
+>(
+    a: DecimalFixedPoint<TSignedness, TTotalBits, TDecimals>,
+    b: NoInfer<DecimalFixedPoint<TSignedness, TTotalBits, TDecimals>>,
+): DecimalFixedPoint<TSignedness, TTotalBits, TDecimals> {
+    assertShapeMatches('addDecimalFixedPoint', describeShape(b), {
+        kind: a.kind,
+        scale: a.decimals,
+        scaleLabel: 'decimals',
+        signedness: a.signedness,
+        totalBits: a.totalBits,
+    });
+    const result = a.raw + b.raw;
+    assertNoArithmeticOverflow(a.kind, 'add', a.signedness, a.totalBits, result);
+    return Object.freeze({ ...a, raw: result });
+}
+
+/**
+ * Subtracts `b` from `a` where both are {@link DecimalFixedPoint} values
+ * of the same shape, and returns the result at the same shape.
+ *
+ * Throws `SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH` if the two operands
+ * differ in shape, and `SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW`
+ * if the difference does not fit the target shape.
+ *
+ * @see {@link addDecimalFixedPoint}
+ */
+export function subtractDecimalFixedPoint<
+    TSignedness extends Signedness,
+    TTotalBits extends number,
+    TDecimals extends number,
+>(
+    a: DecimalFixedPoint<TSignedness, TTotalBits, TDecimals>,
+    b: NoInfer<DecimalFixedPoint<TSignedness, TTotalBits, TDecimals>>,
+): DecimalFixedPoint<TSignedness, TTotalBits, TDecimals> {
+    assertShapeMatches('subtractDecimalFixedPoint', describeShape(b), {
+        kind: a.kind,
+        scale: a.decimals,
+        scaleLabel: 'decimals',
+        signedness: a.signedness,
+        totalBits: a.totalBits,
+    });
+    const result = a.raw - b.raw;
+    assertNoArithmeticOverflow(a.kind, 'subtract', a.signedness, a.totalBits, result);
+    return Object.freeze({ ...a, raw: result });
+}
+
+/**
+ * Multiplies a {@link DecimalFixedPoint} by a scalar.
+ *
+ * The second operand may be another {@link DecimalFixedPoint} with the
+ * same signedness (any total bits or decimals) or a bare `bigint`. The
+ * result always has `a`'s shape.
+ *
+ * Multiplication by a same-kind fixed-point rescales the product back to
+ * `a`'s scale. When that rescaling is not exact, the optional
+ * {@link RoundingMode} is consulted; it defaults to `'strict'` and throws
+ * `SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS` in that case.
+ *
+ * @example
+ * ```ts
+ * const usd = decimalFixedPoint('unsigned', 64, 2);
+ * const rate = decimalFixedPoint('unsigned', 64, 4);
+ * multiplyDecimalFixedPoint(usd('100'), rate('0.0025')); // represents 0.25
+ * multiplyDecimalFixedPoint(usd('1.50'), 3n);             // represents 4.50
+ * ```
+ *
+ * @see {@link divideDecimalFixedPoint}
+ */
+export function multiplyDecimalFixedPoint<
+    TSignedness extends Signedness,
+    TTotalBits extends number,
+    TDecimals extends number,
+>(
+    a: DecimalFixedPoint<TSignedness, TTotalBits, TDecimals>,
+    b: DecimalFixedPoint<NoInfer<TSignedness>, number, number> | bigint,
+    rounding: RoundingMode = 'strict',
+): DecimalFixedPoint<TSignedness, TTotalBits, TDecimals> {
+    let result: bigint;
+    if (typeof b === 'bigint') {
+        result = a.raw * b;
+    } else {
+        assertShapeMatches('multiplyDecimalFixedPoint', describeShape(b), {
+            kind: a.kind,
+            scaleLabel: 'decimals',
+            signedness: a.signedness,
+        });
+        result = roundDivision(a.kind, 'multiply', a.raw * b.raw, 10n ** BigInt(b.decimals), rounding);
+    }
+    assertNoArithmeticOverflow(a.kind, 'multiply', a.signedness, a.totalBits, result);
+    return Object.freeze({ ...a, raw: result });
+}
+
+/**
+ * Divides a {@link DecimalFixedPoint} by a scalar.
+ *
+ * The second operand may be another {@link DecimalFixedPoint} with the
+ * same signedness (any total bits or decimals) or a bare `bigint`. The
+ * result always has `a`'s shape.
+ *
+ * The optional {@link RoundingMode} is consulted whenever the division is
+ * inexact; it defaults to `'strict'` and throws
+ * `SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS` in that case.
+ * A zero divisor always throws
+ * `SOLANA_ERROR__FIXED_POINTS__DIVISION_BY_ZERO`.
+ *
+ * @example
+ * ```ts
+ * const usd = decimalFixedPoint('unsigned', 64, 2);
+ * const rate = decimalFixedPoint('unsigned', 64, 4);
+ * divideDecimalFixedPoint(usd('10'), rate('0.05'));   // represents 200.00
+ * divideDecimalFixedPoint(usd('10.50'), 3n, 'round'); // represents 3.50
+ * ```
+ *
+ * @see {@link multiplyDecimalFixedPoint}
+ */
+export function divideDecimalFixedPoint<
+    TSignedness extends Signedness,
+    TTotalBits extends number,
+    TDecimals extends number,
+>(
+    a: DecimalFixedPoint<TSignedness, TTotalBits, TDecimals>,
+    b: DecimalFixedPoint<NoInfer<TSignedness>, number, number> | bigint,
+    rounding: RoundingMode = 'strict',
+): DecimalFixedPoint<TSignedness, TTotalBits, TDecimals> {
+    let result: bigint;
+    if (typeof b === 'bigint') {
+        assertNoDivisionByZero(a.kind, a.signedness, a.totalBits, b);
+        result = roundDivision(a.kind, 'divide', a.raw, b, rounding);
+    } else {
+        assertShapeMatches('divideDecimalFixedPoint', describeShape(b), {
+            kind: a.kind,
+            scaleLabel: 'decimals',
+            signedness: a.signedness,
+        });
+        assertNoDivisionByZero(a.kind, a.signedness, a.totalBits, b.raw);
+        result = roundDivision(a.kind, 'divide', a.raw * 10n ** BigInt(b.decimals), b.raw, rounding);
+    }
+    assertNoArithmeticOverflow(a.kind, 'divide', a.signedness, a.totalBits, result);
+    return Object.freeze({ ...a, raw: result });
+}
+
+/**
+ * Returns the additive inverse of a signed {@link DecimalFixedPoint}.
+ *
+ * Unsigned values are rejected at the type level; they are also rejected
+ * at runtime with `SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH` in case the
+ * type safety is bypassed. Negating the minimum representable value
+ * overflows and throws `SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW`.
+ *
+ * @see {@link absoluteDecimalFixedPoint}
+ */
+export function negateDecimalFixedPoint<TTotalBits extends number, TDecimals extends number>(
+    a: DecimalFixedPoint<'signed', TTotalBits, TDecimals>,
+): DecimalFixedPoint<'signed', TTotalBits, TDecimals> {
+    assertShapeMatches('negateDecimalFixedPoint', describeShape(a), {
+        kind: a.kind,
+        scaleLabel: 'decimals',
+        signedness: 'signed',
+    });
+    const result = -a.raw;
+    assertNoArithmeticOverflow(a.kind, 'negate', a.signedness, a.totalBits, result);
+    return Object.freeze({ ...a, raw: result });
+}
+
+/**
+ * Returns the absolute value of a {@link DecimalFixedPoint}. Unsigned
+ * inputs are returned unchanged.
+ *
+ * Throws `SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW` when taking the
+ * absolute value of the minimum representable signed value, which has no
+ * positive counterpart in two's-complement.
+ *
+ * @see {@link negateDecimalFixedPoint}
+ */
+export function absoluteDecimalFixedPoint<
+    TSignedness extends Signedness,
+    TTotalBits extends number,
+    TDecimals extends number,
+>(a: DecimalFixedPoint<TSignedness, TTotalBits, TDecimals>): DecimalFixedPoint<TSignedness, TTotalBits, TDecimals> {
+    const result = a.raw < 0n ? -a.raw : a.raw;
+    assertNoArithmeticOverflow(a.kind, 'absolute', a.signedness, a.totalBits, result);
+    return Object.freeze({ ...a, raw: result });
+}

--- a/packages/fixed-points/src/decimal/index.ts
+++ b/packages/fixed-points/src/decimal/index.ts
@@ -1,2 +1,3 @@
+export * from './arithmetics';
 export * from './core';
 export * from './guards';


### PR DESCRIPTION
This PR is part of the stack implementing the fixed-point number types proposed in #1545. It adds the six arithmetic operations for both kinds.

- `add*` / `subtract*` require both operands to share the full shape (signedness, total bits, scale).
- `multiply*` / `divide*` accept a same-signedness fixed-point of any shape or a bare `bigint` as the second operand. The result always takes the first operand's shape. Both default to `'strict'` rounding and accept an optional `RoundingMode`.
- `negate*` only accepts signed values (enforced at the type level and at runtime).
- `absolute*` accepts both signednesses.

```ts
const usd = decimalFixedPoint('unsigned', 64, 2);
const rate = decimalFixedPoint('unsigned', 64, 4);
addDecimalFixedPoint(usd('1.50'), usd('2.25'));      // 3.75
multiplyDecimalFixedPoint(usd('100'), rate('0.0025')); // 0.25
divideDecimalFixedPoint(usd('10.50'), 3n, 'round');   // 3.50
```

All results are range-checked and throw `ARITHMETIC_OVERFLOW` with the operation name in the error context when they don't fit the target shape. Division by zero throws `DIVISION_BY_ZERO`. Shape mismatches throw `SHAPE_MISMATCH`. Inexact operations under `'strict'` throw `STRICT_MODE_PRECISION_LOSS`.

Bigint second operands are especially handy for scalar-by-integer operations like doubling or halving:

```ts
const audioSample = binaryFixedPoint('signed', 16, 15);
multiplyBinaryFixedPoint(audioSample('0.25'), 2n);  // 0.5
divideBinaryFixedPoint(audioSample('0.5'), 2n);     // 0.25
```

Shape-matching is enforced both at compile time (via TypeScript's built-in `NoInfer` utility type, which forces the second operand's shape parameters to match the first operand's exactly) and at runtime (as a defense in case the type safety is bypassed). All returned values are `Object.freeze`-d. The `@solana/fixed-points` README will be written in one pass at the end of this stack.