### PR TITLE
Flatten the inferred type of clients built via `extendClient` and `withCleanup`

### DIFF
--- a/.changeset/empty-jars-double.md
+++ b/.changeset/empty-jars-double.md
@@ -1,0 +1,5 @@
+---
+'@solana/plugin-core': patch
+---
+
+Flatten the inferred return type of `extendClient` and `withCleanup` so that chained `.use()` calls on a `Client` no longer produce deeply nested `Omit<Omit<Omit<...>>>` types in editor tooltips and error messages. The inferred shape now displays as a single flat object literal at every step of the chain, while optional (`?`) and `readonly` modifiers, symbol keys, and override semantics are preserved exactly as before. Also exports the new `ExtendedClient<TClient, TAdditions>` helper type for plugin authors who write their own merging helpers and want the same flattening guarantee.

--- a/packages/plugin-core/src/__typetests__/client-typetest.ts
+++ b/packages/plugin-core/src/__typetests__/client-typetest.ts
@@ -1,8 +1,40 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
-import { type AsyncClient, type Client, type ClientPlugin, createClient, extendClient, withCleanup } from '../client';
+import {
+    type AsyncClient,
+    type Client,
+    type ClientPlugin,
+    createClient,
+    extendClient,
+    type ExtendedClient,
+    withCleanup,
+} from '../client';
 
 const EMPTY_CLIENT = null as unknown as Client<object>;
 const EMPTY_ASYNC_CLIENT = null as unknown as AsyncClient<object>;
+
+/**
+ * Strict type-equality helper used by typetests below. Resolves to `true` only
+ * if `A` and `B` are mutually assignable AND share the same modifier set (`?`,
+ * `readonly`); otherwise resolves to `false`.
+ *
+ * This is stricter than `satisfies` for two reasons:
+ *
+ * 1. **Bidirectionality.** `A satisfies B` only checks that `A` is assignable
+ *    to `B`. A test using `satisfies` passes if the actual type has extra
+ *    members beyond what we asserted — which would silently mask a regression
+ *    that re-introduced a nested `Omit<...>` wrapper, since `Omit<X, K> & A`
+ *    is still structurally assignable to a flat literal.
+ * 2. **Modifier strictness.** `A satisfies B` tolerates losing `?` (required
+ *    is assignable to optional) and losing `readonly` (readonly is assignable
+ *    to mutable). `Equal` distinguishes `{ x: T }` from `{ x?: T }` and from
+ *    `{ readonly x: T }` because the inferred-position generic comparison
+ *    uses identity rather than assignability for the type parameters.
+ *
+ * Use `Equal` when the exact shape (including modifiers) matters. Use
+ * `satisfies` when one-way assignability is the actual requirement (e.g.
+ * "this value is usable where `Disposable & X` is expected").
+ */
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
 // [DESCRIBE] ClientPlugin
 {
@@ -237,6 +269,45 @@ const EMPTY_ASYNC_CLIENT = null as unknown as AsyncClient<object>;
         // @ts-expect-error - additions is not an object.
         extendClient({}, 'hello');
     }
+
+    // It returns an `ExtendedClient` so that chained calls produce a flat object
+    // literal (not a nested `Omit<...>` chain) at every step and modifiers are
+    // preserved. The detailed shape assertions live in the `ExtendedClient`
+    // describe block below; this test only verifies the wiring between
+    // `extendClient` and `ExtendedClient`.
+    {
+        type Result = ReturnType<
+            typeof extendClient<{ fruit: 'apple' }, { readonly grain?: 'rice'; vegetable: 'carrot' }>
+        >;
+        type Expected = ExtendedClient<{ fruit: 'apple' }, { readonly grain?: 'rice'; vegetable: 'carrot' }>;
+        true satisfies Equal<Result, Expected>;
+    }
+
+    // It produces a flat object type (not a nested Omit<...> chain) when chained.
+    // The flat type is exactly the union of all additions, with override semantics
+    // applied (the second `vegetable` replaces the first).
+    {
+        type Step1 = ReturnType<typeof extendClient<{ fruit: 'apple' }, { vegetable: 'carrot' }>>;
+        type Step2 = ReturnType<typeof extendClient<Step1, { grain: 'rice' }>>;
+        type Step3 = ReturnType<typeof extendClient<Step2, { protein: 'tofu' }>>;
+        type Step4 = ReturnType<typeof extendClient<Step3, { dessert: 'pie'; vegetable: 'kale' }>>;
+        true satisfies Equal<
+            Step4,
+            { dessert: 'pie'; fruit: 'apple'; grain: 'rice'; protein: 'tofu'; vegetable: 'kale' }
+        >;
+    }
+
+    // It preserves symbol-keyed properties.
+    {
+        const result = extendClient({ fruit: 'apple' as const }, { [Symbol.dispose]: () => {} });
+        result satisfies { fruit: 'apple'; [Symbol.dispose]: () => void };
+    }
+
+    // It preserves function-valued properties as proper callable signatures.
+    {
+        const result = extendClient({ fruit: 'apple' as const }, { compute: (n: number): number => n + 1 });
+        result satisfies { compute: (n: number) => number; fruit: 'apple' };
+    }
 }
 
 // [Describe] withCleanup
@@ -257,5 +328,81 @@ const EMPTY_ASYNC_CLIENT = null as unknown as AsyncClient<object>;
     {
         const client = null as unknown as AsyncClient<object>;
         withCleanup(client, () => {}) satisfies AsyncClient<object> & Disposable;
+    }
+
+    // Its return type is an `ExtendedClient` so the merged shape is flat — symbol
+    // keys from `Disposable` (`Symbol.dispose`) are merged alongside the client's
+    // data properties without an intervening intersection wrapper.
+    {
+        type Extended = ExtendedClient<{ fruit: 'apple' }, { vegetable: 'carrot' }>;
+        type Result = ReturnType<typeof withCleanup<Extended>>;
+        true satisfies Equal<Result, ExtendedClient<Extended, Disposable>>;
+    }
+}
+
+// [DESCRIBE] ExtendedClient
+{
+    // It flattens an Omit & T intersection into a single object literal type.
+    {
+        type Result = ExtendedClient<{ fruit: 'apple' }, { vegetable: 'carrot' }>;
+        true satisfies Equal<Result, { fruit: 'apple'; vegetable: 'carrot' }>;
+    }
+
+    // It drops keys from the client that are overridden by additions, replacing their type.
+    {
+        type Result = ExtendedClient<{ fruit: 'apple' }, { fruit: 'banana' }>;
+        true satisfies Equal<Result, { fruit: 'banana' }>;
+    }
+
+    // It preserves the `?` modifier of additions.
+    {
+        type Result = ExtendedClient<{ fruit: 'apple' }, { vegetable?: 'carrot' }>;
+        true satisfies Equal<Result, { fruit: 'apple'; vegetable?: 'carrot' }>;
+    }
+
+    // It preserves the `readonly` modifier of additions.
+    {
+        type Result = ExtendedClient<{ fruit: 'apple' }, { readonly vegetable: 'carrot' }>;
+        true satisfies Equal<Result, { fruit: 'apple'; readonly vegetable: 'carrot' }>;
+    }
+
+    // It preserves the `?` modifier of properties that come from the original client.
+    {
+        type Result = ExtendedClient<{ fruit?: 'apple' }, { vegetable: 'carrot' }>;
+        true satisfies Equal<Result, { fruit?: 'apple'; vegetable: 'carrot' }>;
+    }
+
+    // It preserves the `readonly` modifier of properties that come from the original client.
+    {
+        type Result = ExtendedClient<{ readonly fruit: 'apple' }, { vegetable: 'carrot' }>;
+        true satisfies Equal<Result, { readonly fruit: 'apple'; vegetable: 'carrot' }>;
+    }
+
+    // It handles an empty additions type by returning a flat copy of the client.
+    // `NonNullable<unknown>` is the canonical way to express the empty object type
+    // (`{}`) without tripping the `@typescript-eslint/no-empty-object-type` lint rule.
+    {
+        type Result = ExtendedClient<{ fruit: 'apple'; vegetable: 'carrot' }, NonNullable<unknown>>;
+        true satisfies Equal<Result, { fruit: 'apple'; vegetable: 'carrot' }>;
+    }
+
+    // It handles an empty client type by returning a flat copy of the additions.
+    {
+        type Result = ExtendedClient<NonNullable<unknown>, { fruit: 'apple' }>;
+        true satisfies Equal<Result, { fruit: 'apple' }>;
+    }
+
+    // It is structurally equivalent to `Omit<TClient, keyof TAdditions> & TAdditions`.
+    // This guards against accidental changes to the override semantics.
+    {
+        type Result = ExtendedClient<{ fruit: 'apple'; grain: 'rice' }, { fruit: 'banana'; vegetable: 'carrot' }>;
+        type Reference = Omit<{ fruit: 'apple'; grain: 'rice' }, 'fruit' | 'vegetable'> & {
+            fruit: 'banana';
+            vegetable: 'carrot';
+        };
+        const a = null as unknown as Result;
+        const b = null as unknown as Reference;
+        a satisfies Reference;
+        b satisfies Result;
     }
 }

--- a/packages/plugin-core/src/client.ts
+++ b/packages/plugin-core/src/client.ts
@@ -214,12 +214,44 @@ function createAsyncClient<TSelf extends object>(promise: Promise<TSelf>): Async
 }
 
 /**
+ * The result of extending a client of type `TClient` with additional properties of type `TAdditions`.
+ *
+ * Structurally equivalent to `Omit<TClient, keyof TAdditions> & TAdditions` — keys present
+ * on both `TClient` and `TAdditions` are replaced by the `TAdditions` version — but expressed
+ * as a single homomorphic mapped type so the inferred type displays as a flat object literal
+ * rather than a deeply nested chain of `Omit<...>` intersections. Optional (`?`) and `readonly`
+ * modifiers from both sides are preserved.
+ *
+ * Plugin authors who write their own merging helpers can reuse this type to keep the
+ * inferred shape of their plugin's output legible in editor tooltips and error messages.
+ *
+ * @typeParam TClient - The type of the client being extended.
+ * @typeParam TAdditions - The type of the properties being merged in.
+ *
+ * @example
+ * ```ts
+ * function withRpc<TClient extends object>(client: TClient, endpoint: string): ExtendedClient<TClient, { rpc: Rpc }> {
+ *     return extendClient(client, { rpc: createSolanaRpc(endpoint) });
+ * }
+ * ```
+ *
+ * @see {@link extendClient}
+ */
+export type ExtendedClient<TClient extends object, TAdditions extends object> = {
+    [K in keyof (Omit<TClient, keyof TAdditions> & TAdditions)]: (Omit<TClient, keyof TAdditions> & TAdditions)[K];
+} & {};
+
+/**
  * Extends a client object with additional properties, preserving property descriptors
  * (getters, symbol-keyed properties, and non-enumerable properties) from both objects.
  *
  * Use this inside plugins instead of plain object spread (`{...client, ...additions}`)
  * when the client may carry getters or symbol-keyed properties that spread would flatten or lose.
  * When the same key exists on both, `additions` wins.
+ *
+ * The return type is an {@link ExtendedClient}, which flattens the merged shape into a single
+ * object literal so chained `extendClient` calls do not accumulate nested `Omit<...>` wrappers
+ * in editor tooltips and error messages.
  *
  * @typeParam TClient - The type of the original client.
  * @typeParam TAdditions - The type of the properties being added.
@@ -236,14 +268,15 @@ function createAsyncClient<TSelf extends object>(promise: Promise<TSelf>): Async
  * ```
  *
  * @see {@link ClientPlugin}
+ * @see {@link ExtendedClient}
  */
 export function extendClient<TClient extends object, TAdditions extends object>(
     client: TClient,
     additions: TAdditions,
-): Omit<TClient, keyof TAdditions> & TAdditions {
+): ExtendedClient<TClient, TAdditions> {
     const result = Object.defineProperties({}, toConfigurableDescriptors(Object.getOwnPropertyDescriptors(client)));
     Object.defineProperties(result, Object.getOwnPropertyDescriptors(additions));
-    return Object.freeze(result) as Omit<TClient, keyof TAdditions> & TAdditions;
+    return Object.freeze(result) as ExtendedClient<TClient, TAdditions>;
 }
 
 function toConfigurableDescriptors<T extends PropertyDescriptorMap>(descriptors: T): T {
@@ -261,6 +294,10 @@ function toConfigurableDescriptors<T extends PropertyDescriptorMap>(descriptors:
  * connections or clearing timers) that runs when the client is disposed.
  * If the client already implements `Symbol.dispose`, the existing dispose
  * logic is chained so that it runs after the new `cleanup` function.
+ *
+ * The return type is an {@link ExtendedClient}, which flattens the merged shape into a
+ * single object literal so chained calls do not accumulate nested intersections in editor
+ * tooltips and error messages.
  *
  * @typeParam TClient - The type of the original client.
  * @param client - The client to wrap.
@@ -286,8 +323,12 @@ function toConfigurableDescriptors<T extends PropertyDescriptorMap>(descriptors:
  * ```
  *
  * @see {@link extendClient}
+ * @see {@link ExtendedClient}
  */
-export function withCleanup<TClient extends object>(client: TClient, cleanup: () => void): Disposable & TClient {
+export function withCleanup<TClient extends object>(
+    client: TClient,
+    cleanup: () => void,
+): ExtendedClient<TClient, Disposable> {
     if (DISPOSABLE_STACK_PROPERTY in client) {
         return addCleanupToClientWithExistingStack(
             client as Record<typeof DISPOSABLE_STACK_PROPERTY, DisposableStack> & TClient,
@@ -303,17 +344,17 @@ const DISPOSABLE_STACK_PROPERTY = '__PRIVATE__DISPOSABLE_STACK' as const;
 function addCleanupToClientWithExistingStack<TClient extends Record<typeof DISPOSABLE_STACK_PROPERTY, DisposableStack>>(
     client: TClient,
     cleanup: () => void,
-): Disposable & TClient {
+): ExtendedClient<TClient, Disposable> {
     // If we already have the stack, add the new cleanup to it
     client[DISPOSABLE_STACK_PROPERTY].defer(cleanup);
     // We assume we already added a dispose method when we added the stack
-    return client as Disposable & TClient;
+    return client as unknown as ExtendedClient<TClient, Disposable>;
 }
 
 function addCleanupToClientWithoutExistingStack<TClient extends object>(
     client: TClient,
     cleanup: () => void,
-): Disposable & TClient {
+): ExtendedClient<TClient, Disposable> {
     const stack = new DisposableStack();
 
     // If the client has an existing dispose method but not our stack, we maintain this existing cleanup by deferring it to the new stack
@@ -333,5 +374,5 @@ function addCleanupToClientWithoutExistingStack<TClient extends object>(
         },
     };
 
-    return extendClient(client, additions) as unknown as Disposable & TClient;
+    return extendClient(client, additions) as unknown as ExtendedClient<TClient, Disposable>;
 }


### PR DESCRIPTION
#### Problem

When chaining `.use()` calls on a `Client` built with `@solana/plugin-core`, the inferred type accumulates a deep `Omit<Omit<Omit<...>>>` chain because `extendClient` returns `Omit<TClient, keyof TAdditions> & TAdditions`. After five or six plugins, the hover tooltip and any error message referencing the client type become essentially unreadable. `withCleanup` suffers from the same problem with its `Disposable & TClient` return type. The runtime is unaffected — the chain only exists in the type display — but the developer experience for anyone using the plugin system degrades sharply as the chain grows.

#### Summary of Changes

Introduces a new exported `ExtendedClient<TClient, TAdditions>` helper type expressed as a homomorphic mapped type over `Omit<TClient, keyof TAdditions> & TAdditions`, intersected with `& {}` to force TypeScript to eagerly resolve and display the result as a flat object literal rather than retain the alias name. `extendClient` and `withCleanup` now return `ExtendedClient<...>`, so each step of a chain collapses to a single readable object type. Override semantics, optional (`?`) and `readonly` modifiers, symbol-keyed properties (including `Symbol.dispose`), function-valued properties, and branded primitives are all preserved — verified with new compile-time typetests covering modifier preservation in both directions, override behavior, empty-type edge cases, deep chaining (4 steps with an override mid-chain), and `withCleanup` composed after `extendClient`. The change is purely cosmetic at the type level: `ExtendedClient<X, Y>` is structurally equivalent to `Omit<X, keyof Y> & Y`, so all existing consumers remain valid without modification. Also exports `ExtendedClient` from the package so plugin authors can use it in their own custom merging helpers and get the same flattening guarantee.

#### IDE Screenshots

##### Before
<img width="1684" height="782" alt="CleanShot 2026-05-14 at 15 46 22@2x" src="https://github.com/user-attachments/assets/8ce35933-5bfd-42a2-be65-bd88b7c3fde3" />
<img width="1762" height="768" alt="CleanShot 2026-05-14 at 15 46 13@2x" src="https://github.com/user-attachments/assets/7431b2ee-7fef-48d5-816f-1ad71ed2dfa5" />

##### After
<img width="1838" height="802" alt="CleanShot 2026-05-14 at 15 43 07@2x" src="https://github.com/user-attachments/assets/8ad21541-76e1-4fd1-b086-067e86a6a354" />
<img width="1634" height="586" alt="CleanShot 2026-05-14 at 15 43 30@2x" src="https://github.com/user-attachments/assets/90b4cfd2-f49c-45b3-904f-78ce94545e14" />
