### PR TITLE
Add Sol type, conversions, and codecs

### DIFF
--- a/.changeset/three-peas-sniff.md
+++ b/.changeset/three-peas-sniff.md
@@ -1,0 +1,6 @@
+---
+'@solana/rpc-types': minor
+'@solana/kit': minor
+---
+
+Add `Sol`, `sol()`, `solToLamports`, and `lamportsToSol` helpers for converting between SOL amounts expressed as `@solana/fixed-points` values and `Lamports` branded bigints. Also add `getSolEncoder`, `getSolDecoder`, and `getSolCodec` for serializing SOL amounts to bytes (the encoder accepts both `Sol` and `Lamports` inputs; the decoder always returns `Sol`). Finally, update `getLamportsEncoder`/`getDefaultLamportsEncoder` and their codec counterparts to also accept `Sol` as input.

--- a/packages/rpc-types/package.json
+++ b/packages/rpc-types/package.json
@@ -79,6 +79,7 @@
         "@solana/codecs-numbers": "workspace:*",
         "@solana/codecs-strings": "workspace:*",
         "@solana/errors": "workspace:*",
+        "@solana/fixed-points": "workspace:*",
         "@solana/nominal-types": "workspace:*"
     },
     "peerDependencies": {

--- a/packages/rpc-types/src/__tests__/lamports-test.ts
+++ b/packages/rpc-types/src/__tests__/lamports-test.ts
@@ -22,6 +22,7 @@ import {
     getLamportsEncoder,
     lamports,
 } from '../lamports';
+import { sol } from '../sol';
 
 describe('assertIsLamports()', () => {
     it('throws when supplied a negative number', () => {
@@ -66,6 +67,11 @@ describe('getDefaultLamportsEncoder', () => {
         const encoder = getDefaultLamportsEncoder();
         expect(encoder.fixedSize).toBe(8);
     });
+    it('also accepts a Sol value as input', () => {
+        const encoder = getDefaultLamportsEncoder();
+        // 1 SOL = 1_000_000_000 lamports.
+        expect(encoder.encode(sol('1'))).toStrictEqual(new Uint8Array([0, 202, 154, 59, 0, 0, 0, 0]));
+    });
 });
 
 describe('getLamportsEncoder', () => {
@@ -74,6 +80,11 @@ describe('getLamportsEncoder', () => {
         const encoder = getLamportsEncoder(getU8Encoder());
         const buffer = encoder.encode(lamportsValue);
         expect(buffer).toStrictEqual(new Uint8Array([100]));
+    });
+    it('also accepts a Sol value as input', () => {
+        // Smallest Sol = 1 lamport = u8 100... we'll use a real one: sol('0.0000001') = 100 lamports.
+        const encoder = getLamportsEncoder(getU8Encoder());
+        expect(encoder.encode(sol('0.0000001'))).toStrictEqual(new Uint8Array([100]));
     });
     it('encodes a lamports value using a passed big-endian u16 encoder', () => {
         const lamportsValue = lamports(100n);

--- a/packages/rpc-types/src/__tests__/sol-test.ts
+++ b/packages/rpc-types/src/__tests__/sol-test.ts
@@ -1,0 +1,162 @@
+import {
+    SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS,
+    SOLANA_ERROR__FIXED_POINTS__VALUE_OUT_OF_RANGE,
+    SolanaError,
+} from '@solana/errors';
+
+import { lamports } from '../lamports';
+import { getSolCodec, getSolDecoder, getSolEncoder, lamportsToSol, sol, solToLamports } from '../sol';
+
+describe('sol', () => {
+    it('parses whole numbers of SOL', () => {
+        expect(sol('1').raw).toBe(1_000_000_000n);
+    });
+
+    it('parses fractional SOL amounts', () => {
+        expect(sol('1.5').raw).toBe(1_500_000_000n);
+    });
+
+    it('parses zero', () => {
+        expect(sol('0').raw).toBe(0n);
+    });
+
+    it('parses the smallest representable amount (one Lamport)', () => {
+        expect(sol('0.000000001').raw).toBe(1n);
+    });
+
+    it('throws STRICT_MODE_PRECISION_LOSS by default when more than 9 decimals are supplied', () => {
+        expect(() => sol('1.1234567891')).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS, {
+                kind: 'decimalFixedPoint',
+                operation: 'fromString',
+            }),
+        );
+    });
+
+    it('rounds when a rounding mode is supplied', () => {
+        expect(sol('1.1234567891', 'round').raw).toBe(1_123_456_789n);
+        expect(sol('1.1234567899', 'floor').raw).toBe(1_123_456_789n);
+        expect(sol('1.1234567891', 'ceil').raw).toBe(1_123_456_790n);
+    });
+
+    it('throws VALUE_OUT_OF_RANGE when the amount exceeds u64', () => {
+        // u64 max / 10^9 = ~18.45 billion SOL; just above that overflows.
+        expect(() => sol('18446744074')).toThrow(
+            new SolanaError(SOLANA_ERROR__FIXED_POINTS__VALUE_OUT_OF_RANGE, {
+                kind: 'decimalFixedPoint',
+                max: 18_446_744_073_709_551_615n,
+                min: 0n,
+                raw: 18_446_744_074_000_000_000n,
+                signedness: 'unsigned',
+                totalBits: 64,
+            }),
+        );
+    });
+});
+
+describe('solToLamports', () => {
+    it('returns the raw bigint as a Lamports-branded value', () => {
+        expect(solToLamports(sol('1'))).toBe(1_000_000_000n);
+    });
+
+    it('converts zero SOL to zero Lamports', () => {
+        expect(solToLamports(sol('0'))).toBe(0n);
+    });
+
+    it('converts fractional SOL to the correct Lamports', () => {
+        expect(solToLamports(sol('1.5'))).toBe(1_500_000_000n);
+    });
+
+    it('handles the smallest amount (1 Lamport)', () => {
+        expect(solToLamports(sol('0.000000001'))).toBe(1n);
+    });
+});
+
+describe('lamportsToSol', () => {
+    it('converts zero Lamports to a Sol value of zero', () => {
+        expect(lamportsToSol(lamports(0n)).raw).toBe(0n);
+    });
+
+    it('converts one billion Lamports to one SOL', () => {
+        expect(lamportsToSol(lamports(1_000_000_000n)).raw).toBe(1_000_000_000n);
+    });
+
+    it('preserves the Sol shape metadata', () => {
+        const value = lamportsToSol(lamports(1_500_000_000n));
+        expect(value.kind).toBe('decimalFixedPoint');
+        expect(value.signedness).toBe('unsigned');
+        expect(value.totalBits).toBe(64);
+        expect(value.decimals).toBe(9);
+    });
+
+    it('accepts the maximum Lamports value', () => {
+        const maxU64 = 18_446_744_073_709_551_615n;
+        expect(lamportsToSol(lamports(maxU64)).raw).toBe(maxU64);
+    });
+});
+
+describe('round-tripping Sol and Lamports', () => {
+    it.each([0n, 1n, 1_000_000_000n, 1_500_000_000n, 18_446_744_073_709_551_615n])(
+        'round-trips %s Lamports through Sol',
+        raw => {
+            expect(solToLamports(lamportsToSol(lamports(raw)))).toBe(raw);
+        },
+    );
+});
+
+describe('getSolEncoder', () => {
+    it('encodes a Sol value to 8 little-endian bytes', () => {
+        // 1.5 SOL = 1_500_000_000 lamports = 0x59682F00 in u64 LE.
+        expect(getSolEncoder().encode(sol('1.5'))).toEqual(
+            new Uint8Array([0x00, 0x2f, 0x68, 0x59, 0x00, 0x00, 0x00, 0x00]),
+        );
+    });
+
+    it('also accepts a Lamports value', () => {
+        expect(getSolEncoder().encode(lamports(1_500_000_000n))).toEqual(
+            new Uint8Array([0x00, 0x2f, 0x68, 0x59, 0x00, 0x00, 0x00, 0x00]),
+        );
+    });
+
+    it('produces identical bytes for equivalent Sol and Lamports inputs', () => {
+        const fromSol = getSolEncoder().encode(sol('1.5'));
+        const fromLamports = getSolEncoder().encode(lamports(1_500_000_000n));
+        expect(fromSol).toEqual(fromLamports);
+    });
+
+    it('reports a fixed size of 8', () => {
+        expect(getSolEncoder().fixedSize).toBe(8);
+    });
+});
+
+describe('getSolDecoder', () => {
+    it('decodes 8 little-endian bytes into a Sol value', () => {
+        const value = getSolDecoder().decode(new Uint8Array([0x00, 0x2f, 0x68, 0x59, 0x00, 0x00, 0x00, 0x00]));
+        expect(value.raw).toBe(1_500_000_000n);
+    });
+
+    it('returns a Sol with the correct shape metadata', () => {
+        const value = getSolDecoder().decode(new Uint8Array([0x00, 0x2f, 0x68, 0x59, 0x00, 0x00, 0x00, 0x00]));
+        expect(value.kind).toBe('decimalFixedPoint');
+        expect(value.signedness).toBe('unsigned');
+        expect(value.totalBits).toBe(64);
+        expect(value.decimals).toBe(9);
+    });
+
+    it('reports a fixed size of 8', () => {
+        expect(getSolDecoder().fixedSize).toBe(8);
+    });
+});
+
+describe('getSolCodec', () => {
+    it('round-trips a Sol value', () => {
+        const codec = getSolCodec();
+        const input = sol('42.5');
+        expect(codec.decode(codec.encode(input))).toEqual(input);
+    });
+
+    it('round-trips a Lamports value as Sol', () => {
+        const codec = getSolCodec();
+        expect(codec.decode(codec.encode(lamports(1_500_000_000n)))).toEqual(sol('1.5'));
+    });
+});

--- a/packages/rpc-types/src/__typetests__/lamports-typetest.ts
+++ b/packages/rpc-types/src/__typetests__/lamports-typetest.ts
@@ -17,32 +17,39 @@ import {
     getLamportsEncoder,
     Lamports,
 } from '../lamports';
+import { Sol } from '../sol';
 
 // Default encoder
 {
     const encoder = getDefaultLamportsEncoder();
-    encoder satisfies FixedSizeEncoder<Lamports, 8>;
+    encoder satisfies FixedSizeEncoder<Lamports | Sol, 8>;
     encoder.fixedSize satisfies 8;
     encoder.encode(1n as Lamports) satisfies ReadonlyUint8Array;
+    encoder.encode({} as Sol) satisfies ReadonlyUint8Array;
 }
 
 // Fixed size inner encoder
 {
     const innerEncoder = {} as FixedSizeEncoder<bigint | number, 42>;
     const encoder = getLamportsEncoder(innerEncoder);
-    encoder satisfies FixedSizeEncoder<Lamports, 42>;
+    encoder satisfies FixedSizeEncoder<Lamports | Sol, 42>;
     encoder.fixedSize satisfies 42;
     encoder.encode(1n as Lamports) satisfies ReadonlyUint8Array;
+    encoder.encode({} as Sol) satisfies ReadonlyUint8Array;
 }
 
 // Variable size inner encoder
 {
     const innerEncoder = {} as VariableSizeEncoder<bigint | number>;
     const encoder = getLamportsEncoder(innerEncoder);
+    // Note: `getSizeFromValue` retains the inner encoder's signature via `ExtractAdditionalProps`
+    // so we assert against the narrower `VariableSizeEncoder<Lamports>` rather than the widened
+    // `VariableSizeEncoder<Lamports | Sol>` here.
     encoder satisfies VariableSizeEncoder<Lamports>;
     encoder.getSizeFromValue satisfies (value: bigint | number) => number;
     encoder.maxSize satisfies number | undefined;
     encoder.encode(1n as Lamports) satisfies ReadonlyUint8Array;
+    encoder.encode({} as Sol) satisfies ReadonlyUint8Array;
 }
 
 // Default decoder
@@ -74,11 +81,12 @@ import {
 // Default codec
 {
     const codec = getDefaultLamportsCodec();
-    codec satisfies FixedSizeCodec<Lamports, Lamports, 8>;
-    codec satisfies FixedSizeEncoder<Lamports, 8>;
+    codec satisfies FixedSizeCodec<Lamports | Sol, Lamports, 8>;
+    codec satisfies FixedSizeEncoder<Lamports | Sol, 8>;
     codec satisfies FixedSizeDecoder<Lamports, 8>;
     codec.fixedSize satisfies 8;
     codec.encode(1n as Lamports) satisfies ReadonlyUint8Array;
+    codec.encode({} as Sol) satisfies ReadonlyUint8Array;
     codec.decode(null as unknown as ReadonlyUint8Array) satisfies Lamports;
 }
 
@@ -86,11 +94,12 @@ import {
 {
     const innerCodec = {} as FixedSizeCodec<bigint | number, bigint, 42> | FixedSizeCodec<bigint | number, number, 42>;
     const codec = getLamportsCodec(innerCodec);
-    codec satisfies FixedSizeCodec<Lamports, Lamports, 42>;
-    codec satisfies FixedSizeEncoder<Lamports, 42>;
+    codec satisfies FixedSizeCodec<Lamports | Sol, Lamports, 42>;
+    codec satisfies FixedSizeEncoder<Lamports | Sol, 42>;
     codec satisfies FixedSizeDecoder<Lamports, 42>;
     codec.fixedSize satisfies 42;
     codec.encode(1n as Lamports) satisfies ReadonlyUint8Array;
+    codec.encode({} as Sol) satisfies ReadonlyUint8Array;
     codec.decode(null as unknown as ReadonlyUint8Array) satisfies Lamports;
 }
 
@@ -98,10 +107,11 @@ import {
 {
     const innerCodec = {} as VariableSizeCodec<bigint | number, bigint> | VariableSizeCodec<bigint | number, number>;
     const codec = getLamportsCodec(innerCodec);
+    // Note: `getSizeFromValue` retains the inner codec's signature via `ExtractAdditionalProps`
+    // so we assert against the narrower `VariableSizeCodec<Lamports, Lamports>` here.
     codec satisfies VariableSizeCodec<Lamports, Lamports>;
-    codec satisfies VariableSizeCodec<Lamports>;
-    codec satisfies VariableSizeCodec<Lamports>;
     codec.maxSize satisfies number | undefined;
     codec.encode(1n as Lamports) satisfies ReadonlyUint8Array;
+    codec.encode({} as Sol) satisfies ReadonlyUint8Array;
     codec.decode(null as unknown as ReadonlyUint8Array) satisfies Lamports;
 }

--- a/packages/rpc-types/src/__typetests__/sol-typetest.ts
+++ b/packages/rpc-types/src/__typetests__/sol-typetest.ts
@@ -1,0 +1,54 @@
+import { FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder, ReadonlyUint8Array } from '@solana/codecs-core';
+import { type DecimalFixedPoint } from '@solana/fixed-points';
+
+import { type Lamports } from '../lamports';
+import { getSolCodec, getSolDecoder, getSolEncoder, lamportsToSol, type Sol, sol, solToLamports } from '../sol';
+
+// Sol is the canonical unsigned 64-bit decimal fixed-point with 9 decimals.
+{
+    const value = {} as Sol;
+    value satisfies DecimalFixedPoint<'unsigned', 64, 9>;
+}
+
+// sol() returns a Sol.
+{
+    sol('1') satisfies Sol;
+    sol('1', 'round') satisfies Sol;
+}
+
+// solToLamports returns a Lamports.
+{
+    solToLamports({} as Sol) satisfies Lamports;
+}
+
+// lamportsToSol returns a Sol.
+{
+    lamportsToSol({} as Lamports) satisfies Sol;
+}
+
+// getSolEncoder accepts both Sol and Lamports.
+{
+    const encoder = getSolEncoder();
+    encoder satisfies FixedSizeEncoder<Lamports | Sol, 8>;
+    encoder.fixedSize satisfies 8;
+    encoder.encode({} as Sol) satisfies ReadonlyUint8Array;
+    encoder.encode({} as Lamports) satisfies ReadonlyUint8Array;
+}
+
+// getSolDecoder always returns Sol.
+{
+    const decoder = getSolDecoder();
+    decoder satisfies FixedSizeDecoder<Sol, 8>;
+    decoder.fixedSize satisfies 8;
+    decoder.decode(null as unknown as ReadonlyUint8Array) satisfies Sol;
+}
+
+// getSolCodec encodes from Sol | Lamports, decodes to Sol.
+{
+    const codec = getSolCodec();
+    codec satisfies FixedSizeCodec<Lamports | Sol, Sol, 8>;
+    codec.fixedSize satisfies 8;
+    codec.encode({} as Sol) satisfies ReadonlyUint8Array;
+    codec.encode({} as Lamports) satisfies ReadonlyUint8Array;
+    codec.decode(null as unknown as ReadonlyUint8Array) satisfies Sol;
+}

--- a/packages/rpc-types/src/index.ts
+++ b/packages/rpc-types/src/index.ts
@@ -14,6 +14,7 @@ export * from './commitment';
 export * from './encoded-bytes';
 export * from './lamports';
 export * from './rpc-api';
+export * from './sol';
 export * from './stringified-bigint';
 export * from './stringified-number';
 export * from './token-amount';

--- a/packages/rpc-types/src/lamports.ts
+++ b/packages/rpc-types/src/lamports.ts
@@ -7,10 +7,13 @@ import {
     FixedSizeDecoder,
     FixedSizeEncoder,
     transformDecoder,
+    transformEncoder,
 } from '@solana/codecs-core';
 import { getU64Decoder, getU64Encoder, NumberCodec, NumberDecoder, NumberEncoder } from '@solana/codecs-numbers';
 import { SOLANA_ERROR__LAMPORTS_OUT_OF_RANGE, SolanaError } from '@solana/errors';
 import { Brand } from '@solana/nominal-types';
+
+import type { Sol } from './sol';
 
 /**
  * Represents an integer value denominated in Lamports (ie. $1 \times 10^{-9}$ ◎).
@@ -110,14 +113,16 @@ type ExtractAdditionalProps<T, U> = Omit<T, keyof U>;
 
 /**
  * Returns an encoder that you can use to encode a 64-bit {@link Lamports} value to 8 bytes in
- * little endian order.
+ * little endian order. The encoder also accepts a {@link Sol} fixed-point value.
  */
-export function getDefaultLamportsEncoder(): FixedSizeEncoder<Lamports, 8> {
+export function getDefaultLamportsEncoder(): FixedSizeEncoder<Lamports | Sol, 8> {
     return getLamportsEncoder(getMemoizedU64Encoder());
 }
 
 /**
- * Returns an encoder that you can use to encode a {@link Lamports} value to a byte array.
+ * Returns an encoder that you can use to encode a {@link Lamports} value to a byte array. The
+ * encoder also accepts a {@link Sol} fixed-point value, whose `raw` bigint is written as if it
+ * were a Lamports value.
  *
  * You must supply a number decoder that will determine how encode the numeric value.
  *
@@ -134,8 +139,10 @@ export function getDefaultLamportsEncoder(): FixedSizeEncoder<Lamports, 8> {
  */
 export function getLamportsEncoder<TEncoder extends NumberEncoder>(
     innerEncoder: TEncoder,
-): Encoder<Lamports> & ExtractAdditionalProps<TEncoder, NumberEncoder> {
-    return innerEncoder;
+): Encoder<Lamports | Sol> & ExtractAdditionalProps<TEncoder, NumberEncoder> {
+    return transformEncoder<bigint | number, Lamports | Sol>(innerEncoder, value =>
+        typeof value === 'bigint' ? value : value.raw,
+    ) as Encoder<Lamports | Sol> & ExtractAdditionalProps<TEncoder, NumberEncoder>;
 }
 
 /**
@@ -173,23 +180,30 @@ export function getLamportsDecoder<TDecoder extends NumberDecoder>(
 
 /**
  * Returns a codec that you can use to encode from or decode to a 64-bit {@link Lamports} value.
+ * The encoder also accepts a {@link Sol} fixed-point value; the decoder always returns
+ * {@link Lamports}.
  *
  * @see {@link getDefaultLamportsDecoder}
  * @see {@link getDefaultLamportsEncoder}
  */
-export function getDefaultLamportsCodec(): FixedSizeCodec<Lamports, Lamports, 8> {
+export function getDefaultLamportsCodec(): FixedSizeCodec<Lamports | Sol, Lamports, 8> {
     return combineCodec(getDefaultLamportsEncoder(), getDefaultLamportsDecoder());
 }
 
 /**
- * Returns a codec that you can use to encode from or decode to {@link Lamports} value.
+ * Returns a codec that you can use to encode from or decode to a {@link Lamports} value. The
+ * encoder also accepts a {@link Sol} fixed-point value; the decoder always returns
+ * {@link Lamports}.
  *
  * @see {@link getLamportsDecoder}
  * @see {@link getLamportsEncoder}
  */
 export function getLamportsCodec<TCodec extends NumberCodec>(
     innerCodec: TCodec,
-): Codec<Lamports, Lamports> & ExtractAdditionalProps<TCodec, NumberCodec> {
-    return combineCodec(getLamportsEncoder(innerCodec), getLamportsDecoder(innerCodec)) as Codec<Lamports, Lamports> &
+): Codec<Lamports | Sol, Lamports> & ExtractAdditionalProps<TCodec, NumberCodec> {
+    return combineCodec(getLamportsEncoder(innerCodec), getLamportsDecoder(innerCodec)) as Codec<
+        Lamports | Sol,
+        Lamports
+    > &
         ExtractAdditionalProps<TCodec, NumberCodec>;
 }

--- a/packages/rpc-types/src/sol.ts
+++ b/packages/rpc-types/src/sol.ts
@@ -1,0 +1,142 @@
+import {
+    combineCodec,
+    type FixedSizeCodec,
+    type FixedSizeDecoder,
+    type FixedSizeEncoder,
+    transformDecoder,
+    transformEncoder,
+} from '@solana/codecs-core';
+import { getU64Decoder, getU64Encoder } from '@solana/codecs-numbers';
+import {
+    type DecimalFixedPoint,
+    decimalFixedPoint,
+    rawDecimalFixedPoint,
+    type RoundingMode,
+} from '@solana/fixed-points';
+
+import { type Lamports, lamports } from './lamports';
+
+/**
+ * The canonical fixed-point shape for SOL amounts: unsigned 64-bit with 9
+ * decimals. Since 1 SOL equals `10 ** 9` Lamports, a `Sol` value's `raw`
+ * bigint is exactly the corresponding Lamports count.
+ */
+export type Sol = DecimalFixedPoint<'unsigned', 64, 9>;
+
+let memoizedSolFactory: ReturnType<typeof decimalFixedPoint<'unsigned', 64, 9>> | undefined;
+let memoizedRawSolFactory: ReturnType<typeof rawDecimalFixedPoint<'unsigned', 64, 9>> | undefined;
+
+function solFactory(value: string, rounding?: RoundingMode): Sol {
+    if (!memoizedSolFactory) memoizedSolFactory = decimalFixedPoint('unsigned', 64, 9);
+    return memoizedSolFactory(value, rounding);
+}
+
+function rawSolFactory(value: bigint): Sol {
+    if (!memoizedRawSolFactory) memoizedRawSolFactory = rawDecimalFixedPoint('unsigned', 64, 9);
+    return memoizedRawSolFactory(value);
+}
+
+let memoizedU64Encoder: FixedSizeEncoder<bigint | number, 8> | undefined;
+let memoizedU64Decoder: FixedSizeDecoder<bigint, 8> | undefined;
+
+function getMemoizedU64Encoder(): FixedSizeEncoder<bigint | number, 8> {
+    if (!memoizedU64Encoder) memoizedU64Encoder = getU64Encoder();
+    return memoizedU64Encoder;
+}
+
+function getMemoizedU64Decoder(): FixedSizeDecoder<bigint, 8> {
+    if (!memoizedU64Decoder) memoizedU64Decoder = getU64Decoder();
+    return memoizedU64Decoder;
+}
+
+/**
+ * Parses a decimal string as a {@link Sol} fixed-point value.
+ *
+ * The default rounding mode is `'strict'`, which throws
+ * `SOLANA_ERROR__FIXED_POINTS__STRICT_MODE_PRECISION_LOSS` when the input
+ * has more than 9 fractional digits. Pass another `RoundingMode` to accept
+ * a rounded result.
+ *
+ * @example
+ * ```ts
+ * sol('1.5');            // represents 1.5 SOL (raw === 1_500_000_000n)
+ * sol('0.000000001');    // the smallest representable amount: 1 Lamport
+ * sol('1.1234567891', 'round'); // rounded to 9 decimals
+ * ```
+ *
+ * @see {@link solToLamports}
+ * @see {@link lamportsToSol}
+ */
+export function sol(value: string, rounding?: RoundingMode): Sol {
+    return solFactory(value, rounding);
+}
+
+/**
+ * Converts a {@link Sol} fixed-point value to its equivalent {@link Lamports}
+ * bigint. This conversion is exact — a `Sol` value's raw bigint is exactly
+ * the Lamports count.
+ *
+ * @example
+ * ```ts
+ * solToLamports(sol('1.5')); // lamports(1_500_000_000n)
+ * ```
+ *
+ * @see {@link lamportsToSol}
+ * @see {@link sol}
+ */
+export function solToLamports(value: Sol): Lamports {
+    return lamports(value.raw);
+}
+
+/**
+ * Converts a {@link Lamports} bigint to its equivalent {@link Sol}
+ * fixed-point value. This conversion is exact.
+ *
+ * @example
+ * ```ts
+ * lamportsToSol(lamports(1_500_000_000n)); // represents 1.5 SOL
+ * ```
+ *
+ * @see {@link solToLamports}
+ * @see {@link sol}
+ */
+export function lamportsToSol(value: Lamports): Sol {
+    return rawSolFactory(value);
+}
+
+/**
+ * Returns an encoder that writes a {@link Sol} or {@link Lamports} value to
+ * 8 bytes in little-endian order. Since Sol and Lamports share the same
+ * u64 wire format, either can be passed as input.
+ *
+ * @see {@link getSolDecoder}
+ * @see {@link getSolCodec}
+ */
+export function getSolEncoder(): FixedSizeEncoder<Lamports | Sol, 8> {
+    return transformEncoder<bigint | number, Lamports | Sol, 8>(getMemoizedU64Encoder(), value =>
+        typeof value === 'bigint' ? value : value.raw,
+    );
+}
+
+/**
+ * Returns a decoder that reads 8 bytes in little-endian order into a
+ * {@link Sol} value.
+ *
+ * @see {@link getSolEncoder}
+ * @see {@link getSolCodec}
+ */
+export function getSolDecoder(): FixedSizeDecoder<Sol, 8> {
+    return transformDecoder<bigint, Sol, 8>(getMemoizedU64Decoder(), value => rawSolFactory(value));
+}
+
+/**
+ * Returns a codec combining {@link getSolEncoder} and {@link getSolDecoder}.
+ * The encoder accepts either {@link Sol} or {@link Lamports}; the decoder
+ * always returns {@link Sol}.
+ *
+ * @see {@link getSolEncoder}
+ * @see {@link getSolDecoder}
+ */
+export function getSolCodec(): FixedSizeCodec<Lamports | Sol, Sol, 8> {
+    return combineCodec(getSolEncoder(), getSolDecoder());
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1362,6 +1362,9 @@ importers:
       '@solana/errors':
         specifier: workspace:*
         version: link:../errors
+      '@solana/fixed-points':
+        specifier: workspace:*
+        version: link:../fixed-points
       '@solana/nominal-types':
         specifier: workspace:*
         version: link:../nominal-types


### PR DESCRIPTION
This PR adds `Sol` (a `DecimalFixedPoint<'unsigned', 64, 9>` type alias), `sol()`, `solToLamports`, and `lamportsToSol` to `@solana/rpc-types` for converting between SOL amounts expressed as `@solana/fixed-points` values and `Lamports` branded bigints. It also adds `getSolEncoder`, `getSolDecoder`, and `getSolCodec` for serializing SOL amounts to bytes — the encoder accepts both `Sol` and `Lamports` inputs; the decoder always returns `Sol`.

`getLamportsEncoder`, `getDefaultLamportsEncoder`, `getLamportsCodec`, and `getDefaultLamportsCodec` have been widened to also accept `Sol` values on the encode side. Their decode side remains unchanged and continues to return `Lamports`.