### PR TITLE
Write plugin-first Guides

### DIFF
--- a/docs/content/docs/guides/fetching-accounts.mdx
+++ b/docs/content/docs/guides/fetching-accounts.mdx
@@ -3,13 +3,163 @@ title: Fetching accounts
 description: Read and decode onchain account data
 ---
 
-<Callout type="warn" title="Planned Content">
-**Status:** New page
+Reading data from Solana usually means fetching one or more accounts and decoding their data into something your application can use. This guide walks through the helpers Kit provides at each step, from the raw RPC call all the way to typed account objects.
 
-This guide will cover reading account data from the blockchain: **`fetchEncodedAccount(client.rpc, address)`** as the recommended higher-level helper for fetching accounts, **`client.rpc.getMultipleAccounts(addresses)`** for batch fetching, program plugin fetch helpers (e.g. `client.token.accounts.mint.fetch(address)`) for typed fetch + decode in one call, manual decoding with codecs for accounts without a program plugin, understanding encoded vs decoded account data, and account subscriptions via `rpcSubscriptions` for real-time updates.
+## Fetch raw account data
 
-**Draws from:** Current `getting-started/fetch-account.mdx` (account fetching and decoding with `fetchMint`), `@solana/kit-plugin-rpc` README.
+The `fetchEncodedAccount` helper wraps the `getAccountInfo` RPC method and returns a `MaybeEncodedAccount`. The result always has the same shape regardless of whether the account exists, which makes it easier to handle than the raw RPC response.
 
-**Links to:** [Advanced Guides — Codecs](/docs/advanced-guides/codecs) for the serialization system, [RPC Requests](/docs/guides/rpc) for the full RPC API, [Using Program Plugins](/docs/guides/using-program-plugins) for typed account access.
+```ts twoslash
+import { address, fetchEncodedAccount } from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+// ---cut-end---
+const wallet = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+const account = await fetchEncodedAccount(client.rpc, wallet);
+```
 
-</Callout>
+When the account exists, you get back its address, lamports, owner program, and a `data` field containing the raw bytes as a `Uint8Array`. When it does not, the same object is returned with `exists: false` and just the address.
+
+## Handle missing accounts
+
+A `MaybeEncodedAccount` is a discriminated union: TypeScript narrows the type once you check `account.exists`. You can branch on that flag, or use `assertAccountExists` when you would rather throw if the account is not present.
+
+```ts twoslash
+import { address, assertAccountExists, fetchEncodedAccount } from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+// ---cut-end---
+const wallet = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+const account = await fetchEncodedAccount(client.rpc, wallet);
+assertAccountExists(account);
+
+// `account` is now `EncodedAccount`, with `data` typed as `Uint8Array`.
+account.data satisfies Uint8Array;
+```
+
+Asserting up front lets the rest of your function rely on a fully populated account, which is convenient for scripts and tests. In application code, branching on `account.exists` is usually a better fit so you can show a sensible empty state. When working with several accounts at once, `assertAccountsExist(accounts)` performs the same check across an entire array in one call.
+
+## Fetch multiple accounts
+
+When you need several accounts at once, `fetchEncodedAccounts` batches them into a single `getMultipleAccounts` RPC request and returns a parallel array of `MaybeEncodedAccount` values.
+
+```ts twoslash
+import { address, fetchEncodedAccounts } from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+// ---cut-end---
+const accounts = await fetchEncodedAccounts(client.rpc, [
+    address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ'),
+    address('Ay1zdJ3VDbhrAtkRiqBUJgKLHYbgFZN5BXk7svtMowif'),
+]);
+```
+
+Each returned account already carries its own address, so you do not need to zip arrays together to figure out which result belongs to which input. The same `exists` flag works on every entry, and `assertAccountsExist(accounts)` is the multi-account counterpart of `assertAccountExists`.
+
+## Decode accounts manually
+
+Once you have an encoded account, the `decodeAccount` helper turns it into a typed `Account` (or `MaybeAccount`) by running its `data` through any `Decoder`. The [Codecs guide](/docs/advanced-guides/codecs) covers how to build these decoders.
+
+```ts twoslash
+import { address, decodeAccount, fetchEncodedAccount } from '@solana/kit';
+import {
+    addDecoderSizePrefix,
+    Decoder,
+    getStructDecoder,
+    getU32Decoder,
+    getU8Decoder,
+    getUtf8Decoder,
+} from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+// ---cut-end---
+
+type Person = { name: string; age: number };
+const personDecoder: Decoder<Person> = getStructDecoder([
+    ['name', addDecoderSizePrefix(getUtf8Decoder(), getU32Decoder())],
+    ['age', getU8Decoder()],
+]);
+
+const wallet = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+const encodedAccount = await fetchEncodedAccount(client.rpc, wallet);
+const decodedAccount = decodeAccount(encodedAccount, personDecoder);
+```
+
+`decodeAccount` preserves the `MaybeAccount` shape: a missing account stays missing, and a present account gets its `data` swapped from raw bytes to your decoded type. This means you can keep narrowing with `account.exists` exactly like before.
+
+## Decode using program helpers
+
+For most popular Solana programs you will not need to write a decoder yourself. The `@solana-program/*` packages include generated helpers that handle decoding for every account they define, exposed as `decodeX`, `fetchX`, and `fetchMaybeX` functions where `X` is the account name.
+
+```ts twoslash
+import { address } from '@solana/kit';
+import { fetchMint } from '@solana-program/token';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+// ---cut-end---
+const mint = await fetchMint(client.rpc, address('So11111111111111111111111111111111111111112'));
+mint.data.decimals; // typed as `number`
+```
+
+Each program package follows the same naming convention: `fetchMint` and `fetchMaybeMint` for the `Mint` account, `fetchToken` and `fetchMaybeToken` for the `Token` account, and so on. The standalone `decodeMint` and `decodeToken` helpers work on encoded accounts you have already fetched. If you would rather access these through a typed `client.token.accounts.*` namespace, see the [Using program plugins](/docs/guides/using-program-plugins) guide.
+
+## Subscribe to account changes
+
+If you need live updates rather than a one-off read, pair an account fetch with an account subscription. The subscription notifies you whenever the account's data changes onchain, and the same address is used in both calls.
+
+```ts twoslash
+import { address } from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+// ---cut-end---
+const wallet = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+const accountNotifications = await client.rpcSubscriptions
+    .accountNotifications(wallet, { commitment: 'confirmed' })
+    .subscribe({ abortSignal: AbortSignal.timeout(60_000) });
+
+for await (const notification of accountNotifications) {
+    console.log('Account changed:', notification.value);
+}
+```
+
+See the [RPC subscriptions](/docs/guides/rpc-subscriptions) guide for more on cancellation, error handling, and the async iterator model.
+
+## Choose the right fetch helper
+
+Each helper trades a different amount of structure and convenience. The table below summarizes when each one shines.
+
+| Helper                                | Returns                           | Best for                               |
+| ------------------------------------- | --------------------------------- | -------------------------------------- |
+| `client.rpc.getAccountInfo(...)`      | raw RPC response                  | one-off reads with custom encoding     |
+| `client.rpc.getMultipleAccounts(...)` | raw RPC response                  | bulk reads with custom encoding        |
+| `fetchEncodedAccount(...)`            | `MaybeEncodedAccount`             | unified handling of single accounts    |
+| `fetchEncodedAccounts(...)`           | `MaybeEncodedAccount[]`           | unified batch reads                    |
+| `decodeAccount(...)`                  | `Account<T>` / `MaybeAccount<T>`  | turning raw bytes into typed data      |
+| `fetchMint`, `fetchToken`, ...        | `Account<T>` / `MaybeAccount<T>`  | typed reads for known program accounts |
+| `accountNotifications(...)`           | async iterator of account updates | live updates instead of one-off reads  |
+
+In practice you can pick any of them in isolation, or combine them to match the access pattern you need.
+
+## Next steps
+
+- [Codecs](/docs/advanced-guides/codecs) — learn how to build custom decoders.
+- [RPC requests](/docs/guides/rpc) — explore the rest of the RPC API.
+- [Using program plugins](/docs/guides/using-program-plugins) — read typed accounts through `client.token.accounts.mint.fetch(...)` and friends.

--- a/docs/content/docs/guides/index.mdx
+++ b/docs/content/docs/guides/index.mdx
@@ -3,9 +3,10 @@ title: Guides
 description: Practical guides for common tasks with Kit
 ---
 
-<Callout type="warn" title="Planned Content">
-**Status:** New page
+The pages in this section cover the most common tasks you will run into when building Solana applications with Kit. Each guide focuses on a single topic and can be read independently, so you can dip in when a specific question comes up rather than reading them in order.
 
-This index page will provide a brief introduction and list all available guides with one-line descriptions. Each guide is focused on a specific task and can be read independently.
+## How to use these guides
 
-</Callout>
+If you are completely new to Kit, start with the [Getting started](/docs/getting-started) tutorial. It walks through a small end-to-end project so the rest of the documentation has something concrete to reference.
+
+Once you have shipped your first transaction, the guides below are designed to be your day-to-day companion. They focus on practical workflows — composing a client, sending transactions, fetching accounts, testing locally, and so on — and link to the [Advanced guides](/docs/advanced-guides) when you want to learn what is happening under the hood.

--- a/docs/content/docs/guides/rpc-subscriptions.mdx
+++ b/docs/content/docs/guides/rpc-subscriptions.mdx
@@ -3,67 +3,157 @@ title: RPC subscriptions
 description: Get notified of changes to the blockchain
 ---
 
-<Callout type="warn" title="Planned Changes">
-**Status:** Existing page — moved to Guides, updates planned in a follow-up PR
+RPC subscriptions let your application receive live updates from the network instead of polling for them. They are delivered over a WebSocket endpoint and surface as async iterators in Kit, which fit naturally into modern JavaScript control flow.
 
-This page was moved from Advanced Guides to Guides because the current content is a simple RPC Subscriptions introduction. A follow-up PR will update the examples to the plugin-flavored API and explain how `client.rpcSubscriptions` from a plugin-composed client relates to the `RpcSubscriptions` object described here.
-
-**Current content preserved:** Yes, all existing content stays.
-
-</Callout>
-
-## Introduction
-
-Kit offers a TypeScript interface that you can use to subscribe for notifications from a Solana JSON RPC server. Registering subscriptions with a <abbr title="Remote procedure call">RPC</abbr> server will yield notifications over that channel when data matching your subscription is updated.
-
-Kit aims to implement all of the RPC Subscription methods documented in the [Solana RPC WebSocket methods](https://solana.com/docs/rpc/websocket) docs. You can either browse the available methods in the docs, or you can follow Kit's TypeScript types and inline documentation in your editor.
+Kit aims to support every method documented in the [Solana RPC WebSocket methods](https://solana.com/docs/rpc/websocket) docs. As with HTTP RPC, you can either browse the methods in the official documentation or rely on TypeScript autocompletion in your editor.
 
 ## Installation
 
-Functions for creating RPC Subscriptions clients are **included within the `@solana/kit` library** but you may also install them using their standalone package.
+You will typically install Kit alongside the RPC plugin package, which provides both HTTP and WebSocket connectivity.
 
 ```package-install
-@solana/rpc-subscriptions
+@solana/kit @solana/kit-plugin-rpc
 ```
 
-Note that the `@solana/rpc-subscriptions` package itself is composed of several smaller packages, each with a distinct responsibility. Here's the list of all packages that come together to implement the default RPC Subscriptions client should you wish to create your own custom one:
+If you only need subscriptions and prefer not to use a Kit client, the lower-level `createSolanaRpcSubscriptions` function is available directly from `@solana/kit`.
 
-| Package                                                                                                                | Description                                                                                                                                |
-| ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| [`@solana/kit`](https://npmjs.org/package/@solana/kit)                                                                 | Includes `@solana/rpc-subscriptions`, `@solana/rpc-parsed-types`, `@solana/rpc-spec-types`, and `@solana/rpc-types`                        |
-| [`@solana/rpc-subscriptions`](https://npmjs.org/package/@solana/rpc-subscriptions)                                     | Includes `@solana/rpc-subscriptions-api`, `@solana/rpc-subscriptions-spec`, and utilities for creating default RPC Subscriptions instances |
-| [`@solana/rpc-subscriptions-api`](https://npmjs.org/package/@solana/rpc-subscriptions-api)                             | Types that describe every method in the Solana RPC WebSocket API                                                                           |
-| [`@solana/rpc-subscriptions-spec`](https://npmjs.org/package/@solana/rpc-subscriptions-spec)                           | Types and methods that can be used to create an RPC Subscriptions implementation                                                           |
-| [`@solana/rpc-spec-types`](https://npmjs.org/package/@solana/rpc-spec-types)                                           | Utility types common to both RPC and RPC Subscriptions implementations                                                                     |
-| [`@solana/rpc-transformers`](https://npmjs.org/package/@solana/rpc-transformers)                                       | Helpers for transforming RPC subscriptions and notifications in various ways appropriate for use in a JavaScript application               |
-| [`@solana/rpc-subscriptions-channel-websocket`](https://npmjs.org/package/@solana/rpc-subscriptions-channel-websocket) | Utilities for creating custom RPC Subscriptions channels                                                                                   |
-| [`@solana/rpc-types`](https://npmjs.org/package/@solana/rpc-types)                                                     | Types for values used in the [Solana Websocket API](https://docs.solana.com/api/websocket) and a series of helpers for working with them   |
+## Create a subscriptions client
 
-## What is a RPC?
+The bundle plugins from `@solana/kit-plugin-rpc` install both `client.rpc` and `client.rpcSubscriptions` in one step. You do not need to manage two separate transports.
 
-A RPC is a server with an up-to-date view of the Solana blockchain. You can send it subscriptions to request notifications for changes to things like account data, signature statuses, and slot progression.
+```ts twoslash
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
 
-Here's a quick example that subscribes for a notification every time the network's slot count advances, then unsubscribes after 10 seconds.
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+```
+
+By default, the WebSocket endpoint is derived from the HTTP endpoint by swapping `http`/`https` for `ws`/`wss`. If your provider hosts the two endpoints at different URLs, pass `rpcSubscriptionsUrl` explicitly in the plugin configuration.
+
+## Subscribe to slot notifications
+
+Subscriptions return an async iterator. The most idiomatic way to consume one is a `for await` loop, which keeps reading notifications until the underlying subscription ends.
+
+```ts twoslash
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+// ---cut-end---
+const slotNotifications = await client.rpcSubscriptions
+    .slotNotifications()
+    .subscribe({ abortSignal: AbortSignal.timeout(10_000) });
+
+for await (const notification of slotNotifications) {
+    console.log('The network advanced to slot', notification.slot);
+}
+```
+
+The `.subscribe({ abortSignal })` step is mandatory because every subscription must be tied to an `AbortSignal`. This forces you to think up front about when the subscription should end and prevents leaks.
+
+## Cancel subscriptions
+
+You may want to cancel a subscription before it ends naturally — for example, when a component unmounts in a UI. Pass an `AbortController` so that calling `.abort()` from anywhere in your code stops the iterator gracefully.
+
+```ts twoslash
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+// ---cut-end---
+const abortController = new AbortController();
+const slotNotifications = await client.rpcSubscriptions
+    .slotNotifications()
+    .subscribe({ abortSignal: abortController.signal });
+
+// Stop receiving notifications after the user navigates away.
+abortController.abort();
+```
+
+`AbortSignal.timeout(ms)` is a convenient shortcut when you simply want a fixed duration. For one-off subscriptions, that single line is often all you need.
+
+## Subscribe to account changes
+
+Account subscriptions notify you whenever an account's data changes onchain. The shape of the notification mirrors the response of `getAccountInfo`, so the same encoding and commitment options apply.
+
+```ts twoslash
+import { address } from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+// ---cut-end---
+const wallet = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+const accountNotifications = await client.rpcSubscriptions
+    .accountNotifications(wallet, { commitment: 'confirmed' })
+    .subscribe({ abortSignal: AbortSignal.timeout(60_000) });
+
+for await (const notification of accountNotifications) {
+    console.log('Account changed:', notification.value);
+}
+```
+
+If you only need a one-off read of an account, [`fetchEncodedAccount`](/docs/guides/fetching-accounts) is usually a better fit. Use subscriptions for live, ongoing updates.
+
+## Handle disconnects and errors
+
+Long-lived subscriptions can disconnect for many reasons — flaky networks, server restarts, or connection limits — and errors can be raised at any point during iteration. Wrap the iteration in a `try`/`catch` so your application can react gracefully.
+
+```ts twoslash
+import { address } from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+// ---cut-end---
+const wallet = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+const accountNotifications = await client.rpcSubscriptions
+    .accountNotifications(wallet, { commitment: 'confirmed' })
+    .subscribe({ abortSignal: AbortSignal.timeout(60_000) });
+
+try {
+    for await (const notification of accountNotifications) {
+        console.log('Account changed:', notification.value);
+    }
+} catch (error) {
+    // Reconnect, log, surface a UI error, etc.
+}
+```
+
+Depending on your application, you may want to recreate the subscription with a fresh `AbortSignal` after a disconnect, possibly using a small backoff to avoid thrashing the server.
+
+## Use subscriptions without a client
+
+If you do not need a Kit client, you can build an `RpcSubscriptions` object directly with `createSolanaRpcSubscriptions`. This is the lower-level building block the plugins use under the hood.
 
 ```ts twoslash
 import { createSolanaRpcSubscriptions, mainnet } from '@solana/kit';
+
 const rpcSubscriptions = createSolanaRpcSubscriptions(mainnet('wss://api.mainnet-beta.solana.com'));
 const slotNotifications = await rpcSubscriptions
     .slotNotifications()
     .subscribe({ abortSignal: AbortSignal.timeout(10_000) });
-for await (const slotNotification of slotNotifications) {
-    console.log('The network has advanced to slot', slotNotification.slot);
-}
 ```
 
-Most RPC servers implement most of the Solana WebSocket API covered by Kit, but some offer extra methods above and beyond that. Those that do should offer an SDK that you can use to wrap Kit's RPC WebSocket API implementation, merging the method implementations and TypeScript types of both APIs into a single object.
+This is useful when you want maximum tree-shaking, when you are writing a library that should not assume a client, or when you only need a tiny subset of the subscriptions API.
 
-## Where to find an RPC
+## Choose a WebSocket endpoint
 
-For light development or personal use, you can use a public RPC server for the cluster you want to access.
+For light development or personal use, the public WebSocket endpoints maintained by the Solana Foundation work the same way as their HTTP counterparts.
 
 - `wss://api.mainnet-beta.solana.com`
 - `wss://api.testnet.solana.com`
 - `wss://api.devnet.solana.com`
 
-When deploying your application to production, you will want to lease an RPC server or [set up your own](https://docs.anza.xyz/operations/setup-an-rpc-node).
+In production, your HTTP and WebSocket endpoints should match — both clusters and providers — to avoid subtle mismatches between the data each transport returns. Most RPC providers offer paired endpoints; consult their documentation for the exact URLs they expect you to use.
+
+## Next steps
+
+- [RPC requests](/docs/guides/rpc) — read state and submit one-off requests over HTTP.
+- [Fetching accounts](/docs/guides/fetching-accounts) — pair subscriptions with a baseline read.
+- [Sending transactions](/docs/guides/sending-transactions) — submit work to the network.

--- a/docs/content/docs/guides/rpc.mdx
+++ b/docs/content/docs/guides/rpc.mdx
@@ -3,64 +3,111 @@ title: RPC requests
 description: Read and write data to the blockchain
 ---
 
-<Callout type="warn" title="Planned Changes">
-**Status:** Existing page — moved to Guides, updates planned in a follow-up PR
+Solana applications interact with the network through a JSON-RPC server. RPC requests are how your code reads onchain state, simulates transactions, and submits transactions to be processed. Kit ships a fully typed RPC client and exposes it on Kit clients via plugins, so the same RPC API is available whether you compose a client or use the lower-level building blocks directly.
 
-This page was moved from Advanced Guides to Guides because the current content is a simple RPC introduction. A follow-up PR will update the examples to the plugin-flavored API and explain how `client.rpc` from a plugin-composed client relates to the `Rpc` object described here.
-
-**Current content preserved:** Yes, all existing content stays.
-
-</Callout>
-
-## Introduction
-
-Kit offers a TypeScript interface that you can use to communicate with a Solana JSON RPC server. Calling methods on a <abbr title="Remote procedure call">RPC</abbr> server lets you read data from the blockchain, simulate transactions, and send transactions to be processed.
-
-Kit aims to implement all of the RPC methods documented in the [Solana RPC HTTP methods](https://solana.com/docs/rpc/http) docs. You can either browse the available methods in the docs, or you can follow Kit's TypeScript types and inline documentation in your editor.
+Kit aims to support every method documented in the [Solana RPC HTTP methods](https://solana.com/docs/rpc/http) docs. You can either browse the methods in the official documentation or rely on TypeScript autocompletion in your editor.
 
 ## Installation
 
-Functions for creating RPC clients are **included within the `@solana/kit` library** but you may also install them using their standalone package.
+You will typically install Kit alongside the RPC plugin package.
 
 ```package-install
-@solana/rpc
+@solana/kit @solana/kit-plugin-rpc
 ```
 
-Note that the `@solana/rpc` package itself is composed of several smaller packages, each with a distinct responsibility. Here's the list of all packages that come together to implement the default RPC client should you wish to create your own custom one:
+The `@solana/kit-plugin-rpc` package contains the plugins that install RPC connectivity on a client. The `@solana/kit` package contains the lower-level RPC primitives those plugins are built on top of, so you can also use it standalone if you prefer not to use a client.
 
-| Package                                                                              | Description                                                                                                                    |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
-| [`@solana/kit`](https://npmjs.org/package/@solana/kit)                               | Includes `@solana/rpc`, `@solana/rpc-parsed-types`, `@solana/rpc-spec-types`, and `@solana/rpc-types`                          |
-| [`@solana/rpc`](https://npmjs.org/package/@solana/rpc)                               | Includes `@solana/rpc-api`, `@solana/rpc-spec`, and utilities for creating default RPC instances                               |
-| [`@solana/rpc-api`](https://npmjs.org/package/@solana/rpc-api)                       | Types that describe every method in the Solana JSON RPC API                                                                    |
-| [`@solana/rpc-spec`](https://npmjs.org/package/@solana/rpc-spec)                     | Types and methods that can be used to create an RPC implementation                                                             |
-| [`@solana/rpc-spec-types`](https://npmjs.org/package/@solana/rpc-spec-types)         | Utility types common to both RPC and RPC Subscriptions implementations                                                         |
-| [`@solana/rpc-transformers`](https://npmjs.org/package/@solana/rpc-transformers)     | Helpers for transforming RPC requests and responses in various ways appropriate for use in a JavaScript application            |
-| [`@solana/rpc-transport-http`](https://npmjs.org/package/@solana/rpc-transport-http) | Utilities for creating custom RPC transports                                                                                   |
-| [`@solana/rpc-types`](https://npmjs.org/package/@solana/rpc-types)                   | Types for values used in the [Solana JSON-RPC](https://docs.solana.com/api/http) and a series of helpers for working with them |
+## Create an RPC client
 
-## What is a RPC?
-
-A RPC is a server with an up-to-date view of the Solana blockchain. You can make HTTP requests to it for things like account data, token balances, and transaction details. You can also ask it to simulate a transaction of your own creation, or to forward it to the network to be processed.
-
-Here's a quick example that fetches the native token balance of an account at a given address, in Lamports.
+The most convenient way to make RPC requests is to compose a Kit client with one of the bundle plugins, which install both `client.rpc` and `client.rpcSubscriptions` in one call.
 
 ```ts twoslash
-import { address, createSolanaRpc, mainnet } from '@solana/kit';
-const rpc = createSolanaRpc(mainnet('https://api.mainnet-beta.solana.com'));
-const { value: balanceInLamports } = await rpc
-    .getBalance(address('anza1Vgz2kcN9Qo6ECvf43v8RxBzQ7UpvxFoxJtLmGz'))
-    .send();
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
 ```
 
-Most RPC servers implement most of the Solana JSON-RPC API covered by Kit, but some offer extra methods above and beyond that. Those that do should offer an SDK that you can use to wrap Kit's RPC API implementation, merging the method implementations and TypeScript types of both APIs into a single object.
+The bundle plugins also wire up minimum balance computation, transaction planning, and transaction sending, which you will use in the other guides. If you only need to make read-only RPC requests, you can drop the signer plugin and use `solanaRpcConnection(...)` instead, which only installs `client.rpc` and `client.rpcSubscriptions`.
 
-## Where to find an RPC
+## Send your first RPC request
 
-For light development or personal use, you can use a public RPC server for the cluster you want to access.
+Once you have an RPC client, you build a request by calling the corresponding method on `client.rpc` and finalize it with `.send()`. Most RPC responses come back wrapped in a `{ context, value }` object, so destructuring `value` is a common pattern.
+
+```ts twoslash
+import { address } from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+// ---cut-end---
+
+const wallet = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+const { value: balance } = await client.rpc.getBalance(wallet).send();
+```
+
+Although `client.rpc` looks like a regular object, it is actually a [`Proxy`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) that constructs RPC requests on demand. TypeScript provides type safety for every method based on the API installed by your plugin, which makes the available methods discoverable from your editor while keeping the bundle small.
+
+## Use cluster-specific RPC bundles
+
+The `@solana/kit-plugin-rpc` package ships several bundle plugins, each tailored to a specific use case. The cluster-typed variants type the RPC API to match what is available on that cluster, which prevents accidents like calling `airdrop` against mainnet at compile time.
+
+| Plugin                  | Default endpoint                | Adds to the client                                          |
+| ----------------------- | ------------------------------- | ----------------------------------------------------------- |
+| `solanaRpc(config)`     | provided via `rpcUrl`           | RPC, subscriptions, planning, sending                       |
+| `solanaMainnetRpc(...)` | provided via `rpcUrl`           | mainnet-typed RPC, subscriptions, planning, sending         |
+| `solanaDevnetRpc(...)`  | `https://api.devnet.solana.com` | devnet-typed RPC, subscriptions, planning, sending, airdrop |
+| `solanaLocalRpc(...)`   | `http://127.0.0.1:8899`         | localnet RPC, subscriptions, planning, sending, airdrop     |
+
+If you need to talk to a custom RPC provider, pass its URL through `solanaRpc({ rpcUrl: '...' })` or `solanaMainnetRpc({ rpcUrl: '...' })`. The other settings on `SolanaRpcConfig` cover advanced options such as transport configuration and transaction planner overrides.
+
+## Pass request options
+
+Most RPC methods accept a configuration object as their final argument. This is where you control things like the requested commitment level, encoding, or pagination, depending on the method.
+
+```ts twoslash
+import { address } from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(solanaDevnetRpc());
+// ---cut-end---
+
+const wallet = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+const { value: balance } = await client.rpc.getBalance(wallet, { commitment: 'confirmed' }).send();
+```
+
+The `.send(...)` call itself accepts an optional `abortSignal` that lets you cancel the request in flight.
+
+## Use RPC without a client
+
+If you do not need a Kit client, you can build an `Rpc` object directly with `createSolanaRpc`. This is useful when you want maximum tree-shaking, when you are writing a library that should not assume a client, or when you simply want to keep your dependency surface small.
+
+```ts twoslash
+import { address, createSolanaRpc } from '@solana/kit';
+
+const rpc = createSolanaRpc('https://api.devnet.solana.com');
+const wallet = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+const { value: balance } = await rpc.getBalance(wallet).send();
+```
+
+The standalone `Rpc` object exposes the exact same API as `client.rpc`, so any code that takes an `Rpc` will work in either setup. See the [Kit without a client](/docs/advanced-guides/kit-without-a-client) guide for more on this approach.
+
+## Choose an RPC endpoint
+
+For light development or personal use, the public RPC endpoints maintained by the Solana Foundation are a fine starting point.
 
 - `https://api.mainnet-beta.solana.com`
 - `https://api.testnet.solana.com`
 - `https://api.devnet.solana.com`
 
-When deploying your application to production, you will want to lease an RPC server or [set up your own](https://docs.anza.xyz/operations/setup-an-rpc-node).
+These endpoints are heavily rate-limited and should not be used for anything close to production traffic. When you ship to production, lease an RPC node from a provider or [run your own](https://docs.anza.xyz/operations/setup-an-rpc-node). Some RPC providers also expose extra methods on top of the standard JSON-RPC API; many of them ship a Kit-compatible SDK that you can layer on top of `createSolanaRpc(...)` to merge their additional methods into the typed RPC object.
+
+## Next steps
+
+- [RPC subscriptions](/docs/guides/rpc-subscriptions) — receive live updates from a WebSocket endpoint.
+- [Fetching accounts](/docs/guides/fetching-accounts) — go from raw account bytes to typed data.
+- [Sending transactions](/docs/guides/sending-transactions) — submit transactions through your client.

--- a/docs/content/docs/guides/sending-multiple-transactions.mdx
+++ b/docs/content/docs/guides/sending-multiple-transactions.mdx
@@ -1,17 +1,216 @@
 ---
 title: Sending multiple transactions
-description: Plan and execute complex multi-transaction operations
+description: Plan and execute work across several transactions
 ---
 
-<Callout type="warn" title="Planned Content">
-**Status:** New page
+When an operation cannot fit in a single transaction — too many instructions, too much data, or work that should run in parallel — you need to split it across several transactions. Kit clients support this through the same `client.sendTransactions(...)` and `client.planTransactions(...)` methods you used in [Sending transactions](/docs/guides/sending-transactions), but plural.
 
-This guide assumes the reader is familiar with `InstructionPlan` structures (covered in [Sending Transactions](/docs/guides/sending-transactions)), but a brief recap with a link back will be included so this guide works standalone.
+## Prerequisites
 
-The guide will introduce two structures that are new and specific to multi-transaction operations: the **`TransactionPlan`** (the result of planning instruction plans into concrete transactions) and the **`TransactionPlanResult`** (the tree structure returned after execution, containing success, failure, and cancellation states). It will cover **`client.sendTransactions(instructionPlan)`** for sending instruction plans that span multiple transactions, **`client.planTransactions(instructionPlan)`** for planning without executing (inspection, debugging), helper functions like `summarizeTransactionPlanResult` and `flattenTransactionPlanResult` for processing results, error recovery via `passthroughFailedTransactionPlanExecution` to continue past failures, and handling partial failures, cancelled transactions, and successful transactions in the result tree.
+This guide assumes a transaction-ready client, like the one set up in [Sending transactions](/docs/guides/sending-transactions). The same bundle plugins from `@solana/kit-plugin-rpc` and `@solana/kit-plugin-litesvm` install everything `client.sendTransactions(...)` needs out of the box.
 
-**Draws from:** Kit-plugins `token-airdrop` example (multi-address airdrop with parallel plans and error recovery), `@solana/kit-plugin-instruction-plan` README, `@solana/kit-plugin-rpc` README (`rpcTransactionPlanExecutor`).
+## Instruction plans
 
-**Links to:** [Sending Transactions](/docs/guides/sending-transactions) for single transaction basics, [Advanced Guides — Instruction Plans](/docs/advanced-guides/instruction-plans) for the underlying plan system, [Recipes — Airdropping Tokens](/recipes/airdropping-tokens) for a concrete multi-transaction example.
+An instruction plan describes an operation made of several instructions together with constraints on how they can run — some steps must happen sequentially, others may run in parallel, and some must stay atomic. Kit represents this as a tree, so simple operations stay simple while more complex flows can nest sequential and parallel branches inside each other. The plan is then handed to a [transaction planner](/docs/advanced-guides/instruction-plans) that decides how to pack it into transaction messages, and then to a [transaction plan executor](/docs/advanced-guides/instruction-plans) that sends those transactions.
 
-</Callout>
+Kit's planners can divide work, batch it into transactions, and even pack variable-sized data into the available space. For most cases you only need to know about three building blocks: `singleInstructionPlan`, `sequentialInstructionPlan`, and `parallelInstructionPlan`. The [Instruction plans](/docs/advanced-guides/instruction-plans) advanced guide goes much deeper.
+
+## Run work sequentially
+
+Use `sequentialInstructionPlan(...)` when each step depends on the previous one — for example, creating an account before initializing it.
+
+```ts twoslash
+import { Instruction, sequentialInstructionPlan } from '@solana/kit';
+const createAccount = {} as Instruction;
+const initializeAccount = {} as Instruction;
+// ---cut-before---
+const instructionPlan = sequentialInstructionPlan([createAccount, initializeAccount]);
+```
+
+Sequential plans accept either raw instructions or other instruction plans, so you can compose larger flows from smaller ones. A `nonDivisibleSequentialInstructionPlan(...)` variant also exists for steps that must run atomically inside a single transaction (or transaction bundle when not possible).
+
+## Run work in parallel
+
+Use `parallelInstructionPlan(...)` when independent steps can run in any order. The planner is then free to pack them into separate transactions and send them concurrently.
+
+```ts twoslash
+import { Instruction, parallelInstructionPlan } from '@solana/kit';
+const transferToBob = {} as Instruction;
+const transferToCarla = {} as Instruction;
+// ---cut-before---
+const instructionPlan = parallelInstructionPlan([transferToBob, transferToCarla]);
+```
+
+The two helpers compose freely: a sequential plan can contain parallel children and vice versa. This is how you describe operations like "set up these two accounts in parallel, then run the operation that depends on both of them".
+
+## Plan multiple transactions
+
+When you only want to inspect or persist the planned transactions, `client.planTransactions(plan)` runs the planner without executing anything and returns the resulting `TransactionPlan` tree.
+
+```ts twoslash
+import { lamports, parallelInstructionPlan } from '@solana/kit';
+import { getTransferSolInstruction } from '@solana-program/system';
+// ---cut-start---
+import { address } from '@solana/kit';
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(10_000_000_000n)));
+const bob = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+const carla = address('Ay1zdJ3VDbhrAtkRiqBUJgKLHYbgFZN5BXk7svtMowif');
+// ---cut-end---
+const instructionPlan = parallelInstructionPlan([
+    getTransferSolInstruction({
+        source: client.payer,
+        destination: bob,
+        amount: lamports(500_000n),
+    }),
+    getTransferSolInstruction({
+        source: client.payer,
+        destination: carla,
+        amount: lamports(500_000n),
+    }),
+]);
+
+const transactionPlan = await client.planTransactions(instructionPlan);
+```
+
+The returned `TransactionPlan` keeps the same sequential and parallel structure as the original instruction plan, but its leaves are the concrete transaction messages the planner chose to pack the work into. This is useful for dry runs, debugging, or feeding a custom executor.
+
+## Send multiple transactions
+
+To plan and send in one call, use `client.sendTransactions(plan)`. The result is a `TransactionPlanResult` tree that mirrors the original plan, with one leaf per transaction.
+
+```ts twoslash
+import { lamports, parallelInstructionPlan } from '@solana/kit';
+import { getTransferSolInstruction } from '@solana-program/system';
+// ---cut-start---
+import { address } from '@solana/kit';
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(10_000_000_000n)));
+const bob = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+const carla = address('Ay1zdJ3VDbhrAtkRiqBUJgKLHYbgFZN5BXk7svtMowif');
+// ---cut-end---
+const instructionPlan = parallelInstructionPlan([
+    getTransferSolInstruction({
+        source: client.payer,
+        destination: bob,
+        amount: lamports(500_000n),
+    }),
+    getTransferSolInstruction({
+        source: client.payer,
+        destination: carla,
+        amount: lamports(500_000n),
+    }),
+]);
+
+const result = await client.sendTransactions(instructionPlan);
+```
+
+`client.sendTransactions(...)` is the multi-transaction counterpart of `client.sendTransaction(...)`. The single-transaction version asserts that the plan resolves to exactly one transaction and unwraps its result — a convenience for the common case. The plural version preserves the full tree, which you can walk to see what happened.
+
+## Understand transaction plan results
+
+Every leaf in the result tree is a `SingleTransactionPlanResult` with one of three statuses:
+
+- `successful` — the transaction was sent and confirmed; `context.signature` is always present.
+- `failed` — the transaction was attempted but failed during preflight, simulation, or execution. `error` carries the underlying error.
+- `canceled` — the transaction was never attempted, typically because a prior transaction in a sequential branch failed first.
+
+```ts twoslash
+import { TransactionPlanResult } from '@solana/kit';
+const result = {} as TransactionPlanResult;
+// ---cut-before---
+if (result.kind === 'single') {
+    if (result.status === 'successful') {
+        console.log('Signature:', result.context.signature);
+    } else if (result.status === 'failed') {
+        console.error('Failed:', result.error);
+    } else {
+        console.warn('Canceled before being sent');
+    }
+}
+```
+
+Branch nodes use `kind: 'parallel'` or `kind: 'sequential'`, with their child results in `plans`. You usually do not need to walk the tree by hand — the helpers in the next sections cover the common cases.
+
+## Summarize results
+
+`summarizeTransactionPlanResult(...)` flattens the tree and bucketizes the results so you can quickly check whether everything succeeded.
+
+```ts twoslash
+import { summarizeTransactionPlanResult, TransactionPlanResult } from '@solana/kit';
+const result = {} as TransactionPlanResult;
+// ---cut-before---
+const summary = summarizeTransactionPlanResult(result);
+
+if (summary.successful) {
+    console.log(`✅ ${summary.successfulTransactions.length} transactions confirmed`);
+} else {
+    console.warn(
+        `${summary.successfulTransactions.length} ok, ` +
+            `${summary.failedTransactions.length} failed, ` +
+            `${summary.canceledTransactions.length} canceled`,
+    );
+}
+```
+
+This is usually the first thing to reach for after `client.sendTransactions(...)` — it gives you a quick health check without writing any tree-walking code.
+
+## Continue after failures
+
+By default, `client.sendTransactions(...)` throws as soon as any transaction in the plan fails. That behaviour is convenient for small operations, but counterproductive when you are running a large batch and want to inspect partial results. The `passthroughFailedTransactionPlanExecution(...)` helper turns that thrown error back into a `TransactionPlanResult`.
+
+```ts twoslash
+import { InstructionPlan, passthroughFailedTransactionPlanExecution } from '@solana/kit';
+const instructionPlan = {} as InstructionPlan;
+// ---cut-start---
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(10_000_000_000n)));
+// ---cut-end---
+const result = await passthroughFailedTransactionPlanExecution(
+    client.sendTransactions(instructionPlan),
+);
+```
+
+After this call, `result` is the same tree you would have received on full success — but with `failed` and `canceled` leaves where the issues occurred. You can then summarize it, walk it, or react however you need.
+
+## Handle partial success
+
+When you want to react to each transaction individually, `flattenTransactionPlanResult(...)` collapses the tree into an array of leaf results in the order they appear.
+
+```ts twoslash
+import { flattenTransactionPlanResult, TransactionPlanResult } from '@solana/kit';
+const result = {} as TransactionPlanResult;
+// ---cut-before---
+for (const single of flattenTransactionPlanResult(result)) {
+    if (single.status === 'successful') {
+        console.log('✅', single.context.signature);
+    } else if (single.status === 'failed') {
+        console.error('❌', single.error.message);
+    } else {
+        console.warn('⏭️', 'canceled');
+    }
+}
+```
+
+Combined with `passthroughFailedTransactionPlanExecution(...)`, this is enough to drive a UI that shows per-transaction status, retry buttons, or detailed error messages for a long-running multi-transaction operation.
+
+## Next steps
+
+- [Sending transactions](/docs/guides/sending-transactions) — single-transaction basics.
+- [Advanced guides — Instruction plans](/docs/advanced-guides/instruction-plans) — the full instruction plan API.
+- [Advanced guides — Errors](/docs/advanced-guides/errors) — recover from `SolanaError` failures.

--- a/docs/content/docs/guides/sending-transactions.mdx
+++ b/docs/content/docs/guides/sending-transactions.mdx
@@ -1,15 +1,164 @@
 ---
 title: Sending transactions
-description: Send single transactions with error handling and configuration
+description: Send single transactions with a Kit client
 ---
 
-<Callout type="warn" title="Planned Content">
-**Status:** New page
+A Kit client can take a list of instructions and turn it into a fully signed, sent, and confirmed transaction in a single call. This guide covers the basics of sending one transaction at a time. When an operation needs to span multiple transactions, see [Sending multiple transactions](/docs/guides/sending-multiple-transactions).
 
-This guide will cover sending single transactions through the client: **`client.sendTransaction(instruction)`** for the simplest case, passing instruction plans (sequential, parallel, non-divisible) to `sendTransaction`, error handling including catching `SolanaError`, understanding error codes, and extracting program-specific errors, priority fees and compute budget configuration, and **`client.planTransaction(instruction)`** for planning without sending (dry runs, inspection). The guide will also briefly describe the typical lifecycle a client follows when sending a transaction (planning, signing, sending, confirming) while noting that the exact behavior depends on the transaction planner and executor plugins configured on the client, which are fully customizable.
+## Create a transaction-ready client
 
-**Draws from:** Current `getting-started/send-transaction.mdx` (conceptual explanation), `getting-started/build-transaction.mdx` (transaction construction), `@solana/kit-plugin-instruction-plan` README, `@solana/kit-plugin-rpc` README (`rpcTransactionPlanExecutor`), kit-plugins `transfer-lamports` example (error handling).
+Sending transactions requires a client that exposes a `sendTransaction` method. At the lowest level, this means installing the [`planAndSendTransactions`](/docs/plugins/available-plugins) plugin from `@solana/kit-plugin-instruction-plan` on top of a custom `transactionPlanner` and `transactionPlanExecutor`. In practice, you almost always pick a higher-level bundle that does this for you.
 
-**Links to:** [Sending Multiple Transactions](/docs/guides/sending-multiple-transactions) for complex multi-transaction operations, [Advanced Guides — Transactions](/docs/advanced-guides/transactions) for the full manual transaction lifecycle, [Advanced Guides — Instruction Plans](/docs/advanced-guides/instruction-plans) for the underlying plan system.
+```ts twoslash
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
 
-</Callout>
+const client = await createClient().use(generatedSigner()).use(solanaLocalRpc());
+```
+
+The bundle plugins from `@solana/kit-plugin-rpc` (`solanaRpc`, `solanaMainnetRpc`, `solanaDevnetRpc`, `solanaLocalRpc`) and the `litesvm` plugin from `@solana/kit-plugin-litesvm` all install a working planner and executor out of the box. Community plugins that target other backends should follow the same pattern, so the rest of this guide works the same way regardless of where transactions are actually sent.
+
+The signer plugin must be installed before the bundle, because the bundle's transaction planner needs a `payer` on the client to plan transactions. See [Setting up signers](/docs/guides/setting-up-signers) for the full set of signer options.
+
+## Send instructions
+
+Once your client is ready, `client.sendTransaction([...])` accepts an array of instructions and turns them into a single transaction. The client takes care of fetching a recent blockhash, estimating compute units when applicable, setting the fee payer, signing with all attached signers, sending the transaction, and waiting for confirmation.
+
+```ts twoslash
+import { address, lamports } from '@solana/kit';
+import { getTransferSolInstruction } from '@solana-program/system';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)));
+// ---cut-end---
+const recipient = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+
+const result = await client.sendTransaction([
+    getTransferSolInstruction({
+        source: client.payer,
+        destination: recipient,
+        amount: lamports(500_000n),
+    }),
+    getTransferSolInstruction({
+        source: client.payer,
+        destination: recipient,
+        amount: lamports(500_000n),
+    }),
+]);
+```
+
+A single `client.sendTransaction([...])` call always produces exactly one transaction onchain, which means every instruction succeeds together or fails together. If you have so many instructions that they cannot fit in one transaction, use [`client.sendTransactions(...)`](/docs/guides/sending-multiple-transactions) instead.
+
+## Plan before sending
+
+Sometimes you do not want to send the transaction immediately. You may want to inspect the planned message before signing, log it for debugging, or take over the rest of the lifecycle yourself. The `client.planTransaction([...])` method returns the planned transaction message and stops there, leaving signing and sending to you.
+
+```ts twoslash
+import { address, lamports } from '@solana/kit';
+import { getTransferSolInstruction } from '@solana-program/system';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)));
+// ---cut-end---
+const recipient = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+
+const transactionMessage = await client.planTransaction([
+    getTransferSolInstruction({
+        source: client.payer,
+        destination: recipient,
+        amount: lamports(500_000n),
+    }),
+]);
+```
+
+This gives you full control over what happens next: you can sign the message with [`signTransactionMessageWithSigners`](/docs/advanced-guides/signers), encode it for transmission to another service, or pass it to a custom executor. Note that the executor used by `client.sendTransaction([...])` may further mutate the planned message before sending — for example by attaching a fresh blockhash or refreshing the compute unit limit — so the message you inspect here is not guaranteed to be byte-identical to what would land onchain. The [Kit without a client](/docs/advanced-guides/kit-without-a-client) guide goes deeper into building and sending transactions step by step.
+
+## Handle transaction errors
+
+When a transaction fails, `client.sendTransaction(...)` throws a [`SolanaError`](/docs/advanced-guides/errors) with the `SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION` code. The error message identifies whether the failure happened in preflight or onchain, and the `cause` carries the underlying error you can branch on.
+
+```ts twoslash
+import {
+    address,
+    isSolanaError,
+    lamports,
+    SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION,
+} from '@solana/kit';
+import { getTransferSolInstruction } from '@solana-program/system';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)));
+const recipient = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+// ---cut-end---
+try {
+    await client.sendTransaction([
+        getTransferSolInstruction({
+            source: client.payer,
+            destination: recipient,
+            amount: lamports(500_000n),
+        }),
+    ]);
+} catch (error) {
+    if (isSolanaError(error, SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION)) {
+        console.error(error.message);
+        console.error('Logs:', error.context.logs);
+    } else {
+        throw error;
+    }
+}
+```
+
+The same `error.context` object also exposes the underlying `transactionPlanResult`, which is particularly useful when you want to inspect the failed transaction message or its signature. Program-specific errors (such as System program or SPL Token program errors) live deeper inside `error.cause`. The [Errors](/docs/advanced-guides/errors) guide covers how to identify and handle them.
+
+## Inspect transaction signatures
+
+A successful `client.sendTransaction(...)` resolves with a result object whose `context` carries the transaction `signature` and the original transaction message. You can use the signature to log a link to a block explorer or store it for later reference.
+
+```ts twoslash
+import { address, lamports } from '@solana/kit';
+import { getTransferSolInstruction } from '@solana-program/system';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)));
+const recipient = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+// ---cut-end---
+const result = await client.sendTransaction([
+    getTransferSolInstruction({
+        source: client.payer,
+        destination: recipient,
+        amount: lamports(500_000n),
+    }),
+]);
+
+console.log(`✅ ${result.context.signature}`);
+```
+
+Transaction signatures are deterministic, so the signature is known as soon as the fee payer signs the transaction — you do not need to wait for confirmation to learn what it will be. If you build and sign your own transactions, the [`getSignatureFromTransaction`](/docs/advanced-guides/transactions) helper exposes the same value.
+
+## Next steps
+
+- [Sending multiple transactions](/docs/guides/sending-multiple-transactions) — plan and execute work that does not fit in a single transaction.
+- [Using program plugins](/docs/guides/using-program-plugins) — discover the `.sendTransaction()` shortcut on typed program helpers.
+- [Advanced guides — Transactions](/docs/advanced-guides/transactions) — learn the full transaction lifecycle.
+- [Advanced guides — Errors](/docs/advanced-guides/errors) — handle failures with `SolanaError`.

--- a/docs/content/docs/guides/setting-up-signers.mdx
+++ b/docs/content/docs/guides/setting-up-signers.mdx
@@ -1,15 +1,123 @@
 ---
 title: Setting up signers
-description: Use signers to sign and pay for transactions
+description: Authorize transactions, pay fees, and own onchain assets
 ---
 
-<Callout type="warn" title="Planned Content">
-**Status:** New page
+Most Kit applications need at least one signer. Signers represent the accounts that authorize transactions, pay fees, and own onchain assets such as tokens or program authorities. This guide covers the different ways you can attach signers to a Kit client and the situations each one is best suited for.
 
-This guide will cover all the ways to set up signers for your client: **`signer(signer)`** to use one signer as both payer and identity, **`payer(signer)`** and **`identity(signer)`** to set those roles independently, **`signerFromFile(path)`** / **`payerFromFile(path)`** to load a keypair from a JSON file (Node.js only, e.g. Solana CLI keypair), **wallet standard integration** for using a browser wallet as the signer, **`generatedSigner()`** / **`generatedPayer()`** to generate random keypairs for testing, **`generatedSignerWithSol(amount)`** / **`generatedPayerWithSol(amount)`** when an airdrop function is already available, **`airdropSigner(amount)`** / **`airdropPayer(amount)`** when a bundle such as `solanaLocalRpc` adds airdrop support after the signer is installed, and how signer roles flow through transaction planning and signing.
+## Installation
 
-**Draws from:** Current `getting-started/signers.mdx` (signer generation and airdrop sections), `@solana/kit-plugin-signer` README.
+You will need Kit and the signer plugin package.
 
-**Links to:** [Advanced Guides — Signers](/docs/advanced-guides/signers) for the signer interface deep dive.
+```package-install
+@solana/kit @solana/kit-plugin-signer
+```
 
+Some examples below also use `@solana/kit-plugin-rpc` or `@solana/kit-plugin-litesvm` to fund signers in local environments.
+
+## What is a signer?
+
+A signer is an object that carries an `Address` and knows how to produce a signature for that address. Where the underlying private key actually lives — in memory, in a keypair file, in a browser wallet, on a hardware device, or behind a remote signing service — is an implementation detail. As long as the signer implements one of Kit's signer interfaces, it can be plugged into the same APIs.
+
+This means you can swap a generated keypair for a wallet-backed signer without changing the rest of your code. The [Advanced guides — Signers](/docs/advanced-guides/signers) page goes into the different signer interfaces and when each one applies.
+
+## Payer and identity
+
+Kit clients hold two distinct signer roles:
+
+- **`payer`** — the signer that pays transaction fees and storage costs (the rent reserved when creating new accounts).
+- **`identity`** — the signer that represents the wallet your application acts on behalf of, typically the authority over accounts, tokens, or other onchain assets.
+
+In most apps these roles are filled by the same signer, but they can be separated when you want a sponsored fee payer, a custodial backend, or any setup where authority and fee payment do not belong to the same key.
+
+## Install signers on your client
+
+The most common way to install a signer is to use the `signer(...)` plugin, which sets the same signer as both the `payer` and the `identity` of the client.
+
+```ts twoslash
+import { createClient, generateKeyPairSigner } from '@solana/kit';
+import { signer } from '@solana/kit-plugin-signer';
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner));
+```
+
+The `signer(...)` plugin accepts any object that implements the `TransactionSigner` interface, so a signer obtained from somewhere else in your code — a library, a hook, a custom factory — can be passed in directly without any wrapping.
+
+If your application needs a sponsored fee payer or otherwise wants to set the two roles independently, you may use the `payer(...)` and `identity(...)` plugins instead. They have the exact same shape as `signer(...)` but install only one role each.
+
+```ts twoslash
+import { createClient, generateKeyPairSigner } from '@solana/kit';
+import { identity, payer } from '@solana/kit-plugin-signer';
+
+const feePayer = await generateKeyPairSigner();
+const owner = await generateKeyPairSigner();
+
+const client = createClient().use(payer(feePayer)).use(identity(owner));
+```
+
+## Load a signer from a file
+
+Most Solana CLI keypairs are stored as a JSON byte array on disk. The `signerFromFile(...)` plugin reads such a file and installs the resulting signer on both the `payer` and `identity` roles.
+
+```ts twoslash
+import { createClient } from '@solana/kit';
+import { signerFromFile } from '@solana/kit-plugin-signer';
+
+const client = await createClient().use(signerFromFile('~/.config/solana/id.json'));
+```
+
+This is convenient for command-line tools, scripts, and backend services that already use a Solana CLI keypair. As with the in-memory plugins above, `payerFromFile(path)` and `identityFromFile(path)` are available if you only want to install a single role.
+
+<Callout title="Node.js only" type="warn">
+    The file-based signer plugins read from the local filesystem and therefore only work in Node.js
+    environments. They throw an error in browsers and React Native. Make sure your keypair files are
+    excluded from version control and from any production build artifact.
 </Callout>
+
+## Use a browser wallet signer
+
+A dedicated wallet signer plugin is on its way and will be documented here once it lands. It will use the [Wallet Standard](https://github.com/wallet-standard/wallet-standard) under the hood and expose a framework-agnostic reactive layer, so it can be used from any UI framework — not just React.
+
+Until then, the [`@solana/react`](/api) hooks can produce a `TransactionSigner` from a connected wallet account, and you can install that signer on a Kit client with the `signer(...)`, `payer(...)`, or `identity(...)` plugins shown above.
+
+## Generate signers for tests
+
+When writing tests, generating a fresh signer per run keeps each scenario isolated and avoids leaking state between tests. The `generatedSigner()` plugin creates a brand new keypair signer and installs it on both roles.
+
+```ts twoslash
+import { createClient } from '@solana/kit';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+
+const client = await createClient().use(generatedSigner());
+```
+
+`generatedPayer()` and `generatedIdentity()` follow the same pattern when you only want to generate one of the two roles. Generated signers are great for tests but should not be used as long-lived production identities, since the keypair only exists for the lifetime of the client.
+
+## Fund signers in local environments
+
+Generated signers start with no SOL, so they can not pay fees or rent until they have been funded. The typical local pattern is to install a generated signer first, then install a local environment that ships an `airdrop` capability — either `solanaLocalRpc()` or `litesvm()` — and finally airdrop SOL to the signer with the `airdropSigner(...)` plugin.
+
+```ts twoslash
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)));
+```
+
+The order matters: the signer must exist before the RPC bundle is added (so the bundle can wire the signer into transaction planning), and the airdrop function must be available before `airdropSigner(...)` runs (which `solanaLocalRpc()` and `litesvm()` both provide). `airdropPayer(...)` and `airdropIdentity(...)` are available if you split roles between two different signers.
+
+<Callout type="warn">
+    Airdrops only work on test clusters such as devnet, testnet, and local validators. Mainnet does
+    not have a faucet, and `solanaMainnetRpc(...)` will refuse to type-check an `airdrop` call.
+</Callout>
+
+## Next steps
+
+- [Sending transactions](/docs/guides/sending-transactions) — use your client to send and confirm transactions.
+- [Testing and local development](/docs/guides/testing-and-local-development) — set up local validators or LiteSVM for testing.
+- [Advanced guides — Signers](/docs/advanced-guides/signers) — learn the signer interfaces in depth.

--- a/docs/content/docs/guides/testing-and-local-development.mdx
+++ b/docs/content/docs/guides/testing-and-local-development.mdx
@@ -1,15 +1,169 @@
 ---
 title: Testing & local development
-description: Test your Solana applications locally and in CI
+description: Test your Solana applications locally
 ---
 
-<Callout type="warn" title="Planned Content">
-**Status:** New page
+Local development and testing benefit hugely from Kit's plugin system: the same application code can run against devnet, a local validator, or an in-process [LiteSVM](https://github.com/litesvm/litesvm) instance, depending on which bundle plugin you install. This guide walks through the three options and the small patterns that make tests easy to write and maintain.
 
-This guide will cover testing and local development patterns: test validator setup (`solana-test-validator`) and when to use it, airdropping funds on test clusters via `client.airdrop(address, lamports(1_000_000_000n))`, LiteSVM for unit tests (fast, in-process, no network required), composing local clients with `createClient().use(generatedSigner()).use(solanaLocalRpc())` for test validators or `createClient().use(generatedSigner()).use(litesvm())` for LiteSVM, API symmetry so code that works against one setup works against the other, test patterns and fixtures (generating test keypairs, setting up test state), comparing approaches for when to use test validator vs LiteSVM, and CI integration for running tests without a running validator.
+## Choose a local environment
 
-**Draws from:** `@solana/kit-plugin-rpc` README (`solanaLocalRpc`), `@solana/kit-plugin-litesvm` README, `@solana/kit-plugin-signer` README, kit-plugins examples.
+Each environment shines in a different situation. The table below summarizes when to reach for each.
 
-**Links to:** [Plugins — Available Plugins](/docs/plugins/available-plugins) for comparing local RPC and LiteSVM plugin bundles.
+| Environment     | Best for                                             | Tradeoffs                                                 |
+| --------------- | ---------------------------------------------------- | --------------------------------------------------------- |
+| Devnet          | shared/manual testing                                | faucet limits, network latency, shared state across tests |
+| Local validator | integration testing, full RPC API                    | requires a separate process, shared state across tests    |
+| LiteSVM         | fast unit tests, manipulating account state per test | Node.js only, RPC subset, in-memory only state            |
 
+You do not have to commit to one environment for the whole project. It is common to use LiteSVM for fast unit tests, a local validator for integration tests, and devnet for manual exploration.
+
+## Use devnet for shared testing
+
+Devnet is the easiest way to share a Solana environment with your team. The `solanaDevnetRpc()` plugin defaults to the public devnet endpoint and bundles an `airdrop` capability for funding accounts.
+
+```ts twoslash
+import { address, createClient, lamports } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { signerFromFile } from '@solana/kit-plugin-signer';
+
+const client = await createClient()
+    .use(signerFromFile('~/.config/solana/id.json'))
+    .use(solanaDevnetRpc());
+
+await client.airdrop(client.payer.address, lamports(1_000_000_000n));
+```
+
+Devnet is great for one-off scripts and manual exploration, but the public faucet has tight rate limits. For automated tests, prefer one of the local options.
+
+## Use a local validator
+
+A local validator runs the same software as mainnet but on your own machine. You can install the `solana-test-validator` binary by following the [Anza installation guide](https://docs.anza.xyz/cli/install) and start it with a single command.
+
+```shell
+solana-test-validator
+```
+
+Once the validator is running, the `solanaLocalRpc()` plugin connects to its default endpoints (`http://127.0.0.1:8899` and `ws://127.0.0.1:8900`) and ships the same `airdrop` capability as devnet — without any rate limits.
+
+```ts twoslash
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)));
+```
+
+Use this setup for integration tests that need the full Solana RPC API or to load deployed programs the way a real validator would. Make sure the validator is running before your tests start; otherwise, the first RPC call will fail with a connection error.
+
+## Use LiteSVM for fast tests
+
+LiteSVM runs the Solana virtual machine in-process, with no validator and no network. It is significantly faster than a local validator and is ideal for unit tests. The `litesvm()` plugin from `@solana/kit-plugin-litesvm` installs a LiteSVM-backed client that exposes the same `client.rpc`, `client.airdrop`, `client.sendTransaction`, and `client.sendTransactions` APIs as the RPC bundles.
+
+```ts twoslash
+import { createClient, lamports } from '@solana/kit';
+import { litesvm } from '@solana/kit-plugin-litesvm';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+
+const client = await createClient()
+    .use(generatedSigner())
+    .use(litesvm())
+    .use(airdropSigner(lamports(1_000_000_000n)));
+```
+
+Each LiteSVM-backed client owns its own in-memory SVM instance, so every test can have a completely isolated state. This is particularly useful for unit tests where one test should never affect the state observed by another.
+
+<Callout title="Node.js only" type="warn">
+    LiteSVM runs natively in Node.js. It will throw if you try to use it in a browser or in React
+    Native. The exposed RPC also covers a subset of the full API — enough for most tests, but worth
+    double-checking against the [`@solana/kit-plugin-litesvm`
+    README](https://github.com/anza-xyz/kit-plugins/tree/main/packages/kit-plugin-litesvm#readme)
+    for the methods you rely on.
 </Callout>
+
+## Create a funded test client
+
+For most tests you want a fresh, funded signer for every run. The pattern is the same regardless of the chosen environment: install a generated signer, install the environment, and airdrop SOL.
+
+```ts twoslash
+import { createClient, lamports } from '@solana/kit';
+import { litesvm } from '@solana/kit-plugin-litesvm';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+
+const client = await createClient()
+    .use(generatedSigner())
+    .use(litesvm())
+    .use(airdropSigner(lamports(10_000_000_000n)));
+```
+
+Swapping `litesvm()` for `solanaLocalRpc()` is a one-line change and the rest of your test code stays the same. This is one of the main benefits of the plugin model: the surface your tests interact with is a `client`, not a particular environment.
+
+## Reuse setup across tests
+
+Wrap the client creation in a small factory so every test starts from a clean state. Adding any program plugins or extra setup to the factory keeps tests focused on what they are actually testing.
+
+```ts twoslash
+import { createClient, lamports } from '@solana/kit';
+import { litesvm } from '@solana/kit-plugin-litesvm';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { systemProgram } from '@solana-program/system';
+import { tokenProgram } from '@solana-program/token';
+
+async function createTestClient() {
+    return await createClient()
+        .use(generatedSigner())
+        .use(litesvm())
+        .use(airdropSigner(lamports(10_000_000_000n)))
+        .use(systemProgram())
+        .use(tokenProgram());
+}
+```
+
+Because Kit clients are immutable, you do not need to worry about leaking state between tests as long as you do not share a single client instance across them.
+
+## Seed accounts and programs
+
+LiteSVM exposes the underlying SVM through `client.svm`, which lets you preload accounts and programs before your test code runs. This is the quickest way to set up a specific scenario without chaining a series of transactions.
+
+```ts twoslash
+import { address, EncodedAccount, lamports } from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { litesvm } from '@solana/kit-plugin-litesvm';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = await createClient().use(generatedSigner()).use(litesvm());
+// ---cut-end---
+const myAccount: EncodedAccount = {
+    address: address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ'),
+    data: new Uint8Array([1, 2, 3]),
+    executable: false,
+    lamports: lamports(1_000_000_000n),
+    programAddress: address('11111111111111111111111111111111'),
+    space: 3n,
+};
+client.svm.setAccount(myAccount);
+
+client.svm.addProgramFromFile(
+    address('MyProgram111111111111111111111111111111111'),
+    './my_program.so',
+);
+```
+
+A local validator supports similar workflows through its CLI flags (`--account`, `--bpf-program`, etc.), which you can pass when starting `solana-test-validator`. See [`@solana/kit-plugin-litesvm`](/docs/plugins/available-plugins) and the [Anza CLI documentation](https://docs.anza.xyz/cli/) for the exact APIs.
+
+## Troubleshooting
+
+A few issues come up often when wiring up local environments:
+
+- **Faucet rate limits on devnet** — switch to `solanaLocalRpc()` or `litesvm()` for repeated runs, or top up your devnet signer manually from the [Solana Faucet](https://faucet.solana.com).
+- **Validator not running** — `solana-test-validator` must be running before tests start; check the process and the default port (`8899`).
+- **WebSocket endpoint mismatch** — when overriding `rpcUrl`, also set `rpcSubscriptionsUrl` if your provider uses a different URL for WebSocket traffic.
+- **`litesvm()` errors in browser tests** — LiteSVM is Node.js only; run those tests in a Node.js environment or pick a different bundle.
+
+## Next steps
+
+- [Sending transactions](/docs/guides/sending-transactions) — exercise your client end-to-end.
+- [Using program plugins](/docs/guides/using-program-plugins) — add typed program access to your tests.
+- [Available plugins](/docs/plugins/available-plugins) — explore the LiteSVM and RPC plugin packages.

--- a/docs/content/docs/guides/using-program-plugins.mdx
+++ b/docs/content/docs/guides/using-program-plugins.mdx
@@ -3,13 +3,184 @@ title: Using program plugins
 description: Add typed program APIs to your client
 ---
 
-<Callout type="warn" title="Planned Content">
-**Status:** New page
+Program plugins are how Kit clients gain typed access to a specific Solana program. They install a typed namespace under the client — `client.system`, `client.token`, and so on — and expose the program's accounts and instructions through it. This guide walks through adding program plugins to a client and using them, alongside the standalone helpers that the same packages also expose.
 
-This guide will provide a deep dive into program plugins: what program plugins are (Codama-generated plugins that add typed program namespaces to a client), how `client.use(tokenProgram())` works under the hood, accessing typed accounts (`client.token.accounts.mint.fetch(address)`, `client.token.accounts.token.fetchAll(filter)`), accessing typed instructions (`client.token.instructions.transfer({...}).sendTransaction()`), using multiple program plugins together (e.g. System + Token + Compute Budget), how this pattern works for any Codama-generated program (not just official ones), and the relationship between program plugins and the `@solana-program/*` packages.
+## Installation
 
-**Draws from:** Kit-plugins program client documentation, Codama JS renderer docs, `@solana-program/token` README.
+Most popular Solana programs ship a Codama-generated package that doubles as a Kit program plugin. Install one for each program you want to interact with.
 
-**Links to:** [Plugins — Generating Program Plugins](/docs/plugins/generating-program-plugins) for generating plugins for your own programs, [Plugins — Available Plugins](/docs/plugins/available-plugins) for a directory of available program plugins.
+```package-install
+@solana-program/system @solana-program/token
+```
 
-</Callout>
+The [Available plugins](/docs/plugins/available-plugins) page lists the program plugins available today. Once installed, apply each plugin with `.use(...)` after your signer and bundle plugins, and the client gains a new typed namespace named after the program.
+
+```ts twoslash
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { systemProgram } from '@solana-program/system';
+import { tokenProgram } from '@solana-program/token';
+
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(10_000_000_000n)))
+    .use(systemProgram())
+    .use(tokenProgram());
+```
+
+`client.system` and `client.token` now expose `accounts` and `instructions` namespaces typed against the System and Token programs. Multiple program plugins compose freely — installing more of them simply adds more namespaces to the client.
+
+## What is a program plugin?
+
+A program plugin is a function from a Codama-generated package that adds a typed namespace for one program's accounts and instructions to a Kit client. The same package also exports standalone helpers — `getXInstruction`, `fetchX`, `decodeX`, and so on, where `X` is the instruction or account name — for cases where you do not want a client.
+
+```ts twoslash
+import { systemProgram } from '@solana-program/system';
+import { tokenProgram } from '@solana-program/token';
+```
+
+You can think of a program plugin as a typed adapter on top of these standalone helpers. The plugin handles the wiring — passing the client's RPC and payer where needed — so your code can focus on what the program does. This is great for developer experience and program discoverability, but the tradeoff is tree-shakability: pulling an entire program namespace into your client tends to produce a larger bundle than importing only the standalone helpers you actually use.
+
+## Fetch typed accounts
+
+Each `accounts` namespace exposes one entry per account type defined by the program, with `fetch`, `fetchMaybe`, `fetchAll`, and `fetchAllMaybe` methods that already know the codec to use.
+
+```ts twoslash
+import { address } from '@solana/kit';
+// ---cut-start---
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { tokenProgram } from '@solana-program/token';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(10_000_000_000n)))
+    .use(tokenProgram());
+// ---cut-end---
+const mint = await client.token.accounts.mint.fetch(
+    address('So11111111111111111111111111111111111111112'),
+);
+mint.data.decimals; // typed as `number`
+```
+
+Because the account namespace is generated from the program's IDL, every field on `mint.data` is fully typed — autocompletion and refactors flow through naturally. See [Fetching accounts](/docs/guides/fetching-accounts) for raw account fetching that doesn't depend on a program plugin.
+
+## Create typed instructions
+
+The matching `instructions` namespace exposes one builder per instruction the program defines. The builders accept a typed input and return an instruction ready to be sent.
+
+```ts twoslash
+import { address, lamports } from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { systemProgram } from '@solana-program/system';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(10_000_000_000n)))
+    .use(systemProgram());
+const recipient = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+// ---cut-end---
+const transferSol = client.system.instructions.transferSol({
+    source: client.payer,
+    destination: recipient,
+    amount: lamports(500_000n),
+});
+```
+
+## Use the `.sendTransaction()` shortcut
+
+Each typed instruction returned by a program plugin also exposes a `.sendTransaction()` method that wraps `client.sendTransaction([instruction])`. This is the most concise way to send a one-off transaction.
+
+```ts twoslash
+import { address, lamports } from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { systemProgram } from '@solana-program/system';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(10_000_000_000n)))
+    .use(systemProgram());
+const recipient = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+// ---cut-end---
+const result = await client.system.instructions
+    .transferSol({
+        source: client.payer,
+        destination: recipient,
+        amount: lamports(500_000n),
+    })
+    .sendTransaction();
+```
+
+The same returned object also exposes `.sendTransactions()`, `.planTransaction()`, and `.planTransactions()` shortcuts that wrap the matching client methods. The shortcut shines for single-instruction operations where the rest of the transaction would just be ceremony. When you want to combine several instructions into one transaction or compose larger operations, [`client.sendTransaction([...])`](/docs/guides/sending-transactions) is the more flexible primitive.
+
+## Use instruction plans from program plugins
+
+Some operations naturally span more than one instruction — creating and initializing a token mint is a classic example. Program plugins expose these as instruction plans rather than raw instructions, which means they can also be combined into larger plans.
+
+```ts twoslash
+import { generateKeyPairSigner } from '@solana/kit';
+// ---cut-start---
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { tokenProgram } from '@solana-program/token';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(10_000_000_000n)))
+    .use(tokenProgram());
+// ---cut-end---
+const newMint = await generateKeyPairSigner();
+const createMintPlan = client.token.instructions.createMint({
+    newMint,
+    decimals: 9,
+    mintAuthority: client.identity.address,
+});
+```
+
+The returned plan can be sent on its own with `.sendTransaction()` or `.sendTransactions()`, fed into [`client.sendTransaction([...])`](/docs/guides/sending-transactions) alongside other work, or combined with [`sequentialInstructionPlan(...)`](/docs/guides/sending-multiple-transactions) and [`parallelInstructionPlan(...)`](/docs/guides/sending-multiple-transactions) helpers when building larger operations.
+
+## Use program libraries without a client
+
+Every program package also exports standalone helpers that work on a plain `Rpc` object or with raw `Instruction`s. This is useful for libraries that should not assume a Kit client, or when you want maximum tree-shaking.
+
+```ts twoslash
+import { address, createSolanaRpc, generateKeyPairSigner, lamports } from '@solana/kit';
+import { fetchMint } from '@solana-program/token';
+import { getTransferSolInstruction } from '@solana-program/system';
+
+const rpc = createSolanaRpc('https://api.devnet.solana.com');
+
+const mint = await fetchMint(rpc, address('So11111111111111111111111111111111111111112'));
+
+const source = await generateKeyPairSigner();
+const transferSol = getTransferSolInstruction({
+    source,
+    destination: address('Ay1zdJ3VDbhrAtkRiqBUJgKLHYbgFZN5BXk7svtMowif'),
+    amount: lamports(500_000n),
+});
+```
+
+Because the standalone helpers and the plugin-based namespaces are generated from the same IDL, the input shapes match exactly. You can move from one style to the other without rewriting the data your application passes around.
+
+## Generate plugins for your own programs
+
+Any program with a Codama IDL can be turned into a Kit-compatible package, with both standalone helpers and a program plugin, using the [Codama JS renderer](https://github.com/codama-idl/renderers-js). The renderer reads the IDL, emits TypeScript bindings, and wires them up through the same `@solana/program-client-core` primitives the `@solana-program/*` packages use.
+
+If your program is built with Anchor, you can convert its Anchor IDL to a Codama IDL first, which means program plugin generation works for Anchor programs as well. See [Generating program plugins](/docs/plugins/generating-program-plugins) for a step-by-step walkthrough.
+
+## Next steps
+
+- [Available plugins](/docs/plugins/available-plugins) — browse the program plugins available today.
+- [Generating program plugins](/docs/plugins/generating-program-plugins) — generate a plugin for your own program.
+- [Fetching accounts](/docs/guides/fetching-accounts) — combine typed accounts with raw RPC reads.
+- [Sending transactions](/docs/guides/sending-transactions) — use typed instructions with `client.sendTransaction([...])`.


### PR DESCRIPTION
This PR writes every page in the Guides section to deliver a practical, plugin-first reference that sits between the Getting started tutorial and the Advanced guides. Each page follows a consistent rhythm of short paragraph, code snippet, and short clarification, and uses concrete `createClient().use(...)` setups throughout. The Guides index stays intentionally short so Fumadocs can render its sub-pages as cards, while the individual guides cover signer setup, RPC, RPC subscriptions, fetching accounts, sending one and many transactions, using program plugins, and testing and local development across devnet, a local validator, and LiteSVM.