### PR TITLE
Release the caller abort listener in getTimeoutPromise

### DIFF
--- a/.changeset/big-pugs-wish.md
+++ b/.changeset/big-pugs-wish.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-confirmation': patch
+---
+
+Fix an abort listener leak in `getTimeoutPromise`. The listener registered on the caller's `AbortSignal` was never removed after the promise settled, which caused listeners to accumulate when the same signal was reused across multiple calls. `getTimeoutPromise` now registers the listener with the auto-cleanup `signal` option already used by the other strategies in this package and releases it in a `finally` block.

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-timeout-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-timeout-test.ts
@@ -30,4 +30,48 @@ describe('getTimeoutPromise', () => {
         abortController.abort();
         await expect(timeoutPromise).rejects.toThrow(/operation was aborted/);
     });
+    it('registers the caller abort listener with an auto-cleanup signal', () => {
+        const abortController = new AbortController();
+        const addEventListenerSpy = jest.spyOn(abortController.signal, 'addEventListener');
+        const timeoutPromise = getTimeoutPromise({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+        });
+        // Suppress the eventual rejection so the test does not produce an
+        // unhandled rejection warning at teardown.
+        timeoutPromise.catch(() => {});
+        // The listener must be registered with the modern `signal` option so that
+        // it is released automatically when the inner controller aborts in `finally`.
+        expect(addEventListenerSpy).toHaveBeenCalledWith(
+            'abort',
+            expect.any(Function),
+            expect.objectContaining({ signal: expect.objectContaining({ aborted: false }) }),
+        );
+    });
+    it('aborts the cleanup signal once the timeout elapses', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        const addEventListenerSpy = jest.spyOn(abortController.signal, 'addEventListener');
+        const settled = getTimeoutPromise({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+        }).catch((e: unknown) => e);
+        await jest.advanceTimersByTimeAsync(60_000);
+        await settled;
+        const cleanupSignal = (addEventListenerSpy.mock.calls[0][2] as { signal: AbortSignal }).signal;
+        expect(cleanupSignal.aborted).toBe(true);
+    });
+    it('aborts the cleanup signal when the caller aborts', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        const addEventListenerSpy = jest.spyOn(abortController.signal, 'addEventListener');
+        const settled = getTimeoutPromise({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+        }).catch((e: unknown) => e);
+        abortController.abort();
+        await settled;
+        const cleanupSignal = (addEventListenerSpy.mock.calls[0][2] as { signal: AbortSignal }).signal;
+        expect(cleanupSignal.aborted).toBe(true);
+    });
 });

--- a/packages/transaction-confirmation/src/confirmation-strategy-timeout.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-timeout.ts
@@ -1,3 +1,4 @@
+import { AbortController } from '@solana/event-target-impl';
 import type { Commitment } from '@solana/rpc-types';
 
 type Config = Readonly<{
@@ -32,22 +33,29 @@ type Config = Readonly<{
  * ```
  */
 export async function getTimeoutPromise({ abortSignal: callerAbortSignal, commitment }: Config) {
-    return await new Promise((_, reject) => {
-        const handleAbort = (e: AbortSignalEventMap['abort']) => {
-            clearTimeout(timeoutId);
-            const abortError = new DOMException((e.target as AbortSignal).reason, 'AbortError');
-            reject(abortError);
-        };
-        callerAbortSignal.addEventListener('abort', handleAbort);
-        const timeoutMs = commitment === 'processed' ? 30_000 : 60_000;
-        const startMs = performance.now();
-        const timeoutId =
-            // We use `setTimeout` instead of `AbortSignal.timeout()` because we want to measure
-            // elapsed time instead of active time.
-            // See https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static
-            setTimeout(() => {
-                const elapsedMs = performance.now() - startMs;
-                reject(new DOMException(`Timeout elapsed after ${elapsedMs} ms`, 'TimeoutError'));
-            }, timeoutMs);
-    });
+    const abortController = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+        return await new Promise((_, reject) => {
+            const handleAbort = (e: AbortSignalEventMap['abort']) => {
+                clearTimeout(timeoutId);
+                const abortError = new DOMException((e.target as AbortSignal).reason, 'AbortError');
+                reject(abortError);
+            };
+            callerAbortSignal.addEventListener('abort', handleAbort, { signal: abortController.signal });
+            const timeoutMs = commitment === 'processed' ? 30_000 : 60_000;
+            const startMs = performance.now();
+            timeoutId =
+                // We use `setTimeout` instead of `AbortSignal.timeout()` because we want to measure
+                // elapsed time instead of active time.
+                // See https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static
+                setTimeout(() => {
+                    const elapsedMs = performance.now() - startMs;
+                    reject(new DOMException(`Timeout elapsed after ${elapsedMs} ms`, 'TimeoutError'));
+                }, timeoutMs);
+        });
+    } finally {
+        clearTimeout(timeoutId);
+        abortController.abort();
+    }
 }


### PR DESCRIPTION
## Summary

`getTimeoutPromise` in `@solana/transaction-confirmation` registers an `abort` listener on the caller supplied `AbortSignal` but never removes it. When a caller reuses the same signal across multiple calls, listeners accumulate. This change brings the function in line with the auto-cleanup pattern already used by the three sibling confirmation strategies in the same package.

## Before

```ts
export async function getTimeoutPromise({ abortSignal: callerAbortSignal, commitment }: Config) {
    return await new Promise((_, reject) => {
        const handleAbort = (e: AbortSignalEventMap['abort']) => {
            clearTimeout(timeoutId);
            const abortError = new DOMException((e.target as AbortSignal).reason, 'AbortError');
            reject(abortError);
        };
        callerAbortSignal.addEventListener('abort', handleAbort);
        // ...
    });
}
```

The third argument to `addEventListener` is omitted. There is no matching `removeEventListener`, so the listener stays attached for the lifetime of the caller signal regardless of how the promise settles.

## After

`getTimeoutPromise` now creates an inner `AbortController`, registers the caller signal listener with `{ signal: innerController.signal }`, and aborts the inner controller in a `finally` block. The platform releases the listener automatically when the inner controller aborts. The `setTimeout` handle is also cleared in `finally` so that the underlying timer is released on every exit path.

This is the same pattern already used by:

- `confirmation-strategy-recent-signature.ts:87`
- `confirmation-strategy-racer.ts:28`
- `confirmation-strategy-blockheight.ts:89`

Before this change, `confirmation-strategy-timeout.ts` was the only file in the package that deviated from this convention.

## Behavioral impact

None for callers. The function still throws a `TimeoutError` when the timeout elapses and an `AbortError` when the caller signal aborts, exactly as documented. The four existing tests pass unchanged.

The leak itself is silent in the common case (a fresh `AbortController` per confirmation) but surfaces when callers reuse a long-lived signal across many timeout calls. In Node this can produce a `MaxListenersExceededWarning` once the listener count crosses the implicit cap. In any runtime it grows memory proportionally to the number of calls made.

## Tests

Three new tests cover the cleanup contract:

1. `registers the caller abort listener with an auto-cleanup signal` verifies synchronously that the listener is registered with the `signal` option.
2. `aborts the cleanup signal once the timeout elapses` verifies that the inner cleanup signal aborts after the timeout fires, releasing the listener.
3. `aborts the cleanup signal when the caller aborts` verifies the same on the caller abort path.

The four existing tests in `confirmation-strategy-timeout-test.ts` continue to pass without modification.

## Closes

Closes #1639
