### PR TITLE
Fix `extendClient` to allow plugins to override existing keys

### DIFF
--- a/.changeset/clever-gifts-find.md
+++ b/.changeset/clever-gifts-find.md
@@ -1,0 +1,5 @@
+---
+'@solana/plugin-core': patch
+---
+
+Fix `extendClient` so that a later plugin can override a key previously set by an earlier plugin. Previously, chaining two plugins that set the same key threw `TypeError: Cannot redefine property` because the frozen client's non-configurable property descriptors were copied verbatim onto the intermediate object.

--- a/packages/plugin-core/src/__tests__/client-test.ts
+++ b/packages/plugin-core/src/__tests__/client-test.ts
@@ -284,6 +284,21 @@ describe('extendClient', () => {
     it('returns a frozen object', () => {
         expect(extendClient({ fruit: 'apple' as const }, { vegetable: 'carrot' as const })).toBeFrozenObject();
     });
+
+    it('allows a later plugin to override a key set by an earlier plugin', () => {
+        const client = createClient()
+            .use(c => extendClient(c, { payer: 'A' as const }))
+            .use(c => extendClient(c, { payer: 'B' as const }));
+        expect(client.payer).toBe('B');
+    });
+
+    it('allows override when the earlier plugin set multiple keys', () => {
+        const client = createClient()
+            .use(c => extendClient(c, { identity: 'X' as const, payer: 'A' as const }))
+            .use(c => extendClient(c, { payer: 'B' as const }));
+        expect(client.identity).toBe('X');
+        expect(client.payer).toBe('B');
+    });
 });
 
 describe('withCleanup', () => {

--- a/packages/plugin-core/src/client.ts
+++ b/packages/plugin-core/src/client.ts
@@ -241,9 +241,17 @@ export function extendClient<TClient extends object, TAdditions extends object>(
     client: TClient,
     additions: TAdditions,
 ): Omit<TClient, keyof TAdditions> & TAdditions {
-    const result = Object.defineProperties({}, Object.getOwnPropertyDescriptors(client));
+    const result = Object.defineProperties({}, toConfigurableDescriptors(Object.getOwnPropertyDescriptors(client)));
     Object.defineProperties(result, Object.getOwnPropertyDescriptors(additions));
     return Object.freeze(result) as Omit<TClient, keyof TAdditions> & TAdditions;
+}
+
+function toConfigurableDescriptors<T extends PropertyDescriptorMap>(descriptors: T): T {
+    const result = {} as Record<string | symbol, PropertyDescriptor>;
+    for (const key of Reflect.ownKeys(descriptors)) {
+        result[key] = { ...descriptors[key as keyof T], configurable: true };
+    }
+    return result as T;
 }
 
 /**


### PR DESCRIPTION
Fixes a `TypeError: Cannot redefine property` thrown when two plugins set the same key on a client. For example:

```ts
createClient()
    .use(c => extendClient(c, { payer: signerA }))
    .use(c => extendClient(c, { payer: signerB })); // throws TypeError: Cannot redefine property: payer
```

The root cause: `createClient` and `extendClient` freeze their output, which marks every own property as `configurable: false`. When a later `extendClient` call copied those descriptors onto its intermediate object, the subsequent `Object.defineProperties(result, additions)` could not redefine any conflicting key.

The fix normalizes the source descriptors to `configurable: true` before copying, so `additions` can always win on conflicts — matching `extendClient`'s documented behavior. The returned client is still frozen, so external immutability is unchanged.

Added two regression tests covering single-key and multi-key override scenarios.