### PR TITLE
Add fixed-point comparisons

### DIFF
--- a/packages/fixed-points/src/__tests__/binary-comparisons-test.ts
+++ b/packages/fixed-points/src/__tests__/binary-comparisons-test.ts
@@ -1,0 +1,152 @@
+import { SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, SolanaError } from '@solana/errors';
+
+import {
+    binaryFixedPoint,
+    cmpBinaryFixedPoint,
+    eqBinaryFixedPoint,
+    gtBinaryFixedPoint,
+    gteBinaryFixedPoint,
+    ltBinaryFixedPoint,
+    lteBinaryFixedPoint,
+    rawBinaryFixedPoint,
+} from '../binary';
+
+describe('cmpBinaryFixedPoint', () => {
+    it('returns -1 when the first operand is smaller', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(cmpBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBe(-1);
+    });
+
+    it('returns 0 when the two operands are equal', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(cmpBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'))).toBe(0);
+    });
+
+    it('returns 1 when the first operand is greater', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(cmpBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBe(1);
+    });
+
+    it('compares negative and positive signed values correctly', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(cmpBinaryFixedPoint(q1_15('-0.5'), q1_15('0.5'))).toBe(-1);
+        expect(cmpBinaryFixedPoint(q1_15('-0.5'), q1_15('-0.5'))).toBe(0);
+        expect(cmpBinaryFixedPoint(q1_15('-0.25'), q1_15('-0.5'))).toBe(1);
+    });
+
+    it('treats zero as equal to zero', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(cmpBinaryFixedPoint(q1_15('0'), q1_15('0'))).toBe(0);
+    });
+
+    it('allows operands with different signedness', () => {
+        const signed = rawBinaryFixedPoint('signed', 16, 15);
+        const unsigned = rawBinaryFixedPoint('unsigned', 16, 15);
+        expect(cmpBinaryFixedPoint(signed(-1n), unsigned(1n))).toBe(-1);
+        expect(cmpBinaryFixedPoint(signed(1n), unsigned(1n))).toBe(0);
+        expect(cmpBinaryFixedPoint(signed(2n), unsigned(1n))).toBe(1);
+    });
+
+    it('allows operands with different totalBits', () => {
+        const small = rawBinaryFixedPoint('unsigned', 8, 4);
+        const large = rawBinaryFixedPoint('unsigned', 32, 4);
+        expect(cmpBinaryFixedPoint(small(16n), large(16n))).toBe(0);
+        expect(cmpBinaryFixedPoint(small(16n), large(32n))).toBe(-1);
+    });
+
+    it('allows operands with different signedness and totalBits combined', () => {
+        const signed8 = rawBinaryFixedPoint('signed', 8, 0);
+        const unsigned32 = rawBinaryFixedPoint('unsigned', 32, 0);
+        expect(cmpBinaryFixedPoint(signed8(5n), unsigned32(5n))).toBe(0);
+    });
+
+    it('throws SHAPE_MISMATCH when fractionalBits differ', () => {
+        const q1_15 = rawBinaryFixedPoint('signed', 16, 15);
+        const q8_8 = rawBinaryFixedPoint('signed', 16, 8);
+        expect(() =>
+            // @ts-expect-error Operands must share the same fractionalBits.
+            cmpBinaryFixedPoint(q1_15(1n), q8_8(1n)),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'binaryFixedPoint',
+                actualScale: 8,
+                actualScaleLabel: 'fractional bits',
+                actualSignedness: 'signed',
+                actualTotalBits: 16,
+                expectedKind: 'binaryFixedPoint',
+                expectedScale: 15,
+                expectedScaleLabel: 'fractional bits',
+                expectedSignedness: 'signed',
+                expectedTotalBits: 16,
+                operation: 'cmpBinaryFixedPoint',
+            }),
+        );
+    });
+
+    it('throws SHAPE_MISMATCH when the second operand is not a fixed-point value', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(() =>
+            // @ts-expect-error Second operand must be a BinaryFixedPoint.
+            cmpBinaryFixedPoint(q1_15('0.5'), 42),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'unknown',
+                actualScale: 0,
+                actualScaleLabel: 'unknown',
+                actualSignedness: 'unknown',
+                actualTotalBits: 0,
+                expectedKind: 'binaryFixedPoint',
+                expectedScale: 15,
+                expectedScaleLabel: 'fractional bits',
+                expectedSignedness: 'unknown',
+                expectedTotalBits: 0,
+                operation: 'cmpBinaryFixedPoint',
+            }),
+        );
+    });
+});
+
+describe('eqBinaryFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(eqBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBe(false);
+        expect(eqBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'))).toBe(true);
+        expect(eqBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBe(false);
+    });
+});
+
+describe('ltBinaryFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(ltBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBe(true);
+        expect(ltBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'))).toBe(false);
+        expect(ltBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBe(false);
+    });
+});
+
+describe('lteBinaryFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(lteBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBe(true);
+        expect(lteBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'))).toBe(true);
+        expect(lteBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBe(false);
+    });
+});
+
+describe('gtBinaryFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(gtBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBe(false);
+        expect(gtBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'))).toBe(false);
+        expect(gtBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBe(true);
+    });
+});
+
+describe('gteBinaryFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(gteBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBe(false);
+        expect(gteBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'))).toBe(true);
+        expect(gteBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBe(true);
+    });
+});

--- a/packages/fixed-points/src/__tests__/binary-comparisons-test.ts
+++ b/packages/fixed-points/src/__tests__/binary-comparisons-test.ts
@@ -1,0 +1,157 @@
+import { SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, SolanaError } from '@solana/errors';
+
+import {
+    binaryFixedPoint,
+    cmpBinaryFixedPoint,
+    eqBinaryFixedPoint,
+    gtBinaryFixedPoint,
+    gteBinaryFixedPoint,
+    ltBinaryFixedPoint,
+    lteBinaryFixedPoint,
+    rawBinaryFixedPoint,
+} from '../binary';
+
+describe('cmpBinaryFixedPoint', () => {
+    it('returns -1 when the first operand is smaller', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(cmpBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBe(-1);
+    });
+
+    it('returns 0 when the two operands are equal', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(cmpBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'))).toBe(0);
+    });
+
+    it('returns 1 when the first operand is greater', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(cmpBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBe(1);
+    });
+
+    it('compares negative and positive signed values correctly', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(cmpBinaryFixedPoint(q1_15('-0.5'), q1_15('0.5'))).toBe(-1);
+        expect(cmpBinaryFixedPoint(q1_15('-0.5'), q1_15('-0.5'))).toBe(0);
+        expect(cmpBinaryFixedPoint(q1_15('-0.25'), q1_15('-0.5'))).toBe(1);
+    });
+
+    it('treats zero as equal to zero', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(cmpBinaryFixedPoint(q1_15('0'), q1_15('0'))).toBe(0);
+    });
+
+    it('treats minus zero as equal to zero', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(cmpBinaryFixedPoint(q1_15('-0'), q1_15('0'))).toBe(0);
+    });
+
+    it('allows operands with different signedness', () => {
+        const signed = rawBinaryFixedPoint('signed', 16, 15);
+        const unsigned = rawBinaryFixedPoint('unsigned', 16, 15);
+        expect(cmpBinaryFixedPoint(signed(-1n), unsigned(1n))).toBe(-1);
+        expect(cmpBinaryFixedPoint(signed(1n), unsigned(1n))).toBe(0);
+        expect(cmpBinaryFixedPoint(signed(2n), unsigned(1n))).toBe(1);
+    });
+
+    it('allows operands with different totalBits', () => {
+        const small = rawBinaryFixedPoint('unsigned', 8, 4);
+        const large = rawBinaryFixedPoint('unsigned', 32, 4);
+        expect(cmpBinaryFixedPoint(small(16n), large(16n))).toBe(0);
+        expect(cmpBinaryFixedPoint(small(16n), large(32n))).toBe(-1);
+    });
+
+    it('allows operands with different signedness and totalBits combined', () => {
+        const signed8 = rawBinaryFixedPoint('signed', 8, 0);
+        const unsigned32 = rawBinaryFixedPoint('unsigned', 32, 0);
+        expect(cmpBinaryFixedPoint(signed8(5n), unsigned32(5n))).toBe(0);
+    });
+
+    it('throws SHAPE_MISMATCH when fractionalBits differ', () => {
+        const q1_15 = rawBinaryFixedPoint('signed', 16, 15);
+        const q8_8 = rawBinaryFixedPoint('signed', 16, 8);
+        expect(() =>
+            // @ts-expect-error Operands must share the same fractionalBits.
+            cmpBinaryFixedPoint(q1_15(1n), q8_8(1n)),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'binaryFixedPoint',
+                actualScale: 8,
+                actualScaleLabel: 'fractional bits',
+                actualSignedness: 'signed',
+                actualTotalBits: 16,
+                expectedKind: 'binaryFixedPoint',
+                expectedScale: 15,
+                expectedScaleLabel: 'fractional bits',
+                expectedSignedness: 'signed',
+                expectedTotalBits: 16,
+                operation: 'cmpBinaryFixedPoint',
+            }),
+        );
+    });
+
+    it('throws SHAPE_MISMATCH when the second operand is not a fixed-point value', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(() =>
+            // @ts-expect-error Second operand must be a BinaryFixedPoint.
+            cmpBinaryFixedPoint(q1_15('0.5'), 42),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'unknown',
+                actualScale: 0,
+                actualScaleLabel: 'unknown',
+                actualSignedness: 'unknown',
+                actualTotalBits: 0,
+                expectedKind: 'binaryFixedPoint',
+                expectedScale: 15,
+                expectedScaleLabel: 'fractional bits',
+                expectedSignedness: 'unknown',
+                expectedTotalBits: 0,
+                operation: 'cmpBinaryFixedPoint',
+            }),
+        );
+    });
+});
+
+describe('eqBinaryFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(eqBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBe(false);
+        expect(eqBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'))).toBe(true);
+        expect(eqBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBe(false);
+    });
+});
+
+describe('ltBinaryFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(ltBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBe(true);
+        expect(ltBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'))).toBe(false);
+        expect(ltBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBe(false);
+    });
+});
+
+describe('lteBinaryFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(lteBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBe(true);
+        expect(lteBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'))).toBe(true);
+        expect(lteBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBe(false);
+    });
+});
+
+describe('gtBinaryFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(gtBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBe(false);
+        expect(gtBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'))).toBe(false);
+        expect(gtBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBe(true);
+    });
+});
+
+describe('gteBinaryFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const q1_15 = binaryFixedPoint('signed', 16, 15);
+        expect(gteBinaryFixedPoint(q1_15('0.25'), q1_15('0.5'))).toBe(false);
+        expect(gteBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'))).toBe(true);
+        expect(gteBinaryFixedPoint(q1_15('0.75'), q1_15('0.5'))).toBe(true);
+    });
+});

--- a/packages/fixed-points/src/__tests__/decimal-comparisons-test.ts
+++ b/packages/fixed-points/src/__tests__/decimal-comparisons-test.ts
@@ -1,0 +1,152 @@
+import { SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, SolanaError } from '@solana/errors';
+
+import {
+    cmpDecimalFixedPoint,
+    decimalFixedPoint,
+    eqDecimalFixedPoint,
+    gtDecimalFixedPoint,
+    gteDecimalFixedPoint,
+    ltDecimalFixedPoint,
+    lteDecimalFixedPoint,
+    rawDecimalFixedPoint,
+} from '../decimal';
+
+describe('cmpDecimalFixedPoint', () => {
+    it('returns -1 when the first operand is smaller', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(cmpDecimalFixedPoint(usd('1.25'), usd('2.50'))).toBe(-1);
+    });
+
+    it('returns 0 when the two operands are equal', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(cmpDecimalFixedPoint(usd('2.50'), usd('2.50'))).toBe(0);
+    });
+
+    it('returns 1 when the first operand is greater', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(cmpDecimalFixedPoint(usd('3.75'), usd('2.50'))).toBe(1);
+    });
+
+    it('compares negative and positive signed values correctly', () => {
+        const signed = decimalFixedPoint('signed', 64, 2);
+        expect(cmpDecimalFixedPoint(signed('-2.50'), signed('2.50'))).toBe(-1);
+        expect(cmpDecimalFixedPoint(signed('-2.50'), signed('-2.50'))).toBe(0);
+        expect(cmpDecimalFixedPoint(signed('-1.25'), signed('-2.50'))).toBe(1);
+    });
+
+    it('treats zero as equal to zero', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(cmpDecimalFixedPoint(usd('0'), usd('0'))).toBe(0);
+    });
+
+    it('allows operands with different signedness', () => {
+        const signed = rawDecimalFixedPoint('signed', 16, 2);
+        const unsigned = rawDecimalFixedPoint('unsigned', 16, 2);
+        expect(cmpDecimalFixedPoint(signed(-1n), unsigned(1n))).toBe(-1);
+        expect(cmpDecimalFixedPoint(signed(1n), unsigned(1n))).toBe(0);
+        expect(cmpDecimalFixedPoint(signed(2n), unsigned(1n))).toBe(1);
+    });
+
+    it('allows operands with different totalBits', () => {
+        const small = rawDecimalFixedPoint('unsigned', 8, 2);
+        const large = rawDecimalFixedPoint('unsigned', 32, 2);
+        expect(cmpDecimalFixedPoint(small(100n), large(100n))).toBe(0);
+        expect(cmpDecimalFixedPoint(small(100n), large(200n))).toBe(-1);
+    });
+
+    it('allows operands with different signedness and totalBits combined', () => {
+        const signed8 = rawDecimalFixedPoint('signed', 8, 0);
+        const unsigned32 = rawDecimalFixedPoint('unsigned', 32, 0);
+        expect(cmpDecimalFixedPoint(signed8(5n), unsigned32(5n))).toBe(0);
+    });
+
+    it('throws SHAPE_MISMATCH when decimals differ', () => {
+        const twoDecimals = rawDecimalFixedPoint('unsigned', 64, 2);
+        const fourDecimals = rawDecimalFixedPoint('unsigned', 64, 4);
+        expect(() =>
+            // @ts-expect-error Operands must share the same decimals.
+            cmpDecimalFixedPoint(twoDecimals(1n), fourDecimals(1n)),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'decimalFixedPoint',
+                actualScale: 4,
+                actualScaleLabel: 'decimals',
+                actualSignedness: 'unsigned',
+                actualTotalBits: 64,
+                expectedKind: 'decimalFixedPoint',
+                expectedScale: 2,
+                expectedScaleLabel: 'decimals',
+                expectedSignedness: 'unsigned',
+                expectedTotalBits: 64,
+                operation: 'cmpDecimalFixedPoint',
+            }),
+        );
+    });
+
+    it('throws SHAPE_MISMATCH when the second operand is not a fixed-point value', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(() =>
+            // @ts-expect-error Second operand must be a DecimalFixedPoint.
+            cmpDecimalFixedPoint(usd('2.50'), 42),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'unknown',
+                actualScale: 0,
+                actualScaleLabel: 'unknown',
+                actualSignedness: 'unknown',
+                actualTotalBits: 0,
+                expectedKind: 'decimalFixedPoint',
+                expectedScale: 2,
+                expectedScaleLabel: 'decimals',
+                expectedSignedness: 'unknown',
+                expectedTotalBits: 0,
+                operation: 'cmpDecimalFixedPoint',
+            }),
+        );
+    });
+});
+
+describe('eqDecimalFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(eqDecimalFixedPoint(usd('1.25'), usd('2.50'))).toBe(false);
+        expect(eqDecimalFixedPoint(usd('2.50'), usd('2.50'))).toBe(true);
+        expect(eqDecimalFixedPoint(usd('3.75'), usd('2.50'))).toBe(false);
+    });
+});
+
+describe('ltDecimalFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(ltDecimalFixedPoint(usd('1.25'), usd('2.50'))).toBe(true);
+        expect(ltDecimalFixedPoint(usd('2.50'), usd('2.50'))).toBe(false);
+        expect(ltDecimalFixedPoint(usd('3.75'), usd('2.50'))).toBe(false);
+    });
+});
+
+describe('lteDecimalFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(lteDecimalFixedPoint(usd('1.25'), usd('2.50'))).toBe(true);
+        expect(lteDecimalFixedPoint(usd('2.50'), usd('2.50'))).toBe(true);
+        expect(lteDecimalFixedPoint(usd('3.75'), usd('2.50'))).toBe(false);
+    });
+});
+
+describe('gtDecimalFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(gtDecimalFixedPoint(usd('1.25'), usd('2.50'))).toBe(false);
+        expect(gtDecimalFixedPoint(usd('2.50'), usd('2.50'))).toBe(false);
+        expect(gtDecimalFixedPoint(usd('3.75'), usd('2.50'))).toBe(true);
+    });
+});
+
+describe('gteDecimalFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(gteDecimalFixedPoint(usd('1.25'), usd('2.50'))).toBe(false);
+        expect(gteDecimalFixedPoint(usd('2.50'), usd('2.50'))).toBe(true);
+        expect(gteDecimalFixedPoint(usd('3.75'), usd('2.50'))).toBe(true);
+    });
+});

--- a/packages/fixed-points/src/__tests__/decimal-comparisons-test.ts
+++ b/packages/fixed-points/src/__tests__/decimal-comparisons-test.ts
@@ -1,0 +1,157 @@
+import { SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, SolanaError } from '@solana/errors';
+
+import {
+    cmpDecimalFixedPoint,
+    decimalFixedPoint,
+    eqDecimalFixedPoint,
+    gtDecimalFixedPoint,
+    gteDecimalFixedPoint,
+    ltDecimalFixedPoint,
+    lteDecimalFixedPoint,
+    rawDecimalFixedPoint,
+} from '../decimal';
+
+describe('cmpDecimalFixedPoint', () => {
+    it('returns -1 when the first operand is smaller', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(cmpDecimalFixedPoint(usd('1.25'), usd('2.50'))).toBe(-1);
+    });
+
+    it('returns 0 when the two operands are equal', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(cmpDecimalFixedPoint(usd('2.50'), usd('2.50'))).toBe(0);
+    });
+
+    it('returns 1 when the first operand is greater', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(cmpDecimalFixedPoint(usd('3.75'), usd('2.50'))).toBe(1);
+    });
+
+    it('compares negative and positive signed values correctly', () => {
+        const signed = decimalFixedPoint('signed', 64, 2);
+        expect(cmpDecimalFixedPoint(signed('-2.50'), signed('2.50'))).toBe(-1);
+        expect(cmpDecimalFixedPoint(signed('-2.50'), signed('-2.50'))).toBe(0);
+        expect(cmpDecimalFixedPoint(signed('-1.25'), signed('-2.50'))).toBe(1);
+    });
+
+    it('treats zero as equal to zero', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(cmpDecimalFixedPoint(usd('0'), usd('0'))).toBe(0);
+    });
+
+    it('treats minus zero as equal to zero', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(cmpDecimalFixedPoint(usd('-0'), usd('0'))).toBe(0);
+    });
+
+    it('allows operands with different signedness', () => {
+        const signed = rawDecimalFixedPoint('signed', 16, 2);
+        const unsigned = rawDecimalFixedPoint('unsigned', 16, 2);
+        expect(cmpDecimalFixedPoint(signed(-1n), unsigned(1n))).toBe(-1);
+        expect(cmpDecimalFixedPoint(signed(1n), unsigned(1n))).toBe(0);
+        expect(cmpDecimalFixedPoint(signed(2n), unsigned(1n))).toBe(1);
+    });
+
+    it('allows operands with different totalBits', () => {
+        const small = rawDecimalFixedPoint('unsigned', 8, 2);
+        const large = rawDecimalFixedPoint('unsigned', 32, 2);
+        expect(cmpDecimalFixedPoint(small(100n), large(100n))).toBe(0);
+        expect(cmpDecimalFixedPoint(small(100n), large(200n))).toBe(-1);
+    });
+
+    it('allows operands with different signedness and totalBits combined', () => {
+        const signed8 = rawDecimalFixedPoint('signed', 8, 0);
+        const unsigned32 = rawDecimalFixedPoint('unsigned', 32, 0);
+        expect(cmpDecimalFixedPoint(signed8(5n), unsigned32(5n))).toBe(0);
+    });
+
+    it('throws SHAPE_MISMATCH when decimals differ', () => {
+        const twoDecimals = rawDecimalFixedPoint('unsigned', 64, 2);
+        const fourDecimals = rawDecimalFixedPoint('unsigned', 64, 4);
+        expect(() =>
+            // @ts-expect-error Operands must share the same decimals.
+            cmpDecimalFixedPoint(twoDecimals(1n), fourDecimals(1n)),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'decimalFixedPoint',
+                actualScale: 4,
+                actualScaleLabel: 'decimals',
+                actualSignedness: 'unsigned',
+                actualTotalBits: 64,
+                expectedKind: 'decimalFixedPoint',
+                expectedScale: 2,
+                expectedScaleLabel: 'decimals',
+                expectedSignedness: 'unsigned',
+                expectedTotalBits: 64,
+                operation: 'cmpDecimalFixedPoint',
+            }),
+        );
+    });
+
+    it('throws SHAPE_MISMATCH when the second operand is not a fixed-point value', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(() =>
+            // @ts-expect-error Second operand must be a DecimalFixedPoint.
+            cmpDecimalFixedPoint(usd('2.50'), 42),
+        ).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH, {
+                actualKind: 'unknown',
+                actualScale: 0,
+                actualScaleLabel: 'unknown',
+                actualSignedness: 'unknown',
+                actualTotalBits: 0,
+                expectedKind: 'decimalFixedPoint',
+                expectedScale: 2,
+                expectedScaleLabel: 'decimals',
+                expectedSignedness: 'unknown',
+                expectedTotalBits: 0,
+                operation: 'cmpDecimalFixedPoint',
+            }),
+        );
+    });
+});
+
+describe('eqDecimalFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(eqDecimalFixedPoint(usd('1.25'), usd('2.50'))).toBe(false);
+        expect(eqDecimalFixedPoint(usd('2.50'), usd('2.50'))).toBe(true);
+        expect(eqDecimalFixedPoint(usd('3.75'), usd('2.50'))).toBe(false);
+    });
+});
+
+describe('ltDecimalFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(ltDecimalFixedPoint(usd('1.25'), usd('2.50'))).toBe(true);
+        expect(ltDecimalFixedPoint(usd('2.50'), usd('2.50'))).toBe(false);
+        expect(ltDecimalFixedPoint(usd('3.75'), usd('2.50'))).toBe(false);
+    });
+});
+
+describe('lteDecimalFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(lteDecimalFixedPoint(usd('1.25'), usd('2.50'))).toBe(true);
+        expect(lteDecimalFixedPoint(usd('2.50'), usd('2.50'))).toBe(true);
+        expect(lteDecimalFixedPoint(usd('3.75'), usd('2.50'))).toBe(false);
+    });
+});
+
+describe('gtDecimalFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(gtDecimalFixedPoint(usd('1.25'), usd('2.50'))).toBe(false);
+        expect(gtDecimalFixedPoint(usd('2.50'), usd('2.50'))).toBe(false);
+        expect(gtDecimalFixedPoint(usd('3.75'), usd('2.50'))).toBe(true);
+    });
+});
+
+describe('gteDecimalFixedPoint', () => {
+    it('returns the expected boolean for less, equal, and greater', () => {
+        const usd = decimalFixedPoint('unsigned', 64, 2);
+        expect(gteDecimalFixedPoint(usd('1.25'), usd('2.50'))).toBe(false);
+        expect(gteDecimalFixedPoint(usd('2.50'), usd('2.50'))).toBe(true);
+        expect(gteDecimalFixedPoint(usd('3.75'), usd('2.50'))).toBe(true);
+    });
+});

--- a/packages/fixed-points/src/binary/comparisons.ts
+++ b/packages/fixed-points/src/binary/comparisons.ts
@@ -1,0 +1,99 @@
+import { assertShapeMatches, describeShape } from '../assertions';
+import type { Signedness } from '../signedness';
+import type { BinaryFixedPoint } from './core';
+
+/**
+ * Compares two {@link BinaryFixedPoint} values and returns `-1`, `0`, or
+ * `1` depending on whether `a` is less than, equal to, or greater than `b`.
+ *
+ * Only the `kind` and `fractionalBits` of the two operands must match;
+ * `signedness` and `totalBits` are allowed to differ because they are
+ * storage concerns only and do not affect the mathematical value being
+ * compared. Mismatches on the constrained dimensions throw
+ * `SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH`.
+ *
+ * @example
+ * ```ts
+ * const q1_15 = binaryFixedPoint('signed', 16, 15);
+ * cmpBinaryFixedPoint(q1_15('0.25'), q1_15('0.5')); // -1
+ * cmpBinaryFixedPoint(q1_15('0.5'), q1_15('0.5'));  // 0
+ * cmpBinaryFixedPoint(q1_15('0.75'), q1_15('0.5')); // 1
+ * ```
+ *
+ * @see {@link eqBinaryFixedPoint}
+ * @see {@link ltBinaryFixedPoint}
+ * @see {@link lteBinaryFixedPoint}
+ * @see {@link gtBinaryFixedPoint}
+ * @see {@link gteBinaryFixedPoint}
+ */
+export function cmpBinaryFixedPoint<TFractionalBits extends number>(
+    a: BinaryFixedPoint<Signedness, number, TFractionalBits>,
+    b: BinaryFixedPoint<Signedness, number, NoInfer<TFractionalBits>>,
+): -1 | 0 | 1 {
+    assertShapeMatches('cmpBinaryFixedPoint', describeShape(b), {
+        kind: a.kind,
+        scale: a.fractionalBits,
+        scaleLabel: 'fractional bits',
+    });
+    return a.raw < b.raw ? -1 : a.raw > b.raw ? 1 : 0;
+}
+
+/**
+ * Returns `true` when `a` and `b` represent the same value.
+ *
+ * See {@link cmpBinaryFixedPoint} for shape-matching rules.
+ */
+export function eqBinaryFixedPoint<TFractionalBits extends number>(
+    a: BinaryFixedPoint<Signedness, number, TFractionalBits>,
+    b: BinaryFixedPoint<Signedness, number, NoInfer<TFractionalBits>>,
+): boolean {
+    return cmpBinaryFixedPoint(a, b) === 0;
+}
+
+/**
+ * Returns `true` when `a` is strictly less than `b`.
+ *
+ * See {@link cmpBinaryFixedPoint} for shape-matching rules.
+ */
+export function ltBinaryFixedPoint<TFractionalBits extends number>(
+    a: BinaryFixedPoint<Signedness, number, TFractionalBits>,
+    b: BinaryFixedPoint<Signedness, number, NoInfer<TFractionalBits>>,
+): boolean {
+    return cmpBinaryFixedPoint(a, b) < 0;
+}
+
+/**
+ * Returns `true` when `a` is less than or equal to `b`.
+ *
+ * See {@link cmpBinaryFixedPoint} for shape-matching rules.
+ */
+export function lteBinaryFixedPoint<TFractionalBits extends number>(
+    a: BinaryFixedPoint<Signedness, number, TFractionalBits>,
+    b: BinaryFixedPoint<Signedness, number, NoInfer<TFractionalBits>>,
+): boolean {
+    return cmpBinaryFixedPoint(a, b) <= 0;
+}
+
+/**
+ * Returns `true` when `a` is strictly greater than `b`.
+ *
+ * See {@link cmpBinaryFixedPoint} for shape-matching rules.
+ */
+export function gtBinaryFixedPoint<TFractionalBits extends number>(
+    a: BinaryFixedPoint<Signedness, number, TFractionalBits>,
+    b: BinaryFixedPoint<Signedness, number, NoInfer<TFractionalBits>>,
+): boolean {
+    return cmpBinaryFixedPoint(a, b) > 0;
+}
+
+/**
+ * Returns `true` when `a` is greater than or equal to `b`.
+ *
+ * See {@link cmpBinaryFixedPoint} for shape-matching rules.
+ */
+export function gteBinaryFixedPoint<TFractionalBits extends number>(
+    a: BinaryFixedPoint<Signedness, number, TFractionalBits>,
+    b: BinaryFixedPoint<Signedness, number, NoInfer<TFractionalBits>>,
+): boolean {
+    return cmpBinaryFixedPoint(a, b) >= 0;
+}

--- a/packages/fixed-points/src/binary/index.ts
+++ b/packages/fixed-points/src/binary/index.ts
@@ -1,3 +1,4 @@
 export * from './arithmetics';
+export * from './comparisons';
 export * from './core';
 export * from './guards';

--- a/packages/fixed-points/src/decimal/comparisons.ts
+++ b/packages/fixed-points/src/decimal/comparisons.ts
@@ -1,0 +1,99 @@
+import { assertShapeMatches, describeShape } from '../assertions';
+import type { Signedness } from '../signedness';
+import type { DecimalFixedPoint } from './core';
+
+/**
+ * Compares two {@link DecimalFixedPoint} values and returns `-1`, `0`, or
+ * `1` depending on whether `a` is less than, equal to, or greater than `b`.
+ *
+ * Only the `kind` and `decimals` of the two operands must match;
+ * `signedness` and `totalBits` are allowed to differ because they are
+ * storage concerns only and do not affect the mathematical value being
+ * compared. Mismatches on the constrained dimensions throw
+ * `SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH`.
+ *
+ * @example
+ * ```ts
+ * const usd = decimalFixedPoint('unsigned', 64, 2);
+ * cmpDecimalFixedPoint(usd('1.25'), usd('2.50')); // -1
+ * cmpDecimalFixedPoint(usd('2.50'), usd('2.50')); // 0
+ * cmpDecimalFixedPoint(usd('3.75'), usd('2.50')); // 1
+ * ```
+ *
+ * @see {@link eqDecimalFixedPoint}
+ * @see {@link ltDecimalFixedPoint}
+ * @see {@link lteDecimalFixedPoint}
+ * @see {@link gtDecimalFixedPoint}
+ * @see {@link gteDecimalFixedPoint}
+ */
+export function cmpDecimalFixedPoint<TDecimals extends number>(
+    a: DecimalFixedPoint<Signedness, number, TDecimals>,
+    b: DecimalFixedPoint<Signedness, number, NoInfer<TDecimals>>,
+): -1 | 0 | 1 {
+    assertShapeMatches('cmpDecimalFixedPoint', describeShape(b), {
+        kind: a.kind,
+        scale: a.decimals,
+        scaleLabel: 'decimals',
+    });
+    return a.raw < b.raw ? -1 : a.raw > b.raw ? 1 : 0;
+}
+
+/**
+ * Returns `true` when `a` and `b` represent the same value.
+ *
+ * See {@link cmpDecimalFixedPoint} for shape-matching rules.
+ */
+export function eqDecimalFixedPoint<TDecimals extends number>(
+    a: DecimalFixedPoint<Signedness, number, TDecimals>,
+    b: DecimalFixedPoint<Signedness, number, NoInfer<TDecimals>>,
+): boolean {
+    return cmpDecimalFixedPoint(a, b) === 0;
+}
+
+/**
+ * Returns `true` when `a` is strictly less than `b`.
+ *
+ * See {@link cmpDecimalFixedPoint} for shape-matching rules.
+ */
+export function ltDecimalFixedPoint<TDecimals extends number>(
+    a: DecimalFixedPoint<Signedness, number, TDecimals>,
+    b: DecimalFixedPoint<Signedness, number, NoInfer<TDecimals>>,
+): boolean {
+    return cmpDecimalFixedPoint(a, b) < 0;
+}
+
+/**
+ * Returns `true` when `a` is less than or equal to `b`.
+ *
+ * See {@link cmpDecimalFixedPoint} for shape-matching rules.
+ */
+export function lteDecimalFixedPoint<TDecimals extends number>(
+    a: DecimalFixedPoint<Signedness, number, TDecimals>,
+    b: DecimalFixedPoint<Signedness, number, NoInfer<TDecimals>>,
+): boolean {
+    return cmpDecimalFixedPoint(a, b) <= 0;
+}
+
+/**
+ * Returns `true` when `a` is strictly greater than `b`.
+ *
+ * See {@link cmpDecimalFixedPoint} for shape-matching rules.
+ */
+export function gtDecimalFixedPoint<TDecimals extends number>(
+    a: DecimalFixedPoint<Signedness, number, TDecimals>,
+    b: DecimalFixedPoint<Signedness, number, NoInfer<TDecimals>>,
+): boolean {
+    return cmpDecimalFixedPoint(a, b) > 0;
+}
+
+/**
+ * Returns `true` when `a` is greater than or equal to `b`.
+ *
+ * See {@link cmpDecimalFixedPoint} for shape-matching rules.
+ */
+export function gteDecimalFixedPoint<TDecimals extends number>(
+    a: DecimalFixedPoint<Signedness, number, TDecimals>,
+    b: DecimalFixedPoint<Signedness, number, NoInfer<TDecimals>>,
+): boolean {
+    return cmpDecimalFixedPoint(a, b) >= 0;
+}

--- a/packages/fixed-points/src/decimal/index.ts
+++ b/packages/fixed-points/src/decimal/index.ts
@@ -1,3 +1,4 @@
 export * from './arithmetics';
+export * from './comparisons';
 export * from './core';
 export * from './guards';


### PR DESCRIPTION
This PR adds comparison helpers to `@solana/fixed-points`: `cmp`, `eq`, `lt`, `lte`, `gt`, and `gte` variants for both `BinaryFixedPoint` and `DecimalFixedPoint`. The `cmp*` function returns `-1 | 0 | 1` and does the shape assertion; the other five delegate to it and return a boolean.

Comparisons constrain only `kind` and scale (`fractionalBits` for binary, `decimals` for decimal). `signedness` and `totalBits` are allowed to differ because they are storage concerns that do not affect the mathematical value being compared — `u8(5)` and `i32(5)` are the same number. Mismatches on the constrained dimensions throw `SOLANA_ERROR__FIXED_POINTS__SHAPE_MISMATCH`. Compile-time enforcement of the scale dimension uses `NoInfer` on the second operand, matching the pattern already used by `add`/`subtract`/`multiply`/`divide`.