### PR TITLE
ci: replace app-id with client-id

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
       - name: Auto-approve the PR
         run: gh pr review --approve "$PR_URL"

--- a/.github/workflows/update-docs-lockfile.yml
+++ b/.github/workflows/update-docs-lockfile.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.CLIENT_ID }}
           private-key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Set git config


### PR DESCRIPTION
#### Problem

`create-github-app-token` has deprecated `app-id` and recommends using `client-id` instead

#### Summary of Changes

replace app-id with client-id
