### PR TITLE
Write Recipes section

### DIFF
--- a/docs/content/recipes/airdropping-tokens.mdx
+++ b/docs/content/recipes/airdropping-tokens.mdx
@@ -3,13 +3,135 @@ title: Airdropping tokens
 description: Airdrop tokens to many wallets using parallel transaction plans
 ---
 
-<Callout type="warn" title="Planned Content">
-**Status:** New page
+This recipe airdrops a freshly minted SPL token to many recipient wallets at once. It demonstrates how to compose an [instruction plan](/docs/guides/sending-multiple-transactions) that creates the mint sequentially first and then mints to every recipient in parallel — letting Kit pack the work into as few transactions as possible and send the parallel batches concurrently.
 
-This recipe will walk through a multi-address token airdrop: setting up a local client, creating a token mint, generating many recipient addresses, building a complex instruction plan (`sequentialInstructionPlan` containing mint creation followed by a `parallelInstructionPlan` of `getMintToATAInstructionPlanAsync` calls), sending via `client.sendTransactions(plan)` where the client handles splitting into transactions and parallel execution, using `passthroughFailedTransactionPlanExecution` to continue past failures, and processing results with `flattenTransactionPlanResult` to log successes, failures, and cancellations.
+## Set up a client
 
-**Draws from:** Kit-plugins `examples/token-airdrop/` example (complete working implementation with parallel plans and error recovery).
+Install Kit and the plugins you need.
 
-**Links to:** [Sending Multiple Transactions](/docs/guides/sending-multiple-transactions) for the full guide on multi-transaction operations, [Advanced Guides — Instruction Plans](/docs/advanced-guides/instruction-plans) for the underlying plan system.
+```package-install
+@solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer @solana-program/token
+```
 
-</Callout>
+Compose a client with a generated signer, a local RPC connection, an airdrop to fund the signer, and the Token program plugin. Make sure a local validator is running (`solana-test-validator`) before this code executes.
+
+```ts twoslash
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { tokenProgram } from '@solana-program/token';
+
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(100_000_000_000n)))
+    .use(tokenProgram());
+```
+
+The signer is funded with 100 SOL because creating ATAs costs a small amount of rent for each recipient.
+
+## Generate the recipients
+
+For the demo, generate 100 random destination addresses up front. In a real airdrop, this list would come from a database, a CSV, or some other source.
+
+```ts twoslash
+import { generateKeyPairSigner } from '@solana/kit';
+
+const recipients = await Promise.all(
+    Array.from({ length: 100 }, async () => (await generateKeyPairSigner()).address),
+);
+```
+
+## Build the airdrop plan
+
+Compose the work as a `sequentialInstructionPlan` whose first child creates the mint and whose second child is a `parallelInstructionPlan` containing one mint-to-ATA plan per recipient.
+
+```ts twoslash
+import {
+    Address,
+    generateKeyPairSigner,
+    parallelInstructionPlan,
+    sequentialInstructionPlan,
+} from '@solana/kit';
+const recipients = null as unknown as Address[];
+// ---cut-start---
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { tokenProgram } from '@solana-program/token';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(100_000_000_000n)))
+    .use(tokenProgram());
+// ---cut-end---
+const mint = await generateKeyPairSigner();
+
+const instructionPlan = sequentialInstructionPlan([
+    client.token.instructions.createMint({
+        newMint: mint,
+        decimals: 6,
+        mintAuthority: client.identity.address,
+    }),
+    parallelInstructionPlan(
+        await Promise.all(
+            recipients.map((owner) =>
+                client.token.instructions.mintToATA({
+                    mint: mint.address,
+                    owner,
+                    mintAuthority: client.identity,
+                    amount: 1_000n * 10n ** 6n, // 1,000 tokens
+                    decimals: 6,
+                }),
+            ),
+        ),
+    ),
+]);
+```
+
+The mint must exist before any recipient can receive tokens, which is why the outer plan is sequential. Each `mintToATA` is independent of the others, so wrapping them in a `parallelInstructionPlan` lets Kit run them concurrently. The Token plugin's `mintToATA` is asynchronous because it derives each recipient's ATA address up front, so wrap the whole list in a single `Promise.all`.
+
+## Send and inspect the results
+
+`client.sendTransactions(plan)` plans, signs, sends, and confirms every transaction in the tree. Wrap the call in [`passthroughFailedTransactionPlanExecution`](/docs/advanced-guides/errors#walking-transaction-plan-results) so a failure on one transaction does not throw — you keep the full result tree and can decide what to do per recipient.
+
+```ts twoslash
+import {
+    flattenTransactionPlanResult,
+    InstructionPlan,
+    passthroughFailedTransactionPlanExecution,
+} from '@solana/kit';
+const instructionPlan = null as unknown as InstructionPlan;
+// ---cut-start---
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { tokenProgram } from '@solana-program/token';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(100_000_000_000n)))
+    .use(tokenProgram());
+// ---cut-end---
+const result = await passthroughFailedTransactionPlanExecution(
+    client.sendTransactions(instructionPlan),
+);
+
+for (const [index, single] of flattenTransactionPlanResult(result).entries()) {
+    if (single.status === 'successful') {
+        console.log(`#${index} ✅ ${single.context.signature}`);
+    } else if (single.status === 'failed') {
+        console.error(`#${index} ❌ ${single.error.message}`);
+    } else {
+        console.warn(`#${index} ⏭️  canceled`);
+    }
+}
+```
+
+`flattenTransactionPlanResult` collapses the tree into one entry per transaction in the order they were planned, so iterating the array is enough to log each outcome individually. For a single bottom-line view across the whole airdrop, [`summarizeTransactionPlanResult`](/docs/advanced-guides/errors#walking-transaction-plan-results) returns success/failure/cancellation counts and a top-level `successful` boolean.
+
+## Next steps
+
+- [Sending multiple transactions](/docs/guides/sending-multiple-transactions) — the full guide on multi-transaction operations and instruction plan composition.
+- [Advanced guides — Errors](/docs/advanced-guides/errors) — deep dive on `TransactionPlanResult`, walking failed trees, and program-specific errors.
+- [Creating a token](/recipes/creating-a-token) — the simpler single-recipient version of this flow.

--- a/docs/content/recipes/creating-a-token.mdx
+++ b/docs/content/recipes/creating-a-token.mdx
@@ -1,15 +1,131 @@
 ---
 title: Creating a token
-description: Create a new SPL token mint and mint tokens
+description: Create a new SPL token mint, mint tokens, and transfer them
 ---
 
-<Callout type="warn" title="Planned Content">
-**Status:** Adapted from existing content
+This recipe walks through the full lifecycle of an SPL token: creating a mint, minting tokens to your own associated token account (ATA), and transferring some to another wallet. It runs against a local validator so you can experiment without spending mainnet SOL.
 
-This recipe will walk through creating a new SPL token: setting up a client with the Token program plugin, creating a mint account (CreateAccount + InitializeMint instructions), minting tokens to an account, and verifying the mint by fetching and decoding it. It uses a plugin-based client but preserves the functional patterns (`pipe()`, immutability) from the current tutorial as the "Kit way" of building transaction messages where relevant.
+## Set up a client
 
-**Adapted from:** Current `getting-started/instructions.mdx` (CreateAccount + InitializeMint instruction creation), `getting-started/build-transaction.mdx` (transaction construction with `pipe()`), `getting-started/send-transaction.mdx` (sending and confirming), `getting-started/fetch-account.mdx` (fetching the mint).
+Install Kit and the plugins you need.
 
-**Links to:** [Getting Started](/docs/getting-started) for the full tutorial, [Using Program Plugins](/docs/guides/using-program-plugins) for program plugin patterns.
+```package-install
+@solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer @solana-program/token
+```
 
-</Callout>
+Compose a client with a generated signer, a local RPC connection, an airdrop to fund the signer, and the Token program plugin. Make sure a local validator is running (`solana-test-validator`) before this code executes.
+
+```ts twoslash
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { tokenProgram } from '@solana-program/token';
+
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)))
+    .use(tokenProgram());
+```
+
+## Create the mint
+
+Generate a fresh signer for the mint account and ask the Token program plugin to build a `createMint` instruction plan. The plan creates the mint account, funds it for rent exemption, and initializes it as a Token mint — all in one atomic operation.
+
+```ts twoslash
+import { generateKeyPairSigner } from '@solana/kit';
+// ---cut-start---
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { tokenProgram } from '@solana-program/token';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)))
+    .use(tokenProgram());
+// ---cut-end---
+const mint = await generateKeyPairSigner();
+
+await client.token.instructions
+    .createMint({
+        newMint: mint,
+        decimals: 9,
+        mintAuthority: client.identity.address,
+    })
+    .sendTransaction();
+
+console.log(`🎉 Mint created: ${mint.address}`);
+```
+
+The mint authority is the signer allowed to mint new tokens later. Setting it to `client.identity.address` makes the current client's identity the authority, which is what you want for a recipe like this one.
+
+## Mint tokens to your ATA
+
+Tokens live in associated token accounts (ATAs) — one ATA per `(owner, mint)` pair. The plugin's `mintToATA` helper derives the ATA address, creates it if it does not exist yet, and mints tokens to it in a single instruction plan.
+
+```ts twoslash
+import { Address } from '@solana/kit';
+const mintAddress = null as unknown as Address;
+// ---cut-start---
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { tokenProgram } from '@solana-program/token';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)))
+    .use(tokenProgram());
+// ---cut-end---
+await client.token.instructions
+    .mintToATA({
+        mint: mintAddress,
+        owner: client.identity.address,
+        mintAuthority: client.identity,
+        amount: 1_000n * 10n ** 9n, // 1,000 tokens with 9 decimals
+        decimals: 9,
+    })
+    .sendTransaction();
+```
+
+`mintToATA` is asynchronous because it derives the ATA address before building the plan, but the `.sendTransaction()` shortcut is exposed on the returned promise itself — a single `await` on the call is enough. Pass the same `decimals` you used when creating the mint; the plugin uses it as a safety check to make sure you are minting against the mint you think you are.
+
+## Transfer tokens to a recipient
+
+Sending tokens to another wallet follows the same pattern as minting: the plugin derives both the source and destination ATAs, creates the destination if it doesn't exist, and issues the transfer.
+
+```ts twoslash
+import { address, Address } from '@solana/kit';
+const mintAddress = null as unknown as Address;
+// ---cut-start---
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { tokenProgram } from '@solana-program/token';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)))
+    .use(tokenProgram());
+// ---cut-end---
+const recipient = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+
+await client.token.instructions
+    .transferToATA({
+        mint: mintAddress,
+        authority: client.identity,
+        recipient,
+        amount: 100n * 10n ** 9n, // 100 tokens
+        decimals: 9,
+    })
+    .sendTransaction();
+```
+
+The `authority` is the owner of the source tokens, which here is the same identity that minted them. The plugin pulls tokens out of `authority`'s ATA for the given mint, creates the recipient's ATA if needed, and deposits the tokens.
+
+## Next steps
+
+- [Using program plugins](/docs/guides/using-program-plugins) — explore everything `client.token` and other program namespaces expose.
+- [Fetching accounts](/docs/guides/fetching-accounts) — read the mint and token account balances back from the chain.
+- [Airdropping tokens](/recipes/airdropping-tokens) — extend this recipe to many recipients in parallel.

--- a/docs/content/recipes/index.mdx
+++ b/docs/content/recipes/index.mdx
@@ -3,11 +3,6 @@ title: Recipes
 description: Quick how-to guides for common Solana tasks
 ---
 
-<Callout type="warn" title="Planned Content">
-**Status:** New page
+Recipes are short, copy-pasteable walkthroughs for specific tasks. Each one starts with a working setup, then walks through the steps you need to ship a feature — sending SOL, creating a token, airdropping tokens to many wallets, and so on.
 
-This index page will list all available recipes with one-line descriptions. Each recipe is a self-contained, copy-paste-friendly walkthrough for a specific task.
-
-Recipes are task-oriented: they start with the end result, then walk through step by step. They use plugin-based clients and focus on getting things done quickly.
-
-</Callout>
+If you are new to Kit, start with the [Getting started](/docs/getting-started) tutorial first. If you are looking for deeper, reference-style coverage, the [Guides](/docs/guides) section is the next step. Recipes sit between the two: focused, end-to-end snippets you can drop into a project today.

--- a/docs/content/recipes/transferring-sol.mdx
+++ b/docs/content/recipes/transferring-sol.mdx
@@ -3,13 +3,114 @@ title: Transferring SOL
 description: Send SOL from one account to another with error handling
 ---
 
-<Callout type="warn" title="Planned Content">
-**Status:** New page
+This recipe walks through sending SOL from your client's payer to another address. It uses a local validator so you can run it end-to-end without touching real funds, and shows how to surface a useful error when a transfer fails.
 
-This recipe will walk through a complete SOL transfer: setting up a local client, generating a recipient address, building a `getTransferSolInstruction` from `@solana-program/system`, sending via `client.sendTransaction(instruction)`, handling errors by catching `SolanaError` and extracting program-specific error details, and linking to the explorer for debugging.
+## Set up a client
 
-**Draws from:** Kit-plugins `examples/transfer-lamports/` example (complete working implementation with error handling and explorer links).
+Install Kit and the plugins you need.
 
-**Links to:** [Sending Transactions](/docs/guides/sending-transactions) for the full guide on transaction sending.
+```package-install
+@solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer @solana-program/system
+```
 
-</Callout>
+Compose a client with a generated signer, a local RPC connection, an airdrop to fund the signer, and the System program plugin. Make sure a local validator is running (`solana-test-validator`) before this code executes.
+
+```ts twoslash
+import { createClient, lamports } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { systemProgram } from '@solana-program/system';
+
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)))
+    .use(systemProgram());
+```
+
+## Send the transfer
+
+Use `client.system.instructions.transferSol` to build the transfer instruction, then call `.sendTransaction()` to plan, sign, send, and confirm it in one step.
+
+```ts twoslash
+import { address, lamports } from '@solana/kit';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { systemProgram } from '@solana-program/system';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)))
+    .use(systemProgram());
+// ---cut-end---
+const recipient = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+
+const result = await client.system.instructions
+    .transferSol({
+        source: client.payer,
+        destination: recipient,
+        amount: lamports(10_000_000n), // 0.01 SOL
+    })
+    .sendTransaction();
+
+console.log(`✅ ${result.context.signature}`);
+```
+
+The shortcut is equivalent to passing the instruction to `client.sendTransaction([...])`. Reach for the array form when you want to combine several instructions into a single atomic transaction.
+
+## Handle errors
+
+When a transfer fails, `client.sendTransaction(...)` throws a [`SolanaError`](/docs/advanced-guides/errors) with the `SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION` code. Wrapping the call lets you surface a useful message and inspect the underlying program error.
+
+```ts twoslash
+import {
+    address,
+    isSolanaError,
+    lamports,
+    SingleTransactionPlanResult,
+    SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION,
+} from '@solana/kit';
+import { getSystemErrorMessage, isSystemError } from '@solana-program/system';
+// ---cut-start---
+import { createClient } from '@solana/kit';
+import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+import { airdropSigner, generatedSigner } from '@solana/kit-plugin-signer';
+import { systemProgram } from '@solana-program/system';
+const client = await createClient()
+    .use(generatedSigner())
+    .use(solanaLocalRpc())
+    .use(airdropSigner(lamports(1_000_000_000n)))
+    .use(systemProgram());
+const recipient = address('GdnSyH3YtwcxFvQrVVJMm1JhTS4QVX7MFsX56uJLUfiZ');
+// ---cut-end---
+try {
+    await client.system.instructions
+        .transferSol({
+            source: client.payer,
+            destination: recipient,
+            amount: lamports(10_000_000n),
+        })
+        .sendTransaction();
+} catch (e) {
+    if (!isSolanaError(e, SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION)) throw e;
+
+    const result = e.context.transactionPlanResult as SingleTransactionPlanResult;
+    const transactionMessage = result.context.message ?? result.plannedMessage;
+    const cause = e.cause as Error;
+
+    if (isSystemError(cause, transactionMessage)) {
+        console.error(`System program error: ${getSystemErrorMessage(cause.context.code)}`);
+    } else {
+        console.error('Transfer failed:', e.message);
+    }
+}
+```
+
+`error.cause` carries the underlying error, and `error.context.transactionPlanResult` carries the planned transaction message. Pairing them with `isSystemError` and `getSystemErrorMessage` from `@solana-program/system` turns an opaque program error code into a human-readable message — invaluable when something like an underfunded source account causes the transfer to fail.
+
+## Next steps
+
+- [Sending transactions](/docs/guides/sending-transactions) — the full guide on single transactions, including planning and configuration.
+- [Advanced guides — Errors](/docs/advanced-guides/errors) — deep dive on `SolanaError` codes and program-specific error parsing.


### PR DESCRIPTION
This PR replaces the four remaining placeholder callouts in the Recipes section with end-to-end, plugin-first walkthroughs. `Transferring SOL` covers a single-instruction transfer with `SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION` handling and program-specific error parsing. `Creating a token` walks through the full SPL token lifecycle — create the mint, mint to your own ATA, and transfer to another wallet — using the Token program plugin's instruction-plan helpers. `Airdropping tokens` shows how to compose `sequentialInstructionPlan` and `parallelInstructionPlan` to airdrop a freshly minted token to many recipients in parallel, using `passthroughFailedTransactionPlanExecution` and `flattenTransactionPlanResult` to report per-recipient outcomes. The Recipes index now stays intentionally short so Fumadocs can render its sub-pages as cards.