### PR TITLE
Add `withSignal()` to `ReactiveStreamStore` for per-connection cancellation

### DIFF
--- a/.changeset/blue-webs-work.md
+++ b/.changeset/blue-webs-work.md
@@ -1,0 +1,23 @@
+---
+'@solana/subscribable': major
+'@solana/rpc-subscriptions-spec': major
+'@solana/kit': major
+---
+
+Add `withSignal()` to `ReactiveStreamStore` for per-connection cancellation, replacing the construction-time `abortSignal` option. Mirrors the action store's per-dispatch `withSignal()` pattern — callers attach a per-connection signal at the call site instead of baking one into the store.
+
+```ts
+const store = createReactiveStoreFromDataPublisherFactory({
+    createDataPublisher: signal => transport({ signal, ...plan }),
+    dataChannelName: 'notification',
+    errorChannelName: 'error',
+});
+// Per-connection timeout — fresh clock per attempt:
+store.withSignal(AbortSignal.timeout(30_000)).connect();
+```
+
+`store.withSignal(signal)` returns a thin wrapper exposing `connect()` that composes the caller-provided signal with the per-connection inner controller via `AbortSignal.any`. Aborting the caller's signal surfaces the abort reason on state as `{ status: 'error' }`; supersession via the internal controller (a newer `connect()` or `reset()`) stays silent so the newer call owns state. The "permanent kill switch" pattern is expressible by binding once: `const killable = store.withSignal(killCtrl.signal); killable.connect();`. After `killCtrl.abort()`, every `killable.connect()` short-circuits to error.
+
+`createDataPublisher` is widened from `() => Promise<DataPublisher>` to `(signal: AbortSignal) => Promise<DataPublisher>`. The store passes the composed per-connection signal to the factory so the underlying transport can stop on per-connection abort, not just the stream-store's listeners. Existing no-arg factories still satisfy the new shape — TypeScript allows fewer parameters than the declared type.
+
+The construction-time `abortSignal` option on `createReactiveStoreFromDataPublisherFactory`, `createReactiveStoreWithInitialValueAndSlotTracking`, and `PendingRpcSubscriptionsRequest.reactiveStore()` is removed. Callers wanting a long-lived kill switch use the bind-once `withSignal` pattern. `ReactiveStreamSource<T>.reactiveStore()` is now parameter-less (mirrors `ReactiveActionSource<T>.reactiveStore()`).

--- a/packages/kit/src/__tests__/create-reactive-store-with-initial-value-and-slot-tracking-test.ts
+++ b/packages/kit/src/__tests__/create-reactive-store-with-initial-value-and-slot-tracking-test.ts
@@ -124,7 +124,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -138,7 +137,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -154,7 +152,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -171,7 +168,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -191,7 +187,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -209,7 +204,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -229,7 +223,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -243,7 +236,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, reject } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -260,7 +252,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -278,7 +269,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, reject: rejectRpc } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, error: errorSubscription } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -297,7 +287,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, reject: rejectRpc } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, error: errorSubscription } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -319,7 +308,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -337,7 +325,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -356,7 +343,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -379,7 +365,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, reject } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -397,7 +382,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -416,7 +400,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -434,7 +417,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -449,116 +431,106 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
         });
     });
 
-    describe('abort signal', () => {
-        it('aborts the signal passed to the RPC request when the caller aborts', () => {
+    describe('withSignal()', () => {
+        it('forwards the composed signal to the RPC request', () => {
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            store.connect();
+            store.withSignal(abortController.signal).connect();
             const rpcSignal = (rpcRequest.send as jest.Mock).mock.calls[0][0].abortSignal;
             expect(rpcSignal.aborted).toBe(false);
             abortController.abort('test reason');
             expect(rpcSignal.aborted).toBe(true);
             expect(rpcSignal.reason).toBe('test reason');
         });
-        it('aborts the signal passed to the subscription request when the caller aborts', () => {
+        it('forwards the composed signal to the subscription request', () => {
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            store.connect();
+            store.withSignal(abortController.signal).connect();
             const subscriptionSignal = (rpcSubscriptionRequest.subscribe as jest.Mock).mock.calls[0][0].abortSignal;
             expect(subscriptionSignal.aborted).toBe(false);
             abortController.abort('test reason');
             expect(subscriptionSignal.aborted).toBe(true);
             expect(subscriptionSignal.reason).toBe('test reason');
         });
-        it('swallows errors from the RPC request when the caller aborts', async () => {
+        it('transitions to `error` with the caller signal abort reason', () => {
+            const { mockRequest: rpcRequest } = createMockRpcRequest();
+            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
+            const store = createReactiveStoreWithInitialValueAndSlotTracking({
+                rpcRequest,
+                rpcSubscriptionRequest,
+                rpcSubscriptionValueMapper: v => v.count,
+                rpcValueMapper: v => v.count,
+            });
+            store.withSignal(abortController.signal).connect();
+            const reason = new Error('timed out');
+            abortController.abort(reason);
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: undefined,
+                error: reason,
+                status: 'error',
+            });
+        });
+        it('does not overwrite the abort-reason error with a late RPC rejection', async () => {
             expect.assertions(1);
             const { mockRequest: rpcRequest, reject } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            store.connect();
-            abortController.abort();
-            reject(new Error('aborted'));
+            store.withSignal(abortController.signal).connect();
+            const reason = new Error('cancelled');
+            abortController.abort(reason);
+            reject(new Error('rpc-late'));
             await jest.runAllTimersAsync();
-            expect(store.getError()).toBeUndefined();
-        });
-        it('swallows errors from the subscription when the caller aborts', async () => {
-            expect.assertions(1);
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            store.connect();
-            await jest.runAllTimersAsync();
-            abortController.abort();
-            error(new Error('aborted'));
-            await jest.runAllTimersAsync();
-            expect(store.getError()).toBeUndefined();
+            expect(store.getError()).toBe(reason);
         });
         it('does not update state when the RPC response arrives after abort', async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            store.connect();
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
+            store.withSignal(abortController.signal).connect();
             abortController.abort();
             resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             expect(store.getState()).toBeUndefined();
-            expect(subscriber).not.toHaveBeenCalled();
         });
         it('does not update state when a subscription notification arrives after abort', async () => {
-            expect.assertions(2);
+            expect.assertions(1);
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
                 rpcValueMapper: v => v.count,
             });
-            store.connect();
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
+            store.withSignal(abortController.signal).connect();
             await jest.runAllTimersAsync();
             abortController.abort();
             pushNotification(rpcResponse(100, { count: 99 }));
             await jest.runAllTimersAsync();
             expect(store.getState()).toBeUndefined();
-            expect(subscriber).not.toHaveBeenCalled();
         });
     });
 
@@ -567,7 +539,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -585,7 +556,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -605,7 +575,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, reject } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -626,7 +595,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
             const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -689,7 +657,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             expect.assertions(1);
             const { rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -704,7 +671,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             expect.assertions(1);
             const { rpcInstances, rpcRequest, rpcSubscriptionRequest, subscriptionInstances } = createRetryableMocks();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -726,7 +692,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             expect.assertions(2);
             const { rpcInstances, rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -744,7 +709,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             expect.assertions(1);
             const { rpcInstances, rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -767,7 +731,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             expect.assertions(1);
             const { rpcInstances, rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -791,7 +754,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             expect.assertions(1);
             const { rpcInstances, rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
             const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
                 rpcRequest,
                 rpcSubscriptionRequest,
                 rpcSubscriptionValueMapper: v => v.count,
@@ -804,67 +766,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             store.subscribe(subscriber);
             store.retry();
             expect(subscriber).toHaveBeenCalledTimes(1);
-        });
-        it('does not re-invoke the RPC request after the caller has aborted', async () => {
-            expect.assertions(1);
-            const { rpcInstances, rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            store.connect();
-            rpcInstances[0].reject(new Error('fail'));
-            await jest.runAllTimersAsync();
-            abortController.abort();
-            store.retry();
-            await jest.runAllTimersAsync();
-            expect(rpcRequest.send).toHaveBeenCalledTimes(1);
-        });
-        it('leaves the store in `error` state after the caller has aborted', async () => {
-            expect.assertions(1);
-            const { rpcInstances, rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            store.connect();
-            const failure = new Error('fail');
-            rpcInstances[0].reject(failure);
-            await jest.runAllTimersAsync();
-            abortController.abort();
-            store.retry();
-            await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
-                data: undefined,
-                error: failure,
-                status: 'error',
-            });
-        });
-        it('does not notify subscribers after the caller has aborted', async () => {
-            expect.assertions(1);
-            const { rpcInstances, rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                abortSignal: abortController.signal,
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
-            store.connect();
-            rpcInstances[0].reject(new Error('fail'));
-            await jest.runAllTimersAsync();
-            abortController.abort();
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            store.retry();
-            await jest.runAllTimersAsync();
-            expect(subscriber).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
+++ b/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
@@ -16,12 +16,6 @@ import type { ReactiveState, ReactiveStreamStore } from '@solana/subscribable';
  */
 export type CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscriptionValue, TItem> = Readonly<{
     /**
-     * Triggering this abort signal will cancel any in-flight RPC request and subscription, and
-     * permanently disconnect the store from further updates. Subsequent
-     * {@link ReactiveStreamStore.connect | `connect()`} calls become no-ops.
-     */
-    abortSignal: AbortSignal;
-    /**
      * A pending RPC request whose response will be used to set the store's initial state.
      * The response must be a {@link SolanaRpcResponse} so that its slot can be compared with
      * subscription notifications.
@@ -73,8 +67,10 @@ const IDLE_STATE: ReactiveState<never> = Object.freeze({
  *   subscription with a fresh inner abort signal.
  * - {@link ReactiveStreamStore.reset | `reset()`} aborts the current connection and returns the
  *   store to `idle`, clearing `data` and `error`.
- * - Triggering the caller's `abortSignal` disconnects the store permanently; subsequent `connect()`
- *   calls are no-ops.
+ * - Attach a caller-provided cancellation source via
+ *   {@link ReactiveStreamStore.withSignal | `withSignal()`} — `store.withSignal(signal).connect()`
+ *   composes the signal with the per-connection controller. Aborting the caller's signal
+ *   transitions the store to `error` with that abort reason.
  *
  * @param config
  *
@@ -92,7 +88,6 @@ const IDLE_STATE: ReactiveState<never> = Object.freeze({
  * const myAddress = address('FnHyam9w4NZoWR6mKN1CuGBritdsEWZQa4Z4oawLZGxa');
  *
  * const balanceStore = createReactiveStoreWithInitialValueAndSlotTracking({
- *     abortSignal: AbortSignal.timeout(60_000),
  *     rpcRequest: rpc.getBalance(myAddress, { commitment: 'confirmed' }),
  *     rpcValueMapper: lamports => lamports,
  *     rpcSubscriptionRequest: rpcSubscriptions.accountNotifications(myAddress),
@@ -108,13 +103,12 @@ const IDLE_STATE: ReactiveState<never> = Object.freeze({
  *         console.log(`Balance at slot ${state.data.context.slot}:`, state.data.value);
  *     }
  * });
- * balanceStore.connect();
+ * balanceStore.withSignal(AbortSignal.timeout(60_000)).connect();
  * ```
  *
  * @see {@link ReactiveStreamStore}
  */
 export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TSubscriptionValue, TItem>({
-    abortSignal,
     rpcRequest,
     rpcValueMapper,
     rpcSubscriptionRequest,
@@ -126,9 +120,6 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
     let lastUpdateSlot = -1n;
     let currentInnerController: AbortController | undefined;
     const subscribers = new Set<() => void>();
-
-    const outerController = new AbortController();
-    abortSignal.addEventListener('abort', () => outerController.abort(abortSignal.reason));
 
     function notify() {
         subscribers.forEach(cb => cb());
@@ -146,10 +137,14 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
         notify();
     }
 
-    function performConnect() {
-        if (outerController.signal.aborted) return;
+    function performConnect(callerSignal: AbortSignal | undefined) {
         // Abort any currently active connection before starting a fresh one.
         currentInnerController?.abort();
+        // If the caller's signal is already aborted, surface as error and bail.
+        if (callerSignal?.aborted) {
+            setState({ data: currentState.data, error: callerSignal.reason, status: 'error' });
+            return;
+        }
         // Transition based on whether we have prior data/error to preserve.
         if (currentState.status === 'idle') {
             setState({ data: undefined, error: undefined, status: 'loading' });
@@ -159,12 +154,25 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
 
         const innerController = new AbortController();
         currentInnerController = innerController;
-        const forwardAbort = () => innerController.abort(outerController.signal.reason);
-        outerController.signal.addEventListener('abort', forwardAbort, { signal: innerController.signal });
         const innerSignal = innerController.signal;
+        const signal = callerSignal ? AbortSignal.any([innerSignal, callerSignal]) : innerSignal;
+        // Caller's signal aborting (not just supersede via the inner controller) transitions the
+        // store to error with the caller's abort reason. Scoped to the inner signal so the
+        // listener is removed on reconnect / reset.
+        if (callerSignal) {
+            callerSignal.addEventListener(
+                'abort',
+                () => {
+                    if (innerSignal.aborted) return;
+                    setState({ data: currentState.data, error: callerSignal.reason, status: 'error' });
+                    innerController.abort(callerSignal.reason);
+                },
+                { signal: innerSignal },
+            );
+        }
 
         function handleError(err: unknown) {
-            if (innerSignal.aborted) return;
+            if (signal.aborted) return;
             if (currentState.status === 'error') return;
             setState({ data: currentState.data, error: err, status: 'error' });
             innerController.abort(err);
@@ -175,9 +183,9 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
         }
 
         rpcRequest
-            .send({ abortSignal: innerSignal })
+            .send({ abortSignal: signal })
             .then(({ context: { slot }, value }) => {
-                if (innerSignal.aborted) return;
+                if (signal.aborted) return;
                 // `lastUpdateSlot` persists across retries so the store never regresses. If the
                 // retried RPC returns a slot older than one we've already seen, we wait for the
                 // subscription to deliver something newer before leaving `retrying`.
@@ -188,13 +196,13 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
             .catch(handleError);
 
         rpcSubscriptionRequest
-            .subscribe({ abortSignal: innerSignal })
+            .subscribe({ abortSignal: signal })
             .then(async notifications => {
                 for await (const {
                     context: { slot },
                     value,
                 } of notifications) {
-                    if (innerSignal.aborted) return;
+                    if (signal.aborted) return;
                     if (slot < lastUpdateSlot) continue;
                     lastUpdateSlot = slot;
                     handleValue({ context: { slot }, value: rpcSubscriptionValueMapper(value) });
@@ -212,7 +220,9 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
     }
 
     return {
-        connect: performConnect,
+        connect(): void {
+            performConnect(undefined);
+        },
         getError(): unknown {
             return currentState.error;
         },
@@ -225,12 +235,19 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
         reset: performReset,
         retry(): void {
             if (currentState.status !== 'error') return;
-            performConnect();
+            performConnect(undefined);
         },
         subscribe(callback: () => void): () => void {
             subscribers.add(callback);
             return () => {
                 subscribers.delete(callback);
+            };
+        },
+        withSignal(signal: AbortSignal) {
+            return {
+                connect(): void {
+                    performConnect(signal);
+                },
             };
         },
     };

--- a/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-test.ts
+++ b/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-test.ts
@@ -66,9 +66,7 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
     });
 
     it('returns a store that starts in `idle` status and does not call the transport before connect()', () => {
-        const store = rpcSubscriptions
-            .thingNotifications()
-            .reactiveStore({ abortSignal: new AbortController().signal });
+        const store = rpcSubscriptions.thingNotifications().reactiveStore();
         expect(store.getUnifiedState()).toStrictEqual({
             data: undefined,
             error: undefined,
@@ -76,18 +74,18 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
         });
         expect(mockTransport).not.toHaveBeenCalled();
     });
-    it('passes the abort signal to the transport on connect()', async () => {
+    it('passes the per-connection signal to the transport on withSignal().connect()', async () => {
         expect.assertions(1);
         const abortController = new AbortController();
-        const store = rpcSubscriptions.thingNotifications().reactiveStore({ abortSignal: abortController.signal });
-        store.connect();
+        const store = rpcSubscriptions.thingNotifications().reactiveStore();
+        store.withSignal(abortController.signal).connect();
         await flushMicrotasks();
-        expect(mockTransport).toHaveBeenCalledWith(expect.objectContaining({ signal: abortController.signal }));
+        const transportSignal = mockTransport.mock.calls[0][0].signal;
+        // The transport receives a composed signal — aborting the caller's source aborts it.
+        expect(transportSignal.aborted).toBe(false);
     });
     it('transitions to `loading` after connect() before the transport resolves', () => {
-        const store = rpcSubscriptions
-            .thingNotifications()
-            .reactiveStore({ abortSignal: new AbortController().signal });
+        const store = rpcSubscriptions.thingNotifications().reactiveStore();
         store.connect();
         expect(store.getUnifiedState()).toStrictEqual({
             data: undefined,
@@ -97,9 +95,7 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
     });
     it('reflects incoming notifications after connect()', async () => {
         expect.assertions(1);
-        const store = rpcSubscriptions
-            .thingNotifications()
-            .reactiveStore({ abortSignal: new AbortController().signal });
+        const store = rpcSubscriptions.thingNotifications().reactiveStore();
         store.connect();
         await flushMicrotasks();
         publish('notification', { value: 42 });
@@ -111,9 +107,7 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
     });
     it('calls store subscribers when a notification arrives', async () => {
         expect.assertions(1);
-        const store = rpcSubscriptions
-            .thingNotifications()
-            .reactiveStore({ abortSignal: new AbortController().signal });
+        const store = rpcSubscriptions.thingNotifications().reactiveStore();
         store.connect();
         await flushMicrotasks();
         const subscriber = jest.fn();
@@ -123,9 +117,7 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
     });
     it('surfaces errors via getUnifiedState()', async () => {
         expect.assertions(1);
-        const store = rpcSubscriptions
-            .thingNotifications()
-            .reactiveStore({ abortSignal: new AbortController().signal });
+        const store = rpcSubscriptions.thingNotifications().reactiveStore();
         store.connect();
         await flushMicrotasks();
         const error = new Error('o no');
@@ -138,9 +130,7 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
     });
     it('re-invokes the transport on connect() after an error', async () => {
         expect.assertions(1);
-        const store = rpcSubscriptions
-            .thingNotifications()
-            .reactiveStore({ abortSignal: new AbortController().signal });
+        const store = rpcSubscriptions.thingNotifications().reactiveStore();
         store.connect();
         await flushMicrotasks();
         publish('error', new Error('stream died'));
@@ -148,11 +138,11 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
         await flushMicrotasks();
         expect(mockTransport).toHaveBeenCalledTimes(2);
     });
-    it('aborts the signal forwarded to the data publisher listeners when the caller aborts', async () => {
+    it('aborts the signal forwarded to the data publisher listeners when the caller signal aborts', async () => {
         expect.assertions(2);
         const abortController = new AbortController();
-        const store = rpcSubscriptions.thingNotifications().reactiveStore({ abortSignal: abortController.signal });
-        store.connect();
+        const store = rpcSubscriptions.thingNotifications().reactiveStore();
+        store.withSignal(abortController.signal).connect();
         await flushMicrotasks();
         const onCall = mockOn.mock.calls.find(([channel]: [string]) => channel === 'notification');
         const listenerSignal = (onCall![2] as { signal: AbortSignal }).signal;
@@ -162,9 +152,7 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
     });
     it('returns the same getUnifiedState() snapshot across consecutive calls when state has not changed', async () => {
         expect.assertions(2);
-        const store = rpcSubscriptions
-            .thingNotifications()
-            .reactiveStore({ abortSignal: new AbortController().signal });
+        const store = rpcSubscriptions.thingNotifications().reactiveStore();
         store.connect();
         await flushMicrotasks();
         expect(store.getUnifiedState()).toBe(store.getUnifiedState());

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions-request.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions-request.ts
@@ -9,11 +9,12 @@ import { ReactiveStreamStore } from '@solana/subscribable';
  * {@link PendingRpcSubscriptionsRequest | PendingRpcSubscriptionsRequest<TNotification>} will
  * trigger the subscription and return a promise for an async iterable that vends `TNotifications`.
  *
- * Calling the {@link PendingRpcSubscriptionsRequest.reactiveStore | `reactiveStore(options)`}
- * method will return a {@link ReactiveStreamStore} compatible with `useSyncExternalStore`, Svelte
+ * Calling the {@link PendingRpcSubscriptionsRequest.reactiveStore | `reactiveStore()`} method
+ * will return a {@link ReactiveStreamStore} compatible with `useSyncExternalStore`, Svelte
  * stores, and other reactive primitives. The returned store is in `status: 'idle'`; the caller
  * is responsible for invoking {@link ReactiveStreamStore.connect | `connect()`} to open the
- * underlying stream.
+ * underlying stream. Attach a caller-provided cancellation source via
+ * {@link ReactiveStreamStore.withSignal | `withSignal()`}.
  */
 export type PendingRpcSubscriptionsRequest<TNotification> = {
     /**
@@ -21,12 +22,14 @@ export type PendingRpcSubscriptionsRequest<TNotification> = {
      * Compatible with `useSyncExternalStore` and other reactive primitives that expect a
      * `{ subscribe, getUnifiedState }` contract. The returned store is in `status: 'idle'` — call
      * {@link ReactiveStreamStore.connect | `connect()`} to open the subscription; a follow-up
-     * `connect()` after an error reopens it.
+     * `connect()` after an error reopens it. Attach a caller-provided cancellation source via
+     * {@link ReactiveStreamStore.withSignal | `withSignal()`}.
      *
      * @example
      * ```ts
-     * const store = rpc.accountNotifications(address).reactiveStore({ abortSignal });
-     * store.connect();
+     * const store = rpc.accountNotifications(address).reactiveStore();
+     * // Per-connection timeout — fresh clock per attempt:
+     * store.withSignal(AbortSignal.timeout(30_000)).connect();
      * // React — the unified snapshot has stable identity per update.
      * const state = useSyncExternalStore(store.subscribe, store.getUnifiedState);
      * if (state.status === 'error') return <ErrorMessage error={state.error} onRetry={store.connect} />;
@@ -34,7 +37,7 @@ export type PendingRpcSubscriptionsRequest<TNotification> = {
      * return <View data={state.data} />;
      * ```
      */
-    reactiveStore(options: RpcSubscribeOptions): ReactiveStreamStore<TNotification>;
+    reactiveStore(): ReactiveStreamStore<TNotification>;
     /**
      * Triggers the subscription and returns a promise for an async iterable of notifications.
      * Use `for await...of` to consume notifications as they arrive. Abort the signal to

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions.ts
@@ -82,11 +82,10 @@ function createPendingRpcSubscription<TNotification>(
     subscriptionsPlan: RpcSubscriptionsPlan<TNotification>,
 ): PendingRpcSubscriptionsRequest<TNotification> {
     return {
-        reactiveStore({ abortSignal }: RpcSubscribeOptions) {
+        reactiveStore() {
             return createReactiveStoreFromDataPublisherFactory<TNotification>({
-                abortSignal,
-                createDataPublisher() {
-                    return transport({ signal: abortSignal, ...subscriptionsPlan });
+                createDataPublisher(signal) {
+                    return transport({ signal, ...subscriptionsPlan });
                 },
                 dataChannelName: 'notification',
                 errorChannelName: 'error',

--- a/packages/subscribable/src/__tests__/reactive-stream-store-test.ts
+++ b/packages/subscribable/src/__tests__/reactive-stream-store-test.ts
@@ -40,7 +40,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
         it('starts in `idle` status and does not invoke the factory before connect()', () => {
             const { mockRequest } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -58,7 +57,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
         it('transitions from idle to `loading` and invokes the factory', () => {
             const { mockRequest } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -75,7 +73,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -94,7 +91,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             const failure = new Error('connection refused');
             const mockRequest = jest.fn().mockRejectedValue(failure);
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -111,7 +107,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -131,7 +126,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -151,7 +145,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -170,7 +163,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -185,7 +177,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -206,7 +197,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -227,7 +217,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 .mockRejectedValueOnce(new Error('transient'))
                 .mockResolvedValue(publisher.publisher);
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -250,7 +239,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             const secondFailure = new Error('second');
             const mockRequest = jest.fn().mockRejectedValueOnce(firstFailure).mockRejectedValue(secondFailure);
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -268,7 +256,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
         it('stays in `loading` when called again before the first connection resolves', () => {
             const { mockRequest } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -285,7 +272,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
         it('does not notify subscribers on the loading → loading re-entry', () => {
             const { mockRequest } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -300,7 +286,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(2);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -320,7 +305,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -339,7 +323,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(2);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -356,7 +339,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -372,7 +354,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
         it('is a no-op when already idle (subscribers not notified)', () => {
             const { mockRequest } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -386,7 +367,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(2);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -411,7 +391,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(2);
             const { mockRequest } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -427,7 +406,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -450,7 +428,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             expect.assertions(1);
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -466,7 +443,6 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
         it('the unsubscribe function is idempotent', () => {
             const { mockRequest } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: new AbortController().signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
@@ -479,34 +455,32 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
         });
     });
 
-    describe('abort signal', () => {
-        it('prevents further state updates once the caller aborts', async () => {
+    describe('withSignal()', () => {
+        it('forwards a non-aborted composed signal to the data publisher listeners', async () => {
             expect.assertions(1);
             const abortController = new AbortController();
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: abortController.signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
-            store.connect();
+            store.withSignal(abortController.signal).connect();
             await jest.runAllTimersAsync();
-            abortController.abort();
-            publishers[0].publish('data', { value: 'late' });
-            expect(store.getUnifiedState().status).toBe('loading');
+            const dataSignal = publishers[0].mockOn.mock.calls.find(([channel]: [string]) => channel === 'data')![2]
+                .signal;
+            expect(dataSignal.aborted).toBe(false);
         });
-        it('aborts the signal forwarded to the inner DataPublisher listeners', async () => {
+        it('aborts the listener signal when the caller signal aborts', async () => {
             expect.assertions(2);
             const abortController = new AbortController();
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: abortController.signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
-            store.connect();
+            store.withSignal(abortController.signal).connect();
             await jest.runAllTimersAsync();
             const dataSignal = publishers[0].mockOn.mock.calls.find(([channel]: [string]) => channel === 'data')![2]
                 .signal;
@@ -514,53 +488,99 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             abortController.abort();
             expect(dataSignal.aborted).toBe(true);
         });
-        it('connect() before the caller aborts works as normal', async () => {
-            expect.assertions(1);
+        it('transitions the store to `error` with the caller signal abort reason', () => {
             const abortController = new AbortController();
             const { mockRequest } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: abortController.signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
-            store.connect();
-            await jest.runAllTimersAsync();
-            expect(mockRequest).toHaveBeenCalledTimes(1);
-        });
-        it('connect() after abort does not invoke the factory', async () => {
-            expect.assertions(1);
-            const abortController = new AbortController();
-            const { mockRequest } = createFactory();
-            const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: abortController.signal,
-                createDataPublisher: mockRequest,
-                dataChannelName: 'data',
-                errorChannelName: 'error',
+            store.withSignal(abortController.signal).connect();
+            const reason = new Error('timed out');
+            abortController.abort(reason);
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: undefined,
+                error: reason,
+                status: 'error',
             });
-            abortController.abort();
-            store.connect();
-            await jest.runAllTimersAsync();
-            expect(mockRequest).not.toHaveBeenCalled();
         });
-        it('retry() after abort does not re-invoke the factory', async () => {
+        it('preserves prior data when the caller signal aborts mid-stream', async () => {
             expect.assertions(1);
             const abortController = new AbortController();
             const { mockRequest, publishers } = createFactory();
             const store = createReactiveStoreFromDataPublisherFactory({
-                abortSignal: abortController.signal,
                 createDataPublisher: mockRequest,
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
+            store.withSignal(abortController.signal).connect();
+            await jest.runAllTimersAsync();
+            publishers[0].publish('data', { value: 42 });
+            const reason = new Error('timed out');
+            abortController.abort(reason);
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: { value: 42 },
+                error: reason,
+                status: 'error',
+            });
+        });
+        it('when the caller signal is already aborted, transitions to error without invoking the factory', () => {
+            const abortController = new AbortController();
+            const reason = new Error('pre-aborted');
+            abortController.abort(reason);
+            const { mockRequest } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.withSignal(abortController.signal).connect();
+            expect(mockRequest).not.toHaveBeenCalled();
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: undefined,
+                error: reason,
+                status: 'error',
+            });
+        });
+        it('a bound wrapper reused across calls — kill-switch pattern', async () => {
+            expect.assertions(3);
+            const killController = new AbortController();
+            const { mockRequest, publishers } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            const killable = store.withSignal(killController.signal);
+            killable.connect();
+            await jest.runAllTimersAsync();
+            publishers[0].publish('data', { value: 'first' });
+            // Re-connect via the same wrapper.
+            killable.connect();
+            await jest.runAllTimersAsync();
+            expect(mockRequest).toHaveBeenCalledTimes(2);
+            // Once killed, subsequent calls short-circuit to error.
+            const reason = new Error('kill');
+            killController.abort(reason);
+            killable.connect();
+            expect(mockRequest).toHaveBeenCalledTimes(2);
+            expect(store.getUnifiedState().status).toBe('error');
+        });
+        it('does not abort the listener signal on supersede via a fresh connect()', async () => {
+            expect.assertions(1);
+            const abortController = new AbortController();
+            const { mockRequest } = createFactory();
+            const store = createReactiveStoreFromDataPublisherFactory({
+                createDataPublisher: mockRequest,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
+            });
+            store.withSignal(abortController.signal).connect();
+            await jest.runAllTimersAsync();
+            // Bare connect() aborts the prior inner connection but leaves the caller signal alone.
             store.connect();
-            await jest.runAllTimersAsync();
-            publishers[0].publish('error', new Error('fail'));
-            abortController.abort();
-            const callsBefore = mockRequest.mock.calls.length;
-            store.retry();
-            await jest.runAllTimersAsync();
-            expect(mockRequest).toHaveBeenCalledTimes(callsBefore);
+            expect(abortController.signal.aborted).toBe(false);
         });
     });
 });

--- a/packages/subscribable/src/reactive-stream-store.ts
+++ b/packages/subscribable/src/reactive-stream-store.ts
@@ -3,22 +3,22 @@ import { AbortController } from '@solana/event-target-impl';
 import { DataPublisher } from './data-publisher';
 
 type FactoryConfig = Readonly<{
-    /**
-     * Triggering this abort signal will cause the store to stop updating and permanently
-     * disconnect it from any active {@link DataPublisher}. Once the signal has fired,
-     * {@link ReactiveStreamStore.connect | `connect()`} becomes a no-op.
-     */
-    abortSignal: AbortSignal;
     // FIXME: It would be nice to be able to constrain the type returned by `createDataPublisher` to one that
     //        definitely supports the `dataChannelName` and `errorChannelName` channels, and
     //        furthermore publishes `TData` on the `dataChannelName` channel. This is more difficult
     //        than it should be: https://tsplay.dev/NlZelW
     /**
      * An async factory that produces a fresh {@link DataPublisher} each time it is invoked. Called
-     * on every {@link ReactiveStreamStore.connect | `connect()`}. Rejections surface as a store
-     * error.
+     * on every {@link ReactiveStreamStore.connect | `connect()`}.
+     *
+     * Receives an {@link AbortSignal} that fires when this specific connection window should tear
+     * down — composed from the per-connection inner controller and (if attached via
+     * {@link ReactiveStreamStore.withSignal | `withSignal()`}) the caller-provided signal via
+     * `AbortSignal.any`. Thread it into the underlying transport's own cancellation so the
+     * connection itself stops on per-connection abort, not just the stream-store's listeners.
+     * Rejections surface as a store error.
      */
-    createDataPublisher: () => Promise<DataPublisher>;
+    createDataPublisher: (signal: AbortSignal) => Promise<DataPublisher>;
     /**
      * Messages from this channel of the produced `DataPublisher` will be used to update the store's
      * state.
@@ -89,9 +89,6 @@ export type ReactiveStreamStore<T> = {
      * factory, and transitions the store through `loading` (when called from `idle` or while a
      * connection is already in flight) or `retrying` (when called after a previous outcome —
      * i.e. `loaded` or `error`) before settling into `loaded` (on data) or `error` (on failure).
-     *
-     * Idempotent after the caller's `abortSignal` has fired — a no-op once the store has been
-     * permanently killed.
      */
     connect(): void;
     /**
@@ -138,6 +135,26 @@ export type ReactiveStreamStore<T> = {
      * Returns an unsubscribe function. Safe to call multiple times.
      */
     subscribe(callback: () => void): () => void;
+    /**
+     * Returns a thin wrapper exposing `connect()` that composes `signal` with the store's internal
+     * per-connection controller via `AbortSignal.any` — aborting either tears down the active
+     * connection. Aborting the caller-provided signal surfaces the abort reason on state as
+     * `{ status: 'error' }`; the internal controller path (supersession by a newer `connect()` or
+     * `reset()`) is silent by design so the newer call owns state. Use this to attach a
+     * caller-provided cancellation source (per-connection timeout, shared kill switch,
+     * parent-context signal) without touching the bare `connect()` API.
+     *
+     * - Per-connection timeout: `store.withSignal(AbortSignal.timeout(30_000)).connect()` — fresh
+     *   clock per call.
+     * - Permanent kill switch: hold one `AbortController`, bind the wrapper once
+     *   (`const killable = store.withSignal(killCtrl.signal)`), and use `killable.connect()`
+     *   everywhere; aborting the controller cancels the active connection and short-circuits
+     *   future calls through the bound wrapper.
+     *
+     * The wrapper exposes only `connect()` — `getUnifiedState` / `subscribe` / `reset` remain
+     * store-level concerns on the parent.
+     */
+    withSignal(signal: AbortSignal): { readonly connect: () => void };
 };
 
 /**
@@ -147,21 +164,23 @@ export type ReactiveStreamStore<T> = {
 export type ReactiveStore<T> = ReactiveStreamStore<T>;
 
 /**
- * Duck-type for objects that build a {@link ReactiveStreamStore} on demand via a
- * `reactiveStore({ abortSignal })` method. Satisfied by `PendingRpcSubscriptionsRequest<T>`.
- * Reactive-framework bindings (e.g. React's `useSubscription`) consume this duck-type so they
- * don't have to name a concrete producer type.
+ * Duck-type for objects that build a {@link ReactiveStreamStore} on demand via a `reactiveStore()`
+ * method. Satisfied by `PendingRpcSubscriptionsRequest<T>`. Reactive-framework bindings (e.g.
+ * React's `useSubscription`) consume this duck-type so they don't have to name a concrete producer
+ * type.
  *
  * The returned store is in `status: 'idle'` — the caller is responsible for invoking
- * {@link ReactiveStreamStore.connect | `connect()`} to open the underlying stream.
+ * {@link ReactiveStreamStore.connect | `connect()`} to open the underlying stream. Attach a
+ * caller-provided cancellation source via {@link ReactiveStreamStore.withSignal | `withSignal()`}
+ * — `store.withSignal(signal).connect()`.
  *
  * @typeParam T - The value type emitted by the resulting stream store.
  *
  * @example
  * ```ts
- * function bind<T>(source: ReactiveStreamSource<T>, abortSignal: AbortSignal) {
- *     const store = source.reactiveStore({ abortSignal });
- *     store.connect();
+ * function bindWithTimeout<T>(source: ReactiveStreamSource<T>) {
+ *     const store = source.reactiveStore();
+ *     store.withSignal(AbortSignal.timeout(30_000)).connect();
  *     return store;
  * }
  * ```
@@ -170,7 +189,7 @@ export type ReactiveStore<T> = ReactiveStreamStore<T>;
  * @see {@link ReactiveActionSource}
  */
 export type ReactiveStreamSource<T> = {
-    reactiveStore(options: { abortSignal: AbortSignal }): ReactiveStreamStore<T>;
+    reactiveStore(): ReactiveStreamStore<T>;
 };
 
 /**
@@ -179,30 +198,30 @@ export type ReactiveStreamSource<T> = {
  *
  * The store accepts a `createDataPublisher` factory rather than a ready-made publisher — that
  * lets the store tear down a broken stream and open a new one without losing subscribers or the
- * last known value.
+ * last known value. The factory receives the per-connection signal so the underlying transport
+ * can stop on per-connection abort, not just the stream-store's listeners.
  *
  * Things to note:
  *
  * - The returned store starts in `status: 'idle'`. Call `connect()` to open the first stream.
- * - On error, the store transitions to `status: 'error'` preserving the last known value. Only the
- *   first error per connection window is captured — a subsequent `connect()` resets that window.
- * - `connect()` aborts any currently active connection and invokes the factory again, transitioning
- *   through `retrying` (preserving stale data) when called from a non-idle state. If the factory
- *   rejects, the store transitions to `status: 'error'` with the rejection reason.
- * - {@link ReactiveStreamStore.reset | `reset()`} aborts the current connection and returns to
- *   `idle`, clearing both `data` and `error`.
- * - Triggering the caller's `abortSignal` disconnects the store permanently; subsequent `connect()`
- *   calls are no-ops.
+ * - `createDataPublisher` is invoked on every `connect()`. From `idle`, the store transitions
+ *   through `loading`; from any other status, through `retrying` while preserving the last
+ *   known value.
+ * - If `createDataPublisher` rejects, the store transitions to `status: 'error'` with the
+ *   rejection as the error. Call `connect()` to try again.
+ * - `reset()` aborts the current connection and returns the store to `idle`, clearing `data`
+ *   and `error`. A follow-up `connect()` opens a fresh stream.
+ * - Attach a caller-provided cancellation source via
+ *   {@link ReactiveStreamStore.withSignal | `withSignal()`} — `store.withSignal(signal).connect()`
+ *   composes the signal with the per-connection controller. Aborting the caller's signal
+ *   transitions the store to `error` with that abort reason.
  *
  * @param config
  *
  * @example
  * ```ts
  * const store = createReactiveStoreFromDataPublisherFactory({
- *     abortSignal,
- *     async createDataPublisher() {
- *         return getDataPublisherFromEventEmitter(new WebSocket(url));
- *     },
+ *     createDataPublisher: signal => getDataPublisherFromEventEmitter(new WebSocket(url, { signal })),
  *     dataChannelName: 'message',
  *     errorChannelName: 'error',
  * });
@@ -211,11 +230,11 @@ export type ReactiveStreamSource<T> = {
  *     if (snapshot.status === 'error') console.error('Connection failed:', snapshot.error);
  *     else if (snapshot.status === 'loaded') console.log('Latest:', snapshot.data);
  * });
- * store.connect();
+ * // Fresh 30-second clock per connection attempt:
+ * store.withSignal(AbortSignal.timeout(30_000)).connect();
  * ```
  */
 export function createReactiveStoreFromDataPublisherFactory<TData>({
-    abortSignal,
     createDataPublisher,
     dataChannelName,
     errorChannelName,
@@ -223,9 +242,6 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
     let currentState: ReactiveState<TData> = IDLE_STATE;
     let currentInnerController: AbortController | undefined;
     const subscribers = new Set<() => void>();
-
-    const outerController = new AbortController();
-    abortSignal.addEventListener('abort', () => outerController.abort(abortSignal.reason));
 
     function notify() {
         subscribers.forEach(cb => cb());
@@ -243,10 +259,14 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
         notify();
     }
 
-    function performConnect() {
-        if (outerController.signal.aborted) return;
+    function performConnect(callerSignal: AbortSignal | undefined) {
         // Abort any currently active connection before starting a fresh one.
         currentInnerController?.abort();
+        // If the caller's signal is already aborted, surface as error and bail.
+        if (callerSignal?.aborted) {
+            setState({ data: currentState.data, error: callerSignal.reason, status: 'error' });
+            return;
+        }
         // Transition based on whether we have a prior outcome to preserve. If already `loading`,
         // a connection is in flight — we've just aborted it and will rewire to a fresh factory
         // invocation below, but there's no user-visible value yet, so stay in `loading` rather
@@ -256,23 +276,33 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
         } else if (currentState.status !== 'loading') {
             setState({ data: currentState.data, error: undefined, status: 'retrying' });
         }
-        // Inner signal is passed to data publisher.
+        // Inner signal is passed to the data publisher (composed with caller signal if any).
         const innerController = new AbortController();
         currentInnerController = innerController;
-        // Forward an abort from the outer signal to the inner one so a permanent kill propagates.
-        // Scope this forwarder to the inner signal so it's removed on reconnection and we don't
-        // accumulate listeners on the outer signal across connects.
-        const forwardAbort = () => innerController.abort(outerController.signal.reason);
-        outerController.signal.addEventListener('abort', forwardAbort, { signal: innerController.signal });
-        createDataPublisher().then(
+        const signal = callerSignal ? AbortSignal.any([innerController.signal, callerSignal]) : innerController.signal;
+        // Caller's signal aborting (not just supersede via the inner controller) transitions the
+        // store to error with the caller's abort reason. Scoped to the inner signal so the
+        // listener is removed automatically on reconnect / reset.
+        if (callerSignal) {
+            callerSignal.addEventListener(
+                'abort',
+                () => {
+                    if (innerController.signal.aborted) return;
+                    setState({ data: currentState.data, error: callerSignal.reason, status: 'error' });
+                    innerController.abort(callerSignal.reason);
+                },
+                { signal: innerController.signal },
+            );
+        }
+        createDataPublisher(signal).then(
             publisher => {
-                if (innerController.signal.aborted) return;
+                if (signal.aborted) return;
                 publisher.on(
                     dataChannelName,
                     data => {
                         setState({ data: data as TData, error: undefined, status: 'loaded' });
                     },
-                    { signal: innerController.signal },
+                    { signal },
                 );
                 publisher.on(
                     errorChannelName,
@@ -281,11 +311,11 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
                         setState({ data: currentState.data, error: err, status: 'error' });
                         innerController.abort(err);
                     },
-                    { signal: innerController.signal },
+                    { signal },
                 );
             },
             err => {
-                if (innerController.signal.aborted) return;
+                if (signal.aborted) return;
                 setState({ data: currentState.data, error: err, status: 'error' });
                 innerController.abort(err);
             },
@@ -299,7 +329,9 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
     }
 
     return {
-        connect: performConnect,
+        connect(): void {
+            performConnect(undefined);
+        },
         getError(): unknown {
             return currentState.error;
         },
@@ -312,12 +344,19 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
         reset: performReset,
         retry(): void {
             if (currentState.status !== 'error') return;
-            performConnect();
+            performConnect(undefined);
         },
         subscribe(callback: () => void): () => void {
             subscribers.add(callback);
             return () => {
                 subscribers.delete(callback);
+            };
+        },
+        withSignal(signal: AbortSignal) {
+            return {
+                connect(): void {
+                    performConnect(signal);
+                },
             };
         },
     };


### PR DESCRIPTION
#### Summary of Changes

This PR adds a per-connect abort signal to the reactive stream store. It uses the same pattern as the action store:

```ts
// no per-connection signal
store.connect();

// with a signal
store.withSignal(mySignal).connect();
```

Note that the previous PR removes auto-connect from the stream store, so this same pattern applies to all connects, including the first. 

The function to create a data publisher for the store is widened from `() => Promise<DataPublisher>` to `(signal: AbortSignal) => Promise<DataPublisher>`, ie the per-connect abort signal can be used as part of that factory. 

The `abortSignal` input to the stream store (and to `createReactiveStoreWithInitialValueAndSlotTracking`, and `PendingRpcSubscriptionsRequest.reactiveStore()`)  is removed in favour of this per-connect pattern. 