### PR TITLE
Allow branded base58 and base64 strings to satisfy the encoded bytes types

### DIFF
--- a/.changeset/puny-crabs-double.md
+++ b/.changeset/puny-crabs-double.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-types': minor
+---
+
+`Base58EncodedBytes`, `Base64EncodedBytes`, and `Base64EncodedZStdCompressedBytes` are no longer uniquely branded. They are now plain `EncodedString<...>` aliases over their respective encoding tags. As a result, any value that already carries the matching encoding tag (such as `Address`, `Signature`, or `Blockhash` for base 58) can be used wherever `Base58EncodedBytes` is expected. For example, an `Address` may now be passed directly as the `bytes` of a `memcmp` filter in `getProgramAccounts`. The runtime representation is unchanged and existing call sites continue to compile without modification.

--- a/packages/rpc-api/src/__typetests__/get-program-accounts-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-program-accounts-typetest.ts
@@ -1,0 +1,60 @@
+import type { Address } from '@solana/addresses';
+import type { PendingRpcRequest, Rpc } from '@solana/rpc-spec';
+import type { Base58EncodedBytes, Base64EncodedBytes } from '@solana/rpc-types';
+
+import type { GetProgramAccountsApi } from '../getProgramAccounts';
+
+const rpc = null as unknown as Rpc<GetProgramAccountsApi>;
+const programAddress = null as unknown as Address;
+const filterAddress = null as unknown as Address;
+
+// [DESCRIBE] The `memcmp` filter on `getProgramAccounts`.
+{
+    // It accepts an `Address` as the base58 filter bytes.
+    {
+        rpc.getProgramAccounts(programAddress, {
+            encoding: 'base64',
+            filters: [
+                {
+                    memcmp: {
+                        bytes: filterAddress,
+                        encoding: 'base58',
+                        offset: 0n,
+                    },
+                },
+            ],
+        }) satisfies PendingRpcRequest<unknown>;
+    }
+    // It accepts a `Base58EncodedBytes` value as the base58 filter bytes.
+    {
+        const base58Bytes = null as unknown as Base58EncodedBytes;
+        rpc.getProgramAccounts(programAddress, {
+            encoding: 'base64',
+            filters: [
+                {
+                    memcmp: {
+                        bytes: base58Bytes,
+                        encoding: 'base58',
+                        offset: 0n,
+                    },
+                },
+            ],
+        }) satisfies PendingRpcRequest<unknown>;
+    }
+    // It accepts a `Base64EncodedBytes` value as the base64 filter bytes.
+    {
+        const base64Bytes = null as unknown as Base64EncodedBytes;
+        rpc.getProgramAccounts(programAddress, {
+            encoding: 'base64',
+            filters: [
+                {
+                    memcmp: {
+                        bytes: base64Bytes,
+                        encoding: 'base64',
+                        offset: 0n,
+                    },
+                },
+            ],
+        }) satisfies PendingRpcRequest<unknown>;
+    }
+}

--- a/packages/rpc-api/src/__typetests__/get-program-accounts-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-program-accounts-typetest.ts
@@ -1,6 +1,6 @@
 import type { Address } from '@solana/addresses';
 import type { PendingRpcRequest, Rpc } from '@solana/rpc-spec';
-import type { Base58EncodedBytes, Base64EncodedBytes } from '@solana/rpc-types';
+import type { Base58EncodedBytes, Base64EncodedBytes, GetProgramAccountsMemcmpFilter } from '@solana/rpc-types';
 
 import type { GetProgramAccountsApi } from '../getProgramAccounts';
 
@@ -56,5 +56,17 @@ const filterAddress = null as unknown as Address;
                 },
             ],
         }) satisfies PendingRpcRequest<unknown>;
+    }
+    // It rejects an `Address` as the bytes of a base64 memcmp filter.
+    {
+        const filter = {
+            memcmp: {
+                bytes: filterAddress,
+                encoding: 'base64' as const,
+                offset: 0n,
+            },
+        };
+        // @ts-expect-error An `Address` is base-58 encoded, so it cannot serve as the bytes of a base-64 filter.
+        filter satisfies GetProgramAccountsMemcmpFilter;
     }
 }

--- a/packages/rpc-types/src/__typetests__/encoded-bytes-typetests.ts
+++ b/packages/rpc-types/src/__typetests__/encoded-bytes-typetests.ts
@@ -1,3 +1,4 @@
+import { Address } from '@solana/addresses';
 import { CompressedData, EncodedString } from '@solana/nominal-types';
 
 import { Base58EncodedBytes, Base64EncodedBytes, Base64EncodedZStdCompressedBytes } from '../encoded-bytes';
@@ -9,6 +10,17 @@ import { Base58EncodedBytes, Base64EncodedBytes, Base64EncodedZStdCompressedByte
         const encodedBytes = null as unknown as Base58EncodedBytes;
         encodedBytes satisfies EncodedString<string, 'base58'>;
     }
+    // It accepts an Address
+    {
+        const address = null as unknown as Address;
+        address satisfies Base58EncodedBytes;
+    }
+    // A plain string is not assignable to it
+    {
+        const arbitrary = null as unknown as string;
+        // @ts-expect-error A plain string lacks the base-58 encoding tag.
+        arbitrary satisfies Base58EncodedBytes;
+    }
 }
 
 // [DESCRIBE] Base64EncodedBytes
@@ -17,6 +29,24 @@ import { Base58EncodedBytes, Base64EncodedBytes, Base64EncodedZStdCompressedByte
     {
         const encodedBytes = null as unknown as Base64EncodedBytes;
         encodedBytes satisfies EncodedString<string, 'base64'>;
+    }
+    // A plain string is not assignable to it
+    {
+        const arbitrary = null as unknown as string;
+        // @ts-expect-error A plain string lacks the base-64 encoding tag.
+        arbitrary satisfies Base64EncodedBytes;
+    }
+    // Base58 bytes are not assignable to it
+    {
+        const b58 = null as unknown as Base58EncodedBytes;
+        // @ts-expect-error A base-58 encoded string is not a base-64 encoded string.
+        b58 satisfies Base64EncodedBytes;
+    }
+    // An Address is not assignable to it
+    {
+        const address = null as unknown as Address;
+        // @ts-expect-error An Address is base-58 encoded, not base-64.
+        address satisfies Base64EncodedBytes;
     }
 }
 
@@ -31,5 +61,11 @@ import { Base58EncodedBytes, Base64EncodedBytes, Base64EncodedZStdCompressedByte
     {
         const encodedBytes = null as unknown as Base64EncodedZStdCompressedBytes;
         encodedBytes satisfies CompressedData<string, 'zstd'>;
+    }
+    // Plain base64 bytes are not assignable to it
+    {
+        const b64 = null as unknown as Base64EncodedBytes;
+        // @ts-expect-error Uncompressed base-64 bytes are not zstd-compressed.
+        b64 satisfies Base64EncodedZStdCompressedBytes;
     }
 }

--- a/packages/rpc-types/src/encoded-bytes.ts
+++ b/packages/rpc-types/src/encoded-bytes.ts
@@ -1,11 +1,8 @@
-import { Brand, CompressedData, EncodedString } from '@solana/nominal-types';
+import { CompressedData, EncodedString } from '@solana/nominal-types';
 
-export type Base58EncodedBytes = Brand<EncodedString<string, 'base58'>, 'Base58EncodedBytes'>;
-export type Base64EncodedBytes = Brand<EncodedString<string, 'base64'>, 'Base64EncodedBytes'>;
-export type Base64EncodedZStdCompressedBytes = Brand<
-    EncodedString<CompressedData<string, 'zstd'>, 'base64'>,
-    'Base64EncodedZStdCompressedBytes'
->;
+export type Base58EncodedBytes = EncodedString<string, 'base58'>;
+export type Base64EncodedBytes = EncodedString<string, 'base64'>;
+export type Base64EncodedZStdCompressedBytes = EncodedString<CompressedData<string, 'zstd'>, 'base64'>;
 
 export type Base58EncodedDataResponse = [Base58EncodedBytes, 'base58'];
 export type Base64EncodedDataResponse = [Base64EncodedBytes, 'base64'];


### PR DESCRIPTION
## Summary

`Base58EncodedBytes`, `Base64EncodedBytes`, and `Base64EncodedZStdCompressedBytes` were declared as uniquely branded types. That prevented any other value carrying the same encoding tag, such as `Address`, `Signature`, or `Blockhash`, from being used wherever these types were expected, even though those values are by definition already a valid base 58 or base 64 encoded string. This change drops the brand wrapper so the three aliases become plain `EncodedString<...>` types over their respective encoding tags. The runtime representation is unchanged and the encoding tag still discriminates base 58 from base 64.

## Motivation

`#950` reports that passing an `Address` as the `bytes` of a `memcmp` filter in `getProgramAccounts` was a type error and could only be worked around with `as unknown as Base58EncodedBytes`. The maintainer suggestion from `#950` was to make the encoded bytes types "dumber" by dropping the brand, and `@mcintyre94` agreed in the same thread that the unique brand was not adding meaningful type safety because nothing was verifying the documented 128 byte limit at the type level.

## Before

```ts
export type Base58EncodedBytes = Brand<EncodedString<string, 'base58'>, 'Base58EncodedBytes'>;
export type Base64EncodedBytes = Brand<EncodedString<string, 'base64'>, 'Base64EncodedBytes'>;
export type Base64EncodedZStdCompressedBytes = Brand<
    EncodedString<CompressedData<string, 'zstd'>, 'base64'>,
    'Base64EncodedZStdCompressedBytes'
>;
```

```ts
const programAddress = null as unknown as Address;
const filterAddress = null as unknown as Address;

rpc.getProgramAccounts(programAddress, {
    filters: [
        {
            memcmp: {
                bytes: filterAddress, // Type error: Address is not Base58EncodedBytes
                encoding: 'base58',
                offset: 0n,
            },
        },
    ],
});
```

## After

```ts
export type Base58EncodedBytes = EncodedString<string, 'base58'>;
export type Base64EncodedBytes = EncodedString<string, 'base64'>;
export type Base64EncodedZStdCompressedBytes = EncodedString<CompressedData<string, 'zstd'>, 'base64'>;
```

The same call now compiles directly, with no cast required. `Base58EncodedBytes` and `Address` still remain distinguishable from `Base64EncodedBytes` because the encoding tag inside `EncodedString` is preserved.

## Tests

The existing typetests in `packages/rpc-types/src/__typetests__/encoded-bytes-typetests.ts` continue to assert that the three aliases satisfy the `EncodedString` brand over their respective encodings and that `Base64EncodedZStdCompressedBytes` also satisfies `CompressedData<string, 'zstd'>`.

The following additional cases are added:

- `Address` satisfies `Base58EncodedBytes`. This is the case originally reported in `#950`.
- A plain `string` does not satisfy `Base58EncodedBytes` or `Base64EncodedBytes`. The encoding tag is still enforced.
- `Base58EncodedBytes` does not satisfy `Base64EncodedBytes`. Encodings remain disjoint.
- An `Address` does not satisfy `Base64EncodedBytes`. Base 58 branded strings cannot pose as base 64.
- Plain `Base64EncodedBytes` does not satisfy `Base64EncodedZStdCompressedBytes`. The compression marker is still required.

A new typetest in `packages/rpc-api/src/__typetests__/get-program-accounts-typetest.ts` covers the original repro from `#950` end to end: `Address`, `Base58EncodedBytes`, and `Base64EncodedBytes` are each accepted by the `memcmp` filter at the appropriate encoding.

## Behavioral impact

None at runtime. The change is type only. Existing call sites that already use `Base58EncodedBytes`, `Base64EncodedBytes`, or `Base64EncodedZStdCompressedBytes` continue to type check without modification, because the brand wrapper was a strict superset of the encoding tagged type. Removing the wrapper widens what can flow into those positions but does not narrow anything.

## Closes

Closes #950
