### PR TITLE
Harden update-docs-lockfile workflow

### DIFF
--- a/.github/workflows/update-docs-lockfile.yml
+++ b/.github/workflows/update-docs-lockfile.yml
@@ -6,16 +6,14 @@ on:
       - 'docs/package.json'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update-lockfile:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
           app-id: ${{ vars.APP_ID }}
@@ -30,14 +28,24 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ github.event.pull_request.head.ref }}
           persist-credentials: false
 
-      - name: Install Dependencies
-        uses: ./.github/workflows/actions/install-dependencies
+      # Avoid `cache: 'pnpm'`: this workflow runs under pull_request_target
+      # trust, and the pnpm cache key in actions/install-dependencies collides 
+      # with main-branch workflows.
+      - name: Install pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.24.0
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: lts/*
 
       - name: Update Docs Lockfile
         working-directory: ./docs/


### PR DESCRIPTION
Being extremely cautious after https://tanstack.com/blog/npm-supply-chain-compromise-postmortem

`update-docs-lockfile` was our only workflow that uses `pull_request_target` and has any cache writes. The cache write was via the compose `actions/install-dependencies` which installs pnpm, sets up Node and runs `pnpm install` in root. It sets up Node with the pnpm cache:

```yaml
    - name: Setup Node
      uses: actions/setup-node@v4
      with:
        cache: 'pnpm'
        node-version: ${{ inputs.version }}
        registry-url: 'https://registry.npmjs.org'
```

`update-docs-lockfile` is scoped to dependabot runs, but that's not really giving us any safety - its entire point is installing new versions of docs dependencies that could be attacker controlled.

If we look at how `actions/setup-node` creates the cache key, it only takes as input runner features that are shared across all workflow runs, and the hash of the root lockfile:

https://github.com/actions/setup-node/blob/49933ea5288caeca8642d1e84afbd3f7d6820020/src/cache-restore.ts#L43-L44

So that cache key collides with the key used by workflows on main

It's very unlikely this could either be exploited or cause issues, because this job only runs install with `--ignore-scripts` (which is pnpm default anyway) and never runs dependencies. But since this is just installing its own lockfile, it doesn't need to share the cache with the root lockfile.

Also `actions/install-dependencies` runs `pnpm install` at root which this workflow doesn't need. So I've removed that from this job, it now just installs pnpm/node for itself without the cache.

Also other small things:

- Changes to `contents: read` permission, since the workflow uses the app token for the git push and doesn't need to write anything with the github token
- Removes `id-token: write` which isn't used. Couldn't be exploited because trusted publishing is scoped to a workflow, probably a copy-paste mistake, but not needed. 
- Pin SHA hashes, which matches what other `pull_request_target` jobs do

Other pull_request_target jobs don't have the same risk:

- backport.yml only runs on merged PRs with a backport label, and runs only `tibdex/backport` at a pinned SHA, no access to repo code/dependencies/cache
- dismiss-stale-pr-reviews.yml runs only `withgraphite/dismiss-stale-approvals` at a pinned SHA, no access to repo code/dependencies/cache

As an aside this is another argument for pulling docs to a separate repo, its dependency surface is much bigger than Kit. And this workflow wouldn't exist because dependabot would work properly. 