### PR TITLE
Update RPC tests for Agave 4.0

### DIFF
--- a/.changeset/hip-mugs-sing.md
+++ b/.changeset/hip-mugs-sing.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-api': minor
+---
+
+Added the `clientId` field to the `getClusterNodes` response type, exposing the name of the validator client software advertised by each node. Also marked the `tpu` and `tpuForwards` fields as `@deprecated` in favor of their QUIC equivalents (`tpuQuic` and `tpuForwardsQuic`); validators may report the UDP fields as `null`.

--- a/packages/rpc-api/src/__tests__/get-cluster-nodes-test.ts
+++ b/packages/rpc-api/src/__tests__/get-cluster-nodes-test.ts
@@ -9,7 +9,7 @@ import { createLocalhostSolanaRpc } from './__setup__';
 const logFilePath = path.resolve(__dirname, '../../../../test-ledger/validator.log');
 
 // TPU does not seem to be reliably matchable from the log file
-const featureSetPattern = /feat:([\d]+)/;
+const featureSetPattern = /feat:([0-9a-f]+)/;
 const gossipPattern = /local gossip address: [\d.]+:([\d]+)/;
 const pubkeyPattern = /identity pubkey: ([\w]{32,})/;
 const rpcPattern = /rpc bound to [\d.]+:([\d]+)/;
@@ -28,7 +28,7 @@ async function getNodeInfoFromLogFile() {
         for await (const line of file.readLines({ encoding: 'utf-8' })) {
             const featureSetMatch = line.match(featureSetPattern);
             if (featureSetMatch) {
-                featureSet = parseInt(featureSetMatch[1]);
+                featureSet = parseInt(featureSetMatch[1], 16);
             }
             const gossipMatch = line.match(gossipPattern);
             if (gossipMatch) {
@@ -72,6 +72,7 @@ describe('getClusterNodes', () => {
             const [featureSet, gossip, pubkey, rpc, shredVersion, version] = await getNodeInfoFromLogFile();
             const res = await mockRpc.getClusterNodes().send();
             expect(res[0]).toStrictEqual({
+                clientId: 'Agave',
                 featureSet,
                 gossip,
                 pubkey,
@@ -79,8 +80,8 @@ describe('getClusterNodes', () => {
                 rpc,
                 serveRepair: expect.stringMatching(/127.0.0.1(:\d+)?/),
                 shredVersion,
-                tpu: expect.stringMatching(/127.0.0.1(:\d+)?/),
-                tpuForwards: expect.stringMatching(/127.0.0.1(:\d+)?/),
+                tpu: null,
+                tpuForwards: null,
                 tpuForwardsQuic: expect.stringMatching(/127.0.0.1(:\d+)?/),
                 tpuQuic: expect.stringMatching(/127.0.0.1(:\d+)?/),
                 tpuVote: expect.stringMatching(/127.0.0.1(:\d+)?/),

--- a/packages/rpc-api/src/__tests__/get-version-test.ts
+++ b/packages/rpc-api/src/__tests__/get-version-test.ts
@@ -7,7 +7,7 @@ import { GetVersionApi } from '../index';
 import { createLocalhostSolanaRpc } from './__setup__';
 
 const logFilePath = path.resolve(__dirname, '../../../../test-ledger/validator.log');
-const featureSetPattern = /feat:([\d]+)/;
+const featureSetPattern = /feat:([0-9a-f]+)/;
 const versionPattern = /agave-validator ([\d.]+)/;
 
 async function getVersionFromLogFile() {
@@ -18,7 +18,7 @@ async function getVersionFromLogFile() {
         for await (const line of file.readLines({ encoding: 'utf-8' })) {
             const featureSetMatch = line.match(featureSetPattern);
             if (featureSetMatch) {
-                featureSet = parseInt(featureSetMatch[1]);
+                featureSet = parseInt(featureSetMatch[1], 16);
             }
             const versionMatch = line.match(versionPattern);
             if (versionMatch) {

--- a/packages/rpc-api/src/__tests__/get-vote-accounts.ts
+++ b/packages/rpc-api/src/__tests__/get-vote-accounts.ts
@@ -26,7 +26,7 @@ describe('getVoteAccounts', () => {
                             activatedStake: expect.any(BigInt), // Changes
                             commission: 50,
                             epochCredits: expect.any(Array), // Changes
-                            epochVoteAccount: true,
+                            epochVoteAccount: expect.any(Boolean), // Changes
                             lastVote: expect.any(BigInt), // Changes
                             nodePubkey: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
                             rootSlot: expect.any(BigInt), // Changes

--- a/packages/rpc-api/src/getClusterNodes.ts
+++ b/packages/rpc-api/src/getClusterNodes.ts
@@ -2,6 +2,11 @@ import { Address } from '@solana/addresses';
 
 type ClusterNode = Readonly<{
     /**
+     * The name of the validator client software the node is running,
+     * or `null` if the client identifier is not advertised.
+     */
+    clientId: string | null;
+    /**
      * The unique identifier of the node's feature set.
      *
      * This value is computed by sorting all feature addresses' byte arrays lexicographically,
@@ -21,9 +26,19 @@ type ClusterNode = Readonly<{
     serveRepair: string | null;
     /** The shred version the node has been configured to use */
     shredVersion: number | null;
-    /** TPU network address for the node (host:port) */
+    /**
+     * TPU UDP network address for the node (host:port).
+     *
+     * @deprecated TPU UDP is phased out in favor of QUIC. Use {@link tpuQuic} instead.
+     * Validators may report this as `null`.
+     */
     tpu: string | null;
-    /** Tpu UDP forwards network address for the node (host:port) */
+    /**
+     * TPU UDP forwards network address for the node (host:port).
+     *
+     * @deprecated TPU UDP is phased out in favor of QUIC. Use {@link tpuForwardsQuic} instead.
+     * Validators may report this as `null`.
+     */
     tpuForwards: string | null;
     /** Tpu QUIC forwards network address for the node (host:port) */
     tpuForwardsQuic: string | null;

--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -132,7 +132,7 @@ describe('account', () => {
                             address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
                             executable: true,
                             lamports: expect.any(BigInt),
-                            space: 133352n,
+                            space: 36n,
                         },
                     },
                 },
@@ -169,10 +169,10 @@ describe('account', () => {
                         ownerProgram: {
                             address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
                             ownerProgram: {
-                                address: 'BPFLoader2111111111111111111111111111111111',
+                                address: 'BPFLoaderUpgradeab1e11111111111111111111111',
                                 executable: true,
                                 lamports: expect.any(BigInt),
-                                space: 25n,
+                                space: 37n,
                             },
                         },
                     },
@@ -210,7 +210,7 @@ describe('account', () => {
                         ownerProgram: {
                             address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
                             ownerProgram: {
-                                address: 'BPFLoader2111111111111111111111111111111111',
+                                address: 'BPFLoaderUpgradeab1e11111111111111111111111',
                                 ownerProgram: {
                                     address: 'NativeLoader1111111111111111111111111111111',
                                 },


### PR DESCRIPTION
#### Problem

Our CI is now picking up Agave 4.0 as the latest stable version, which has broke a few tests

#### Summary of Changes

- `getClusterNodes`: Add the `clientId` field, deprecate the `tpu` and `tpuForward` fields that now return null on Agave 4.0. Also updated on the response type (not just tests),  with a minor changeset. `feat` is now hex (was decimal). 
- `getVersion`: `feat` is now hex (was decimal)
- `getVoteAccounts`: `epochVoteAccount` is no longer always true for our test fixtures, just using `expect.any(Boolean)` as other unpredictable fields in this test do 
- rpc-graphql: changes to token program representation on chain

Fixes: CI 🤞