### PR TITLE
Drop auto-connect from stream stores

### DIFF
--- a/.changeset/bumpy-seas-melt.md
+++ b/.changeset/bumpy-seas-melt.md
@@ -1,0 +1,25 @@
+---
+'@solana/subscribable': major
+'@solana/rpc-subscriptions-spec': major
+'@solana/kit': major
+---
+
+Drop auto-connect from `ReactiveStreamStore`; callers explicitly invoke `connect()` to open the underlying stream. Mirrors the action store's caller-driven `dispatch()` pattern — the store is a state machine that callers orchestrate, not a self-starting subscription.
+
+The factory variant returned by `createReactiveStoreFromDataPublisherFactory` now starts in `status: 'idle'`. Call `store.connect()` to open the stream; from `idle`, the store transitions through `loading` → `loaded` (or `error`). A subsequent `connect()` from any non-idle status transitions through `retrying` while preserving the last known value. A new `reset()` method aborts the current connection and returns the store to `idle` without permanently killing it — natural for React effect cleanup.
+
+```ts
+const store = createReactiveStoreFromDataPublisherFactory({
+    abortSignal,
+    createDataPublisher,
+    dataChannelName: 'notification',
+    errorChannelName: 'error',
+});
+store.connect(); // opens the stream — previously this happened on construction
+```
+
+`retry()` is now deprecated; it remains as an error-only alias for `connect()`. Migrate to calling `connect()` directly. Code that previously relied on `retry()` being a no-op when the store was not in `error` state should add an explicit `if (status === 'error') store.connect();` guard at the call site.
+
+`createReactiveStoreFromDataPublisher` (the deprecated non-factory variant accepting a ready-made `DataPublisher`) is removed. Its only documented use was as a backwards-compatibility alias behind `PendingRpcSubscriptionsRequest.reactive()`, which is also removed in this release. Migrate to the factory variant — wrap a ready-made publisher in `() => Promise.resolve(publisher)` if needed — and use `reactiveStore()` for RPC subscriptions.
+
+`createReactiveStoreWithInitialValueAndSlotTracking` in `@solana/kit` no longer fires the RPC request on construction — call `store.connect()` to start it, or wrap in a `useEffect` that calls `connect()` on mount and `reset()` on cleanup. The store starts in `status: 'idle'` and follows the same lifecycle as the underlying stream store.

--- a/packages/kit/src/__tests__/create-async-generator-with-initial-value-and-slot-tracking-test.ts
+++ b/packages/kit/src/__tests__/create-async-generator-with-initial-value-and-slot-tracking-test.ts
@@ -93,7 +93,6 @@ function createMockSubscriptionRequest(): {
         complete,
         error,
         mockRequest: {
-            reactive: jest.fn().mockRejectedValue(new Error('not implemented')),
             reactiveStore: jest.fn().mockImplementation(() => {
                 throw new Error('not implemented');
             }),

--- a/packages/kit/src/__tests__/create-reactive-store-with-initial-value-and-slot-tracking-test.ts
+++ b/packages/kit/src/__tests__/create-reactive-store-with-initial-value-and-slot-tracking-test.ts
@@ -93,7 +93,6 @@ function createMockSubscriptionRequest(): {
         complete,
         error,
         mockRequest: {
-            reactive: jest.fn().mockRejectedValue(new Error('not implemented')),
             reactiveStore: jest.fn().mockImplementation(() => {
                 throw new Error('not implemented');
             }),
@@ -131,6 +130,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             expect(store.getState()).toBeUndefined();
         });
         it('updates with the RPC response value', async () => {
@@ -144,6 +144,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             expect(store.getState()).toEqual({ context: { slot: 100n }, value: 42 });
@@ -159,6 +160,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             await jest.runAllTimersAsync();
             pushNotification(rpcResponse(100, { count: 99 }));
             await jest.runAllTimersAsync();
@@ -175,6 +177,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             await jest.runAllTimersAsync();
             pushNotification(rpcResponse(200, { count: 99 }));
             await jest.runAllTimersAsync();
@@ -194,6 +197,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             resolve(rpcResponse(200, { count: 42 }));
             await jest.runAllTimersAsync();
             pushNotification(rpcResponse(100, { count: 99 }));
@@ -211,6 +215,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             error(new Error('subscription failed'));
@@ -230,6 +235,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             expect(store.getError()).toBeUndefined();
         });
         it('captures an error from the RPC request', async () => {
@@ -243,6 +249,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const error = new Error('rpc failed');
             reject(error);
             await jest.runAllTimersAsync();
@@ -259,6 +266,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             await jest.runAllTimersAsync();
             const subscriptionError = new Error('subscription failed');
             error(subscriptionError);
@@ -276,6 +284,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             await jest.runAllTimersAsync();
             rejectRpc(new Error('rpc error'));
             await jest.runAllTimersAsync();
@@ -294,6 +303,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             await jest.runAllTimersAsync();
             errorSubscription(new Error('subscription error'));
             await jest.runAllTimersAsync();
@@ -315,6 +325,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const subscriber = jest.fn();
             store.subscribe(subscriber);
             resolve(rpcResponse(100, { count: 42 }));
@@ -332,6 +343,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const subscriber = jest.fn();
             store.subscribe(subscriber);
             await jest.runAllTimersAsync();
@@ -350,6 +362,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const subscriber = jest.fn();
             store.subscribe(subscriber);
             resolve(rpcResponse(200, { count: 42 }));
@@ -372,6 +385,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const subscriber = jest.fn();
             store.subscribe(subscriber);
             reject(new Error('fail'));
@@ -389,6 +403,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const subscriber = jest.fn();
             store.subscribe(subscriber);
             await jest.runAllTimersAsync();
@@ -407,6 +422,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const subscriber = jest.fn();
             const unsubscribe = store.subscribe(subscriber);
             unsubscribe();
@@ -424,6 +440,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const unsubscribe = store.subscribe(jest.fn());
             expect(() => {
                 unsubscribe();
@@ -436,13 +453,14 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
         it('aborts the signal passed to the RPC request when the caller aborts', () => {
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            createReactiveStoreWithInitialValueAndSlotTracking({
+            const store = createReactiveStoreWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const rpcSignal = (rpcRequest.send as jest.Mock).mock.calls[0][0].abortSignal;
             expect(rpcSignal.aborted).toBe(false);
             abortController.abort('test reason');
@@ -452,13 +470,14 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
         it('aborts the signal passed to the subscription request when the caller aborts', () => {
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            createReactiveStoreWithInitialValueAndSlotTracking({
+            const store = createReactiveStoreWithInitialValueAndSlotTracking({
                 abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const subscriptionSignal = (rpcSubscriptionRequest.subscribe as jest.Mock).mock.calls[0][0].abortSignal;
             expect(subscriptionSignal.aborted).toBe(false);
             abortController.abort('test reason');
@@ -476,6 +495,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             abortController.abort();
             reject(new Error('aborted'));
             await jest.runAllTimersAsync();
@@ -492,6 +512,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             await jest.runAllTimersAsync();
             abortController.abort();
             error(new Error('aborted'));
@@ -509,6 +530,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const subscriber = jest.fn();
             store.subscribe(subscriber);
             abortController.abort();
@@ -528,6 +550,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const subscriber = jest.fn();
             store.subscribe(subscriber);
             await jest.runAllTimersAsync();
@@ -550,6 +573,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             expect(store.getUnifiedState()).toStrictEqual({
                 data: undefined,
                 error: undefined,
@@ -567,6 +591,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             expect(store.getUnifiedState()).toStrictEqual({
@@ -586,6 +611,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const failure = new Error('rpc failed');
             reject(failure);
             await jest.runAllTimersAsync();
@@ -606,6 +632,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             const failure = new Error('subscription failed');
@@ -643,7 +670,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 }),
             };
             const rpcSubscriptionRequest: PendingRpcSubscriptionsRequest<SolanaRpcResponse<TestValue>> = {
-                reactive: jest.fn().mockRejectedValue(new Error('not implemented')),
                 reactiveStore: jest.fn().mockImplementation(() => {
                     throw new Error('not implemented');
                 }),
@@ -669,6 +695,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             await jest.runAllTimersAsync();
             store.retry();
             expect(rpcRequest.send).toHaveBeenCalledTimes(1);
@@ -683,6 +710,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             rpcInstances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             subscriptionInstances[0].error(new Error('stream died'));
@@ -704,6 +732,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             rpcInstances[0].reject(new Error('boom'));
             await jest.runAllTimersAsync();
             store.retry();
@@ -721,6 +750,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             rpcInstances[0].reject(new Error('first failure'));
             await jest.runAllTimersAsync();
             store.retry();
@@ -743,6 +773,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             rpcInstances[0].reject(new Error('first'));
             await jest.runAllTimersAsync();
             store.retry();
@@ -766,6 +797,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             rpcInstances[0].reject(new Error('fail'));
             await jest.runAllTimersAsync();
             const subscriber = jest.fn();
@@ -783,6 +815,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             rpcInstances[0].reject(new Error('fail'));
             await jest.runAllTimersAsync();
             abortController.abort();
@@ -800,6 +833,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             const failure = new Error('fail');
             rpcInstances[0].reject(failure);
             await jest.runAllTimersAsync();
@@ -822,6 +856,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
+            store.connect();
             rpcInstances[0].reject(new Error('fail'));
             await jest.runAllTimersAsync();
             abortController.abort();

--- a/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
+++ b/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
@@ -16,8 +16,9 @@ import type { ReactiveState, ReactiveStreamStore } from '@solana/subscribable';
  */
 export type CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscriptionValue, TItem> = Readonly<{
     /**
-     * Triggering this abort signal will cancel the pending RPC request and subscription, and
-     * disconnect the store from further updates.
+     * Triggering this abort signal will cancel any in-flight RPC request and subscription, and
+     * permanently disconnect the store from further updates. Subsequent
+     * {@link ReactiveStreamStore.connect | `connect()`} calls become no-ops.
      */
     abortSignal: AbortSignal;
     /**
@@ -42,10 +43,10 @@ export type CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TRpcValue, 
     rpcValueMapper: (value: TRpcValue) => TItem;
 }>;
 
-const LOADING_STATE: ReactiveState<never> = Object.freeze({
+const IDLE_STATE: ReactiveState<never> = Object.freeze({
     data: undefined,
     error: undefined,
-    status: 'loading',
+    status: 'idle',
 });
 
 /**
@@ -59,15 +60,20 @@ const LOADING_STATE: ReactiveState<never> = Object.freeze({
  *
  * Things to note:
  *
- * - `getUnifiedState()` starts in `status: 'loading'` until the first response or notification
- *   arrives. Once data arrives it transitions to `status: 'loaded'` with a
- *   {@link SolanaRpcResponse} containing the value and the slot context at which it was observed.
+ * - The returned store starts in `status: 'idle'`. Call
+ *   {@link ReactiveStreamStore.connect | `connect()`} to fire the RPC request and open the
+ *   subscription.
+ * - From `idle`, the store transitions through `loading` until the first response or notification
+ *   arrives, then to `loaded` with a {@link SolanaRpcResponse} containing the value and the slot
+ *   context at which it was observed.
  * - On error from either source, the store transitions to `status: 'error'` preserving the last
  *   known value. Only the first error per connection window is captured.
- * - Calling {@link ReactiveStreamStore.retry | `retry()`} while in `status: 'error'` re-sends the RPC
- *   request and re-subscribes to the subscription using a fresh inner abort signal. The store
- *   transitions through `status: 'retrying'` back to `loaded`/`error`.
- * - Triggering the caller's abort signal disconnects the store permanently; subsequent `retry()`
+ * - A subsequent `connect()` after `loaded` or `error` aborts the current connection, transitions
+ *   through `status: 'retrying'` (preserving stale data), and re-fires the RPC request and
+ *   subscription with a fresh inner abort signal.
+ * - {@link ReactiveStreamStore.reset | `reset()`} aborts the current connection and returns the
+ *   store to `idle`, clearing `data` and `error`.
+ * - Triggering the caller's `abortSignal` disconnects the store permanently; subsequent `connect()`
  *   calls are no-ops.
  *
  * @param config
@@ -97,11 +103,12 @@ const LOADING_STATE: ReactiveState<never> = Object.freeze({
  *     const state = balanceStore.getUnifiedState();
  *     if (state.status === 'error') {
  *         console.error('Error:', state.error);
- *         balanceStore.retry();
+ *         balanceStore.connect();
  *     } else if (state.status === 'loaded') {
  *         console.log(`Balance at slot ${state.data.context.slot}:`, state.data.value);
  *     }
  * });
+ * balanceStore.connect();
  * ```
  *
  * @see {@link ReactiveStreamStore}
@@ -115,8 +122,9 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
 }: CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscriptionValue, TItem>): ReactiveStreamStore<
     SolanaRpcResponse<TItem>
 > {
-    let currentState: ReactiveState<SolanaRpcResponse<TItem>> = LOADING_STATE;
+    let currentState: ReactiveState<SolanaRpcResponse<TItem>> = IDLE_STATE;
     let lastUpdateSlot = -1n;
+    let currentInnerController: AbortController | undefined;
     const subscribers = new Set<() => void>();
 
     const outerController = new AbortController();
@@ -126,9 +134,31 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
         subscribers.forEach(cb => cb());
     }
 
-    function connect() {
+    function setState(next: ReactiveState<SolanaRpcResponse<TItem>>) {
+        if (
+            currentState.status === next.status &&
+            currentState.data === next.data &&
+            currentState.error === next.error
+        ) {
+            return;
+        }
+        currentState = next;
+        notify();
+    }
+
+    function performConnect() {
         if (outerController.signal.aborted) return;
+        // Abort any currently active connection before starting a fresh one.
+        currentInnerController?.abort();
+        // Transition based on whether we have prior data/error to preserve.
+        if (currentState.status === 'idle') {
+            setState({ data: undefined, error: undefined, status: 'loading' });
+        } else {
+            setState({ data: currentState.data, error: undefined, status: 'retrying' });
+        }
+
         const innerController = new AbortController();
+        currentInnerController = innerController;
         const forwardAbort = () => innerController.abort(outerController.signal.reason);
         outerController.signal.addEventListener('abort', forwardAbort, { signal: innerController.signal });
         const innerSignal = innerController.signal;
@@ -136,14 +166,12 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
         function handleError(err: unknown) {
             if (innerSignal.aborted) return;
             if (currentState.status === 'error') return;
-            currentState = { data: currentState.data, error: err, status: 'error' };
+            setState({ data: currentState.data, error: err, status: 'error' });
             innerController.abort(err);
-            notify();
         }
 
         function handleValue(value: SolanaRpcResponse<TItem>) {
-            currentState = { data: value, error: undefined, status: 'loaded' };
-            notify();
+            setState({ data: value, error: undefined, status: 'loaded' });
         }
 
         rpcRequest
@@ -175,9 +203,16 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
             .catch(handleError);
     }
 
-    connect();
+    function performReset() {
+        currentInnerController?.abort();
+        currentInnerController = undefined;
+        // `lastUpdateSlot` resets too — a fresh connect() starts a new slot window.
+        lastUpdateSlot = -1n;
+        setState(IDLE_STATE);
+    }
 
     return {
+        connect: performConnect,
         getError(): unknown {
             return currentState.error;
         },
@@ -187,12 +222,10 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
         getUnifiedState(): ReactiveState<SolanaRpcResponse<TItem>> {
             return currentState;
         },
+        reset: performReset,
         retry(): void {
-            if (outerController.signal.aborted) return;
             if (currentState.status !== 'error') return;
-            currentState = { data: currentState.data, error: undefined, status: 'retrying' };
-            notify();
-            connect();
+            performConnect();
         },
         subscribe(callback: () => void): () => void {
             subscribers.add(callback);

--- a/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-test.ts
+++ b/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-test.ts
@@ -34,74 +34,6 @@ describe('createSubscriptionRpc', () => {
     });
 });
 
-describe('PendingRpcSubscriptionsRequest.reactive()', () => {
-    let mockTransport: jest.MockedFunction<RpcSubscriptionsTransport>;
-    let mockOn: jest.Mock;
-    let mockDataPublisher: DataPublisher;
-    let rpcSubscriptions: RpcSubscriptions<TestRpcSubscriptionNotifications>;
-    function publish(type: string, payload: unknown) {
-        mockOn.mock.calls.filter(([actualType]) => actualType === type).forEach(([_, listener]) => listener(payload));
-    }
-    beforeEach(() => {
-        mockOn = jest.fn().mockReturnValue(function unsubscribe() {});
-        mockDataPublisher = { on: mockOn };
-        mockTransport = jest.fn().mockResolvedValue(mockDataPublisher);
-        rpcSubscriptions = createSubscriptionRpc<TestRpcSubscriptionNotifications>({
-            api: {
-                thingNotifications(...args: unknown[]) {
-                    return {
-                        execute: jest.fn().mockResolvedValue(mockDataPublisher),
-                        request: { methodName: 'thingNotifications', params: args },
-                    };
-                },
-            },
-            transport: mockTransport,
-        });
-    });
-
-    it('passes the abort signal to the transport', async () => {
-        expect.assertions(1);
-        const abortController = new AbortController();
-        await rpcSubscriptions.thingNotifications().reactive({ abortSignal: abortController.signal });
-        expect(mockTransport).toHaveBeenCalledWith(expect.objectContaining({ signal: abortController.signal }));
-    });
-    it('returns a store whose getState() starts as undefined', async () => {
-        expect.assertions(1);
-        const store = await rpcSubscriptions
-            .thingNotifications()
-            .reactive({ abortSignal: new AbortController().signal });
-        expect(store.getState()).toBeUndefined();
-    });
-    it('returns a store whose getState() reflects incoming notifications', async () => {
-        expect.assertions(1);
-        const store = await rpcSubscriptions
-            .thingNotifications()
-            .reactive({ abortSignal: new AbortController().signal });
-        publish('notification', { value: 42 });
-        expect(store.getState()).toStrictEqual({ value: 42 });
-    });
-    it('calls store subscribers when a notification arrives', async () => {
-        expect.assertions(1);
-        const store = await rpcSubscriptions
-            .thingNotifications()
-            .reactive({ abortSignal: new AbortController().signal });
-        const subscriber = jest.fn();
-        store.subscribe(subscriber);
-        publish('notification', { value: 42 });
-        expect(subscriber).toHaveBeenCalledTimes(1);
-    });
-    it('surfaces errors via getError()', async () => {
-        expect.assertions(2);
-        const store = await rpcSubscriptions
-            .thingNotifications()
-            .reactive({ abortSignal: new AbortController().signal });
-        expect(store.getError()).toBeUndefined();
-        const error = new Error('o no');
-        publish('error', error);
-        expect(store.getError()).toBe(error);
-    });
-});
-
 describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
     let mockTransport: jest.MockedFunction<RpcSubscriptionsTransport>;
     let mockOn: jest.Mock;
@@ -133,28 +65,42 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
         });
     });
 
-    it('passes the abort signal to the transport', async () => {
-        expect.assertions(1);
-        const abortController = new AbortController();
-        rpcSubscriptions.thingNotifications().reactiveStore({ abortSignal: abortController.signal });
-        await flushMicrotasks();
-        expect(mockTransport).toHaveBeenCalledWith(expect.objectContaining({ signal: abortController.signal }));
-    });
-    it('returns a store that starts in `loading` status before the transport resolves', () => {
+    it('returns a store that starts in `idle` status and does not call the transport before connect()', () => {
         const store = rpcSubscriptions
             .thingNotifications()
             .reactiveStore({ abortSignal: new AbortController().signal });
         expect(store.getUnifiedState()).toStrictEqual({
             data: undefined,
             error: undefined,
+            status: 'idle',
+        });
+        expect(mockTransport).not.toHaveBeenCalled();
+    });
+    it('passes the abort signal to the transport on connect()', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        const store = rpcSubscriptions.thingNotifications().reactiveStore({ abortSignal: abortController.signal });
+        store.connect();
+        await flushMicrotasks();
+        expect(mockTransport).toHaveBeenCalledWith(expect.objectContaining({ signal: abortController.signal }));
+    });
+    it('transitions to `loading` after connect() before the transport resolves', () => {
+        const store = rpcSubscriptions
+            .thingNotifications()
+            .reactiveStore({ abortSignal: new AbortController().signal });
+        store.connect();
+        expect(store.getUnifiedState()).toStrictEqual({
+            data: undefined,
+            error: undefined,
             status: 'loading',
         });
     });
-    it('returns a store whose state reflects incoming notifications', async () => {
+    it('reflects incoming notifications after connect()', async () => {
         expect.assertions(1);
         const store = rpcSubscriptions
             .thingNotifications()
             .reactiveStore({ abortSignal: new AbortController().signal });
+        store.connect();
         await flushMicrotasks();
         publish('notification', { value: 42 });
         expect(store.getUnifiedState()).toStrictEqual({
@@ -168,6 +114,7 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
         const store = rpcSubscriptions
             .thingNotifications()
             .reactiveStore({ abortSignal: new AbortController().signal });
+        store.connect();
         await flushMicrotasks();
         const subscriber = jest.fn();
         store.subscribe(subscriber);
@@ -179,6 +126,7 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
         const store = rpcSubscriptions
             .thingNotifications()
             .reactiveStore({ abortSignal: new AbortController().signal });
+        store.connect();
         await flushMicrotasks();
         const error = new Error('o no');
         publish('error', error);
@@ -188,21 +136,23 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
             status: 'error',
         });
     });
-    it('re-invokes the transport on retry() after an error', async () => {
+    it('re-invokes the transport on connect() after an error', async () => {
         expect.assertions(1);
         const store = rpcSubscriptions
             .thingNotifications()
             .reactiveStore({ abortSignal: new AbortController().signal });
+        store.connect();
         await flushMicrotasks();
         publish('error', new Error('stream died'));
-        store.retry();
+        store.connect();
         await flushMicrotasks();
         expect(mockTransport).toHaveBeenCalledTimes(2);
     });
     it('aborts the signal forwarded to the data publisher listeners when the caller aborts', async () => {
         expect.assertions(2);
         const abortController = new AbortController();
-        rpcSubscriptions.thingNotifications().reactiveStore({ abortSignal: abortController.signal });
+        const store = rpcSubscriptions.thingNotifications().reactiveStore({ abortSignal: abortController.signal });
+        store.connect();
         await flushMicrotasks();
         const onCall = mockOn.mock.calls.find(([channel]: [string]) => channel === 'notification');
         const listenerSignal = (onCall![2] as { signal: AbortSignal }).signal;
@@ -215,6 +165,7 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
         const store = rpcSubscriptions
             .thingNotifications()
             .reactiveStore({ abortSignal: new AbortController().signal });
+        store.connect();
         await flushMicrotasks();
         expect(store.getUnifiedState()).toBe(store.getUnifiedState());
         publish('notification', { value: 42 });

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions-request.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions-request.ts
@@ -11,43 +11,26 @@ import { ReactiveStreamStore } from '@solana/subscribable';
  *
  * Calling the {@link PendingRpcSubscriptionsRequest.reactiveStore | `reactiveStore(options)`}
  * method will return a {@link ReactiveStreamStore} compatible with `useSyncExternalStore`, Svelte
- * stores, and other reactive primitives.
+ * stores, and other reactive primitives. The returned store is in `status: 'idle'`; the caller
+ * is responsible for invoking {@link ReactiveStreamStore.connect | `connect()`} to open the
+ * underlying stream.
  */
 export type PendingRpcSubscriptionsRequest<TNotification> = {
     /**
-     * Triggers the subscription and returns a promise for a {@link ReactiveStreamStore} that holds
-     * the latest notification. Compatible with `useSyncExternalStore` and other reactive primitives
-     * that expect a `{ subscribe, getState }` contract.
-     *
-     * @example
-     * ```ts
-     * const store = await rpc.accountNotifications(address).reactive({ abortSignal });
-     * // React — throw error from snapshot to surface via Error Boundary
-     * const state = useSyncExternalStore(store.subscribe, () => {
-     *     if (store.getError()) throw store.getError();
-     *     return store.getState();
-     * });
-     * ```
-     *
-     * @deprecated Use {@link PendingRpcSubscriptionsRequest.reactiveStore | `reactiveStore()`}
-     * instead. The synchronous variant returns a store that reconnects on
-     * {@link ReactiveStreamStore.retry | `retry()`} after an error, whereas the store returned by
-     * `reactive()` cannot recover once its underlying `DataPublisher` has failed.
-     */
-    reactive(options: RpcSubscribeOptions): Promise<ReactiveStreamStore<TNotification>>;
-    /**
-     * Synchronously returns a {@link ReactiveStreamStore} that subscribes in the background and
-     * holds the latest notification. Compatible with `useSyncExternalStore` and other reactive
-     * primitives that expect a `{ subscribe, getUnifiedState }` contract. The store opens a fresh
-     * subscription on construction and on every {@link ReactiveStreamStore.retry | `retry()`}.
+     * Synchronously returns a {@link ReactiveStreamStore} that holds the latest notification.
+     * Compatible with `useSyncExternalStore` and other reactive primitives that expect a
+     * `{ subscribe, getUnifiedState }` contract. The returned store is in `status: 'idle'` — call
+     * {@link ReactiveStreamStore.connect | `connect()`} to open the subscription; a follow-up
+     * `connect()` after an error reopens it.
      *
      * @example
      * ```ts
      * const store = rpc.accountNotifications(address).reactiveStore({ abortSignal });
+     * store.connect();
      * // React — the unified snapshot has stable identity per update.
      * const state = useSyncExternalStore(store.subscribe, store.getUnifiedState);
-     * if (state.status === 'error') return <ErrorMessage error={state.error} onRetry={store.retry} />;
-     * if (state.status === 'loading') return <Spinner />;
+     * if (state.status === 'error') return <ErrorMessage error={state.error} onRetry={store.connect} />;
+     * if (state.status === 'loading' || state.status === 'idle') return <Spinner />;
      * return <View data={state.data} />;
      * ```
      */

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
@@ -2,7 +2,6 @@ import { SOLANA_ERROR__RPC_SUBSCRIPTIONS__CANNOT_CREATE_SUBSCRIPTION_PLAN, Solan
 import { Callable, Flatten, OverloadImplementations, UnionToIntersection } from '@solana/rpc-spec-types';
 import {
     createAsyncIterableFromDataPublisher,
-    createReactiveStoreFromDataPublisher,
     createReactiveStoreFromDataPublisherFactory,
 } from '@solana/subscribable';
 
@@ -83,18 +82,6 @@ function createPendingRpcSubscription<TNotification>(
     subscriptionsPlan: RpcSubscriptionsPlan<TNotification>,
 ): PendingRpcSubscriptionsRequest<TNotification> {
     return {
-        async reactive({ abortSignal }: RpcSubscribeOptions) {
-            const notificationsDataPublisher = await transport({
-                signal: abortSignal,
-                ...subscriptionsPlan,
-            });
-            return createReactiveStoreFromDataPublisher<TNotification>({
-                abortSignal,
-                dataChannelName: 'notification',
-                dataPublisher: notificationsDataPublisher,
-                errorChannelName: 'error',
-            });
-        },
         reactiveStore({ abortSignal }: RpcSubscribeOptions) {
             return createReactiveStoreFromDataPublisherFactory<TNotification>({
                 abortSignal,

--- a/packages/subscribable/README.md
+++ b/packages/subscribable/README.md
@@ -38,18 +38,25 @@ type ReactiveState<T> =
     | { data: undefined; error: undefined; status: 'loading' }
     | { data: T; error: undefined; status: 'loaded' }
     | { data: T | undefined; error: unknown; status: 'error' }
-    | { data: T | undefined; error: undefined; status: 'retrying' };
+    | { data: T | undefined; error: undefined; status: 'retrying' }
+    | { data: undefined; error: undefined; status: 'idle' };
 ```
 
 > Also exported as `ReactiveStore<T>` for backwards compatibility. That alias is deprecated and will be removed in a future major release.
+
+The store starts in `status: 'idle'`. Call `connect()` to open the underlying stream; the store will transition through `loading` → `loaded` (or `error`). A subsequent `connect()` after `loaded` or `error` transitions through `retrying` while preserving the last known value. Call `reset()` to tear down the connection and return to `idle` without permanently killing the store.
 
 ```ts
 const store: ReactiveStreamStore<AccountInfo> = /* ... */;
 
 // React — snapshot identity is stable between updates, so it can be passed directly.
 const state = useSyncExternalStore(store.subscribe, store.getUnifiedState);
-if (state.status === 'error') return <ErrorMessage error={state.error} onRetry={store.retry} />;
-if (state.status === 'loading') return <Spinner />;
+useEffect(() => {
+    store.connect();
+    return () => store.reset();
+}, [store]);
+if (state.status === 'error') return <ErrorMessage error={state.error} onRetry={store.connect} />;
+if (state.status === 'loading' || state.status === 'idle') return <Spinner />;
 return <View data={state.data} />;
 
 // Vue
@@ -57,9 +64,10 @@ const snapshot = shallowRef(store.getUnifiedState());
 store.subscribe(() => {
     snapshot.value = store.getUnifiedState();
 });
+store.connect();
 ```
 
-`retry()` re-opens the stream after an error. When the underlying store supports restart (see [`createReactiveStoreFromDataPublisherFactory`](#createreactivestorefromdatapublisherfactory-abortsignal-createdatapublisher-datachannelname-errorchannelname-)), the store transitions to `status: 'retrying'` and reconnects. Stores that cannot be restarted throw a `SolanaError` with code `SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED` instead.
+`retry()` is a deprecated alias for the error-recovery case — prefer calling `connect()` directly. `connect()` always reopens the stream, regardless of current status; wrap with a status guard at the call site if you need the error-only behaviour.
 
 The individual `getState()` and `getError()` getters on `ReactiveStreamStore<T>` are `@deprecated` &mdash; prefer `getUnifiedState()`, which exposes the same information with a stable snapshot identity and `status` discriminator.
 
@@ -187,33 +195,9 @@ Things to note:
 - If there are messages in the queue and the abort signal fires, all queued messages will be vended to the iterator after which it will return.
 - Any new iterators created after the first error is encountered will reject with that error when polled.
 
-### `createReactiveStoreFromDataPublisher({ abortSignal, dataChannelName, dataPublisher, errorChannelName })`
-
-> **Deprecated.** Prefer [`createReactiveStoreFromDataPublisherFactory`](#createreactivestorefromdatapublisherfactory-abortsignal-createdatapublisher-datachannelname-errorchannelname-) &mdash; it supports `retry()`. Because this function accepts a ready-made `DataPublisher` rather than a factory, it cannot restart the underlying source, and calling `retry()` on the returned store throws a `SolanaError` with code `SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED`.
-
-Returns a `ReactiveStreamStore` given a data publisher. The store holds the most recent message published to `dataChannelName` and notifies subscribers on each update. When a message is published to `errorChannelName`, the store transitions to `status: 'error'` preserving the last known value. Triggering the abort signal disconnects the store from the data publisher.
-
-```ts
-const store = createReactiveStoreFromDataPublisher({
-    abortSignal: AbortSignal.timeout(10_000),
-    dataChannelName: 'notification',
-    dataPublisher,
-    errorChannelName: 'error',
-});
-const unsubscribe = store.subscribe(() => {
-    console.log('State updated:', store.getUnifiedState());
-});
-```
-
-Things to note:
-
-- `getUnifiedState()` starts in `status: 'loading'` until the first notification arrives.
-- On error, `status` becomes `'error'` with the last known value preserved on `data`. Only the first error is captured.
-- The function returned by `subscribe` is idempotent &mdash; calling it multiple times is safe.
-
 ### `createReactiveStoreFromDataPublisherFactory({ abortSignal, createDataPublisher, dataChannelName, errorChannelName })`
 
-Returns a `ReactiveStreamStore` that wires itself to a fresh `DataPublisher` on construction and on every `retry()`. Unlike `createReactiveStoreFromDataPublisher`, this variant accepts an async factory so the store can tear down a broken stream and open a new one without losing subscribers or the last known value.
+Returns a `ReactiveStreamStore` that wires itself to a fresh `DataPublisher` on every `connect()`. Accepts an async factory so the store can tear down a broken stream and open a new one without losing subscribers or the last known value.
 
 ```ts
 const store = createReactiveStoreFromDataPublisherFactory({
@@ -226,16 +210,18 @@ const store = createReactiveStoreFromDataPublisherFactory({
 });
 store.subscribe(() => {
     const snapshot = store.getUnifiedState();
-    if (snapshot.status === 'error') store.retry();
+    if (snapshot.status === 'error') store.connect();
 });
+store.connect();
 ```
 
 Things to note:
 
-- `createDataPublisher` is called once on construction and again on every `retry()`.
-- `retry()` is a no-op unless the store is in `status: 'error'`; otherwise the store transitions to `status: 'retrying'` (preserving stale data) and reconnects.
-- If `createDataPublisher` rejects, the store transitions to `status: 'error'` with the rejection as the error. Call `retry()` to try again.
-- Triggering the caller's `abortSignal` disconnects the store permanently; subsequent `retry()` calls are no-ops.
+- The returned store starts in `status: 'idle'`. Call `connect()` to open the first stream.
+- `createDataPublisher` is invoked on every `connect()`. From `idle`, the store transitions through `loading`; from any other status, through `retrying` while preserving the last known value.
+- If `createDataPublisher` rejects, the store transitions to `status: 'error'` with the rejection as the error. Call `connect()` to try again.
+- `reset()` aborts the current connection and returns the store to `idle`, clearing `data` and `error`. A follow-up `connect()` opens a fresh stream.
+- Triggering the caller's `abortSignal` disconnects the store permanently; subsequent `connect()` calls are no-ops.
 
 ### `demultiplexDataPublisher(publisher, sourceChannelName, messageTransformer)`
 

--- a/packages/subscribable/src/__tests__/reactive-stream-store-test.ts
+++ b/packages/subscribable/src/__tests__/reactive-stream-store-test.ts
@@ -1,352 +1,7 @@
-import { SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED, SolanaError } from '@solana/errors';
-
 import { DataPublisher } from '../data-publisher';
-import {
-    createReactiveStoreFromDataPublisher,
-    createReactiveStoreFromDataPublisherFactory,
-} from '../reactive-stream-store';
+import { createReactiveStoreFromDataPublisherFactory } from '../reactive-stream-store';
 
 jest.useFakeTimers();
-
-describe('createReactiveStoreFromDataPublisher', () => {
-    let mockDataPublisher: DataPublisher;
-    let mockOn: jest.Mock;
-    function publish(type: string, payload: unknown) {
-        mockOn.mock.calls.filter(([actualType]) => actualType === type).forEach(([_, listener]) => listener(payload));
-    }
-    beforeEach(() => {
-        mockOn = jest.fn().mockReturnValue(function unsubscribe() {});
-        mockDataPublisher = {
-            on: mockOn,
-        };
-    });
-
-    describe('getState()', () => {
-        it('returns `undefined` before any notification arrives', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            expect(store.getState()).toBeUndefined();
-        });
-        it('returns the latest notification after one arrives', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            publish('data', { value: 42 });
-            expect(store.getState()).toStrictEqual({ value: 42 });
-        });
-        it('returns the most recent notification when multiple arrive', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            publish('data', { value: 1 });
-            publish('data', { value: 2 });
-            publish('data', { value: 3 });
-            expect(store.getState()).toStrictEqual({ value: 3 });
-        });
-        it('preserves the last known value after an error', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            publish('data', { value: 42 });
-            publish('error', new Error('o no'));
-            expect(store.getState()).toStrictEqual({ value: 42 });
-        });
-        it('returns `undefined` after an error when no notification has arrived', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            publish('error', new Error('o no'));
-            expect(store.getState()).toBeUndefined();
-        });
-    });
-
-    describe('getError()', () => {
-        it('returns `undefined` before any error', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            expect(store.getError()).toBeUndefined();
-        });
-        it('returns the error after one arrives', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const error = new Error('o no');
-            publish('error', error);
-            expect(store.getError()).toBe(error);
-        });
-        it('preserves the first error when multiple errors arrive', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const firstError = new Error('first');
-            const secondError = new Error('second');
-            publish('error', firstError);
-            publish('error', secondError);
-            expect(store.getError()).toBe(firstError);
-        });
-        it('remains `undefined` when only data notifications arrive', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            publish('data', { value: 1 });
-            publish('data', { value: 2 });
-            expect(store.getError()).toBeUndefined();
-        });
-    });
-
-    describe('getUnifiedState()', () => {
-        it('starts in `loading` status with no data or error', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            expect(store.getUnifiedState()).toStrictEqual({
-                data: undefined,
-                error: undefined,
-                status: 'loading',
-            });
-        });
-        it('transitions to `loaded` with the value when a notification arrives', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            publish('data', { value: 42 });
-            expect(store.getUnifiedState()).toStrictEqual({
-                data: { value: 42 },
-                error: undefined,
-                status: 'loaded',
-            });
-        });
-        it('transitions to `error` preserving the last known value', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const error = new Error('o no');
-            publish('data', { value: 42 });
-            publish('error', error);
-            expect(store.getUnifiedState()).toStrictEqual({
-                data: { value: 42 },
-                error,
-                status: 'error',
-            });
-        });
-        it('transitions to `error` with undefined data when no value arrived first', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const error = new Error('o no');
-            publish('error', error);
-            expect(store.getUnifiedState()).toStrictEqual({
-                data: undefined,
-                error,
-                status: 'error',
-            });
-        });
-    });
-
-    describe('retry()', () => {
-        it('throws a SolanaError because a raw DataPublisher cannot be restarted', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            expect(() => store.retry()).toThrow(new SolanaError(SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED));
-        });
-    });
-
-    describe('subscribe()', () => {
-        it('calls the subscriber when a notification arrives', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            publish('data', { value: 1 });
-            expect(subscriber).toHaveBeenCalledTimes(1);
-        });
-        it('calls the subscriber on each new notification', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            publish('data', { value: 1 });
-            publish('data', { value: 2 });
-            publish('data', { value: 3 });
-            expect(subscriber).toHaveBeenCalledTimes(3);
-        });
-        it('calls the subscriber when an error arrives', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            publish('error', new Error('o no'));
-            expect(subscriber).toHaveBeenCalledTimes(1);
-        });
-        it('does not notify subscribers on subsequent errors', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            publish('error', new Error('first'));
-            publish('error', new Error('second'));
-            expect(subscriber).toHaveBeenCalledTimes(1);
-        });
-        it('calls multiple concurrent subscribers on each notification', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const subscriberA = jest.fn();
-            const subscriberB = jest.fn();
-            store.subscribe(subscriberA);
-            store.subscribe(subscriberB);
-            publish('data', { value: 1 });
-            expect(subscriberA).toHaveBeenCalledTimes(1);
-            expect(subscriberB).toHaveBeenCalledTimes(1);
-        });
-        it('stops calling the subscriber after the returned unsubscribe is called', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const subscriber = jest.fn();
-            const unsubscribe = store.subscribe(subscriber);
-            unsubscribe();
-            publish('data', { value: 1 });
-            expect(subscriber).not.toHaveBeenCalled();
-        });
-        it('only unsubscribes the subscriber whose unsubscribe function was called', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const subscriberA = jest.fn();
-            const subscriberB = jest.fn();
-            const unsubscribeA = store.subscribe(subscriberA);
-            store.subscribe(subscriberB);
-            unsubscribeA();
-            publish('data', { value: 1 });
-            expect(subscriberA).not.toHaveBeenCalled();
-            expect(subscriberB).toHaveBeenCalledTimes(1);
-        });
-        it('the unsubscribe function is idempotent', () => {
-            const store = createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const unsubscribe = store.subscribe(jest.fn());
-            expect(() => {
-                unsubscribe();
-                unsubscribe();
-            }).not.toThrow();
-        });
-    });
-
-    describe('abort signal', () => {
-        it('aborts the signals forwarded to dataPublisher.on() when the caller aborts', () => {
-            const abortController = new AbortController();
-            createReactiveStoreFromDataPublisher({
-                abortSignal: abortController.signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const dataChannelSignal = mockOn.mock.calls.find(([type]: [string]) => type === 'data')![2].signal;
-            const errorChannelSignal = mockOn.mock.calls.find(([type]: [string]) => type === 'error')![2].signal;
-            expect(dataChannelSignal.aborted).toBe(false);
-            expect(errorChannelSignal.aborted).toBe(false);
-            const reason = new Error('go away');
-            abortController.abort(reason);
-            expect(dataChannelSignal.aborted).toBe(true);
-            expect(dataChannelSignal.reason).toBe(reason);
-            expect(errorChannelSignal.aborted).toBe(true);
-            expect(errorChannelSignal.reason).toBe(reason);
-        });
-        it('aborts the signals forwarded to dataPublisher.on() when an error arrives', () => {
-            createReactiveStoreFromDataPublisher({
-                abortSignal: new AbortController().signal,
-                dataChannelName: 'data',
-                dataPublisher: mockDataPublisher,
-                errorChannelName: 'error',
-            });
-            const dataChannelSignal = mockOn.mock.calls.find(([type]: [string]) => type === 'data')![2].signal;
-            const errorChannelSignal = mockOn.mock.calls.find(([type]: [string]) => type === 'error')![2].signal;
-            expect(dataChannelSignal.aborted).toBe(false);
-            expect(errorChannelSignal.aborted).toBe(false);
-            const error = new Error('o no');
-            publish('error', error);
-            expect(dataChannelSignal.aborted).toBe(true);
-            expect(dataChannelSignal.reason).toBe(error);
-            expect(errorChannelSignal.aborted).toBe(true);
-            expect(errorChannelSignal.reason).toBe(error);
-        });
-    });
-});
 
 describe('createReactiveStoreFromDataPublisherFactory', () => {
     function createMockDataPublisher(): {
@@ -381,8 +36,8 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
         return { mockRequest, publishers };
     }
 
-    describe('initial connection', () => {
-        it('starts in `loading` before the factory resolves', () => {
+    describe('initial state', () => {
+        it('starts in `idle` status and does not invoke the factory before connect()', () => {
             const { mockRequest } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
                 abortSignal: new AbortController().signal,
@@ -393,8 +48,28 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect(store.getUnifiedState()).toStrictEqual({
                 data: undefined,
                 error: undefined,
+                status: 'idle',
+            });
+            expect(mockRequest).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('connect()', () => {
+        it('transitions from idle to `loading` and invokes the factory', () => {
+            const { mockRequest } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: undefined,
+                error: undefined,
                 status: 'loading',
             });
+            expect(mockRequest).toHaveBeenCalledTimes(1);
         });
         it('transitions to `loaded` once the factory resolves and data arrives', async () => {
             expect.assertions(1);
@@ -405,6 +80,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.connect();
             await jest.runAllTimersAsync();
             publishers[0].publish('data', { value: 42 });
             expect(store.getUnifiedState()).toStrictEqual({
@@ -423,6 +99,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.connect();
             await jest.runAllTimersAsync();
             expect(store.getUnifiedState()).toStrictEqual({
                 data: undefined,
@@ -439,6 +116,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.connect();
             await jest.runAllTimersAsync();
             publishers[0].publish('data', { value: 42 });
             const failure = new Error('stream died');
@@ -449,25 +127,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 status: 'error',
             });
         });
-    });
-
-    describe('retry()', () => {
-        it('is a no-op when the store is not in `error` state', async () => {
-            expect.assertions(2);
-            const { mockRequest } = createFactory();
-            const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
-                createDataPublisher: mockRequest,
-                dataChannelName: 'data',
-                errorChannelName: 'error',
-            });
-            await jest.runAllTimersAsync();
-            const callsBefore = mockRequest.mock.calls.length;
-            store.retry();
-            expect(mockRequest).toHaveBeenCalledTimes(callsBefore);
-            expect(store.getUnifiedState().status).toBe('loading');
-        });
-        it('transitions to `retrying` and preserves stale data', async () => {
+        it('from `error`, transitions through `retrying` preserving stale data', async () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
@@ -476,17 +136,18 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.connect();
             await jest.runAllTimersAsync();
             publishers[0].publish('data', { value: 42 });
             publishers[0].publish('error', new Error('fail'));
-            store.retry();
+            store.connect();
             expect(store.getUnifiedState()).toStrictEqual({
                 data: { value: 42 },
                 error: undefined,
                 status: 'retrying',
             });
         });
-        it('invokes the factory a second time', async () => {
+        it('from `loaded`, transitions through `retrying` preserving the last value', async () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
@@ -495,12 +156,32 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.connect();
+            await jest.runAllTimersAsync();
+            publishers[0].publish('data', { value: 42 });
+            store.connect();
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: { value: 42 },
+                error: undefined,
+                status: 'retrying',
+            });
+        });
+        it('invokes the factory again on each connect()', async () => {
+            expect.assertions(1);
+            const { mockRequest, publishers } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
             await jest.runAllTimersAsync();
             publishers[0].publish('error', new Error('fail'));
-            store.retry();
+            store.connect();
             expect(mockRequest).toHaveBeenCalledTimes(2);
         });
-        it('transitions back to `loaded` when the retried stream publishes a value', async () => {
+        it('transitions back to `loaded` when the reconnected stream publishes a value', async () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
@@ -509,9 +190,10 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.connect();
             await jest.runAllTimersAsync();
             publishers[0].publish('error', new Error('fail'));
-            store.retry();
+            store.connect();
             await jest.runAllTimersAsync();
             publishers[1].publish('data', { value: 'recovered' });
             expect(store.getUnifiedState()).toStrictEqual({
@@ -529,14 +211,15 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.connect();
             await jest.runAllTimersAsync();
             publishers[0].publish('error', new Error('fail'));
             const subscriber = jest.fn();
             store.subscribe(subscriber);
-            store.retry();
+            store.connect();
             expect(subscriber).toHaveBeenCalledTimes(1);
         });
-        it('can recover from a factory-rejection error by retrying', async () => {
+        it('can recover from a factory-rejection error by calling connect() again', async () => {
             expect.assertions(2);
             const publisher = createMockDataPublisher();
             const mockRequest = jest
@@ -549,9 +232,10 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.connect();
             await jest.runAllTimersAsync();
             expect(store.getUnifiedState().status).toBe('error');
-            store.retry();
+            store.connect();
             await jest.runAllTimersAsync();
             publisher.publish('data', { value: 99 });
             expect(store.getUnifiedState()).toStrictEqual({
@@ -560,7 +244,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 status: 'loaded',
             });
         });
-        it('transitions back to `error` when the retried factory rejects again', async () => {
+        it('transitions back to `error` when the reconnected factory rejects again', async () => {
             expect.assertions(1);
             const firstFailure = new Error('first');
             const secondFailure = new Error('second');
@@ -571,14 +255,227 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.connect();
             await jest.runAllTimersAsync();
-            store.retry();
+            store.connect();
             await jest.runAllTimersAsync();
             expect(store.getUnifiedState()).toStrictEqual({
                 data: undefined,
                 error: secondFailure,
                 status: 'error',
             });
+        });
+        it('stays in `loading` when called again before the first connection resolves', () => {
+            const { mockRequest } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
+            store.connect();
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: undefined,
+                error: undefined,
+                status: 'loading',
+            });
+            expect(mockRequest).toHaveBeenCalledTimes(2);
+        });
+        it('does not notify subscribers on the loading → loading re-entry', () => {
+            const { mockRequest } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
+            const subscriber = jest.fn();
+            store.subscribe(subscriber);
+            store.connect();
+            expect(subscriber).not.toHaveBeenCalled();
+        });
+        it('aborts the prior connection when called again before data arrives', async () => {
+            expect.assertions(2);
+            const { mockRequest, publishers } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
+            await jest.runAllTimersAsync();
+            const firstSignal = publishers[0].mockOn.mock.calls.find(([channel]: [string]) => channel === 'data')![2]
+                .signal;
+            expect(firstSignal.aborted).toBe(false);
+            store.connect();
+            expect(firstSignal.aborted).toBe(true);
+        });
+    });
+
+    describe('reset()', () => {
+        it('returns to `idle` and clears prior data', async () => {
+            expect.assertions(1);
+            const { mockRequest, publishers } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
+            await jest.runAllTimersAsync();
+            publishers[0].publish('data', { value: 42 });
+            store.reset();
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: undefined,
+                error: undefined,
+                status: 'idle',
+            });
+        });
+        it('aborts the in-flight connection', async () => {
+            expect.assertions(2);
+            const { mockRequest, publishers } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
+            await jest.runAllTimersAsync();
+            const listenerSignal = publishers[0].mockOn.mock.calls.find(([channel]: [string]) => channel === 'data')![2]
+                .signal;
+            expect(listenerSignal.aborted).toBe(false);
+            store.reset();
+            expect(listenerSignal.aborted).toBe(true);
+        });
+        it('notifies subscribers when state changes from non-idle', async () => {
+            expect.assertions(1);
+            const { mockRequest, publishers } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
+            await jest.runAllTimersAsync();
+            publishers[0].publish('data', { value: 42 });
+            const subscriber = jest.fn();
+            store.subscribe(subscriber);
+            store.reset();
+            expect(subscriber).toHaveBeenCalledTimes(1);
+        });
+        it('is a no-op when already idle (subscribers not notified)', () => {
+            const { mockRequest } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            const subscriber = jest.fn();
+            store.subscribe(subscriber);
+            store.reset();
+            expect(subscriber).not.toHaveBeenCalled();
+        });
+        it('allows a follow-up connect() to open a fresh stream', async () => {
+            expect.assertions(2);
+            const { mockRequest, publishers } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
+            await jest.runAllTimersAsync();
+            store.reset();
+            store.connect();
+            await jest.runAllTimersAsync();
+            publishers[1].publish('data', { value: 'fresh' });
+            expect(mockRequest).toHaveBeenCalledTimes(2);
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: { value: 'fresh' },
+                error: undefined,
+                status: 'loaded',
+            });
+        });
+    });
+
+    describe('retry() (deprecated)', () => {
+        it('is a no-op when the store is not in `error` state', async () => {
+            expect.assertions(2);
+            const { mockRequest } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
+            await jest.runAllTimersAsync();
+            const callsBefore = mockRequest.mock.calls.length;
+            store.retry();
+            expect(mockRequest).toHaveBeenCalledTimes(callsBefore);
+            expect(store.getUnifiedState().status).toBe('loading');
+        });
+        it('transitions to `retrying` from `error`', async () => {
+            expect.assertions(1);
+            const { mockRequest, publishers } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
+            await jest.runAllTimersAsync();
+            publishers[0].publish('data', { value: 42 });
+            publishers[0].publish('error', new Error('fail'));
+            store.retry();
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: { value: 42 },
+                error: undefined,
+                status: 'retrying',
+            });
+        });
+    });
+
+    describe('subscribe()', () => {
+        it('stops calling the subscriber after the returned unsubscribe is called', async () => {
+            expect.assertions(1);
+            const { mockRequest, publishers } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
+            await jest.runAllTimersAsync();
+            const subscriber = jest.fn();
+            const unsubscribe = store.subscribe(subscriber);
+            unsubscribe();
+            publishers[0].publish('data', { value: 1 });
+            expect(subscriber).not.toHaveBeenCalled();
+        });
+        it('the unsubscribe function is idempotent', () => {
+            const { mockRequest } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: new AbortController().signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            const unsubscribe = store.subscribe(jest.fn());
+            expect(() => {
+                unsubscribe();
+                unsubscribe();
+            }).not.toThrow();
         });
     });
 
@@ -593,6 +490,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.connect();
             await jest.runAllTimersAsync();
             abortController.abort();
             publishers[0].publish('data', { value: 'late' });
@@ -602,18 +500,48 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(2);
             const abortController = new AbortController();
             const { mockRequest, publishers } = createFactory();
-            createReactiveStoreFromDataPublisherFactory({
+            const store = createReactiveStoreFromDataPublisherFactory({
                 abortSignal: abortController.signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.connect();
             await jest.runAllTimersAsync();
             const dataSignal = publishers[0].mockOn.mock.calls.find(([channel]: [string]) => channel === 'data')![2]
                 .signal;
             expect(dataSignal.aborted).toBe(false);
             abortController.abort();
             expect(dataSignal.aborted).toBe(true);
+        });
+        it('connect() before the caller aborts works as normal', async () => {
+            expect.assertions(1);
+            const abortController = new AbortController();
+            const { mockRequest } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: abortController.signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.connect();
+            await jest.runAllTimersAsync();
+            expect(mockRequest).toHaveBeenCalledTimes(1);
+        });
+        it('connect() after abort does not invoke the factory', async () => {
+            expect.assertions(1);
+            const abortController = new AbortController();
+            const { mockRequest } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                abortSignal: abortController.signal,
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            abortController.abort();
+            store.connect();
+            await jest.runAllTimersAsync();
+            expect(mockRequest).not.toHaveBeenCalled();
         });
         it('retry() after abort does not re-invoke the factory', async () => {
             expect.assertions(1);
@@ -625,6 +553,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.connect();
             await jest.runAllTimersAsync();
             publishers[0].publish('error', new Error('fail'));
             abortController.abort();
@@ -632,47 +561,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             store.retry();
             await jest.runAllTimersAsync();
             expect(mockRequest).toHaveBeenCalledTimes(callsBefore);
-        });
-        it('retry() after abort leaves the store in `error` state', async () => {
-            expect.assertions(1);
-            const abortController = new AbortController();
-            const { mockRequest, publishers } = createFactory();
-            const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: abortController.signal,
-                createDataPublisher: mockRequest,
-                dataChannelName: 'data',
-                errorChannelName: 'error',
-            });
-            await jest.runAllTimersAsync();
-            const failure = new Error('fail');
-            publishers[0].publish('error', failure);
-            abortController.abort();
-            store.retry();
-            await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
-                data: undefined,
-                error: failure,
-                status: 'error',
-            });
-        });
-        it('retry() after abort does not notify subscribers', async () => {
-            expect.assertions(1);
-            const abortController = new AbortController();
-            const { mockRequest, publishers } = createFactory();
-            const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: abortController.signal,
-                createDataPublisher: mockRequest,
-                dataChannelName: 'data',
-                errorChannelName: 'error',
-            });
-            await jest.runAllTimersAsync();
-            publishers[0].publish('error', new Error('fail'));
-            abortController.abort();
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            store.retry();
-            await jest.runAllTimersAsync();
-            expect(subscriber).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/subscribable/src/reactive-stream-store.ts
+++ b/packages/subscribable/src/reactive-stream-store.ts
@@ -1,41 +1,22 @@
-import { SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED, SolanaError } from '@solana/errors';
 import { AbortController } from '@solana/event-target-impl';
 
 import { DataPublisher } from './data-publisher';
 
-type Config = Readonly<{
+type FactoryConfig = Readonly<{
     /**
-     * Triggering this abort signal will cause the store to stop updating and will disconnect it from
-     * the underlying data publisher.
+     * Triggering this abort signal will cause the store to stop updating and permanently
+     * disconnect it from any active {@link DataPublisher}. Once the signal has fired,
+     * {@link ReactiveStreamStore.connect | `connect()`} becomes a no-op.
      */
     abortSignal: AbortSignal;
-    /**
-     * Messages from this channel of `dataPublisher` will be used to update the store's state.
-     */
-    dataChannelName: string;
-    // FIXME: It would be nice to be able to constrain the type of `dataPublisher` to one that
+    // FIXME: It would be nice to be able to constrain the type returned by `createDataPublisher` to one that
     //        definitely supports the `dataChannelName` and `errorChannelName` channels, and
     //        furthermore publishes `TData` on the `dataChannelName` channel. This is more difficult
     //        than it should be: https://tsplay.dev/NlZelW
-    dataPublisher: DataPublisher;
-    /**
-     * Messages from this channel of `dataPublisher` will cause subscribers to be notified without
-     * updating the state, so that they can respond to the error condition.
-     */
-    errorChannelName: string;
-}>;
-
-type FactoryConfig = Readonly<{
-    /**
-     * Triggering this abort signal will cause the store to stop updating and will disconnect it from
-     * any active {@link DataPublisher}. Subsequent calls to {@link ReactiveStreamStore.retry | `retry()`}
-     * are no-ops once this signal has fired.
-     */
-    abortSignal: AbortSignal;
     /**
      * An async factory that produces a fresh {@link DataPublisher} each time it is invoked. Called
-     * once on construction and again on every {@link ReactiveStreamStore.retry | `retry()`}. Rejections
-     * surface as a store error.
+     * on every {@link ReactiveStreamStore.connect | `connect()`}. Rejections surface as a store
+     * error.
      */
     createDataPublisher: () => Promise<DataPublisher>;
     /**
@@ -53,23 +34,27 @@ type FactoryConfig = Readonly<{
 /**
  * The lifecycle state of a {@link ReactiveStreamStore} as a single snapshot.
  *
- * - `loading`: the store is waiting for its first value. `data` is `undefined`.
- * - `loaded`: a value has been received and no error is active. `data` is defined.
- * - `error`: the stream failed. `data` is the last known value (or `undefined` if no value ever
- *   arrived), and `error` holds the failure.
- * - `retrying`: a {@link ReactiveStreamStore.retry | `retry()`} is in progress after a previous error.
- *   `error` is cleared; `data` is preserved from before the failure if present.
+ * - `idle`: the store has not yet been connected, or has been reset via
+ *   {@link ReactiveStreamStore.reset | `reset()`}. Call
+ *   {@link ReactiveStreamStore.connect | `connect()`} to open the underlying stream.
+ * - `loading`: a first connection is in progress; no data has arrived yet.
+ * - `loaded`: a value has been received and no error is active.
+ * - `error`: the stream failed. `data` holds the last known value (or `undefined` if none ever
+ *   arrived) and `error` holds the failure.
+ * - `retrying`: a follow-up `connect()` is in progress after a previous outcome. `error` is
+ *   cleared; `data` is preserved from the previous connection if any.
  */
 export type ReactiveState<T> =
     | { readonly data: T | undefined; readonly error: undefined; readonly status: 'retrying' }
     | { readonly data: T | undefined; readonly error: unknown; readonly status: 'error' }
     | { readonly data: T; readonly error: undefined; readonly status: 'loaded' }
+    | { readonly data: undefined; readonly error: undefined; readonly status: 'idle' }
     | { readonly data: undefined; readonly error: undefined; readonly status: 'loading' };
 
-const LOADING_STATE: ReactiveState<never> = Object.freeze({
+const IDLE_STATE: ReactiveState<never> = Object.freeze({
     data: undefined,
     error: undefined,
-    status: 'loading',
+    status: 'idle',
 });
 
 /**
@@ -77,19 +62,38 @@ const LOADING_STATE: ReactiveState<never> = Object.freeze({
  * systems to subscribe to changes. Compatible with `useSyncExternalStore`, Svelte stores, Solid's
  * `from()`, and other reactive primitives that expect a `{ subscribe, getUnifiedState }` contract.
  *
+ * The store starts in `status: 'idle'`. Call {@link ReactiveStreamStore.connect | `connect()`}
+ * to open the underlying stream; the store will then transition through `loading` → `loaded` (or
+ * `error`). A subsequent `connect()` after `loaded` or `error` transitions through `retrying`
+ * while preserving the last known value.
+ *
  * @example
  * ```ts
  * // React — the unified state snapshot has stable identity per update, making it suitable as
  * // the second argument to `useSyncExternalStore`.
  * const state = useSyncExternalStore(store.subscribe, store.getUnifiedState);
- * if (state.status === 'error') return <ErrorMessage error={state.error} onRetry={store.retry} />;
- * if (state.status === 'loading') return <Spinner />;
+ * useEffect(() => {
+ *     store.connect();
+ *     return () => store.reset();
+ * }, [store]);
+ * if (state.status === 'error') return <ErrorMessage error={state.error} onRetry={store.connect} />;
+ * if (state.status === 'loading' || state.status === 'idle') return <Spinner />;
  * return <View data={state.data} />;
  * ```
  *
  * @see {@link createReactiveStoreFromDataPublisherFactory}
  */
 export type ReactiveStreamStore<T> = {
+    /**
+     * Open the underlying stream. Aborts any currently active connection, invokes the configured
+     * factory, and transitions the store through `loading` (when called from `idle` or while a
+     * connection is already in flight) or `retrying` (when called after a previous outcome —
+     * i.e. `loaded` or `error`) before settling into `loaded` (on data) or `error` (on failure).
+     *
+     * Idempotent after the caller's `abortSignal` has fired — a no-op once the store has been
+     * permanently killed.
+     */
+    connect(): void;
     /**
      * Returns the error published to the error channel, or `undefined` if no error has occurred.
      *
@@ -115,7 +119,18 @@ export type ReactiveStreamStore<T> = {
      */
     getUnifiedState(): ReactiveState<T>;
     /**
-     * Re-opens the stream after an error. No-op when the store is not in the `error` state.
+     * Aborts any currently active connection and resets the store to `{ status: 'idle' }`. Both
+     * `data` and `error` are cleared. Use this to tear down the connection without permanently
+     * killing the store — a follow-up {@link ReactiveStreamStore.connect | `connect()`} will open
+     * a fresh stream.
+     */
+    reset(): void;
+    /**
+     * Re-opens the stream after an error. No-op when the store is not in `status: 'error'`.
+     *
+     * @deprecated Use {@link ReactiveStreamStore.connect | `connect()`} instead. `connect()`
+     * always (re)connects, regardless of current status — wrap with a status guard at the call
+     * site if you need the error-only behaviour.
      */
     retry(): void;
     /**
@@ -137,12 +152,17 @@ export type ReactiveStore<T> = ReactiveStreamStore<T>;
  * Reactive-framework bindings (e.g. React's `useSubscription`) consume this duck-type so they
  * don't have to name a concrete producer type.
  *
+ * The returned store is in `status: 'idle'` — the caller is responsible for invoking
+ * {@link ReactiveStreamStore.connect | `connect()`} to open the underlying stream.
+ *
  * @typeParam T - The value type emitted by the resulting stream store.
  *
  * @example
  * ```ts
  * function bind<T>(source: ReactiveStreamSource<T>, abortSignal: AbortSignal) {
- *     return source.reactiveStore({ abortSignal });
+ *     const store = source.reactiveStore({ abortSignal });
+ *     store.connect();
+ *     return store;
  * }
  * ```
  *
@@ -154,104 +174,24 @@ export type ReactiveStreamSource<T> = {
 };
 
 /**
- * Returns a {@link ReactiveStreamStore} given a data publisher.
- *
- * The store will update its state with each message published to `dataChannelName` and notify all
- * subscribers. When a message is published to `errorChannelName`, subscribers are notified so they
- * can react to the error condition, but the last-known state is preserved. Triggering the abort
- * signal disconnects the store from the data publisher.
- *
- * Things to note:
- *
- * - `getUnifiedState()` starts in `status: 'loading'` until the first notification arrives.
- * - On error, `getUnifiedState().data` continues to return the last known value and `error` holds
- *   the failure. Only the first error is captured.
- * - The function returned by `subscribe` is idempotent — calling it multiple times is safe.
- * - Because a `DataPublisher` instance cannot be restarted, {@link ReactiveStreamStore.retry | `retry()`}
- *   on the returned store throws a
- *   {@link SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED | `SolanaError`}.
- *
- * @param config
- *
- * @deprecated Use {@link createReactiveStoreFromDataPublisherFactory} instead. That variant accepts
- * a factory function for the underlying {@link DataPublisher} and can therefore support
- * {@link ReactiveStreamStore.retry | `retry()`}.
- */
-export function createReactiveStoreFromDataPublisher<TData>({
-    abortSignal,
-    dataChannelName,
-    dataPublisher,
-    errorChannelName,
-}: Config): ReactiveStreamStore<TData> {
-    let currentState: ReactiveState<TData> = LOADING_STATE;
-    const subscribers = new Set<() => void>();
-
-    const abortController = new AbortController();
-    abortSignal.addEventListener('abort', () => abortController.abort(abortSignal.reason));
-
-    function notify() {
-        subscribers.forEach(cb => cb());
-    }
-
-    dataPublisher.on(
-        dataChannelName,
-        data => {
-            currentState = { data: data as TData, error: undefined, status: 'loaded' };
-            notify();
-        },
-        { signal: abortController.signal },
-    );
-    dataPublisher.on(
-        errorChannelName,
-        err => {
-            if (currentState.status === 'error') return;
-            currentState = { data: currentState.data, error: err, status: 'error' };
-            abortController.abort(err);
-            notify();
-        },
-        { signal: abortController.signal },
-    );
-
-    return {
-        getError(): unknown {
-            return currentState.error;
-        },
-        getState(): TData | undefined {
-            return currentState.data;
-        },
-        getUnifiedState(): ReactiveState<TData> {
-            return currentState;
-        },
-        retry(): void {
-            throw new SolanaError(SOLANA_ERROR__SUBSCRIBABLE__RETRY_NOT_SUPPORTED);
-        },
-        subscribe(callback: () => void): () => void {
-            subscribers.add(callback);
-            return () => {
-                subscribers.delete(callback);
-            };
-        },
-    };
-}
-
-/**
  * Returns a {@link ReactiveStreamStore} that wires itself to a fresh {@link DataPublisher} on
- * construction and on every {@link ReactiveStreamStore.retry | `retry()`}.
+ * every {@link ReactiveStreamStore.connect | `connect()`}.
  *
- * Unlike {@link createReactiveStoreFromDataPublisher}, this variant accepts a `createDataPublisher`
- * factory rather than a ready-made publisher. That lets the store tear down a broken stream and
- * open a new one without losing subscribers or the last known value.
+ * The store accepts a `createDataPublisher` factory rather than a ready-made publisher — that
+ * lets the store tear down a broken stream and open a new one without losing subscribers or the
+ * last known value.
  *
  * Things to note:
  *
- * - `getUnifiedState()` starts in `status: 'loading'` until the first notification arrives.
+ * - The returned store starts in `status: 'idle'`. Call `connect()` to open the first stream.
  * - On error, the store transitions to `status: 'error'` preserving the last known value. Only the
- *   first error per connection window is captured — a subsequent `retry()` resets that window.
- * - `retry()` is a no-op unless the store is currently in `status: 'error'`. When it fires, the
- *   store transitions to `status: 'retrying'` (preserving stale data), invokes
- *   `createDataPublisher()`, and wires up a fresh connection. If the factory rejects, the store
- *   transitions to `status: 'error'` with the rejection reason.
- * - Triggering the caller's `abortSignal` disconnects the store permanently; subsequent `retry()`
+ *   first error per connection window is captured — a subsequent `connect()` resets that window.
+ * - `connect()` aborts any currently active connection and invokes the factory again, transitioning
+ *   through `retrying` (preserving stale data) when called from a non-idle state. If the factory
+ *   rejects, the store transitions to `status: 'error'` with the rejection reason.
+ * - {@link ReactiveStreamStore.reset | `reset()`} aborts the current connection and returns to
+ *   `idle`, clearing both `data` and `error`.
+ * - Triggering the caller's `abortSignal` disconnects the store permanently; subsequent `connect()`
  *   calls are no-ops.
  *
  * @param config
@@ -271,7 +211,7 @@ export function createReactiveStoreFromDataPublisher<TData>({
  *     if (snapshot.status === 'error') console.error('Connection failed:', snapshot.error);
  *     else if (snapshot.status === 'loaded') console.log('Latest:', snapshot.data);
  * });
- * // Call `store.retry()` to recover after an error — e.g. from a user-triggered "Retry" button.
+ * store.connect();
  * ```
  */
 export function createReactiveStoreFromDataPublisherFactory<TData>({
@@ -280,7 +220,8 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
     dataChannelName,
     errorChannelName,
 }: FactoryConfig): ReactiveStreamStore<TData> {
-    let currentState: ReactiveState<TData> = LOADING_STATE;
+    let currentState: ReactiveState<TData> = IDLE_STATE;
+    let currentInnerController: AbortController | undefined;
     const subscribers = new Set<() => void>();
 
     const outerController = new AbortController();
@@ -290,13 +231,37 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
         subscribers.forEach(cb => cb());
     }
 
-    function connect() {
+    function setState(next: ReactiveState<TData>) {
+        if (
+            currentState.status === next.status &&
+            currentState.data === next.data &&
+            currentState.error === next.error
+        ) {
+            return;
+        }
+        currentState = next;
+        notify();
+    }
+
+    function performConnect() {
         if (outerController.signal.aborted) return;
-        // Inner signal is passed to data publisher
+        // Abort any currently active connection before starting a fresh one.
+        currentInnerController?.abort();
+        // Transition based on whether we have a prior outcome to preserve. If already `loading`,
+        // a connection is in flight — we've just aborted it and will rewire to a fresh factory
+        // invocation below, but there's no user-visible value yet, so stay in `loading` rather
+        // than detour through `retrying`.
+        if (currentState.status === 'idle') {
+            setState({ data: undefined, error: undefined, status: 'loading' });
+        } else if (currentState.status !== 'loading') {
+            setState({ data: currentState.data, error: undefined, status: 'retrying' });
+        }
+        // Inner signal is passed to data publisher.
         const innerController = new AbortController();
-        // Forward an abort from the outer signal to the inner one, so that when the caller aborts, we disconnect
-        // Scope this forwarder to the inner signal so it's removed on reconnection
-        // and we don't accumulate listeners on the outer signal across retries.
+        currentInnerController = innerController;
+        // Forward an abort from the outer signal to the inner one so a permanent kill propagates.
+        // Scope this forwarder to the inner signal so it's removed on reconnection and we don't
+        // accumulate listeners on the outer signal across connects.
         const forwardAbort = () => innerController.abort(outerController.signal.reason);
         outerController.signal.addEventListener('abort', forwardAbort, { signal: innerController.signal });
         createDataPublisher().then(
@@ -305,8 +270,7 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
                 publisher.on(
                     dataChannelName,
                     data => {
-                        currentState = { data: data as TData, error: undefined, status: 'loaded' };
-                        notify();
+                        setState({ data: data as TData, error: undefined, status: 'loaded' });
                     },
                     { signal: innerController.signal },
                 );
@@ -314,25 +278,28 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
                     errorChannelName,
                     err => {
                         if (currentState.status === 'error') return;
-                        currentState = { data: currentState.data, error: err, status: 'error' };
+                        setState({ data: currentState.data, error: err, status: 'error' });
                         innerController.abort(err);
-                        notify();
                     },
                     { signal: innerController.signal },
                 );
             },
             err => {
                 if (innerController.signal.aborted) return;
-                currentState = { data: currentState.data, error: err, status: 'error' };
+                setState({ data: currentState.data, error: err, status: 'error' });
                 innerController.abort(err);
-                notify();
             },
         );
     }
 
-    connect();
+    function performReset() {
+        currentInnerController?.abort();
+        currentInnerController = undefined;
+        setState(IDLE_STATE);
+    }
 
     return {
+        connect: performConnect,
         getError(): unknown {
             return currentState.error;
         },
@@ -342,12 +309,10 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
         getUnifiedState(): ReactiveState<TData> {
             return currentState;
         },
+        reset: performReset,
         retry(): void {
-            if (outerController.signal.aborted) return;
             if (currentState.status !== 'error') return;
-            currentState = { data: currentState.data, error: undefined, status: 'retrying' };
-            notify();
-            connect();
+            performConnect();
         },
         subscribe(callback: () => void): () => void {
             subscribers.add(callback);


### PR DESCRIPTION
#### Summary of Changes

This PR removes auto-connect from `ReactiveStreamStore`, such that it starts in an idle state and begins streaming only after `.connect()` is called. This mirrors the behaviour of the action store, and means that we can add per-connection signals (in a following PR) for subscriptions with a similar API to the action store.

We deprecate `.retry()`, which was previously only available after an error, in favour of `.connect()` which now also starts the stream for the first time.

The previously deprecated `createReactiveStoreFromDataPublisher`, which takes a `DataPublisher` rather than a `() => DataPublisher` function and therefore can't be called multiple times, is removed.