### PR TITLE
Add fixed-point rescaling

### DIFF
--- a/packages/fixed-points/src/__tests__/binary-conversions-test.ts
+++ b/packages/fixed-points/src/__tests__/binary-conversions-test.ts
@@ -1,8 +1,22 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
-import { SOLANA_ERROR__FIXED_POINTS__VALUE_OUT_OF_RANGE, SolanaError } from '@solana/errors';
+import {
+    SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW,
+    SOLANA_ERROR__FIXED_POINTS__FRACTIONAL_BITS_EXCEED_TOTAL_BITS,
+    SOLANA_ERROR__FIXED_POINTS__INVALID_FRACTIONAL_BITS,
+    SOLANA_ERROR__FIXED_POINTS__INVALID_TOTAL_BITS,
+    SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS,
+    SOLANA_ERROR__FIXED_POINTS__VALUE_OUT_OF_RANGE,
+    SolanaError,
+} from '@solana/errors';
 
-import { rawBinaryFixedPoint, toSignedBinaryFixedPoint, toUnsignedBinaryFixedPoint } from '../binary';
+import {
+    binaryFixedPoint,
+    rawBinaryFixedPoint,
+    rescaleBinaryFixedPoint,
+    toSignedBinaryFixedPoint,
+    toUnsignedBinaryFixedPoint,
+} from '../binary';
 
 describe('toUnsignedBinaryFixedPoint', () => {
     it('converts a signed non-negative value to unsigned', () => {
@@ -78,6 +92,128 @@ describe('toSignedBinaryFixedPoint', () => {
                 min: -128n,
                 raw: 200n,
                 signedness: 'signed',
+                totalBits: 8,
+            }),
+        );
+    });
+});
+
+describe('rescaleBinaryFixedPoint', () => {
+    it('returns the same reference when the requested shape matches', () => {
+        const value = binaryFixedPoint('signed', 16, 15)('0.5');
+        expect(rescaleBinaryFixedPoint(value, 16, 15)).toBe(value);
+    });
+
+    it('scales up fractionalBits exactly', () => {
+        // raw 1 at Q?.2 represents 0.25; moving to Q?.4 scales raw to 4.
+        const source = rawBinaryFixedPoint('unsigned', 8, 2)(1n);
+        const rescaled = rescaleBinaryFixedPoint(source, 8, 4);
+        expect(rescaled.raw).toBe(4n);
+        expect(rescaled.fractionalBits).toBe(4);
+        expect(rescaled.totalBits).toBe(8);
+    });
+
+    it('scales down fractionalBits exactly', () => {
+        // raw 16 at Q?.4 represents 1.0; moving to Q?.2 scales raw to 4.
+        const source = rawBinaryFixedPoint('unsigned', 8, 4)(16n);
+        expect(rescaleBinaryFixedPoint(source, 8, 2).raw).toBe(4n);
+    });
+
+    it('widens totalBits while preserving fractionalBits and raw', () => {
+        const source = rawBinaryFixedPoint('unsigned', 8, 4)(10n);
+        const rescaled = rescaleBinaryFixedPoint(source, 16, 4);
+        expect(rescaled.raw).toBe(10n);
+        expect(rescaled.totalBits).toBe(16);
+        expect(rescaled.fractionalBits).toBe(4);
+    });
+
+    it('narrows totalBits when the value fits', () => {
+        const source = rawBinaryFixedPoint('unsigned', 16, 0)(100n);
+        expect(rescaleBinaryFixedPoint(source, 8, 0).raw).toBe(100n);
+    });
+
+    it('preserves signedness', () => {
+        const source = rawBinaryFixedPoint('signed', 8, 0)(-1n);
+        expect(rescaleBinaryFixedPoint(source, 16, 0).signedness).toBe('signed');
+    });
+
+    it('returns a frozen value when the shape changes', () => {
+        const source = rawBinaryFixedPoint('unsigned', 8, 2)(1n);
+        expect(rescaleBinaryFixedPoint(source, 8, 4)).toBeFrozenObject();
+    });
+
+    it('throws STRICT_MODE_PRECISION_LOSS under the default rounding when scale-down is inexact', () => {
+        // raw 1 at Q?.2 represents 0.25; moving to Q?.1 would halve it (0.5 / 0.5 = 0 or 1).
+        const source = rawBinaryFixedPoint('unsigned', 8, 2)(1n);
+        expect(() => rescaleBinaryFixedPoint(source, 8, 1)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS, {
+                kind: 'binaryFixedPoint',
+                operation: 'rescale',
+            }),
+        );
+    });
+
+    it('rounds an inexact scale-down when a non-strict rounding mode is supplied', () => {
+        const source = rawBinaryFixedPoint('unsigned', 8, 2)(1n);
+        expect(rescaleBinaryFixedPoint(source, 8, 1, 'floor').raw).toBe(0n);
+        expect(rescaleBinaryFixedPoint(source, 8, 1, 'ceil').raw).toBe(1n);
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when narrowing totalBits overflows the target range', () => {
+        const source = rawBinaryFixedPoint('unsigned', 16, 0)(300n);
+        expect(() => rescaleBinaryFixedPoint(source, 8, 0)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'binaryFixedPoint',
+                max: 255n,
+                min: 0n,
+                operation: 'rescale',
+                result: 300n,
+                signedness: 'unsigned',
+                totalBits: 8,
+            }),
+        );
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when scaling up fractionalBits overflows the target totalBits', () => {
+        // raw 100 at Q?.0 → scaling up to Q?.4 multiplies by 16 → 1600 which exceeds signed 8-bit max 127.
+        const source = rawBinaryFixedPoint('signed', 8, 0)(100n);
+        expect(() => rescaleBinaryFixedPoint(source, 8, 4)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'binaryFixedPoint',
+                max: 127n,
+                min: -128n,
+                operation: 'rescale',
+                result: 1600n,
+                signedness: 'signed',
+                totalBits: 8,
+            }),
+        );
+    });
+
+    it('throws INVALID_TOTAL_BITS for a non-positive target totalBits', () => {
+        const source = rawBinaryFixedPoint('unsigned', 8, 4)(1n);
+        expect(() => rescaleBinaryFixedPoint(source, 0, 0)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__INVALID_TOTAL_BITS, {
+                kind: 'binaryFixedPoint',
+                totalBits: 0,
+            }),
+        );
+    });
+
+    it('throws INVALID_FRACTIONAL_BITS for a negative target fractionalBits', () => {
+        const source = rawBinaryFixedPoint('unsigned', 8, 4)(1n);
+        expect(() => rescaleBinaryFixedPoint(source, 8, -1)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__INVALID_FRACTIONAL_BITS, {
+                fractionalBits: -1,
+            }),
+        );
+    });
+
+    it('throws FRACTIONAL_BITS_EXCEED_TOTAL_BITS when the target fractionalBits exceeds totalBits', () => {
+        const source = rawBinaryFixedPoint('unsigned', 16, 4)(1n);
+        expect(() => rescaleBinaryFixedPoint(source, 8, 16)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__FRACTIONAL_BITS_EXCEED_TOTAL_BITS, {
+                fractionalBits: 16,
                 totalBits: 8,
             }),
         );

--- a/packages/fixed-points/src/__tests__/decimal-conversions-test.ts
+++ b/packages/fixed-points/src/__tests__/decimal-conversions-test.ts
@@ -1,8 +1,21 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
-import { SOLANA_ERROR__FIXED_POINTS__VALUE_OUT_OF_RANGE, SolanaError } from '@solana/errors';
+import {
+    SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW,
+    SOLANA_ERROR__FIXED_POINTS__INVALID_DECIMALS,
+    SOLANA_ERROR__FIXED_POINTS__INVALID_TOTAL_BITS,
+    SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS,
+    SOLANA_ERROR__FIXED_POINTS__VALUE_OUT_OF_RANGE,
+    SolanaError,
+} from '@solana/errors';
 
-import { rawDecimalFixedPoint, toSignedDecimalFixedPoint, toUnsignedDecimalFixedPoint } from '../decimal';
+import {
+    decimalFixedPoint,
+    rawDecimalFixedPoint,
+    rescaleDecimalFixedPoint,
+    toSignedDecimalFixedPoint,
+    toUnsignedDecimalFixedPoint,
+} from '../decimal';
 
 describe('toUnsignedDecimalFixedPoint', () => {
     it('converts a signed non-negative value to unsigned', () => {
@@ -79,6 +92,126 @@ describe('toSignedDecimalFixedPoint', () => {
                 raw: 200n,
                 signedness: 'signed',
                 totalBits: 8,
+            }),
+        );
+    });
+});
+
+describe('rescaleDecimalFixedPoint', () => {
+    it('returns the same reference when the requested shape matches', () => {
+        const value = decimalFixedPoint('unsigned', 64, 2)('1.50');
+        expect(rescaleDecimalFixedPoint(value, 64, 2)).toBe(value);
+    });
+
+    it('scales up decimals exactly', () => {
+        // raw 1 at d2 represents 0.01; moving to d4 scales raw to 100.
+        const source = rawDecimalFixedPoint('unsigned', 64, 2)(1n);
+        const rescaled = rescaleDecimalFixedPoint(source, 64, 4);
+        expect(rescaled.raw).toBe(100n);
+        expect(rescaled.decimals).toBe(4);
+        expect(rescaled.totalBits).toBe(64);
+    });
+
+    it('scales down decimals exactly', () => {
+        // raw 100 at d4 represents 0.01; moving to d2 scales raw to 1.
+        const source = rawDecimalFixedPoint('unsigned', 64, 4)(100n);
+        expect(rescaleDecimalFixedPoint(source, 64, 2).raw).toBe(1n);
+    });
+
+    it('widens totalBits while preserving decimals and raw', () => {
+        const source = rawDecimalFixedPoint('unsigned', 16, 2)(100n);
+        const rescaled = rescaleDecimalFixedPoint(source, 64, 2);
+        expect(rescaled.raw).toBe(100n);
+        expect(rescaled.totalBits).toBe(64);
+        expect(rescaled.decimals).toBe(2);
+    });
+
+    it('narrows totalBits when the value fits', () => {
+        const source = rawDecimalFixedPoint('unsigned', 16, 0)(100n);
+        expect(rescaleDecimalFixedPoint(source, 8, 0).raw).toBe(100n);
+    });
+
+    it('preserves signedness', () => {
+        const source = rawDecimalFixedPoint('signed', 16, 2)(-100n);
+        expect(rescaleDecimalFixedPoint(source, 32, 2).signedness).toBe('signed');
+    });
+
+    it('returns a frozen value when the shape changes', () => {
+        const source = rawDecimalFixedPoint('unsigned', 64, 2)(1n);
+        expect(rescaleDecimalFixedPoint(source, 64, 4)).toBeFrozenObject();
+    });
+
+    it('bridges EVM USDC (u128 d18) down to SPL USDC (u64 d6) with floor rounding', () => {
+        const evmUsdc = decimalFixedPoint('unsigned', 128, 18);
+        const bridged = rescaleDecimalFixedPoint(evmUsdc('100.123456789012345678'), 64, 6, 'floor');
+        expect(bridged.raw).toBe(100_123_456n);
+        expect(bridged.totalBits).toBe(64);
+        expect(bridged.decimals).toBe(6);
+    });
+
+    it('throws STRICT_MODE_PRECISION_LOSS under the default rounding when scale-down is inexact', () => {
+        // raw 1 at d4 represents 0.0001; moving to d2 requires dividing by 100 which is lossy.
+        const source = rawDecimalFixedPoint('unsigned', 64, 4)(1n);
+        expect(() => rescaleDecimalFixedPoint(source, 64, 2)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS, {
+                kind: 'decimalFixedPoint',
+                operation: 'rescale',
+            }),
+        );
+    });
+
+    it('rounds an inexact scale-down when a non-strict rounding mode is supplied', () => {
+        const source = rawDecimalFixedPoint('unsigned', 64, 4)(1n);
+        expect(rescaleDecimalFixedPoint(source, 64, 2, 'floor').raw).toBe(0n);
+        expect(rescaleDecimalFixedPoint(source, 64, 2, 'ceil').raw).toBe(1n);
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when narrowing totalBits overflows the target range', () => {
+        const source = rawDecimalFixedPoint('unsigned', 16, 0)(300n);
+        expect(() => rescaleDecimalFixedPoint(source, 8, 0)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'decimalFixedPoint',
+                max: 255n,
+                min: 0n,
+                operation: 'rescale',
+                result: 300n,
+                signedness: 'unsigned',
+                totalBits: 8,
+            }),
+        );
+    });
+
+    it('throws ARITHMETIC_OVERFLOW when scaling up decimals overflows the target totalBits', () => {
+        // raw 100 at d0 → scaling up to d2 multiplies by 100 → 10000 which exceeds signed 8-bit max 127.
+        const source = rawDecimalFixedPoint('signed', 8, 0)(100n);
+        expect(() => rescaleDecimalFixedPoint(source, 8, 2)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW, {
+                kind: 'decimalFixedPoint',
+                max: 127n,
+                min: -128n,
+                operation: 'rescale',
+                result: 10000n,
+                signedness: 'signed',
+                totalBits: 8,
+            }),
+        );
+    });
+
+    it('throws INVALID_TOTAL_BITS for a non-positive target totalBits', () => {
+        const source = rawDecimalFixedPoint('unsigned', 8, 2)(1n);
+        expect(() => rescaleDecimalFixedPoint(source, 0, 0)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__INVALID_TOTAL_BITS, {
+                kind: 'decimalFixedPoint',
+                totalBits: 0,
+            }),
+        );
+    });
+
+    it('throws INVALID_DECIMALS for a negative target decimals', () => {
+        const source = rawDecimalFixedPoint('unsigned', 8, 2)(1n);
+        expect(() => rescaleDecimalFixedPoint(source, 8, -1)).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__INVALID_DECIMALS, {
+                decimals: -1,
             }),
         );
     });

--- a/packages/fixed-points/src/__typetests__/binary-conversions-typetest.ts
+++ b/packages/fixed-points/src/__typetests__/binary-conversions-typetest.ts
@@ -1,4 +1,9 @@
-import { type BinaryFixedPoint, toSignedBinaryFixedPoint, toUnsignedBinaryFixedPoint } from '../binary';
+import {
+    type BinaryFixedPoint,
+    rescaleBinaryFixedPoint,
+    toSignedBinaryFixedPoint,
+    toUnsignedBinaryFixedPoint,
+} from '../binary';
 
 // [DESCRIBE] toUnsignedBinaryFixedPoint.
 {
@@ -31,5 +36,24 @@ import { type BinaryFixedPoint, toSignedBinaryFixedPoint, toUnsignedBinaryFixedP
     {
         const value = {} as BinaryFixedPoint<'unsigned', 8, 4>;
         toSignedBinaryFixedPoint(value) satisfies BinaryFixedPoint<'signed', 8, 4>;
+    }
+}
+
+// [DESCRIBE] rescaleBinaryFixedPoint.
+{
+    // It preserves the input signedness and picks up the new totalBits and fractionalBits.
+    {
+        const value = {} as BinaryFixedPoint<'signed', 128, 64>;
+        rescaleBinaryFixedPoint(value, 16, 8) satisfies BinaryFixedPoint<'signed', 16, 8>;
+    }
+    {
+        const value = {} as BinaryFixedPoint<'unsigned', 8, 4>;
+        rescaleBinaryFixedPoint(value, 32, 16) satisfies BinaryFixedPoint<'unsigned', 32, 16>;
+    }
+
+    // It accepts an optional RoundingMode as its fourth argument.
+    {
+        const value = {} as BinaryFixedPoint<'signed', 32, 16>;
+        rescaleBinaryFixedPoint(value, 16, 8, 'floor') satisfies BinaryFixedPoint<'signed', 16, 8>;
     }
 }

--- a/packages/fixed-points/src/__typetests__/decimal-conversions-typetest.ts
+++ b/packages/fixed-points/src/__typetests__/decimal-conversions-typetest.ts
@@ -1,4 +1,9 @@
-import { type DecimalFixedPoint, toSignedDecimalFixedPoint, toUnsignedDecimalFixedPoint } from '../decimal';
+import {
+    type DecimalFixedPoint,
+    rescaleDecimalFixedPoint,
+    toSignedDecimalFixedPoint,
+    toUnsignedDecimalFixedPoint,
+} from '../decimal';
 
 // [DESCRIBE] toUnsignedDecimalFixedPoint.
 {
@@ -31,5 +36,24 @@ import { type DecimalFixedPoint, toSignedDecimalFixedPoint, toUnsignedDecimalFix
     {
         const value = {} as DecimalFixedPoint<'unsigned', 8, 2>;
         toSignedDecimalFixedPoint(value) satisfies DecimalFixedPoint<'signed', 8, 2>;
+    }
+}
+
+// [DESCRIBE] rescaleDecimalFixedPoint.
+{
+    // It preserves the input signedness and picks up the new totalBits and decimals.
+    {
+        const value = {} as DecimalFixedPoint<'unsigned', 128, 18>;
+        rescaleDecimalFixedPoint(value, 64, 6) satisfies DecimalFixedPoint<'unsigned', 64, 6>;
+    }
+    {
+        const value = {} as DecimalFixedPoint<'signed', 16, 2>;
+        rescaleDecimalFixedPoint(value, 64, 9) satisfies DecimalFixedPoint<'signed', 64, 9>;
+    }
+
+    // It accepts an optional RoundingMode as its fourth argument.
+    {
+        const value = {} as DecimalFixedPoint<'unsigned', 128, 18>;
+        rescaleDecimalFixedPoint(value, 64, 6, 'floor') satisfies DecimalFixedPoint<'unsigned', 64, 6>;
     }
 }

--- a/packages/fixed-points/src/binary/conversions.ts
+++ b/packages/fixed-points/src/binary/conversions.ts
@@ -1,4 +1,11 @@
-import { assertRawFitsInRange } from '../assertions';
+import {
+    assertFractionalBitsFitInTotalBits,
+    assertNoArithmeticOverflow,
+    assertRawFitsInRange,
+    assertValidFractionalBits,
+    assertValidTotalBits,
+} from '../assertions';
+import { roundDivision, type RoundingMode } from '../rounding';
 import type { Signedness } from '../signedness';
 import type { BinaryFixedPoint } from './core';
 
@@ -60,4 +67,61 @@ export function toSignedBinaryFixedPoint<TTotalBits extends number, TFractionalB
     }
     assertRawFitsInRange('binaryFixedPoint', 'signed', value.totalBits, value.raw);
     return Object.freeze({ ...value, signedness: 'signed' });
+}
+
+/**
+ * Returns a {@link BinaryFixedPoint} with the same signedness as `value`
+ * but a new `totalBits` and `fractionalBits`. If the requested shape
+ * matches the input shape, the same reference is returned.
+ *
+ * Scale-up (higher `fractionalBits`) is always exact. Scale-down (lower
+ * `fractionalBits`) is potentially lossy; the optional {@link RoundingMode}
+ * is consulted on inexact results and defaults to `'strict'`, which throws
+ * `SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS`.
+ *
+ * Throws `SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW` when the
+ * rescaled raw value does not fit the new `totalBits`.
+ *
+ * @example
+ * ```ts
+ * const q1_15 = binaryFixedPoint('signed', 16, 15);
+ * rescaleBinaryFixedPoint(q1_15('0.5'), 32, 30);          // wider, higher precision
+ * rescaleBinaryFixedPoint(q1_15('0.5'), 16, 8, 'floor');  // lower precision, explicit rounding
+ * ```
+ *
+ * @see {@link toSignedBinaryFixedPoint}
+ * @see {@link toUnsignedBinaryFixedPoint}
+ */
+export function rescaleBinaryFixedPoint<
+    TSignedness extends Signedness,
+    TNewTotalBits extends number,
+    TNewFractionalBits extends number,
+>(
+    value: BinaryFixedPoint<TSignedness, number, number>,
+    newTotalBits: TNewTotalBits,
+    newFractionalBits: TNewFractionalBits,
+    rounding: RoundingMode = 'strict',
+): BinaryFixedPoint<TSignedness, TNewTotalBits, TNewFractionalBits> {
+    assertValidTotalBits('binaryFixedPoint', newTotalBits);
+    assertValidFractionalBits(newFractionalBits);
+    assertFractionalBitsFitInTotalBits(newFractionalBits, newTotalBits);
+    if (value.totalBits === newTotalBits && value.fractionalBits === newFractionalBits) {
+        return value as BinaryFixedPoint<TSignedness, TNewTotalBits, TNewFractionalBits>;
+    }
+    let result: bigint;
+    if (newFractionalBits === value.fractionalBits) {
+        result = value.raw;
+    } else if (newFractionalBits > value.fractionalBits) {
+        result = value.raw << BigInt(newFractionalBits - value.fractionalBits);
+    } else {
+        result = roundDivision(
+            'binaryFixedPoint',
+            'rescale',
+            value.raw,
+            1n << BigInt(value.fractionalBits - newFractionalBits),
+            rounding,
+        );
+    }
+    assertNoArithmeticOverflow('binaryFixedPoint', 'rescale', value.signedness, newTotalBits, result);
+    return Object.freeze({ ...value, fractionalBits: newFractionalBits, raw: result, totalBits: newTotalBits });
 }

--- a/packages/fixed-points/src/decimal/conversions.ts
+++ b/packages/fixed-points/src/decimal/conversions.ts
@@ -1,4 +1,10 @@
-import { assertRawFitsInRange } from '../assertions';
+import {
+    assertNoArithmeticOverflow,
+    assertRawFitsInRange,
+    assertValidDecimals,
+    assertValidTotalBits,
+} from '../assertions';
+import { roundDivision, type RoundingMode } from '../rounding';
 import type { Signedness } from '../signedness';
 import type { DecimalFixedPoint } from './core';
 
@@ -60,4 +66,61 @@ export function toSignedDecimalFixedPoint<TTotalBits extends number, TDecimals e
     }
     assertRawFitsInRange('decimalFixedPoint', 'signed', value.totalBits, value.raw);
     return Object.freeze({ ...value, signedness: 'signed' });
+}
+
+/**
+ * Returns a {@link DecimalFixedPoint} with the same signedness as `value`
+ * but a new `totalBits` and `decimals`. If the requested shape matches
+ * the input shape, the same reference is returned.
+ *
+ * Scale-up (higher `decimals`) is always exact. Scale-down (lower
+ * `decimals`) is potentially lossy; the optional {@link RoundingMode} is
+ * consulted on inexact results and defaults to `'strict'`, which throws
+ * `SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS`.
+ *
+ * Throws `SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW` when the
+ * rescaled raw value does not fit the new `totalBits`.
+ *
+ * @example
+ * ```ts
+ * // Bridge EVM USDC (u128 d18) down to SPL USDC (u64 d6).
+ * const evmUsdc = decimalFixedPoint('unsigned', 128, 18);
+ * rescaleDecimalFixedPoint(evmUsdc('100.123456789012345678'), 64, 6, 'floor');
+ * // represents 100.123456
+ * ```
+ *
+ * @see {@link toSignedDecimalFixedPoint}
+ * @see {@link toUnsignedDecimalFixedPoint}
+ */
+export function rescaleDecimalFixedPoint<
+    TSignedness extends Signedness,
+    TNewTotalBits extends number,
+    TNewDecimals extends number,
+>(
+    value: DecimalFixedPoint<TSignedness, number, number>,
+    newTotalBits: TNewTotalBits,
+    newDecimals: TNewDecimals,
+    rounding: RoundingMode = 'strict',
+): DecimalFixedPoint<TSignedness, TNewTotalBits, TNewDecimals> {
+    assertValidTotalBits('decimalFixedPoint', newTotalBits);
+    assertValidDecimals(newDecimals);
+    if (value.totalBits === newTotalBits && value.decimals === newDecimals) {
+        return value as DecimalFixedPoint<TSignedness, TNewTotalBits, TNewDecimals>;
+    }
+    let result: bigint;
+    if (newDecimals === value.decimals) {
+        result = value.raw;
+    } else if (newDecimals > value.decimals) {
+        result = value.raw * 10n ** BigInt(newDecimals - value.decimals);
+    } else {
+        result = roundDivision(
+            'decimalFixedPoint',
+            'rescale',
+            value.raw,
+            10n ** BigInt(value.decimals - newDecimals),
+            rounding,
+        );
+    }
+    assertNoArithmeticOverflow('decimalFixedPoint', 'rescale', value.signedness, newTotalBits, result);
+    return Object.freeze({ ...value, decimals: newDecimals, raw: result, totalBits: newTotalBits });
 }


### PR DESCRIPTION
This PR adds `rescaleBinaryFixedPoint` and `rescaleDecimalFixedPoint` to `@solana/fixed-points`. These helpers change a fixed-point's `totalBits` and scale (`fractionalBits` for binary, `decimals` for decimal) in a single call while preserving signedness, matching the API shape established in the proposal's bridge example.

When the requested shape matches the input shape exactly, the same reference is returned with no new allocation. Scale-up is always exact; scale-down consults the optional `RoundingMode` argument, which defaults to `'strict'` and throws `SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS` on inexact results. Rescaled values are range-checked against the new `totalBits` and throw `SOLANA_ERROR__FIXED_POINTS__ARITHMETIC_OVERFLOW` (with `operation: 'rescale'`) when they do not fit. Invalid targets reuse the existing `INVALID_TOTAL_BITS`, `INVALID_FRACTIONAL_BITS`, `INVALID_DECIMALS`, and `FRACTIONAL_BITS_EXCEED_TOTAL_BITS` codes. No new error codes were introduced.