### PR TITLE
ci: add github-actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -55,3 +55,9 @@ updates:
         patterns:
           - 'undici'
           - 'undici-types'
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
#### Problem

I noticed that we don't ask dependabot to check `github-actions`

#### Summary of Changes

add it to the process