### PR TITLE
Add optional transactionIndex to getSignaturesForAddress response

### DIFF
--- a/.changeset/afraid-peaches-heal.md
+++ b/.changeset/afraid-peaches-heal.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-api': minor
+---
+
+Add the optional `transactionIndex` field to each element of the `getSignaturesForAddress` response. Agave 4.0 (anza-xyz/agave#9683) included the 0 based transaction index inside the block alongside each returned signature. The field is omitted by older RPC servers, so the new property is optional and existing call sites continue to compile without modification.

--- a/packages/rpc-api/src/__typetests__/get-signatures-for-address-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-signatures-for-address-typetest.ts
@@ -1,0 +1,48 @@
+import type { Address } from '@solana/addresses';
+import type { Signature } from '@solana/keys';
+import type { PendingRpcRequest, Rpc } from '@solana/rpc-spec';
+import type { Commitment, Slot, TransactionError, UnixTimestamp } from '@solana/rpc-types';
+
+import type { GetSignaturesForAddressApi } from '../getSignaturesForAddress';
+
+const rpc = null as unknown as Rpc<GetSignaturesForAddressApi>;
+const address = null as unknown as Address;
+
+type GetSignaturesForAddressElement = Awaited<
+    ReturnType<ReturnType<typeof rpc.getSignaturesForAddress>['send']>
+>[number];
+
+// [DESCRIBE] getSignaturesForAddress response
+{
+    // It returns a pending RPC request when called with no config
+    {
+        rpc.getSignaturesForAddress(address) satisfies PendingRpcRequest<readonly unknown[]>;
+    }
+    // It exposes the documented core fields on each element
+    {
+        const element = null as unknown as GetSignaturesForAddressElement;
+        element.signature satisfies Signature;
+        element.slot satisfies Slot;
+        element.blockTime satisfies UnixTimestamp | null;
+        element.confirmationStatus satisfies Commitment | null;
+        element.err satisfies TransactionError | null;
+        element.memo satisfies string | null;
+    }
+    // It exposes `transactionIndex` as an optional number
+    {
+        const element = null as unknown as GetSignaturesForAddressElement;
+        element.transactionIndex satisfies number | undefined;
+    }
+    // `transactionIndex` is optional, so it may be omitted by older RPC servers
+    {
+        const responseFromOldRpc: GetSignaturesForAddressElement = {
+            blockTime: null,
+            confirmationStatus: null,
+            err: null,
+            memo: null,
+            signature: null as unknown as Signature,
+            slot: 0n as Slot,
+        };
+        responseFromOldRpc satisfies GetSignaturesForAddressElement;
+    }
+}

--- a/packages/rpc-api/src/getSignaturesForAddress.ts
+++ b/packages/rpc-api/src/getSignaturesForAddress.ts
@@ -15,6 +15,14 @@ type GetSignaturesForAddressTransaction = Readonly<{
     signature: Signature;
     /** The slot that contains the block with the transaction */
     slot: Slot;
+    /**
+     * The 0 based index of the transaction within its block.
+     *
+     * This field was added in Agave 4.0
+     * (see https://github.com/anza-xyz/agave/pull/9683) and is omitted by
+     * older versions of the RPC server.
+     */
+    transactionIndex?: number;
 }>;
 
 type GetSignaturesForAddressApiResponse = readonly GetSignaturesForAddressTransaction[];

--- a/packages/rpc-api/src/index.ts
+++ b/packages/rpc-api/src/index.ts
@@ -304,6 +304,7 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
                 [KEYPATH_WILDCARD, 'account', ...c],
             ]),
             getRecentPerformanceSamples: [[KEYPATH_WILDCARD, 'samplePeriodSecs']],
+            getSignaturesForAddress: [[KEYPATH_WILDCARD, 'transactionIndex']],
             getTokenAccountBalance: [
                 ['value', 'decimals'],
                 ['value', 'uiAmount'],


### PR DESCRIPTION
## Summary

Agave 4.0 added a 0 based transaction index inside the block to every signature returned by `getSignaturesForAddress` (anza-xyz/agave#9683). The Kit response type does not currently expose this field, so callers that want to read it have to cast through `any` or define their own response shape. This change adds an optional `transactionIndex` property to `GetSignaturesForAddressTransaction` so that the new field is surfaced as soon as the RPC server provides it, without breaking compatibility with older servers that omit it.

## Background

The upstream Rust change adds the field on `RpcConfirmedTransactionStatusWithSignature` as:

```rust
#[serde(default, skip_serializing_if = "Option::is_none")]
pub transaction_index: Option<u32>,
```

The combination of `default` and `skip_serializing_if = "Option::is_none"` means the field can be missing from the JSON payload entirely when the server has nothing to report (or when an older server is in use). The TypeScript counterpart of that shape is an optional `transactionIndex?: number`, which is what this change adds.

## Before

```ts
type GetSignaturesForAddressTransaction = Readonly<{
    blockTime: UnixTimestamp | null;
    confirmationStatus: Commitment | null;
    err: TransactionError | null;
    memo: string | null;
    signature: Signature;
    slot: Slot;
}>;
```

Reading the field required a cast:

```ts
const sigs = await rpc.getSignaturesForAddress(address).send();
const idx = (sigs[0] as { transactionIndex?: number }).transactionIndex;
```

## After

```ts
type GetSignaturesForAddressTransaction = Readonly<{
    blockTime: UnixTimestamp | null;
    confirmationStatus: Commitment | null;
    err: TransactionError | null;
    memo: string | null;
    signature: Signature;
    slot: Slot;
    /**
     * The 0 based index of the transaction within its block.
     *
     * This field was added in Agave 4.0
     * (see https://github.com/anza-xyz/agave/pull/9683) and is omitted by
     * older versions of the RPC server.
     */
    transactionIndex?: number;
}>;
```

Reading it now type checks directly:

```ts
const sigs = await rpc.getSignaturesForAddress(address).send();
const idx = sigs[0].transactionIndex; // number | undefined
```

## Tests

A new typetest in `packages/rpc-api/src/__typetests__/get-signatures-for-address-typetest.ts` covers:

- The documented core fields (`signature`, `slot`, `blockTime`, `confirmationStatus`, `err`, `memo`) remain on each response element with their existing types.
- `transactionIndex` is exposed as `number | undefined`.
- An object literal that omits `transactionIndex` still satisfies the response element type, which models the older RPC server case.

## Behavioral impact

None at runtime. The change is purely additive on the response type. Existing call sites that destructure or read other fields continue to compile without modification, and callers that already worked around the missing field with a cast can drop that cast.

## Closes

Closes #1246
