### PR TITLE
Add `useRequest` for one-shot RPC reads/data fetching

### DIFF
--- a/.changeset/fresh-eggs-hear.md
+++ b/.changeset/fresh-eggs-hear.md
@@ -1,0 +1,24 @@
+---
+'@solana/react': minor
+---
+
+Add `useRequest` — a React hook for one-shot async reads. Pass either an async function `(signal) => Promise<T>` or a memoized `ReactiveActionSource<T>` (satisfied by `PendingRpcRequest`). The hook fires the call on mount, re-fires whenever the source identity changes, and aborts the in-flight call on cleanup.
+
+```tsx
+// `ReactiveActionSource` (e.g. `PendingRpcRequest`):
+const source = useMemo(() => client.rpc.getLatestBlockhash(), [client]);
+const { data, error, refresh } = useRequest(source);
+
+// Bare async function:
+const fetcher = useCallback(
+    (signal: AbortSignal) => fetch(`/api/users/${userId}`, { signal }).then(r => r.json()),
+    [userId],
+);
+const { data, error, refresh } = useRequest(fetcher);
+```
+
+The result reports `status` as one of `fetching | success | error | disabled`. A request in flight is always `fetching`; inspect `data` and `error` to know what stale content (if any) is available to render alongside a spinner — first attempt has neither, a refresh after a prior outcome carries one or both forward. Pass `null` for the source to gate the request off — useful while inputs aren't yet known. The result then reports `status: 'disabled'`.
+
+Optional `getAbortSignal: () => AbortSignal` is a factory invoked on every attempt (initial fire + every `refresh()`). Each attempt gets a fresh signal that's composed with the store's internal per-dispatch controller via `AbortSignal.any`. The natural use is per-attempt timeouts: `getAbortSignal: () => AbortSignal.timeout(5_000)` gives every attempt its own 5-second clock that resets on refresh. The factory is held in a ref synced to the latest render, so inline closures are fine — no `useCallback` needed. `refresh()` also accepts an optional `{ abortSignal }` override to replace the factory for one specific attempt.
+
+The new `RequestResult<T>` and `UseRequestOptions` types are exported alongside the hook so plugin hooks built on top can declare their return shape against them.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -129,6 +129,76 @@ try {
 }
 ```
 
+### `useRequest(source, options?)`
+
+Fires a one-shot request on mount and re-fires whenever `source` changes identity. Returns `{ data, error, status, refresh }` where `status` is one of `'fetching' | 'success' | 'error' | 'disabled'`. Use it for RPC reads, or for any other one-shot async work an app needs (a `fetch`, a third-party SDK call, etc.).
+
+`source` is either an async function `(signal: AbortSignal) => Promise<T>` (most general), or any reactive store source `{ reactiveStore(): ReactiveActionStore<[], T> }` — `PendingRpcRequest` is the canonical implementation. Pass `null` to disable (the result reports `status: 'disabled'`).
+
+> Unlike `useAction`, `useRequest` needs the input to have stable identity across renders — it's how the hook knows when to re-fire. Memoize with `useMemo` (for a reactive store source) or `useCallback` (for a function), keyed on whatever inputs your call depends on.
+
+```tsx
+import { useClient, useRequest } from '@solana/react';
+import type { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+
+function LatestBlockhash() {
+    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+    const source = useMemo(() => client.rpc.getLatestBlockhash(), [client]);
+    const { data, error, refresh } = useRequest(source);
+    if (error) return <button onClick={refresh}>Retry</button>;
+    return <p>{data ? `Blockhash: ${data.value.blockhash}` : 'Loading…'}</p>;
+}
+```
+
+`refresh()` re-fires the request manually. While a refresh is in flight, `status` returns to `'fetching'` and `data` / `error` from the prior outcome stay populated until the new attempt resolves (stale-while-revalidate). On the first attempt both are `undefined`.
+
+```tsx
+function Balance({ address }: { address: Address | null }) {
+    const client = useClient<ClientWithRpc<GetBalanceApi>>();
+    // Disabled until an address is selected.
+    const source = useMemo(() => (address ? client.rpc.getBalance(address) : null), [client, address]);
+    const { data, status } = useRequest(source);
+    if (status === 'disabled') return <p>Select an account to see its balance.</p>;
+    return <p>{data?.value !== undefined ? `${data.value} lamports` : 'Loading…'}</p>;
+}
+```
+
+For any other one-shot async work — `fetch`, a third-party SDK call, or anything that isn't a `ReactiveActionSource` — pass an async function instead of a source. The `signal` argument fires when the request is superseded, the source changes, or the component unmounts; thread it into your call's own abort plumbing:
+
+```tsx
+function Profile({ userId }: { userId: string }) {
+    const fetcher = useCallback(
+        (signal: AbortSignal) => fetch(`/api/users/${userId}`, { signal }).then(r => r.json()),
+        [userId],
+    );
+    const { data, error, refresh } = useRequest(fetcher);
+    if (error) return <button onClick={refresh}>Retry</button>;
+    return <p>{data ? data.name : 'Loading…'}</p>;
+}
+```
+
+#### Per-attempt cancellation
+
+Pass `getAbortSignal` to attach a cancellation signal to each individual attempt — initial fire plus every `refresh()`. The natural use is per-attempt timeouts:
+
+```tsx
+const { data, error, refresh } = useRequest(source, {
+    // Each attempt gets a fresh 5-second clock. `refresh()` resets it.
+    getAbortSignal: () => AbortSignal.timeout(5_000),
+});
+```
+
+The factory is held in a ref synced to the latest render, so inline closures are fine — no `useCallback` needed. To kill the hook entirely (e.g. on a route change), set the memoized source to `null` (the result reports `disabled`), or let the component unmount.
+
+`refresh()` accepts an optional `{ abortSignal }` override that replaces the configured factory for just that attempt — useful when one specific refresh needs different cancellation semantics:
+
+```tsx
+const userInitiatedCtrl = new AbortController();
+refresh({ abortSignal: userInitiatedCtrl.signal }); // override: use this signal, ignore the factory
+refresh({ abortSignal: undefined }); // no abort signal for this attempt
+refresh(); // omit the key to use the factory (default)
+```
+
 ## Hooks
 
 ### `useSignIn(uiWalletAccount, chain)`

--- a/packages/react/src/__tests__/staticStores-test.ts
+++ b/packages/react/src/__tests__/staticStores-test.ts
@@ -1,0 +1,55 @@
+import { disabledActionStore } from '../staticStores';
+
+describe('disabledActionStore', () => {
+    it('reports a frozen `idle` state with no data or error', () => {
+        const store = disabledActionStore<string>();
+        const state = store.getState();
+        expect(state).toEqual({ data: undefined, error: undefined, status: 'idle' });
+        expect(Object.isFrozen(state)).toBe(true);
+    });
+
+    it('returns the same state reference across calls', () => {
+        const store = disabledActionStore<string>();
+        expect(store.getState()).toBe(store.getState());
+    });
+
+    it('`dispatch()` is a no-op — state does not change', () => {
+        const store = disabledActionStore<string>();
+        const before = store.getState();
+        store.dispatch();
+        store.dispatch();
+        expect(store.getState()).toBe(before);
+    });
+
+    it('`reset()` is a no-op — state does not change', () => {
+        const store = disabledActionStore<string>();
+        const before = store.getState();
+        store.reset();
+        expect(store.getState()).toBe(before);
+    });
+
+    it('`withSignal(signal).dispatch()` is a no-op — state does not change, signal is not observed', () => {
+        const store = disabledActionStore<string>();
+        const ctrl = new AbortController();
+        const before = store.getState();
+        store.withSignal(ctrl.signal).dispatch();
+        ctrl.abort(new Error('would-be-cancellation'));
+        expect(store.getState()).toBe(before);
+    });
+
+    it('`subscribe()` never notifies (dispatch + reset produce no state change to observe)', () => {
+        const store = disabledActionStore<string>();
+        const listener = jest.fn();
+        const unsubscribe = store.subscribe(listener);
+        store.dispatch();
+        store.reset();
+        store.withSignal(new AbortController().signal).dispatch();
+        expect(listener).not.toHaveBeenCalled();
+        unsubscribe();
+    });
+
+    it('`dispatchAsync()` rejects with an AbortError so accidental awaits surface, not silently hang', async () => {
+        const store = disabledActionStore<string>();
+        await expect(store.dispatchAsync()).rejects.toMatchObject({ name: 'AbortError' });
+    });
+});

--- a/packages/react/src/__tests__/useLatest-test.browser.tsx
+++ b/packages/react/src/__tests__/useLatest-test.browser.tsx
@@ -1,0 +1,24 @@
+import { renderHook } from '../__test-utils__/render';
+import { useLatest } from '../useLatest';
+
+describe('useLatest', () => {
+    it('exposes the most recently rendered value via the ref', () => {
+        const { result, rerender } = renderHook(({ value }) => useLatest(value), {
+            initialProps: { value: 'first' },
+        });
+        expect(result.current.current).toBe('first');
+
+        rerender({ value: 'second' });
+        expect(result.current.current).toBe('second');
+    });
+
+    it('returns a stable ref object across renders', () => {
+        const { result, rerender } = renderHook(({ value }) => useLatest(value), {
+            initialProps: { value: 1 },
+        });
+        const ref = result.current;
+
+        rerender({ value: 2 });
+        expect(result.current).toBe(ref);
+    });
+});

--- a/packages/react/src/__tests__/useReactiveStoreLifecycle-test.browser.tsx
+++ b/packages/react/src/__tests__/useReactiveStoreLifecycle-test.browser.tsx
@@ -1,0 +1,133 @@
+import { act } from '@testing-library/react';
+
+import { renderHook } from '../__test-utils__/render';
+import { useReactiveStoreLifecycle } from '../useReactiveStoreLifecycle';
+
+type FakeStore = { reset: jest.Mock };
+
+function makeFakeStore(): FakeStore {
+    return { reset: jest.fn() };
+}
+
+describe('useReactiveStoreLifecycle', () => {
+    it('fires on mount with the store and the factory-provided signal', () => {
+        const store = makeFakeStore();
+        const fire = jest.fn();
+        const signal = new AbortController().signal;
+        renderHook(() => useReactiveStoreLifecycle(store, fire, () => signal));
+        expect(fire).toHaveBeenCalledWith(store, signal);
+    });
+
+    it('fires on mount with an undefined signal when no factory is configured', () => {
+        const store = makeFakeStore();
+        const fire = jest.fn();
+        renderHook(() => useReactiveStoreLifecycle(store, fire, undefined));
+        expect(fire).toHaveBeenCalledWith(store, undefined);
+    });
+
+    it('resets the store on unmount', () => {
+        const store = makeFakeStore();
+        const fire = jest.fn();
+        const { unmount } = renderHook(() => useReactiveStoreLifecycle(store, fire, undefined));
+        store.reset.mockClear();
+        unmount();
+        expect(store.reset).toHaveBeenCalled();
+    });
+
+    it('returns a stable refresh callback across renders', () => {
+        const store = makeFakeStore();
+        const fire = jest.fn();
+        const { result, rerender } = renderHook(() => useReactiveStoreLifecycle(store, fire, undefined));
+        const refresh = result.current;
+        rerender();
+        expect(result.current).toBe(refresh);
+    });
+
+    it('re-fires when refresh() is called, reading the latest factory', () => {
+        const store = makeFakeStore();
+        const fire = jest.fn();
+        const signal = new AbortController().signal;
+        const { result } = renderHook(() => useReactiveStoreLifecycle(store, fire, () => signal));
+        fire.mockClear();
+        act(() => result.current());
+        expect(fire).toHaveBeenCalledWith(store, signal);
+    });
+
+    describe('per-attempt abort signal override', () => {
+        it('refresh({ abortSignal }) overrides the factory for that attempt', () => {
+            const store = makeFakeStore();
+            const fire = jest.fn();
+            const factorySignal = new AbortController().signal;
+            const { result } = renderHook(() => useReactiveStoreLifecycle(store, fire, () => factorySignal));
+            fire.mockClear();
+            const override = new AbortController().signal;
+            act(() => result.current({ abortSignal: override }));
+            expect(fire).toHaveBeenCalledWith(store, override);
+        });
+
+        it('refresh({ abortSignal: undefined }) opts out of the factory for that attempt', () => {
+            const store = makeFakeStore();
+            const fire = jest.fn();
+            const factorySignal = new AbortController().signal;
+            const { result } = renderHook(() => useReactiveStoreLifecycle(store, fire, () => factorySignal));
+            fire.mockClear();
+            act(() => result.current({ abortSignal: undefined }));
+            expect(fire).toHaveBeenCalledWith(store, undefined);
+        });
+    });
+
+    describe('dev-mode store-churn warning', () => {
+        let errorSpy: jest.SpyInstance;
+        beforeEach(() => {
+            (globalThis as typeof globalThis & { __DEV__: boolean }).__DEV__ = true;
+            errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        });
+        afterEach(() => {
+            errorSpy.mockRestore();
+        });
+
+        it('warns when the store identity changes on too many consecutive renders', () => {
+            const fire = jest.fn();
+            const { rerender } = renderHook(({ store }) => useReactiveStoreLifecycle(store, fire, undefined), {
+                initialProps: { store: makeFakeStore() },
+            });
+            for (let i = 0; i < 40; i++) {
+                rerender({ store: makeFakeStore() });
+            }
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('recreated its store'),
+                expect.any(Number),
+            );
+        });
+
+        it('does not warn when the store identity is stable across renders', () => {
+            const store = makeFakeStore();
+            const fire = jest.fn();
+            const { rerender } = renderHook(() => useReactiveStoreLifecycle(store, fire, undefined));
+            for (let i = 0; i < 40; i++) {
+                rerender();
+            }
+            expect(errorSpy).not.toHaveBeenCalledWith(
+                expect.stringContaining('recreated its store'),
+                expect.anything(),
+            );
+        });
+    });
+
+    it('does not warn in production mode even when the store churns', () => {
+        // `__DEV__` defaults to `false` in the test harness.
+        const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const fire = jest.fn();
+        const { rerender } = renderHook(({ store }) => useReactiveStoreLifecycle(store, fire, undefined), {
+            initialProps: { store: makeFakeStore() },
+        });
+        for (let i = 0; i < 40; i++) {
+            rerender({ store: makeFakeStore() });
+        }
+        expect(errorSpy).not.toHaveBeenCalledWith(
+            expect.stringContaining('recreated its store'),
+            expect.anything(),
+        );
+        errorSpy.mockRestore();
+    });
+});

--- a/packages/react/src/__tests__/useRequest-test.browser.tsx
+++ b/packages/react/src/__tests__/useRequest-test.browser.tsx
@@ -1,0 +1,355 @@
+import { createReactiveActionStore, ReactiveActionSource } from '@solana/subscribable';
+import { act } from '@testing-library/react';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+import { renderHook } from '../__test-utils__/render';
+import { useRequest } from '../useRequest';
+
+function makeFakeRequest<T>(): {
+    fn: jest.Mock<Promise<T>, [AbortSignal]>;
+    rejectLatest: (err: unknown) => void;
+    resolveLatest: (value: T) => void;
+    source: ReactiveActionSource<T>;
+} {
+    let latest: PromiseWithResolvers<T> | null = null;
+    const fn = jest.fn<Promise<T>, [AbortSignal]>(() => {
+        latest = Promise.withResolvers<T>();
+        return latest.promise;
+    });
+    return {
+        fn,
+        rejectLatest(err) {
+            latest!.reject(err);
+        },
+        resolveLatest(value) {
+            latest!.resolve(value);
+        },
+        source: {
+            reactiveStore() {
+                return createReactiveActionStore<[], T>(fn);
+            },
+        },
+    };
+}
+
+describe('useRequest', () => {
+    it('auto-dispatches on mount and transitions fetching → success', async () => {
+        const req = makeFakeRequest<string>();
+        const { result } = renderHook(() => useRequest(req.source));
+
+        expect(result.current.status).toBe('fetching');
+        expect(result.current.data).toBeUndefined();
+        expect(req.fn).toHaveBeenCalledTimes(1);
+
+        await act(async () => req.resolveLatest('hi'));
+        expect(result.current.status).toBe('success');
+        expect(result.current.data).toBe('hi');
+    });
+
+    it('reports error status with the error value when the call rejects', async () => {
+        const boom = new Error('boom');
+        const req = makeFakeRequest<string>();
+        const { result } = renderHook(() => useRequest(req.source));
+
+        await act(async () => req.rejectLatest(boom));
+        expect(result.current.status).toBe('error');
+        expect(result.current.error).toBe(boom);
+    });
+
+    it('refresh() after an error returns to fetching while preserving the stale error', async () => {
+        const boom = new Error('boom');
+        const req = makeFakeRequest<string>();
+        const { result } = renderHook(() => useRequest(req.source));
+
+        await act(async () => req.rejectLatest(boom));
+        expect(result.current.status).toBe('error');
+        expect(result.current.error).toBe(boom);
+        expect(req.fn).toHaveBeenCalledTimes(1);
+
+        act(() => result.current.refresh());
+        expect(req.fn).toHaveBeenCalledTimes(2);
+        expect(result.current.status).toBe('fetching');
+        expect(result.current.data).toBeUndefined();
+        expect(result.current.error).toBe(boom);
+
+        await act(async () => req.resolveLatest('ok'));
+        expect(result.current.status).toBe('success');
+        expect(result.current.data).toBe('ok');
+        expect(result.current.error).toBeUndefined();
+    });
+
+    it('refresh() re-dispatches and returns to fetching while preserving stale data', async () => {
+        const req = makeFakeRequest<string>();
+        const { result } = renderHook(() => useRequest(req.source));
+
+        await act(async () => req.resolveLatest('first'));
+        expect(result.current.data).toBe('first');
+        expect(req.fn).toHaveBeenCalledTimes(1);
+
+        act(() => result.current.refresh());
+        expect(req.fn).toHaveBeenCalledTimes(2);
+        expect(result.current.status).toBe('fetching');
+        expect(result.current.data).toBe('first');
+
+        await act(async () => req.resolveLatest('second'));
+        expect(result.current.status).toBe('success');
+        expect(result.current.data).toBe('second');
+    });
+
+    it('rebuilds the store and fires a fresh request when the source identity changes', () => {
+        const reqA = makeFakeRequest<string>();
+        const reqB = makeFakeRequest<string>();
+        const { rerender } = renderHook(
+            ({ which }: { which: 'a' | 'b' }) => useRequest(which === 'a' ? reqA.source : reqB.source),
+            { initialProps: { which: 'a' } },
+        );
+        expect(reqA.fn).toHaveBeenCalledTimes(1);
+        expect(reqB.fn).not.toHaveBeenCalled();
+
+        rerender({ which: 'b' });
+        expect(reqB.fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports status: disabled when the source is null', () => {
+        const { result } = renderHook(() => useRequest<string>(null));
+        expect(result.current.status).toBe('disabled');
+        expect(result.current.data).toBeUndefined();
+    });
+
+    it('starts firing when the source transitions from null to a real source', () => {
+        const req = makeFakeRequest<string>();
+        const initialProps: { source: ReactiveActionSource<string> | null } = { source: null };
+        const { result, rerender } = renderHook(({ source }) => useRequest(source), { initialProps });
+        expect(result.current.status).toBe('disabled');
+        expect(req.fn).not.toHaveBeenCalled();
+
+        rerender({ source: req.source });
+        expect(result.current.status).toBe('fetching');
+        expect(req.fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns to disabled when the source transitions from a real source to null', async () => {
+        const req = makeFakeRequest<string>();
+        const initialProps: { source: ReactiveActionSource<string> | null } = { source: req.source };
+        const { result, rerender } = renderHook(({ source }) => useRequest(source), { initialProps });
+        await act(async () => req.resolveLatest('hi'));
+        expect(result.current.status).toBe('success');
+
+        rerender({ source: null });
+        expect(result.current.status).toBe('disabled');
+        expect(result.current.data).toBeUndefined();
+    });
+
+    it('aborts the in-flight request when the source transitions to null', () => {
+        const req = makeFakeRequest<string>();
+        const initialProps: { source: ReactiveActionSource<string> | null } = { source: req.source };
+        const { rerender } = renderHook(({ source }) => useRequest(source), { initialProps });
+        const inFlightSignal = req.fn.mock.calls[0][0];
+        expect(inFlightSignal.aborted).toBe(false);
+
+        rerender({ source: null });
+        expect(inFlightSignal.aborted).toBe(true);
+    });
+
+    it('aborts the in-flight request when the component unmounts', () => {
+        const req = makeFakeRequest<string>();
+        const { unmount } = renderHook(() => useRequest(req.source));
+        const inFlightSignal = req.fn.mock.calls[0][0];
+        expect(inFlightSignal.aborted).toBe(false);
+
+        unmount();
+        expect(inFlightSignal.aborted).toBe(true);
+    });
+
+    it('keeps a stable refresh reference across re-renders', () => {
+        const req = makeFakeRequest<string>();
+        const { result, rerender } = renderHook(() => useRequest(req.source));
+        const { refresh } = result.current;
+        rerender();
+        expect(result.current.refresh).toBe(refresh);
+    });
+
+    it('invokes getAbortSignal on every attempt with a fresh signal', () => {
+        const req = makeFakeRequest<string>();
+        const signals: AbortSignal[] = [];
+        const getAbortSignal = jest.fn(() => {
+            const ctrl = new AbortController();
+            signals.push(ctrl.signal);
+            return ctrl.signal;
+        });
+        const { result } = renderHook(() => useRequest(req.source, { getAbortSignal }));
+
+        expect(getAbortSignal).toHaveBeenCalledTimes(1);
+
+        act(() => result.current.refresh());
+        expect(getAbortSignal).toHaveBeenCalledTimes(2);
+        expect(signals[1]).not.toBe(signals[0]); // fresh identity per attempt
+    });
+
+    it('refresh({ abortSignal }) overrides the getAbortSignal factory for that attempt', async () => {
+        const req = makeFakeRequest<string>();
+        const getAbortSignal = jest.fn(() => new AbortController().signal);
+        const { result } = renderHook(() => useRequest(req.source, { getAbortSignal }));
+
+        // Initial fire uses the factory.
+        expect(getAbortSignal).toHaveBeenCalledTimes(1);
+        expect(req.fn).toHaveBeenCalledTimes(1);
+
+        // Refresh with an override signal: factory is NOT called this time.
+        const overrideCtrl = new AbortController();
+        act(() => result.current.refresh({ abortSignal: overrideCtrl.signal }));
+        expect(getAbortSignal).toHaveBeenCalledTimes(1);
+        expect(req.fn).toHaveBeenCalledTimes(2);
+
+        // Aborting the override signal cancels the current attempt and surfaces on state.
+        const reason = new Error('overridden');
+        await act(async () => overrideCtrl.abort(reason));
+        expect(result.current.status).toBe('error');
+        expect(result.current.error).toBe(reason);
+    });
+
+    it('refresh() without an abortSignal arg falls back to the getAbortSignal factory', () => {
+        const req = makeFakeRequest<string>();
+        const getAbortSignal = jest.fn(() => new AbortController().signal);
+        const { result } = renderHook(() => useRequest(req.source, { getAbortSignal }));
+
+        expect(getAbortSignal).toHaveBeenCalledTimes(1);
+        act(() => result.current.refresh());
+        expect(getAbortSignal).toHaveBeenCalledTimes(2);
+    });
+
+    it('refresh({ abortSignal: undefined }) opts out of the getAbortSignal factory for that attempt', () => {
+        const req = makeFakeRequest<string>();
+        const getAbortSignal = jest.fn(() => new AbortController().signal);
+        const { result } = renderHook(() => useRequest(req.source, { getAbortSignal }));
+
+        // Initial fire uses the factory.
+        expect(getAbortSignal).toHaveBeenCalledTimes(1);
+        expect(req.fn).toHaveBeenCalledTimes(1);
+        // First-attempt signal is the factory's signal — composed via AbortSignal.any with the
+        // store's internal controller, so the fn receives a fresh non-aborted signal.
+        expect(req.fn.mock.calls[0][0].aborted).toBe(false);
+
+        // Refresh with explicit undefined: factory is NOT invoked.
+        act(() => result.current.refresh({ abortSignal: undefined }));
+        expect(getAbortSignal).toHaveBeenCalledTimes(1);
+        expect(req.fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('aborting the getAbortSignal transitions the current attempt to error; refresh starts a fresh one', async () => {
+        const req = makeFakeRequest<string>();
+        let currentCtrl: AbortController | undefined;
+        const getAbortSignal = () => {
+            currentCtrl = new AbortController();
+            return currentCtrl.signal;
+        };
+        const { result } = renderHook(() => useRequest(req.source, { getAbortSignal }));
+
+        const timeoutReason = new Error('timeout');
+        await act(async () => currentCtrl!.abort(timeoutReason));
+        expect(result.current.status).toBe('error');
+        expect(result.current.error).toBe(timeoutReason);
+
+        act(() => result.current.refresh());
+        expect(currentCtrl!.signal.aborted).toBe(false); // brand-new controller for the new attempt
+
+        await act(async () => req.resolveLatest('recovered'));
+        expect(result.current.status).toBe('success');
+        expect(result.current.data).toBe('recovered');
+    });
+
+    describe('function shape', () => {
+        it('accepts a bare async function and fires it on mount', async () => {
+            const { promise, resolve } = Promise.withResolvers<string>();
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => promise);
+            const { result } = renderHook(() => useRequest(fn));
+            expect(fn).toHaveBeenCalledTimes(1);
+            expect(result.current.status).toBe('fetching');
+
+            await act(async () => resolve('hi'));
+            expect(result.current.status).toBe('success');
+            expect(result.current.data).toBe('hi');
+        });
+
+        it('refresh() re-invokes the function with a fresh signal', async () => {
+            const { promise, resolve } = Promise.withResolvers<string>();
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => promise);
+            const { result } = renderHook(() => useRequest(fn));
+            await act(async () => resolve('ok'));
+            expect(fn).toHaveBeenCalledTimes(1);
+
+            act(() => result.current.refresh());
+            expect(fn).toHaveBeenCalledTimes(2);
+            expect(fn.mock.calls[1][0]).not.toBe(fn.mock.calls[0][0]);
+        });
+
+        it('combines a per-request signal into the signal passed to the function', () => {
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => new Promise<string>(() => {}));
+            const ctrl = new AbortController();
+            renderHook(() => useRequest(fn, { getAbortSignal: () => ctrl.signal }));
+
+            const innerSignal = fn.mock.calls[0][0];
+            expect(innerSignal.aborted).toBe(false);
+
+            ctrl.abort(new Error('timeout'));
+            expect(innerSignal.aborted).toBe(true);
+        });
+
+        it('rebuilds the store and fires a fresh request when one function source replaces another', () => {
+            const fnA = jest.fn<Promise<string>, [AbortSignal]>(() => new Promise<string>(() => {}));
+            const fnB = jest.fn<Promise<string>, [AbortSignal]>(() => new Promise<string>(() => {}));
+            const { rerender } = renderHook(
+                ({ fn }: { fn: (signal: AbortSignal) => Promise<string> }) => useRequest(fn),
+                {
+                    initialProps: { fn: fnA },
+                },
+            );
+            expect(fnA).toHaveBeenCalledTimes(1);
+            expect(fnB).not.toHaveBeenCalled();
+
+            rerender({ fn: fnB });
+            expect(fnA.mock.calls[0][0].aborted).toBe(true); // prior in-flight call aborted
+            expect(fnB).toHaveBeenCalledTimes(1);
+        });
+
+        it('rebuilds the store when switching between function and source shapes', () => {
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => new Promise<string>(() => {}));
+            const req = makeFakeRequest<string>();
+            type Source = ReactiveActionSource<string> | ((signal: AbortSignal) => Promise<string>);
+            const initialProps: { source: Source } = { source: fn };
+            const { rerender } = renderHook(({ source }) => useRequest(source), { initialProps });
+            expect(fn).toHaveBeenCalledTimes(1);
+            expect(req.fn).not.toHaveBeenCalled();
+
+            rerender({ source: req.source });
+            expect(fn.mock.calls[0][0].aborted).toBe(true);
+            expect(req.fn).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('SSR', () => {
+        it('renders `fetching` on the server without firing the request', () => {
+            const req = makeFakeRequest<string>();
+            function Component() {
+                const { status } = useRequest(req.source);
+                return <p>{status}</p>;
+            }
+            // `renderToString` drives `useSyncExternalStore` through its server-snapshot path
+            // (the third arg to `useSyncExternalStore`), and effects don't run during server
+            // rendering — so the store stays `idle` and the bridge maps that to `fetching`.
+            const html = renderToString(<Component />);
+            expect(html).toBe('<p>fetching</p>');
+            expect(req.fn).not.toHaveBeenCalled();
+        });
+
+        it('renders `disabled` on the server when the source is null', () => {
+            function Component() {
+                const { status } = useRequest<string>(null);
+                return <p>{status}</p>;
+            }
+            const html = renderToString(<Component />);
+            expect(html).toBe('<p>disabled</p>');
+        });
+    });
+});

--- a/packages/react/src/__typetests__/useRequest-typetest.ts
+++ b/packages/react/src/__typetests__/useRequest-typetest.ts
@@ -1,0 +1,36 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import { ReactiveActionSource } from '@solana/subscribable';
+
+import { RequestResult, useRequest } from '../useRequest';
+
+const slotSource = null as unknown as ReactiveActionSource<{ slot: bigint }>;
+
+// [DESCRIBE] useRequest
+{
+    // Infers T from the source
+    {
+        useRequest(slotSource) satisfies RequestResult<{ slot: bigint }>;
+    }
+
+    // The source argument accepts null
+    {
+        useRequest<{ slot: bigint }>(null) satisfies RequestResult<{ slot: bigint }>;
+    }
+
+    // Options accept a `getAbortSignal` factory
+    {
+        useRequest(slotSource, { getAbortSignal: () => AbortSignal.timeout(5_000) });
+    }
+
+    // `refresh` accepts no args (uses the factory), an `{ abortSignal }` override, or
+    // `{ abortSignal: undefined }` to opt out of the factory entirely.
+    {
+        const { refresh } = useRequest(slotSource);
+        refresh();
+        refresh({ abortSignal: AbortSignal.timeout(1_000) });
+        refresh({ abortSignal: undefined });
+        // @ts-expect-error - abortSignal must be an AbortSignal (or undefined)
+        refresh({ abortSignal: 'nope' });
+    }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -7,6 +7,7 @@ export * from './ClientProvider';
 export * from './useAction';
 export * from './useClient';
 export * from './useClientCapability';
+export * from './useRequest';
 export * from './useSignAndSendTransaction';
 export * from './useSignIn';
 export * from './useSignMessage';

--- a/packages/react/src/staticStores.ts
+++ b/packages/react/src/staticStores.ts
@@ -1,0 +1,34 @@
+import { ReactiveActionStore } from '@solana/subscribable';
+
+const DISABLED_ACTION_STATE = Object.freeze({
+    data: undefined,
+    error: undefined,
+    status: 'idle' as const,
+});
+
+const noopUnsubscribe = () => {};
+const noopSubscribe = () => noopUnsubscribe;
+const rejectedAbortError = (): Promise<never> => Promise.reject(new DOMException('Aborted', 'AbortError'));
+
+/**
+ * A {@link ReactiveActionStore} that never transitions out of `idle` and rejects any attempt to
+ * dispatch. Returned by `useRequest` (and other action-store hooks) when their factory function
+ * returns `null`, signalling that the call should be gated off — for example because a required
+ * input (an address, a query string) is not yet known.
+ *
+ * The hook's result bridge maps this store's `idle` state to a `disabled` status so call sites
+ * can distinguish "not enabled" from "loading" without an extra flag.
+ */
+export function disabledActionStore<T>(): ReactiveActionStore<[], T> {
+    return {
+        dispatch: noopUnsubscribe,
+        dispatchAsync: rejectedAbortError,
+        getState: () => DISABLED_ACTION_STATE,
+        reset: noopUnsubscribe,
+        subscribe: noopSubscribe,
+        withSignal: () => ({
+            dispatch: noopUnsubscribe,
+            dispatchAsync: rejectedAbortError,
+        }),
+    };
+}

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -1,10 +1,7 @@
 import { createReactiveActionStore } from '@solana/subscribable';
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 
-// `useLayoutEffect` warns on the server. The ref-sync only needs to be in place by the time an
-// event handler can fire, which can't happen during SSR — so on the server, plain `useEffect`
-// is functionally equivalent and silent.
-const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
 
 /**
  * Reactive state and controls for an async action managed by {@link useAction}

--- a/packages/react/src/useIsomorphicLayoutEffect.ts
+++ b/packages/react/src/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,11 @@
+import { useEffect, useLayoutEffect } from 'react';
+
+/**
+ * `useLayoutEffect` warns when run on the server because layout effects only make sense after a
+ * DOM is mounted. For our use, plain `useEffect` is functionally equivalent on the server (no
+ * event handlers can fire mid-render anyway), so we pick at module load time and stay silent
+ * during SSR.
+ *
+ * @internal
+ */
+export const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;

--- a/packages/react/src/useLatest.ts
+++ b/packages/react/src/useLatest.ts
@@ -1,0 +1,24 @@
+import { type MutableRefObject, useRef } from 'react';
+
+import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';
+
+/**
+ * Hold `value` in a ref that is re-synced to the latest render's value after every commit.
+ *
+ * Lets a callback (or a store created once) read the freshest closure value at call time without
+ * taking it as a dependency, so the consumer's own identity stays stable across renders. The sync
+ * runs in a layout effect so the ref is current before passive effects and event handlers fire.
+ *
+ * @typeParam T - The type of the value being tracked.
+ *
+ * @returns A stable {@link MutableRefObject} whose `current` always reflects the most recent render.
+ *
+ * @internal
+ */
+export function useLatest<T>(value: T): MutableRefObject<T> {
+    const ref = useRef(value);
+    useIsomorphicLayoutEffect(() => {
+        ref.current = value;
+    });
+    return ref;
+}

--- a/packages/react/src/useReactiveStoreLifecycle.ts
+++ b/packages/react/src/useReactiveStoreLifecycle.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { useLatest } from './useLatest';
+
+/**
+ * Options accepted by the `refresh`-style callback returned from {@link useReactiveStoreLifecycle}.
+ *
+ * @internal
+ */
+type RefireOptions = {
+    /**
+     * Override the configured `getAbortSignal` factory for this attempt. Passing the key at all
+     * (even as `undefined`) opts out of the factory; omitting it falls back to the factory.
+     */
+    abortSignal?: AbortSignal | undefined;
+};
+
+// In dev, warn when the store identity changes this many times inside `CHURN_WINDOW_MS`. A handful
+// of recreations is normal (StrictMode's mount/cleanup/mount, an occasional dependency change); a
+// burst this large within a second only happens when an unmemoized `source`/`spec` mints a fresh
+// store every render — the self-sustaining dispatch/abort loop. Set well above any legitimate churn.
+const CHURN_WARNING_THRESHOLD = 25;
+const CHURN_WINDOW_MS = 1_000;
+
+/**
+ * Shared lifecycle for the source-keyed reactive-store hooks (`useRequest`, and the stream-store
+ * hooks built on the same shape). Owns the three pieces each of them otherwise repeats verbatim:
+ *
+ * - ref-syncs `getAbortSignal` so an inline factory passed every render doesn't churn the caller's
+ *   store memo,
+ * - fires the store on commit and resets it on teardown / store-identity change,
+ * - returns a stable `refresh`-style callback carrying the presence-based signal override.
+ *
+ * `fire` performs the store's "go" verb — `dispatch` for action stores, `connect` for stream
+ * stores — optionally with a per-attempt {@link AbortSignal}. Pass it as a stable (module-level)
+ * function so the returned callback stays referentially stable.
+ *
+ * In development it also emits a `console.error` when the store identity changes far more often
+ * than legitimate use would explain, which is the signature of an unmemoized `source`/`spec`
+ * driving an infinite dispatch/abort loop.
+ *
+ * @typeParam TStore - The reactive store type; only its `reset()` method is needed here.
+ *
+ * @param store - The store to drive; recreated by the caller whenever the source identity changes.
+ * @param fire - Performs the store's go verb, optionally with a per-attempt signal.
+ * @param getAbortSignal - Optional factory invoked per attempt to mint a fresh signal.
+ *
+ * @returns A stable callback that re-fires the store, accepting the per-attempt signal override.
+ *
+ * @internal
+ */
+export function useReactiveStoreLifecycle<TStore extends { reset(): void }>(
+    store: TStore,
+    fire: (store: TStore, signal: AbortSignal | undefined) => void,
+    getAbortSignal: (() => AbortSignal) | undefined,
+): (options?: RefireOptions) => void {
+    const getAbortSignalRef = useLatest(getAbortSignal);
+
+    const refresh = useCallback(
+        (options?: RefireOptions) => {
+            // Presence-based override: an explicit `abortSignal` key (even `undefined`) opts out
+            // of the factory for this attempt. Omitting the key falls back to the factory.
+            const signal = options && 'abortSignal' in options ? options.abortSignal : getAbortSignalRef.current?.();
+            fire(store, signal);
+        },
+        // `getAbortSignalRef` is a stable ref and `fire` a stable (module-level) function, so
+        // `refresh` only changes identity when `store` does.
+        [fire, getAbortSignalRef, store],
+    );
+
+    // Dev-only churn guard. This effect re-runs once per store identity (deps include `store`), so
+    // counting its runs within a rolling window flags an unmemoized `source`/`spec` that mints a
+    // fresh store every render. Counting lives here, not in render, so there's no render-phase
+    // ref mutation for StrictMode to flag.
+    const churnRef = useRef({ count: 0, warned: false, windowStart: 0 });
+
+    useEffect(() => {
+        if (__DEV__) {
+            const churn = churnRef.current;
+            const now = Date.now();
+            if (now - churn.windowStart > CHURN_WINDOW_MS) {
+                churn.windowStart = now;
+                churn.count = 0;
+            }
+            if (++churn.count > CHURN_WARNING_THRESHOLD && !churn.warned) {
+                churn.warned = true;
+                // eslint-disable-next-line no-console
+                console.error(
+                    'A reactive-store hook (e.g. `useRequest`) recreated its store %d times within ' +
+                        '1s. This almost always means the `source`/`spec` passed to it is a fresh ' +
+                        'reference on every render — wrap it in `useMemo`/`useCallback` keyed on its ' +
+                        'inputs. Each recreation aborts the in-flight request before it can complete, ' +
+                        'so nothing ever loads.',
+                    churn.count,
+                );
+            }
+        }
+        refresh();
+        return () => store.reset();
+    }, [refresh, store]);
+
+    return refresh;
+}

--- a/packages/react/src/useRequest.ts
+++ b/packages/react/src/useRequest.ts
@@ -1,0 +1,146 @@
+import { createReactiveActionStore, ReactiveActionSource, ReactiveActionStore } from '@solana/subscribable';
+import { useMemo } from 'react';
+
+import { disabledActionStore } from './staticStores';
+import { useReactiveStoreLifecycle } from './useReactiveStoreLifecycle';
+import { useRequestResult } from './useRequestResult';
+
+// Module-level so it's a stable reference — keeps the `refresh` callback from
+// `useReactiveStoreLifecycle` referentially stable across renders.
+function fireAction<T>(store: ReactiveActionStore<[], T>, signal: AbortSignal | undefined): void {
+    if (signal) store.withSignal(signal).dispatch();
+    else store.dispatch();
+}
+
+/**
+ * Reactive state for a one-shot request managed by {@link useRequest}.
+ *
+ * Lifecycle: starts at `fetching` (or `disabled` when the source is `null`) and auto-fires on
+ * mount; transitions to `success` on success or `error` on failure. `refresh()` re-fires the
+ * request — while a re-fire is in flight, `status` returns to `fetching` and the stale `data`
+ * and/or `error` from the prior outcome remain populated (stale-while-revalidate).
+ *
+ * @typeParam T - The value the underlying request resolves to.
+ */
+export type RequestResult<T> = {
+    /**
+     * The most recent successful value, or `undefined` if no call has succeeded yet (or while
+     * disabled). Persists across subsequent refreshes (including failed ones) until a new success
+     * replaces it or `reset()` clears the store.
+     */
+    data: T | undefined;
+    /**
+     * The error from the most recent failed call, or `undefined` if no call has failed (or while
+     * disabled). Persists across subsequent refreshes until a new success clears it. May coexist
+     * with `data` when a successful attempt is followed by a failing one.
+     */
+    error: unknown;
+    /**
+     * Re-fire the request. By default each call mints a fresh signal from `getAbortSignal` (if
+     * configured) and threads it through the underlying store's
+     * `withSignal(signal).dispatch()`. Pass `{ abortSignal }` to override the configured factory
+     * for just this attempt. Pass `{ abortSignal: undefined }` to opt out of the factory entirely
+     * for this attempt and fire with no caller-provided signal.
+     *
+     * Stable reference.
+     */
+    refresh: (options?: { abortSignal?: AbortSignal | undefined }) => void;
+    /**
+     * Lifecycle status as a discriminated string:
+     * - `fetching`: a request is in flight. `data` and `error` carry whatever stale content was
+     *   available before this attempt (both `undefined` on the first attempt; either or both
+     *   populated on a refresh after a prior outcome).
+     * - `success`: most recent call succeeded; `data` holds the result.
+     * - `error`: most recent call failed; `error` holds the reason.
+     * - `disabled`: source was `null`.
+     */
+    status: 'disabled' | 'error' | 'fetching' | 'success';
+};
+
+/** Options accepted by {@link useRequest}. */
+export type UseRequestOptions = {
+    /**
+     * Factory invoked on every attempt (initial fire + every `refresh()`). The returned signal is
+     * attached to that attempt via the underlying store's `withSignal(signal).dispatch()`, so
+     * aborting it cancels just the current attempt.
+     *
+     * The most common use is per-attempt timeouts: `getAbortSignal: () => AbortSignal.timeout(5000)`
+     * gives every attempt its own 5-second clock that resets on `refresh()`.
+     *
+     * Held in a ref synced to the latest render's closure — there is no need to memoize an inline
+     * factory.
+     */
+    getAbortSignal?: () => AbortSignal;
+};
+
+/**
+ * Fire a one-shot request on mount and re-fire each time `source` changes identity or `refresh()`
+ * is called. Returns reactive state tracking the call's lifecycle.
+ *
+ * Two ways to pass the work:
+ *
+ * - A {@link ReactiveActionSource} — the `{ reactiveStore() }` duck-type satisfied by
+ *   `PendingRpcRequest`.
+ * - An async function `(signal: AbortSignal) => Promise<T>` — wrap any one-shot async source
+ *   (a `fetch`, a third-party SDK call, etc). Most general shape.
+ *
+ * Pass `null` to disable; the result reports `status: 'disabled'`.
+ *
+ * Memoize the input (`useMemo` for a source, `useCallback` for a function) keyed on whatever
+ * inputs it depends on.
+ *
+ * @typeParam T - The value the underlying request resolves to.
+ *
+ * @example
+ * ```tsx
+ * function LatestBlockhash() {
+ *     const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+ *     const source = useMemo(() => client.rpc.getLatestBlockhash(), [client]);
+ *     const { data, error, refresh } = useRequest(source, {
+ *         getAbortSignal: () => AbortSignal.timeout(5_000),
+ *     });
+ *     if (error) return <button onClick={refresh}>Retry</button>;
+ *     return <p>{data ? `Blockhash: ${data.value.blockhash}` : 'Loading…'}</p>;
+ * }
+ *
+ * // Function shape — wraps an arbitrary async call:
+ * function Profile({ userId }: { userId: string }) {
+ *     const fetcher = useCallback(
+ *         (signal: AbortSignal) => fetch(`/api/users/${userId}`, { signal }).then(r => r.json()),
+ *         [userId],
+ *     );
+ *     const { data, error, refresh } = useRequest(fetcher);
+ *     if (error) return <button onClick={refresh}>Retry</button>;
+ *     return <p>{data ? data.name : 'Loading…'}</p>;
+ * }
+ * ```
+ *
+ * @see {@link RequestResult}
+ * @see {@link UseRequestOptions}
+ */
+export function useRequest<T>(
+    source: ReactiveActionSource<T> | ((signal: AbortSignal) => Promise<T>) | null,
+    options?: UseRequestOptions,
+): RequestResult<T> {
+    // One store per `source`. Both creation paths return an `idle` store; the initial dispatch
+    // lives in the lifecycle effect below so the memo body stays pure (StrictMode's dev
+    // double-render, and any future render-discard, won't fire a network request from a discarded
+    // render).
+    //
+    // Note: `useMemo` is permitted to discard memoized values across renders (independent of deps);
+    // if React ever does so here, the discard surfaces as a fresh store with empty `data` /
+    // `error` and an immediate refetch — same shape as a remount. In practice this doesn't happen,
+    // but if React changes and it becomes an issue, we'd need to rework this.
+    const store = useMemo(() => {
+        if (source == null) return disabledActionStore<T>();
+        return typeof source === 'function' ? createReactiveActionStore<[], T>(source) : source.reactiveStore();
+    }, [source]);
+
+    // Fire on commit, reset on store change / unmount, and expose the stable `refresh` callback.
+    // `store.reset()` aborts the in-flight request via the action store's internal controller, so
+    // under StrictMode's mount → cleanup → mount sequence the first dispatch is properly aborted
+    // before the second one fires.
+    const refresh = useReactiveStoreLifecycle(store, fireAction, options?.getAbortSignal);
+
+    return useRequestResult(store, refresh, source == null);
+}

--- a/packages/react/src/useRequestResult.ts
+++ b/packages/react/src/useRequestResult.ts
@@ -1,0 +1,48 @@
+import { ReactiveActionStore } from '@solana/subscribable';
+import { useMemo, useSyncExternalStore } from 'react';
+
+import { RequestResult } from './useRequest';
+
+/**
+ * Subscribes to a {@link ReactiveActionStore} and maps its `idle | running | success | error`
+ * lifecycle onto the {@link RequestResult} shape consumed by `useRequest`.
+ *
+ * `idle` is ambiguous on its own: it covers both "no source — store is disabled" and "real source,
+ * dispatch effect hasn't fired yet on the current render." The `disabled` flag disambiguates:
+ * disabled → `status: 'disabled'`, enabled → `status: 'fetching'` (the dispatch is about to fire
+ * on commit; consumers see a single `fetching` paint rather than briefly flashing `disabled`).
+ *
+ * - `idle` + disabled → `disabled`
+ * - `idle` + enabled → `fetching` (first paint, dispatch effect about to commit)
+ * - `running` → `fetching` (caller inspects `data` / `error` to know if there's stale content)
+ * - `success` → `success`
+ * - `error` → `error`
+ *
+ * The action store's built-in stale-while-revalidate carries `state.data` and `state.error`
+ * across attempts, so the bridge doesn't need to mirror them.
+ *
+ * @internal
+ */
+export function useRequestResult<T>(
+    store: ReactiveActionStore<[], T>,
+    refresh: (options?: { abortSignal?: AbortSignal | undefined }) => void,
+    disabled: boolean,
+): RequestResult<T> {
+    const state = useSyncExternalStore(store.subscribe, store.getState, store.getState);
+    return useMemo(() => {
+        const status: RequestResult<T>['status'] =
+            state.status === 'idle'
+                ? disabled
+                    ? 'disabled'
+                    : 'fetching'
+                : state.status === 'running'
+                  ? 'fetching'
+                  : state.status; // 'success' | 'error'
+        return {
+            data: state.data,
+            error: state.error,
+            refresh,
+            status,
+        };
+    }, [state, refresh, disabled]);
+}


### PR DESCRIPTION
#### Summary of Changes

This PR adds the `useRequest` hook:

```typescript
function LatestBlockhash() {
    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
    const source = useMemo(() => client.rpc.getLatestBlockhash(), [client]);
    const { data, error, refresh, status } = useRequest(source);

    if (status === 'fetching') return <p>Loading…</p>;
    if (error) return <button onClick={refresh}>Retry</button>;
    return (
        <p>
            Blockhash: {data?.value.blockhash} <button onClick={refresh}>↻</button>
        </p>
    );
}
```

This uses the `ReactiveActionStore` state machine like `useAction`, but the request is immediately dispatched.

The hook was designed around `ReactiveActionSource`, ie the type `PendingRpcRequest` now satisfies with its `.reactiveStore()` function. But I realised that since it's using `ReactiveActionStore` it can actually work with any async function with hardly any extra code (all the logic is in the store):

```typescript
function Profile({ userId }: { userId: string }) {
    const fetcher = useCallback(
        (signal: AbortSignal) => fetch(`/api/users/${userId}`, { signal }).then(r => r.json()),
        [userId],
    );
    const { data, error, refresh } = useRequest(fetcher);
    if (error) return <button onClick={refresh}>Retry</button>;
    return <p>{data ? data.name : 'Loading…'}</p>;
}
```

I think this makes it much more useful for apps since it can cover much more of their data fetching requirements now. Apps using indexers/databases/SDKs etc in addition to RPC requests can transparently use this hook for everything, and it's all using the same state machine logic under the hood.

Note that we won't have the same flexibility with the subscription hooks since they build on `DataPublisher`, this works because the action store was always designed for arbitrary async functions.

The hook takes an optional `getAbortSignal` prop with a function to create an abort signal per request. This is also used to create the signal for the auto-dispatch request:

```tsx
function LatestBlockhash() {
    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
    const source = useMemo(() => client.rpc.getLatestBlockhash(), [client]);
    const { data, error, refresh, status } = useRequest(source, {
        getAbortSignal: () => AbortSignal.timeout(5_000),
    });

    if (status === 'fetching') return <p>Loading…</p>;
    if (error) return <button onClick={refresh}>Retry</button>;
    return (
        <p>
            Blockhash: {data?.value.blockhash} <button onClick={refresh}>↻</button>
        </p>
    );
}
```

The signal can optionally be overridden for `refresh` requests: `refresh({ abortSignal: userClickedCancel.signal })`.  