### PR TITLE
fix: align codec branch size types

### DIFF
--- a/.changeset/tidy-codecs-type-branches.md
+++ b/.changeset/tidy-codecs-type-branches.md
@@ -1,5 +1,5 @@
 ---
-'@solana/codecs-data-structures': patch
+'@solana/codecs-data-structures': major
 ---
 
-Correct union, predicate, and pattern-match codec return types so fixed-size results are only exposed when all known branch sizes match.
+Correct union, predicate, and pattern-match codec return types so fixed-size results are only exposed when all known branch sizes match. This is a type-only change with no runtime impact, but it is breaking: branches whose fixed sizes are unequal or not statically known now widen from `FixedSize*` to a plain `Encoder`/`Decoder`/`Codec`, so consumers that relied on the previous (unsound) fixed-size typing — e.g. reading `.fixedSize` or passing the result where a `FixedSize*` is required — will need to adjust.

--- a/.changeset/tidy-codecs-type-branches.md
+++ b/.changeset/tidy-codecs-type-branches.md
@@ -2,4 +2,9 @@
 '@solana/codecs-data-structures': major
 ---
 
-Correct union, predicate, and pattern-match codec return types so fixed-size results are only exposed when all known branch sizes match. This is a type-only change with no runtime impact, but it is breaking: branches whose fixed sizes are unequal or not statically known now widen from `FixedSize*` to a plain `Encoder`/`Decoder`/`Codec`, so consumers that relied on the previous (unsound) fixed-size typing — e.g. reading `.fixedSize` or passing the result where a `FixedSize*` is required — will need to adjust.
+Align the return types of the union, predicate, and pattern-match codecs so that a fixed-size result is only exposed when every branch is fixed-size _and_ of the same statically-known size. Branches whose sizes are unequal or not statically known now widen from `FixedSize*` to `VariableSize*` (when at least one branch is variable-size) or to a plain `Encoder`/`Decoder`/`Codec` (when the branches are fixed-size but their sizes are not statically comparable), matching what these codecs actually produce at runtime.
+
+This is a type-only change with no runtime impact, but it is breaking in two ways:
+
+- **Return types change.** Consumers that relied on the previous (unsound) fixed-size typing — e.g. reading `.fixedSize`, or passing the result where a `FixedSize*` is required — will need to adjust.
+- **The predicate and pattern-match signatures changed.** Their value/output type is now inferred from the branch encoders, decoders, or codecs rather than from an explicit type argument. Passing an explicit type argument no longer sets the branch domain: `getPatternMatchEncoder<MyType>([...])` (and the decoder/codec equivalents) now fails to compile, and `getPredicateEncoder<MyType>(...)` silently degrades its return to a plain `Encoder<MyType>`. Instead, type the branch predicates' parameters (e.g. `(value: MyType) => ...`) and let the return type be inferred.

--- a/.changeset/tidy-codecs-type-branches.md
+++ b/.changeset/tidy-codecs-type-branches.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-data-structures': patch
+---
+
+Correct union, predicate, and pattern-match codec return types so fixed-size results are only exposed when all known branch sizes match.

--- a/packages/codecs-data-structures/src/__typetests__/pattern-match-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/pattern-match-typetest.ts
@@ -27,17 +27,35 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
         // It returns an encoder for the same type as the inputs
         getPatternMatchEncoder([[numberValuePredicate, {} as Encoder<number>]]) satisfies Encoder<number>;
 
-        // It returns a FixedSizeEncoder if all encoders are FixedSizeEncoder
-        getPatternMatchEncoder([
-            [numberValuePredicate, {} as FixedSizeEncoder<number>],
-            [numberValuePredicate, {} as FixedSizeEncoder<number>],
-        ]) satisfies FixedSizeEncoder<number>;
+        // It returns an encoder if all fixed-size encoders have unknown sizes.
+        {
+            const encoder = getPatternMatchEncoder([
+                [numberValuePredicate, {} as FixedSizeEncoder<number>],
+                [numberValuePredicate, {} as FixedSizeEncoder<number>],
+            ]);
+            encoder satisfies Encoder<number>;
+            // @ts-expect-error The runtime sizes may differ between matched branches.
+            encoder satisfies FixedSizeEncoder<number>;
+        }
 
         // It maintains the size if all encoders are FixedSizeEncoder with the same size
         getPatternMatchEncoder([
             [stringValuePredicate, {} as FixedSizeEncoder<string, 4>],
             [stringValuePredicate, {} as FixedSizeEncoder<string, 4>],
         ]) satisfies FixedSizeEncoder<string, 4>;
+
+        // It returns an encoder when branch-size precision is represented as a TSize union.
+        {
+            const encoder = getPatternMatchEncoder([
+                [numberValuePredicate, {} as FixedSizeEncoder<number, 1>],
+                [numberValuePredicate, {} as FixedSizeEncoder<number, 4>],
+            ]);
+            encoder satisfies Encoder<number>;
+            // @ts-expect-error The same TSize union can also come from ambiguous branch sizes.
+            encoder satisfies FixedSizeEncoder<number>;
+            // @ts-expect-error The same TSize union can also come from ambiguous branch sizes.
+            encoder satisfies VariableSizeEncoder<number>;
+        }
 
         // It returns a VariableSizeEncoder if all encoders are VariableSizeEncoder
         getPatternMatchEncoder([
@@ -70,11 +88,16 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
             [stringTypePredicate, {} as Encoder<string>],
         ]) satisfies Encoder<number | string>;
 
-        // It returns a FixedSizeEncoder if all encoders are FixedSizeEncoder
-        getPatternMatchEncoder<number | string>([
-            [numberTypePredicate, {} as FixedSizeEncoder<number>],
-            [stringTypePredicate, {} as FixedSizeEncoder<string>],
-        ]) satisfies FixedSizeEncoder<number | string>;
+        // It returns an encoder if all fixed-size encoders have unknown sizes.
+        {
+            const encoder = getPatternMatchEncoder<number | string>([
+                [numberTypePredicate, {} as FixedSizeEncoder<number>],
+                [stringTypePredicate, {} as FixedSizeEncoder<string>],
+            ]);
+            encoder satisfies Encoder<number | string>;
+            // @ts-expect-error The runtime sizes may differ between narrowed branches.
+            encoder satisfies FixedSizeEncoder<number | string>;
+        }
 
         // It maintains the size if all encoders are FixedSizeEncoder with the same size
         getPatternMatchEncoder<number | string, 4>([
@@ -111,17 +134,33 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
     // It returns a decoder for the same type as the inputs
     getPatternMatchDecoder([[bytesPredicate, {} as Decoder<number>]]) satisfies Decoder<number>;
 
-    // It returns a FixedSizeDecoder if all decoders are FixedSizeDecoder
-    getPatternMatchDecoder([
-        [bytesPredicate, {} as FixedSizeDecoder<number>],
-        [bytesPredicate, {} as FixedSizeDecoder<number>],
-    ]) satisfies FixedSizeDecoder<number>;
+    // It returns a decoder if all fixed-size decoders have unknown sizes.
+    {
+        const decoder = getPatternMatchDecoder([
+            [bytesPredicate, {} as FixedSizeDecoder<number>],
+            [bytesPredicate, {} as FixedSizeDecoder<number>],
+        ]);
+        decoder satisfies Decoder<number>;
+        // @ts-expect-error The runtime sizes may differ between matched branches.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
 
     // It maintains the size if all decoders are FixedSizeDecoder with the same size
     getPatternMatchDecoder([
         [bytesPredicate, {} as FixedSizeDecoder<string, 4>],
         [bytesPredicate, {} as FixedSizeDecoder<string, 4>],
     ]) satisfies FixedSizeDecoder<string, 4>;
+
+    // It returns a decoder when branch-size precision is represented as a TSize union.
+    {
+        const decoder = getPatternMatchDecoder([
+            [bytesPredicate, {} as FixedSizeDecoder<number, 1>],
+            [bytesPredicate, {} as FixedSizeDecoder<number, 4>],
+        ]);
+        decoder satisfies Decoder<number>;
+        // @ts-expect-error The same TSize union can also come from ambiguous branch sizes.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
 
     // It returns a VariableSizeDecoder if all decoders are VariableSizeDecoder
     getPatternMatchDecoder([
@@ -153,17 +192,35 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
         // It returns a codec for the same type as the inputs
         getPatternMatchCodec([[numberValuePredicate, bytesPredicate, {} as Codec<number>]]) satisfies Codec<number>;
 
-        // It returns a FixedSizeCodec if all codecs are FixedSizeCodec
-        getPatternMatchCodec([
-            [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
-            [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
-        ]) satisfies FixedSizeCodec<number>;
+        // It returns a codec if all fixed-size codecs have unknown sizes.
+        {
+            const codec = getPatternMatchCodec([
+                [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+                [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+            ]);
+            codec satisfies Codec<number>;
+            // @ts-expect-error The runtime sizes may differ between matched branches.
+            codec satisfies FixedSizeCodec<number>;
+        }
 
         // It maintains the size if all codecs are FixedSizeCodec with the same size
         getPatternMatchCodec([
             [stringValuePredicate, bytesPredicate, {} as FixedSizeCodec<string, string, 4>],
             [stringValuePredicate, bytesPredicate, {} as FixedSizeCodec<string, string, 4>],
         ]) satisfies FixedSizeCodec<string, string, 4>;
+
+        // It returns a codec when branch-size precision is represented as a TSize union.
+        {
+            const codec = getPatternMatchCodec([
+                [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number, number, 1>],
+                [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number, number, 4>],
+            ]);
+            codec satisfies Codec<number>;
+            // @ts-expect-error The same TSize union can also come from ambiguous branch sizes.
+            codec satisfies FixedSizeCodec<number>;
+            // @ts-expect-error The same TSize union can also come from ambiguous branch sizes.
+            codec satisfies VariableSizeCodec<number>;
+        }
 
         // It returns a VariableSizeCodec if all codecs are VariableSizeCodec
         getPatternMatchCodec([
@@ -196,11 +253,16 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
             [stringTypePredicate, bytesPredicate, {} as Codec<string>],
         ]) satisfies Codec<number | string>;
 
-        // It returns a FixedSizeCodec if all codecs are FixedSizeCodec
-        getPatternMatchCodec<number | string>([
-            [numberTypePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
-            [stringTypePredicate, bytesPredicate, {} as FixedSizeCodec<string>],
-        ]) satisfies FixedSizeCodec<number | string>;
+        // It returns a codec if all fixed-size codecs have unknown sizes.
+        {
+            const codec = getPatternMatchCodec<number | string>([
+                [numberTypePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+                [stringTypePredicate, bytesPredicate, {} as FixedSizeCodec<string>],
+            ]);
+            codec satisfies Codec<number | string>;
+            // @ts-expect-error The runtime sizes may differ between narrowed branches.
+            codec satisfies FixedSizeCodec<number | string>;
+        }
 
         // It maintains the size if all codecs are FixedSizeCodec with the same size
         getPatternMatchCodec<number | string, number | string, 4>([

--- a/packages/codecs-data-structures/src/__typetests__/pattern-match-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/pattern-match-typetest.ts
@@ -85,21 +85,51 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
             [numberValuePredicate, {} as VariableSizeEncoder<number>],
         ]) satisfies VariableSizeEncoder<number>;
 
-        // It returns an Encoder if some input encoders are VariableSizeEncoder
-        getPatternMatchEncoder([
-            [numberValuePredicate, {} as VariableSizeEncoder<number>],
-            [numberValuePredicate, {} as VariableSizeEncoder<number>],
-        ]) satisfies Encoder<number>;
+        // It returns a variable size encoder if any known variant is variable size.
+        {
+            const encoder = getPatternMatchEncoder([
+                [numberValuePredicate, {} as FixedSizeEncoder<number>],
+                [numberValuePredicate, {} as VariableSizeEncoder<number>],
+            ]);
+            encoder satisfies VariableSizeEncoder<number>;
+            // @ts-expect-error A variable-size branch makes the union variable at runtime.
+            encoder satisfies FixedSizeEncoder<number>;
+        }
+        {
+            const encoder = getPatternMatchEncoder([
+                [numberValuePredicate, {} as VariableSizeEncoder<number>],
+                [numberValuePredicate, {} as FixedSizeEncoder<number>],
+            ]);
+            encoder satisfies VariableSizeEncoder<number>;
+            // @ts-expect-error A variable-size branch makes the union variable at runtime.
+            encoder satisfies FixedSizeEncoder<number>;
+        }
 
-        getPatternMatchEncoder([
-            [numberValuePredicate, {} as FixedSizeEncoder<number>],
-            [numberValuePredicate, {} as VariableSizeEncoder<number>],
-        ]) satisfies Encoder<number>;
+        // It returns a plain encoder when a branch's size is entirely unknown.
+        {
+            const encoder = getPatternMatchEncoder([
+                [numberValuePredicate, {} as Encoder<number>],
+                [numberValuePredicate, {} as FixedSizeEncoder<number>],
+            ]);
+            encoder satisfies Encoder<number>;
+            // @ts-expect-error An unknown-size branch may be fixed or variable at runtime.
+            encoder satisfies FixedSizeEncoder<number>;
+            // @ts-expect-error An unknown-size branch may be fixed or variable at runtime.
+            encoder satisfies VariableSizeEncoder<number>;
+        }
 
-        getPatternMatchEncoder([
-            [numberValuePredicate, {} as VariableSizeEncoder<number>],
-            [numberValuePredicate, {} as FixedSizeEncoder<number>],
-        ]) satisfies Encoder<number>;
+        // It infers the union value type from inline arrow predicates over distinct per-branch
+        // encoders (mirroring real call sites such as getCompiledTransactionMessageEncoder, whose
+        // branches each encode a different member of a discriminated union).
+        {
+            type Legacy = { data: number; version: 'legacy' };
+            type V0 = { data: string; version: 0 };
+            const encoder = getPatternMatchEncoder([
+                [(m: Legacy | V0) => m.version === 'legacy', {} as VariableSizeEncoder<Legacy>],
+                [(m: Legacy | V0) => m.version === 0, {} as VariableSizeEncoder<V0>],
+            ]);
+            encoder satisfies VariableSizeEncoder<Legacy | V0>;
+        }
     }
 
     // [DESCRIBE] For type guard predicates
@@ -144,21 +174,38 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
             [stringTypePredicate, {} as VariableSizeEncoder<string>],
         ]) satisfies VariableSizeEncoder<number | string>;
 
-        // It returns an Encoder if some input encoders are VariableSizeEncoder
-        getPatternMatchEncoder([
-            [numberTypePredicate, {} as VariableSizeEncoder<number>],
-            [stringTypePredicate, {} as VariableSizeEncoder<string>],
-        ]) satisfies Encoder<number | string>;
+        // It returns a variable size encoder if any known variant is variable size.
+        {
+            const encoder = getPatternMatchEncoder([
+                [numberTypePredicate, {} as FixedSizeEncoder<number>],
+                [stringTypePredicate, {} as VariableSizeEncoder<string>],
+            ]);
+            encoder satisfies VariableSizeEncoder<number | string>;
+            // @ts-expect-error A variable-size branch makes the union variable at runtime.
+            encoder satisfies FixedSizeEncoder<number | string>;
+        }
+        {
+            const encoder = getPatternMatchEncoder([
+                [numberTypePredicate, {} as VariableSizeEncoder<number>],
+                [numberTypePredicate, {} as FixedSizeEncoder<number>],
+            ]);
+            encoder satisfies VariableSizeEncoder<number>;
+            // @ts-expect-error A variable-size branch makes the union variable at runtime.
+            encoder satisfies FixedSizeEncoder<number>;
+        }
 
-        getPatternMatchEncoder([
-            [numberTypePredicate, {} as FixedSizeEncoder<number>],
-            [stringTypePredicate, {} as VariableSizeEncoder<string>],
-        ]) satisfies Encoder<number | string>;
-
-        getPatternMatchEncoder([
-            [numberTypePredicate, {} as VariableSizeEncoder<number>],
-            [numberTypePredicate, {} as FixedSizeEncoder<number>],
-        ]) satisfies Encoder<number>;
+        // It returns a plain encoder when a branch's size is entirely unknown.
+        {
+            const encoder = getPatternMatchEncoder([
+                [numberTypePredicate, {} as Encoder<number>],
+                [stringTypePredicate, {} as FixedSizeEncoder<string>],
+            ]);
+            encoder satisfies Encoder<number | string>;
+            // @ts-expect-error An unknown-size branch may be fixed or variable at runtime.
+            encoder satisfies FixedSizeEncoder<number | string>;
+            // @ts-expect-error An unknown-size branch may be fixed or variable at runtime.
+            encoder satisfies VariableSizeEncoder<number | string>;
+        }
     }
 }
 
@@ -212,21 +259,25 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
         [bytesPredicate, {} as VariableSizeDecoder<number>],
     ]) satisfies VariableSizeDecoder<number>;
 
-    // It returns a Decoder if some input decoders are VariableSizeDecoder
-    getPatternMatchDecoder([
-        [bytesPredicate, {} as VariableSizeDecoder<number>],
-        [bytesPredicate, {} as VariableSizeDecoder<number>],
-    ]) satisfies Decoder<number>;
-
-    getPatternMatchDecoder([
-        [bytesPredicate, {} as FixedSizeDecoder<number>],
-        [bytesPredicate, {} as VariableSizeDecoder<number>],
-    ]) satisfies Decoder<number>;
-
-    getPatternMatchDecoder([
-        [bytesPredicate, {} as VariableSizeDecoder<number>],
-        [bytesPredicate, {} as FixedSizeDecoder<number>],
-    ]) satisfies Decoder<number>;
+    // It returns a variable size decoder if any known variant is variable size.
+    {
+        const decoder = getPatternMatchDecoder([
+            [bytesPredicate, {} as FixedSizeDecoder<number>],
+            [bytesPredicate, {} as VariableSizeDecoder<number>],
+        ]);
+        decoder satisfies VariableSizeDecoder<number>;
+        // @ts-expect-error A variable-size branch makes the union variable at runtime.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
+    {
+        const decoder = getPatternMatchDecoder([
+            [bytesPredicate, {} as VariableSizeDecoder<number>],
+            [bytesPredicate, {} as FixedSizeDecoder<number>],
+        ]);
+        decoder satisfies VariableSizeDecoder<number>;
+        // @ts-expect-error A variable-size branch makes the union variable at runtime.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
 }
 
 // [DESCRIBE] getPatternMatchCodec
@@ -292,21 +343,38 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
             [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
         ]) satisfies VariableSizeCodec<number>;
 
-        // It returns a Codec if some input codecs are VariableSizeCodec
-        getPatternMatchCodec([
-            [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
-            [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
-        ]) satisfies Codec<number>;
+        // It returns a variable size codec if any known variant is variable size.
+        {
+            const codec = getPatternMatchCodec([
+                [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+                [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
+            ]);
+            codec satisfies VariableSizeCodec<number>;
+            // @ts-expect-error A variable-size branch makes the union variable at runtime.
+            codec satisfies FixedSizeCodec<number>;
+        }
+        {
+            const codec = getPatternMatchCodec([
+                [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
+                [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+            ]);
+            codec satisfies VariableSizeCodec<number>;
+            // @ts-expect-error A variable-size branch makes the union variable at runtime.
+            codec satisfies FixedSizeCodec<number>;
+        }
 
-        getPatternMatchCodec([
-            [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
-            [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
-        ]) satisfies Codec<number>;
-
-        getPatternMatchCodec([
-            [numberValuePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
-            [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
-        ]) satisfies Codec<number>;
+        // It returns a plain codec when a branch's size is entirely unknown.
+        {
+            const codec = getPatternMatchCodec([
+                [numberValuePredicate, bytesPredicate, {} as Codec<number>],
+                [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+            ]);
+            codec satisfies Codec<number>;
+            // @ts-expect-error An unknown-size branch may be fixed or variable at runtime.
+            codec satisfies FixedSizeCodec<number>;
+            // @ts-expect-error An unknown-size branch may be fixed or variable at runtime.
+            codec satisfies VariableSizeCodec<number>;
+        }
     }
 
     // [DESCRIBE] For type guard predicates
@@ -351,20 +419,37 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
             [stringTypePredicate, bytesPredicate, {} as VariableSizeCodec<string>],
         ]) satisfies VariableSizeCodec<number | string>;
 
-        // It returns a Codec if some input codecs are VariableSizeCodec
-        getPatternMatchCodec([
-            [numberTypePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
-            [stringTypePredicate, bytesPredicate, {} as VariableSizeCodec<string>],
-        ]) satisfies Codec<number | string>;
+        // It returns a variable size codec if any known variant is variable size.
+        {
+            const codec = getPatternMatchCodec([
+                [numberTypePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
+                [stringTypePredicate, bytesPredicate, {} as VariableSizeCodec<string>],
+            ]);
+            codec satisfies VariableSizeCodec<number | string>;
+            // @ts-expect-error A variable-size branch makes the union variable at runtime.
+            codec satisfies FixedSizeCodec<number | string>;
+        }
+        {
+            const codec = getPatternMatchCodec([
+                [numberTypePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
+                [stringTypePredicate, bytesPredicate, {} as FixedSizeCodec<string>],
+            ]);
+            codec satisfies VariableSizeCodec<number | string>;
+            // @ts-expect-error A variable-size branch makes the union variable at runtime.
+            codec satisfies FixedSizeCodec<number | string>;
+        }
 
-        getPatternMatchCodec([
-            [numberTypePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
-            [stringTypePredicate, bytesPredicate, {} as VariableSizeCodec<string>],
-        ]) satisfies Codec<number | string>;
-
-        getPatternMatchCodec([
-            [numberTypePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
-            [stringTypePredicate, bytesPredicate, {} as FixedSizeCodec<string>],
-        ]) satisfies Codec<number | string>;
+        // It returns a plain codec when a branch's size is entirely unknown.
+        {
+            const codec = getPatternMatchCodec([
+                [numberTypePredicate, bytesPredicate, {} as Codec<number>],
+                [stringTypePredicate, bytesPredicate, {} as FixedSizeCodec<string>],
+            ]);
+            codec satisfies Codec<number | string>;
+            // @ts-expect-error An unknown-size branch may be fixed or variable at runtime.
+            codec satisfies FixedSizeCodec<number | string>;
+            // @ts-expect-error An unknown-size branch may be fixed or variable at runtime.
+            codec satisfies VariableSizeCodec<number | string>;
+        }
     }
 }

--- a/packages/codecs-data-structures/src/__typetests__/pattern-match-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/pattern-match-typetest.ts
@@ -27,6 +27,15 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
         // It returns an encoder for the same type as the inputs
         getPatternMatchEncoder([[numberValuePredicate, {} as Encoder<number>]]) satisfies Encoder<number>;
 
+        // It does not allow mixing incompatible value types across boolean-predicate branches
+        getPatternMatchEncoder(
+            // @ts-expect-error A string branch is not compatible with a number-typed pattern match.
+            [
+                [numberValuePredicate, {} as Encoder<number>],
+                [stringValuePredicate, {} as Encoder<string>],
+            ],
+        );
+
         // It returns an encoder if all fixed-size encoders have unknown sizes.
         {
             const encoder = getPatternMatchEncoder([
@@ -36,6 +45,21 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
             encoder satisfies Encoder<number>;
             // @ts-expect-error The runtime sizes may differ between matched branches.
             encoder satisfies FixedSizeEncoder<number>;
+            // @ts-expect-error The runtime sizes may differ between matched branches.
+            encoder satisfies VariableSizeEncoder<number>;
+        }
+
+        // It returns an encoder if fixed-size encoders carry ambiguous literal-union sizes.
+        {
+            const encoder = getPatternMatchEncoder([
+                [numberValuePredicate, {} as FixedSizeEncoder<number, 1 | 4>],
+                [numberValuePredicate, {} as FixedSizeEncoder<number, 1 | 4>],
+            ]);
+            encoder satisfies Encoder<number>;
+            // @ts-expect-error Each branch may resolve to the same runtime size.
+            encoder satisfies VariableSizeEncoder<number>;
+            // @ts-expect-error Each branch may resolve to different runtime sizes.
+            encoder satisfies FixedSizeEncoder<number>;
         }
 
         // It maintains the size if all encoders are FixedSizeEncoder with the same size
@@ -44,17 +68,15 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
             [stringValuePredicate, {} as FixedSizeEncoder<string, 4>],
         ]) satisfies FixedSizeEncoder<string, 4>;
 
-        // It returns an encoder when branch-size precision is represented as a TSize union.
+        // It returns a variable size encoder if all variants are fixed size with different known sizes.
         {
             const encoder = getPatternMatchEncoder([
                 [numberValuePredicate, {} as FixedSizeEncoder<number, 1>],
                 [numberValuePredicate, {} as FixedSizeEncoder<number, 4>],
             ]);
-            encoder satisfies Encoder<number>;
-            // @ts-expect-error The same TSize union can also come from ambiguous branch sizes.
-            encoder satisfies FixedSizeEncoder<number>;
-            // @ts-expect-error The same TSize union can also come from ambiguous branch sizes.
             encoder satisfies VariableSizeEncoder<number>;
+            // @ts-expect-error Known unequal fixed sizes make the union variable at runtime.
+            encoder satisfies FixedSizeEncoder<number>;
         }
 
         // It returns a VariableSizeEncoder if all encoders are VariableSizeEncoder
@@ -83,14 +105,14 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
     // [DESCRIBE] For type guard predicates
     {
         // It returns an encoder for the same type as the inputs
-        getPatternMatchEncoder<number | string>([
+        getPatternMatchEncoder([
             [numberTypePredicate, {} as Encoder<number>],
             [stringTypePredicate, {} as Encoder<string>],
         ]) satisfies Encoder<number | string>;
 
         // It returns an encoder if all fixed-size encoders have unknown sizes.
         {
-            const encoder = getPatternMatchEncoder<number | string>([
+            const encoder = getPatternMatchEncoder([
                 [numberTypePredicate, {} as FixedSizeEncoder<number>],
                 [stringTypePredicate, {} as FixedSizeEncoder<string>],
             ]);
@@ -100,29 +122,40 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
         }
 
         // It maintains the size if all encoders are FixedSizeEncoder with the same size
-        getPatternMatchEncoder<number | string, 4>([
+        getPatternMatchEncoder([
             [numberTypePredicate, {} as FixedSizeEncoder<number, 4>],
             [stringTypePredicate, {} as FixedSizeEncoder<string, 4>],
         ]) satisfies FixedSizeEncoder<number | string, 4>;
 
+        // It returns a variable size encoder if all variants are fixed size with different known sizes.
+        {
+            const encoder = getPatternMatchEncoder([
+                [numberTypePredicate, {} as FixedSizeEncoder<number, 1>],
+                [stringTypePredicate, {} as FixedSizeEncoder<string, 4>],
+            ]);
+            encoder satisfies VariableSizeEncoder<number | string>;
+            // @ts-expect-error Known unequal fixed sizes make the union variable at runtime.
+            encoder satisfies FixedSizeEncoder<number | string>;
+        }
+
         // It returns a VariableSizeEncoder if all encoders are VariableSizeEncoder
-        getPatternMatchEncoder<number | string>([
+        getPatternMatchEncoder([
             [numberTypePredicate, {} as VariableSizeEncoder<number>],
             [stringTypePredicate, {} as VariableSizeEncoder<string>],
         ]) satisfies VariableSizeEncoder<number | string>;
 
         // It returns an Encoder if some input encoders are VariableSizeEncoder
-        getPatternMatchEncoder<number | string>([
+        getPatternMatchEncoder([
             [numberTypePredicate, {} as VariableSizeEncoder<number>],
             [stringTypePredicate, {} as VariableSizeEncoder<string>],
         ]) satisfies Encoder<number | string>;
 
-        getPatternMatchEncoder<number | string>([
+        getPatternMatchEncoder([
             [numberTypePredicate, {} as FixedSizeEncoder<number>],
             [stringTypePredicate, {} as VariableSizeEncoder<string>],
         ]) satisfies Encoder<number | string>;
 
-        getPatternMatchEncoder<number | string>([
+        getPatternMatchEncoder([
             [numberTypePredicate, {} as VariableSizeEncoder<number>],
             [numberTypePredicate, {} as FixedSizeEncoder<number>],
         ]) satisfies Encoder<number>;
@@ -145,20 +178,31 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
         decoder satisfies FixedSizeDecoder<number>;
     }
 
+    // It returns a decoder if fixed-size decoders carry ambiguous literal-union sizes.
+    {
+        const decoder = getPatternMatchDecoder([
+            [bytesPredicate, {} as FixedSizeDecoder<number, 1 | 4>],
+            [bytesPredicate, {} as FixedSizeDecoder<number, 1 | 4>],
+        ]);
+        decoder satisfies Decoder<number>;
+        // @ts-expect-error Each branch may resolve to different runtime sizes.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
+
     // It maintains the size if all decoders are FixedSizeDecoder with the same size
     getPatternMatchDecoder([
         [bytesPredicate, {} as FixedSizeDecoder<string, 4>],
         [bytesPredicate, {} as FixedSizeDecoder<string, 4>],
     ]) satisfies FixedSizeDecoder<string, 4>;
 
-    // It returns a decoder when branch-size precision is represented as a TSize union.
+    // It returns a variable size decoder if all variants are fixed size with different known sizes.
     {
         const decoder = getPatternMatchDecoder([
             [bytesPredicate, {} as FixedSizeDecoder<number, 1>],
             [bytesPredicate, {} as FixedSizeDecoder<number, 4>],
         ]);
-        decoder satisfies Decoder<number>;
-        // @ts-expect-error The same TSize union can also come from ambiguous branch sizes.
+        decoder satisfies VariableSizeDecoder<number>;
+        // @ts-expect-error Known unequal fixed sizes make the union variable at runtime.
         decoder satisfies FixedSizeDecoder<number>;
     }
 
@@ -192,6 +236,15 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
         // It returns a codec for the same type as the inputs
         getPatternMatchCodec([[numberValuePredicate, bytesPredicate, {} as Codec<number>]]) satisfies Codec<number>;
 
+        // It does not allow mixing incompatible value types across boolean-predicate branches
+        getPatternMatchCodec(
+            // @ts-expect-error A string branch is not compatible with a number-typed pattern match.
+            [
+                [numberValuePredicate, bytesPredicate, {} as Codec<number>],
+                [stringValuePredicate, bytesPredicate, {} as Codec<string>],
+            ],
+        );
+
         // It returns a codec if all fixed-size codecs have unknown sizes.
         {
             const codec = getPatternMatchCodec([
@@ -203,23 +256,34 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
             codec satisfies FixedSizeCodec<number>;
         }
 
+        // It returns a codec if fixed-size codecs carry ambiguous literal-union sizes.
+        {
+            const codec = getPatternMatchCodec([
+                [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number, number, 1 | 4>],
+                [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number, number, 1 | 4>],
+            ]);
+            codec satisfies Codec<number>;
+            // @ts-expect-error Each branch may resolve to the same runtime size.
+            codec satisfies VariableSizeCodec<number>;
+            // @ts-expect-error Each branch may resolve to different runtime sizes.
+            codec satisfies FixedSizeCodec<number>;
+        }
+
         // It maintains the size if all codecs are FixedSizeCodec with the same size
         getPatternMatchCodec([
             [stringValuePredicate, bytesPredicate, {} as FixedSizeCodec<string, string, 4>],
             [stringValuePredicate, bytesPredicate, {} as FixedSizeCodec<string, string, 4>],
         ]) satisfies FixedSizeCodec<string, string, 4>;
 
-        // It returns a codec when branch-size precision is represented as a TSize union.
+        // It returns a variable size codec if all variants are fixed size with different known sizes.
         {
             const codec = getPatternMatchCodec([
                 [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number, number, 1>],
                 [numberValuePredicate, bytesPredicate, {} as FixedSizeCodec<number, number, 4>],
             ]);
-            codec satisfies Codec<number>;
-            // @ts-expect-error The same TSize union can also come from ambiguous branch sizes.
-            codec satisfies FixedSizeCodec<number>;
-            // @ts-expect-error The same TSize union can also come from ambiguous branch sizes.
             codec satisfies VariableSizeCodec<number>;
+            // @ts-expect-error Known unequal fixed sizes make the union variable at runtime.
+            codec satisfies FixedSizeCodec<number>;
         }
 
         // It returns a VariableSizeCodec if all codecs are VariableSizeCodec
@@ -248,14 +312,14 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
     // [DESCRIBE] For type guard predicates
     {
         // It returns a codec for the same type as the inputs
-        getPatternMatchCodec<number | string>([
+        getPatternMatchCodec([
             [numberTypePredicate, bytesPredicate, {} as Codec<number>],
             [stringTypePredicate, bytesPredicate, {} as Codec<string>],
         ]) satisfies Codec<number | string>;
 
         // It returns a codec if all fixed-size codecs have unknown sizes.
         {
-            const codec = getPatternMatchCodec<number | string>([
+            const codec = getPatternMatchCodec([
                 [numberTypePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
                 [stringTypePredicate, bytesPredicate, {} as FixedSizeCodec<string>],
             ]);
@@ -265,29 +329,40 @@ const stringTypePredicate = null as unknown as (value: number | string) => value
         }
 
         // It maintains the size if all codecs are FixedSizeCodec with the same size
-        getPatternMatchCodec<number | string, number | string, 4>([
+        getPatternMatchCodec([
             [stringTypePredicate, bytesPredicate, {} as FixedSizeCodec<string, string, 4>],
             [numberTypePredicate, bytesPredicate, {} as FixedSizeCodec<number, number, 4>],
         ]) satisfies FixedSizeCodec<number | string, number | string, 4>;
 
+        // It returns a variable size codec if all variants are fixed size with different known sizes.
+        {
+            const codec = getPatternMatchCodec([
+                [stringTypePredicate, bytesPredicate, {} as FixedSizeCodec<string, string, 1>],
+                [numberTypePredicate, bytesPredicate, {} as FixedSizeCodec<number, number, 4>],
+            ]);
+            codec satisfies VariableSizeCodec<number | string>;
+            // @ts-expect-error Known unequal fixed sizes make the union variable at runtime.
+            codec satisfies FixedSizeCodec<number | string>;
+        }
+
         // It returns a VariableSizeCodec if all codecs are VariableSizeCodec
-        getPatternMatchCodec<number | string>([
+        getPatternMatchCodec([
             [numberTypePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
             [stringTypePredicate, bytesPredicate, {} as VariableSizeCodec<string>],
         ]) satisfies VariableSizeCodec<number | string>;
 
         // It returns a Codec if some input codecs are VariableSizeCodec
-        getPatternMatchCodec<number | string>([
+        getPatternMatchCodec([
             [numberTypePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
             [stringTypePredicate, bytesPredicate, {} as VariableSizeCodec<string>],
         ]) satisfies Codec<number | string>;
 
-        getPatternMatchCodec<number | string>([
+        getPatternMatchCodec([
             [numberTypePredicate, bytesPredicate, {} as FixedSizeCodec<number>],
             [stringTypePredicate, bytesPredicate, {} as VariableSizeCodec<string>],
         ]) satisfies Codec<number | string>;
 
-        getPatternMatchCodec<number | string>([
+        getPatternMatchCodec([
             [numberTypePredicate, bytesPredicate, {} as VariableSizeCodec<number>],
             [stringTypePredicate, bytesPredicate, {} as FixedSizeCodec<string>],
         ]) satisfies Codec<number | string>;

--- a/packages/codecs-data-structures/src/__typetests__/predicate-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/predicate-typetest.ts
@@ -82,6 +82,16 @@ const predicate = null as unknown as () => boolean;
         {} as FixedSizeEncoder<number>,
     ) satisfies VariableSizeEncoder<number>;
 
+    // It returns a plain encoder when an input encoder's size is entirely unknown.
+    {
+        const encoder = getPredicateEncoder(predicate, {} as Encoder<number>, {} as FixedSizeEncoder<number>);
+        encoder satisfies Encoder<number>;
+        // @ts-expect-error An unknown-size encoder may be fixed or variable at runtime.
+        encoder satisfies FixedSizeEncoder<number>;
+        // @ts-expect-error An unknown-size encoder may be fixed or variable at runtime.
+        encoder satisfies VariableSizeEncoder<number>;
+    }
+
     // It does not allow different encoder types
     {
         // @ts-expect-error Different encoder types
@@ -238,6 +248,16 @@ const predicate = null as unknown as () => boolean;
         {} as VariableSizeCodec<number>,
         {} as FixedSizeCodec<number>,
     ) satisfies VariableSizeCodec<number>;
+
+    // It returns a plain codec when an input codec's size is entirely unknown.
+    {
+        const codec = getPredicateCodec(predicate, predicate, {} as Codec<number>, {} as FixedSizeCodec<number>);
+        codec satisfies Codec<number>;
+        // @ts-expect-error An unknown-size codec may be fixed or variable at runtime.
+        codec satisfies FixedSizeCodec<number>;
+        // @ts-expect-error An unknown-size codec may be fixed or variable at runtime.
+        codec satisfies VariableSizeCodec<number>;
+    }
 
     // It does not allow different codec types
     {

--- a/packages/codecs-data-structures/src/__typetests__/predicate-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/predicate-typetest.ts
@@ -19,12 +19,29 @@ const predicate = null as unknown as () => boolean;
     // It returns an encoder for the same type as the inputs
     getPredicateEncoder(predicate, {} as Encoder<number>, {} as Encoder<number>) satisfies Encoder<number>;
 
-    // It returns a FixedSizeEncoder if both encoders are FixedSizeEncoder
-    getPredicateEncoder(
-        predicate,
-        {} as FixedSizeEncoder<number>,
-        {} as FixedSizeEncoder<number>,
-    ) satisfies FixedSizeEncoder<number>;
+    // It returns an encoder if both fixed-size encoders have unknown sizes.
+    {
+        const encoder = getPredicateEncoder(predicate, {} as FixedSizeEncoder<number>, {} as FixedSizeEncoder<number>);
+        encoder satisfies Encoder<number>;
+        // @ts-expect-error The two runtime sizes may differ.
+        encoder satisfies FixedSizeEncoder<number>;
+        // @ts-expect-error The two runtime sizes may still match.
+        encoder satisfies VariableSizeEncoder<number>;
+    }
+
+    // It returns an encoder if both fixed-size encoders carry ambiguous literal-union sizes.
+    {
+        const encoder = getPredicateEncoder(
+            predicate,
+            {} as FixedSizeEncoder<number, 1 | 4>,
+            {} as FixedSizeEncoder<number, 1 | 4>,
+        );
+        encoder satisfies Encoder<number>;
+        // @ts-expect-error Each branch may resolve to the same runtime size.
+        encoder satisfies VariableSizeEncoder<number>;
+        // @ts-expect-error Each branch may resolve to different runtime sizes.
+        encoder satisfies FixedSizeEncoder<number>;
+    }
 
     // It maintains the size if both encoders are FixedSizeEncoder with the same size
     getPredicateEncoder(
@@ -33,6 +50,18 @@ const predicate = null as unknown as () => boolean;
         {} as FixedSizeEncoder<string, 4>,
     ) satisfies FixedSizeEncoder<string, 4>;
 
+    // It returns a variable size encoder if both encoders are fixed size with different known sizes.
+    {
+        const encoder = getPredicateEncoder(
+            predicate,
+            {} as FixedSizeEncoder<number, 1>,
+            {} as FixedSizeEncoder<number, 4>,
+        );
+        encoder satisfies VariableSizeEncoder<number>;
+        // @ts-expect-error Known unequal fixed sizes make the predicate encoder variable at runtime.
+        encoder satisfies FixedSizeEncoder<number>;
+    }
+
     // It returns a VariableSizeEncoder if both encoders are VariableSizeEncoder
     getPredicateEncoder(
         predicate,
@@ -40,24 +69,18 @@ const predicate = null as unknown as () => boolean;
         {} as VariableSizeEncoder<number>,
     ) satisfies VariableSizeEncoder<number>;
 
-    // It returns an Encoder if some input encoders are VariableSizeEncoder
-    getPredicateEncoder(
-        predicate,
-        {} as VariableSizeEncoder<number>,
-        {} as VariableSizeEncoder<number>,
-    ) satisfies Encoder<number>;
-
+    // It returns a VariableSizeEncoder if any known input encoder is VariableSizeEncoder
     getPredicateEncoder(
         predicate,
         {} as FixedSizeEncoder<number>,
         {} as VariableSizeEncoder<number>,
-    ) satisfies Encoder<number>;
+    ) satisfies VariableSizeEncoder<number>;
 
     getPredicateEncoder(
         predicate,
         {} as VariableSizeEncoder<number>,
         {} as FixedSizeEncoder<number>,
-    ) satisfies Encoder<number>;
+    ) satisfies VariableSizeEncoder<number>;
 
     // It does not allow different encoder types
     {
@@ -71,12 +94,25 @@ const predicate = null as unknown as () => boolean;
     // It returns an encoder for the same type as the inputs
     getPredicateDecoder(predicate, {} as Decoder<number>, {} as Decoder<number>) satisfies Decoder<number>;
 
-    // It returns a FixedSizeDecoder if both Decoders are FixedSizeDecoder
-    getPredicateDecoder(
-        predicate,
-        {} as FixedSizeDecoder<number>,
-        {} as FixedSizeDecoder<number>,
-    ) satisfies FixedSizeDecoder<number>;
+    // It returns a decoder if both fixed-size decoders have unknown sizes.
+    {
+        const decoder = getPredicateDecoder(predicate, {} as FixedSizeDecoder<number>, {} as FixedSizeDecoder<number>);
+        decoder satisfies Decoder<number>;
+        // @ts-expect-error The two runtime sizes may differ.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
+
+    // It returns a decoder if both fixed-size decoders carry ambiguous literal-union sizes.
+    {
+        const decoder = getPredicateDecoder(
+            predicate,
+            {} as FixedSizeDecoder<number, 1 | 4>,
+            {} as FixedSizeDecoder<number, 1 | 4>,
+        );
+        decoder satisfies Decoder<number>;
+        // @ts-expect-error Each branch may resolve to different runtime sizes.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
 
     // It maintains the size if both decoders are FixedSizeDecoder with the same size
     getPredicateDecoder(
@@ -85,6 +121,18 @@ const predicate = null as unknown as () => boolean;
         {} as FixedSizeDecoder<string, 4>,
     ) satisfies FixedSizeDecoder<string, 4>;
 
+    // It returns a variable size decoder if both decoders are fixed size with different known sizes.
+    {
+        const decoder = getPredicateDecoder(
+            predicate,
+            {} as FixedSizeDecoder<number, 1>,
+            {} as FixedSizeDecoder<number, 4>,
+        );
+        decoder satisfies VariableSizeDecoder<number>;
+        // @ts-expect-error Known unequal fixed sizes make the predicate decoder variable at runtime.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
+
     // It returns a VariableSizeDecoder if both decoders are VariableSizeDecoder
     getPredicateDecoder(
         predicate,
@@ -92,24 +140,18 @@ const predicate = null as unknown as () => boolean;
         {} as VariableSizeDecoder<number>,
     ) satisfies VariableSizeDecoder<number>;
 
-    // It returns an Decoder if some input Decoders are VariableSizeDecoder
-    getPredicateDecoder(
-        predicate,
-        {} as VariableSizeDecoder<number>,
-        {} as VariableSizeDecoder<number>,
-    ) satisfies Decoder<number>;
-
+    // It returns a VariableSizeDecoder if any known input decoder is VariableSizeDecoder
     getPredicateDecoder(
         predicate,
         {} as FixedSizeDecoder<number>,
         {} as VariableSizeDecoder<number>,
-    ) satisfies Decoder<number>;
+    ) satisfies VariableSizeDecoder<number>;
 
     getPredicateDecoder(
         predicate,
         {} as VariableSizeDecoder<number>,
         {} as FixedSizeDecoder<number>,
-    ) satisfies Decoder<number>;
+    ) satisfies VariableSizeDecoder<number>;
 
     // It does not allow different Decoder types
     {
@@ -123,13 +165,35 @@ const predicate = null as unknown as () => boolean;
     // It returns a codec for the same type as the inputs
     getPredicateCodec(predicate, predicate, {} as Codec<number>, {} as Codec<number>) satisfies Codec<number>;
 
-    // It returns a FixedSizeCodec if both codecs are FixedSizeCodec
-    getPredicateCodec(
-        predicate,
-        predicate,
-        {} as FixedSizeCodec<number>,
-        {} as FixedSizeCodec<number>,
-    ) satisfies FixedSizeCodec<number>;
+    // It returns a codec if both fixed-size codecs have unknown sizes.
+    {
+        const codec = getPredicateCodec(
+            predicate,
+            predicate,
+            {} as FixedSizeCodec<number>,
+            {} as FixedSizeCodec<number>,
+        );
+        codec satisfies Codec<number>;
+        // @ts-expect-error The two runtime sizes may differ.
+        codec satisfies FixedSizeCodec<number>;
+        // @ts-expect-error The two runtime sizes may still match.
+        codec satisfies VariableSizeCodec<number>;
+    }
+
+    // It returns a codec if both fixed-size codecs carry ambiguous literal-union sizes.
+    {
+        const codec = getPredicateCodec(
+            predicate,
+            predicate,
+            {} as FixedSizeCodec<number, number, 1 | 4>,
+            {} as FixedSizeCodec<number, number, 1 | 4>,
+        );
+        codec satisfies Codec<number>;
+        // @ts-expect-error Each branch may resolve to the same runtime size.
+        codec satisfies VariableSizeCodec<number>;
+        // @ts-expect-error Each branch may resolve to different runtime sizes.
+        codec satisfies FixedSizeCodec<number>;
+    }
 
     // It maintains the size if both codecs are FixedSizeCodec with the same size
     getPredicateCodec(
@@ -139,6 +203,19 @@ const predicate = null as unknown as () => boolean;
         {} as FixedSizeCodec<string, string, 4>,
     ) satisfies FixedSizeCodec<string, string, 4>;
 
+    // It returns a variable size codec if both codecs are fixed size with different known sizes.
+    {
+        const codec = getPredicateCodec(
+            predicate,
+            predicate,
+            {} as FixedSizeCodec<number, number, 1>,
+            {} as FixedSizeCodec<number, number, 4>,
+        );
+        codec satisfies VariableSizeCodec<number>;
+        // @ts-expect-error Known unequal fixed sizes make the predicate codec variable at runtime.
+        codec satisfies FixedSizeCodec<number>;
+    }
+
     // It returns a VariableSizeCodec if both codecs are VariableSizeCodec
     getPredicateCodec(
         predicate,
@@ -147,27 +224,20 @@ const predicate = null as unknown as () => boolean;
         {} as VariableSizeCodec<number>,
     ) satisfies VariableSizeCodec<number>;
 
-    // It returns a Codec if some input codecs are VariableSizeCodec
-    getPredicateCodec(
-        predicate,
-        predicate,
-        {} as VariableSizeCodec<number>,
-        {} as VariableSizeCodec<number>,
-    ) satisfies Codec<number>;
-
+    // It returns a VariableSizeCodec if any known input codec is VariableSizeCodec
     getPredicateCodec(
         predicate,
         predicate,
         {} as FixedSizeCodec<number>,
         {} as VariableSizeCodec<number>,
-    ) satisfies Codec<number>;
+    ) satisfies VariableSizeCodec<number>;
 
     getPredicateCodec(
         predicate,
         predicate,
         {} as VariableSizeCodec<number>,
         {} as FixedSizeCodec<number>,
-    ) satisfies Codec<number>;
+    ) satisfies VariableSizeCodec<number>;
 
     // It does not allow different codec types
     {

--- a/packages/codecs-data-structures/src/__typetests__/union-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/union-typetest.ts
@@ -1,4 +1,14 @@
-import { Codec, Decoder, Encoder, FixedSizeCodec, FixedSizeDecoder, FixedSizeEncoder } from '@solana/codecs-core';
+import {
+    Codec,
+    Decoder,
+    Encoder,
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
+} from '@solana/codecs-core';
 
 import { getUnionCodec, getUnionDecoder, getUnionEncoder } from '../union';
 
@@ -19,25 +29,79 @@ const getIndex = () => 0;
         ) satisfies Encoder<bigint | number | { value: string } | { x: number; y: number } | null>;
     }
 
-    // It returns a fixed size encoder if all variants are fixed size.
+    // It returns a fixed size encoder if all variants are fixed size with the same size.
     {
         getUnionEncoder(
             [
-                {} as FixedSizeEncoder<null>,
-                {} as FixedSizeEncoder<bigint | number>,
-                {} as FixedSizeEncoder<{ value: string }>,
-                {} as FixedSizeEncoder<{ x: number; y: number }>,
+                {} as FixedSizeEncoder<null, 8>,
+                {} as FixedSizeEncoder<bigint | number, 8>,
+                {} as FixedSizeEncoder<{ value: string }, 8>,
+                {} as FixedSizeEncoder<{ x: number; y: number }, 8>,
             ],
             getIndex,
-        ) satisfies FixedSizeEncoder<bigint | number | { value: string } | { x: number; y: number } | null>;
+        ) satisfies FixedSizeEncoder<bigint | number | { value: string } | { x: number; y: number } | null, 8>;
     }
 
-    // It does not return a fixed size encoder if any variant is variable size.
+    // It returns a variable size encoder if all variants are fixed size with different known sizes.
     {
-        const decoder = getUnionEncoder([{} as Encoder<number>, {} as FixedSizeEncoder<number>], getIndex);
-        decoder satisfies Encoder<number>;
-        // @ts-expect-error Encoder is not fixed size.
-        decoder satisfies FixedSizeEncoder<number>;
+        const encoder = getUnionEncoder(
+            [{} as FixedSizeEncoder<number, 1>, {} as FixedSizeEncoder<number, 4>],
+            getIndex,
+        );
+        encoder satisfies VariableSizeEncoder<number>;
+        // @ts-expect-error Known unequal fixed sizes make the union variable at runtime.
+        encoder satisfies FixedSizeEncoder<number>;
+    }
+
+    // It returns an encoder if all variants are fixed size but their sizes are not known.
+    {
+        const encoder = getUnionEncoder([{} as FixedSizeEncoder<number>, {} as FixedSizeEncoder<number>], getIndex);
+        encoder satisfies Encoder<number>;
+        // @ts-expect-error The two runtime sizes may differ.
+        encoder satisfies FixedSizeEncoder<number>;
+        // @ts-expect-error The two runtime sizes may still match.
+        encoder satisfies VariableSizeEncoder<number>;
+    }
+
+    // It returns an encoder if fixed-size variants carry ambiguous literal-union sizes.
+    {
+        const encoder = getUnionEncoder(
+            [{} as FixedSizeEncoder<number, 1 | 4>, {} as FixedSizeEncoder<number, 1 | 4>],
+            getIndex,
+        );
+        encoder satisfies Encoder<number>;
+        // @ts-expect-error Each branch may resolve to the same runtime size.
+        encoder satisfies VariableSizeEncoder<number>;
+        // @ts-expect-error Each branch may resolve to different runtime sizes.
+        encoder satisfies FixedSizeEncoder<number>;
+    }
+
+    // It keeps dynamic arrays fixed-size without promising one literal size.
+    {
+        const variants = [] as FixedSizeEncoder<number, 4>[];
+        const encoder = getUnionEncoder(variants, getIndex);
+        encoder satisfies FixedSizeEncoder<number>;
+        // @ts-expect-error The array may be empty, whose runtime fixedSize is 0.
+        encoder satisfies FixedSizeEncoder<number, 4>;
+    }
+
+    // It returns an encoder for dynamic arrays with ambiguous element sizes.
+    {
+        const variants = [] as FixedSizeEncoder<number, 1 | 4>[];
+        const encoder = getUnionEncoder(variants, getIndex);
+        encoder satisfies Encoder<number>;
+        // @ts-expect-error Elements may share one runtime size or disagree.
+        encoder satisfies FixedSizeEncoder<number>;
+        // @ts-expect-error Elements may share one runtime size or disagree.
+        encoder satisfies VariableSizeEncoder<number>;
+    }
+
+    // It returns a variable size encoder if any known variant is variable size.
+    {
+        const encoder = getUnionEncoder([{} as VariableSizeEncoder<number>, {} as FixedSizeEncoder<number>], getIndex);
+        encoder satisfies VariableSizeEncoder<number>;
+        // @ts-expect-error The runtime helper cannot expose fixedSize in this case.
+        encoder satisfies FixedSizeEncoder<number>;
     }
 }
 
@@ -56,25 +120,55 @@ const getIndex = () => 0;
         ) satisfies Decoder<bigint | number | { value: string } | { x: number; y: number } | null>;
     }
 
-    // It returns a fixed size decoder if all variants are fixed size.
+    // It returns a fixed size decoder if all variants are fixed size with the same size.
     {
         const decoder = getUnionDecoder(
             [
-                {} as FixedSizeDecoder<null>,
-                {} as FixedSizeDecoder<bigint | number>,
-                {} as FixedSizeDecoder<{ value: string }>,
-                {} as FixedSizeDecoder<{ x: number; y: number }>,
+                {} as FixedSizeDecoder<null, 8>,
+                {} as FixedSizeDecoder<bigint | number, 8>,
+                {} as FixedSizeDecoder<{ value: string }, 8>,
+                {} as FixedSizeDecoder<{ x: number; y: number }, 8>,
             ],
             getIndex,
         );
-        decoder satisfies FixedSizeDecoder<bigint | number | { value: string } | { x: number; y: number } | null>;
+        decoder satisfies FixedSizeDecoder<bigint | number | { value: string } | { x: number; y: number } | null, 8>;
     }
 
-    // It does not return a fixed size decoder if any variant is variable size.
+    // It returns a variable size decoder if all variants are fixed size with different known sizes.
     {
-        const decoder = getUnionDecoder([{} as Decoder<number>, {} as FixedSizeDecoder<number>], getIndex);
+        const decoder = getUnionDecoder(
+            [{} as FixedSizeDecoder<number, 1>, {} as FixedSizeDecoder<number, 4>],
+            getIndex,
+        );
+        decoder satisfies VariableSizeDecoder<number>;
+        // @ts-expect-error Known unequal fixed sizes make the union variable at runtime.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
+
+    // It returns a decoder if all variants are fixed size but their sizes are not known.
+    {
+        const decoder = getUnionDecoder([{} as FixedSizeDecoder<number>, {} as FixedSizeDecoder<number>], getIndex);
         decoder satisfies Decoder<number>;
-        // @ts-expect-error Decoder is not fixed size.
+        // @ts-expect-error The two runtime sizes may differ.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
+
+    // It returns a decoder if fixed-size variants carry ambiguous literal-union sizes.
+    {
+        const decoder = getUnionDecoder(
+            [{} as FixedSizeDecoder<number, 1 | 4>, {} as FixedSizeDecoder<number, 1 | 4>],
+            getIndex,
+        );
+        decoder satisfies Decoder<number>;
+        // @ts-expect-error Each branch may resolve to different runtime sizes.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
+
+    // It returns a variable size decoder if any known variant is variable size.
+    {
+        const decoder = getUnionDecoder([{} as VariableSizeDecoder<number>, {} as FixedSizeDecoder<number>], getIndex);
+        decoder satisfies VariableSizeDecoder<number>;
+        // @ts-expect-error The runtime helper cannot expose fixedSize in this case.
         decoder satisfies FixedSizeDecoder<number>;
     }
 }
@@ -95,25 +189,69 @@ const getIndex = () => 0;
         ) satisfies Codec<bigint | number | { value: string } | { x: number; y: number } | null>;
     }
 
-    // It returns a fixed size codec if all variants are fixed size.
+    // It returns a fixed size codec if all variants are fixed size with the same size.
     {
         getUnionCodec(
             [
-                {} as FixedSizeCodec<null>,
-                {} as FixedSizeCodec<bigint | number>,
-                {} as FixedSizeCodec<{ value: string }>,
-                {} as FixedSizeCodec<{ x: number; y: number }>,
+                {} as FixedSizeCodec<null, null, 8>,
+                {} as FixedSizeCodec<bigint | number, bigint | number, 8>,
+                {} as FixedSizeCodec<{ value: string }, { value: string }, 8>,
+                {} as FixedSizeCodec<{ x: number; y: number }, { x: number; y: number }, 8>,
             ],
             getIndex,
             getIndex,
-        ) satisfies FixedSizeCodec<bigint | number | { value: string } | { x: number; y: number } | null>;
+        ) satisfies FixedSizeCodec<
+            bigint | number | { value: string } | { x: number; y: number } | null,
+            bigint | number | { value: string } | { x: number; y: number } | null,
+            8
+        >;
     }
 
-    // It does not return a fixed size codec if any variant is variable size.
+    // It returns a variable size codec if all variants are fixed size with different known sizes.
     {
-        const codec = getUnionCodec([{} as Codec<number>, {} as FixedSizeCodec<number>], getIndex, getIndex);
+        const codec = getUnionCodec(
+            [{} as FixedSizeCodec<number, number, 1>, {} as FixedSizeCodec<number, number, 4>],
+            getIndex,
+            getIndex,
+        );
+        codec satisfies VariableSizeCodec<number>;
+        // @ts-expect-error Known unequal fixed sizes make the union variable at runtime.
+        codec satisfies FixedSizeCodec<number>;
+    }
+
+    // It returns a codec if all variants are fixed size but their sizes are not known.
+    {
+        const codec = getUnionCodec([{} as FixedSizeCodec<number>, {} as FixedSizeCodec<number>], getIndex, getIndex);
         codec satisfies Codec<number>;
-        // @ts-expect-error Codec is not fixed size.
+        // @ts-expect-error The two runtime sizes may differ.
+        codec satisfies FixedSizeCodec<number>;
+        // @ts-expect-error The two runtime sizes may still match.
+        codec satisfies VariableSizeCodec<number>;
+    }
+
+    // It returns a codec if fixed-size variants carry ambiguous literal-union sizes.
+    {
+        const codec = getUnionCodec(
+            [{} as FixedSizeCodec<number, number, 1 | 4>, {} as FixedSizeCodec<number, number, 1 | 4>],
+            getIndex,
+            getIndex,
+        );
+        codec satisfies Codec<number>;
+        // @ts-expect-error Each branch may resolve to the same runtime size.
+        codec satisfies VariableSizeCodec<number>;
+        // @ts-expect-error Each branch may resolve to different runtime sizes.
+        codec satisfies FixedSizeCodec<number>;
+    }
+
+    // It returns a variable size codec if any known variant is variable size.
+    {
+        const codec = getUnionCodec(
+            [{} as VariableSizeCodec<number>, {} as FixedSizeCodec<number>],
+            getIndex,
+            getIndex,
+        );
+        codec satisfies VariableSizeCodec<number>;
+        // @ts-expect-error The runtime helper cannot expose fixedSize in this case.
         codec satisfies FixedSizeCodec<number>;
     }
 }

--- a/packages/codecs-data-structures/src/__typetests__/union-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/union-typetest.ts
@@ -114,6 +114,16 @@ const getIndex = () => 0;
         // @ts-expect-error The runtime helper cannot expose fixedSize in this case.
         encoder satisfies FixedSizeEncoder<number>;
     }
+
+    // It returns a plain encoder when a variant's size is entirely unknown.
+    {
+        const encoder = getUnionEncoder([{} as Encoder<number>, {} as FixedSizeEncoder<number>], getIndex);
+        encoder satisfies Encoder<number>;
+        // @ts-expect-error An unknown-size variant may be fixed or variable at runtime.
+        encoder satisfies FixedSizeEncoder<number>;
+        // @ts-expect-error An unknown-size variant may be fixed or variable at runtime.
+        encoder satisfies VariableSizeEncoder<number>;
+    }
 }
 
 // [DESCRIBE] getUnionDecoder.
@@ -284,5 +294,15 @@ const getIndex = () => 0;
         codec satisfies VariableSizeCodec<number>;
         // @ts-expect-error The runtime helper cannot expose fixedSize in this case.
         codec satisfies FixedSizeCodec<number>;
+    }
+
+    // It returns a plain codec when a variant's size is entirely unknown.
+    {
+        const codec = getUnionCodec([{} as Codec<number>, {} as FixedSizeCodec<number>], getIndex, getIndex);
+        codec satisfies Codec<number>;
+        // @ts-expect-error An unknown-size variant may be fixed or variable at runtime.
+        codec satisfies FixedSizeCodec<number>;
+        // @ts-expect-error An unknown-size variant may be fixed or variable at runtime.
+        codec satisfies VariableSizeCodec<number>;
     }
 }

--- a/packages/codecs-data-structures/src/__typetests__/union-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/union-typetest.ts
@@ -96,6 +96,17 @@ const getIndex = () => 0;
         encoder satisfies VariableSizeEncoder<number>;
     }
 
+    // It returns an encoder for dynamic arrays of variable-size variants.
+    {
+        const variants = [] as VariableSizeEncoder<number>[];
+        const encoder = getUnionEncoder(variants, getIndex);
+        encoder satisfies Encoder<number>;
+        // @ts-expect-error The array may be empty, whose runtime fixedSize is 0.
+        encoder satisfies FixedSizeEncoder<number>;
+        // @ts-expect-error The array may be non-empty, whose runtime is variable size.
+        encoder satisfies VariableSizeEncoder<number>;
+    }
+
     // It returns a variable size encoder if any known variant is variable size.
     {
         const encoder = getUnionEncoder([{} as VariableSizeEncoder<number>, {} as FixedSizeEncoder<number>], getIndex);
@@ -161,6 +172,15 @@ const getIndex = () => 0;
         );
         decoder satisfies Decoder<number>;
         // @ts-expect-error Each branch may resolve to different runtime sizes.
+        decoder satisfies FixedSizeDecoder<number>;
+    }
+
+    // It returns a decoder for dynamic arrays of variable-size variants.
+    {
+        const variants = [] as VariableSizeDecoder<number>[];
+        const decoder = getUnionDecoder(variants, getIndex);
+        decoder satisfies Decoder<number>;
+        // @ts-expect-error The array may be non-empty, whose runtime is variable size.
         decoder satisfies FixedSizeDecoder<number>;
     }
 
@@ -241,6 +261,17 @@ const getIndex = () => 0;
         codec satisfies VariableSizeCodec<number>;
         // @ts-expect-error Each branch may resolve to different runtime sizes.
         codec satisfies FixedSizeCodec<number>;
+    }
+
+    // It returns a codec for dynamic arrays of variable-size variants.
+    {
+        const variants = [] as VariableSizeCodec<number>[];
+        const codec = getUnionCodec(variants, getIndex, getIndex);
+        codec satisfies Codec<number>;
+        // @ts-expect-error The array may be empty, whose runtime fixedSize is 0.
+        codec satisfies FixedSizeCodec<number>;
+        // @ts-expect-error The array may be non-empty, whose runtime is variable size.
+        codec satisfies VariableSizeCodec<number>;
     }
 
     // It returns a variable size codec if any known variant is variable size.

--- a/packages/codecs-data-structures/src/pattern-match.ts
+++ b/packages/codecs-data-structures/src/pattern-match.ts
@@ -26,23 +26,35 @@ type PatternMatchEncoderEntry<TNarrowed, TFrom = TNarrowed> = TNarrowed extends 
           | readonly [(value: TFrom) => value is TNarrowed, Encoder<TNarrowed>]
     : never;
 
+type IsUnion<T, U = T> = [T] extends [never] ? false : T extends unknown ? ([U] extends [T] ? false : true) : false;
+
 type FixedSizePatternMatchEncoderEntry<
     TNarrowed,
     TFrom = TNarrowed,
     TSize extends number = number,
 > = TNarrowed extends TFrom
-    ? // Boolean predicate with original encoder
+    ?
           | readonly [(value: TFrom) => boolean, FixedSizeEncoder<TFrom, TSize>]
-          // Type predicate with narrowed encoder
           | readonly [(value: TFrom) => value is TNarrowed, FixedSizeEncoder<TNarrowed, TSize>]
     : never;
 
 type VariableSizePatternMatchEncoderEntry<TNarrowed, TFrom = TNarrowed> = TNarrowed extends TFrom
-    ? // Boolean predicate with original encoder
+    ?
           | readonly [(value: TFrom) => boolean, VariableSizeEncoder<TFrom>]
-          // Type predicate with narrowed encoder
           | readonly [(value: TFrom) => value is TNarrowed, VariableSizeEncoder<TNarrowed>]
     : never;
+
+type PatternMatchFixedSizeEncoder<TFrom, TSize extends number> = number extends TSize
+    ? Encoder<TFrom>
+    : IsUnion<TSize> extends true
+      ? Encoder<TFrom>
+      : FixedSizeEncoder<TFrom, TSize>;
+
+type PatternMatchFixedSizeDecoder<TTo, TSize extends number> = number extends TSize
+    ? Decoder<TTo>
+    : IsUnion<TSize> extends true
+      ? Decoder<TTo>
+      : FixedSizeDecoder<TTo, TSize>;
 
 /**
  * Returns an encoder that selects which variant encoder to use based on pattern matching.
@@ -91,10 +103,7 @@ type VariableSizePatternMatchEncoderEntry<TNarrowed, TFrom = TNarrowed> = TNarro
  */
 export function getPatternMatchEncoder<TFrom, TSize extends number>(
     patterns: FixedSizePatternMatchEncoderEntry<TFrom, TFrom, TSize>[],
-): FixedSizeEncoder<TFrom, TSize>;
-export function getPatternMatchEncoder<TFrom>(
-    patterns: FixedSizePatternMatchEncoderEntry<TFrom>[],
-): FixedSizeEncoder<TFrom>;
+): PatternMatchFixedSizeEncoder<TFrom, TSize>;
 export function getPatternMatchEncoder<TFrom>(
     patterns: VariableSizePatternMatchEncoderEntry<TFrom>[],
 ): VariableSizeEncoder<TFrom>;
@@ -148,10 +157,7 @@ export function getPatternMatchEncoder<TFrom>(patterns: PatternMatchEncoderEntry
  */
 export function getPatternMatchDecoder<TTo, TSize extends number>(
     patterns: [(value: ReadonlyUint8Array) => boolean, FixedSizeDecoder<TTo, TSize>][],
-): FixedSizeDecoder<TTo, TSize>;
-export function getPatternMatchDecoder<TTo>(
-    patterns: [(value: ReadonlyUint8Array) => boolean, FixedSizeDecoder<TTo>][],
-): FixedSizeDecoder<TTo>;
+): PatternMatchFixedSizeDecoder<TTo, TSize>;
 export function getPatternMatchDecoder<TTo>(
     patterns: [(value: ReadonlyUint8Array) => boolean, VariableSizeDecoder<TTo>][],
 ): VariableSizeDecoder<TTo>;
@@ -228,6 +234,12 @@ type VariableSizePatternMatchCodecEntry<
         : never
     : never;
 
+type PatternMatchFixedSizeCodec<TFrom, TTo extends TFrom, TSize extends number> = number extends TSize
+    ? Codec<TFrom, TTo>
+    : IsUnion<TSize> extends true
+      ? Codec<TFrom, TTo>
+      : FixedSizeCodec<TFrom, TTo, TSize>;
+
 /**
  * Returns a codec that selects which variant codec to use based on pattern matching.
  *
@@ -290,10 +302,7 @@ type VariableSizePatternMatchCodecEntry<
  */
 export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom, TSize extends number = number>(
     patterns: FixedSizePatternMatchCodecEntry<TFrom, TFrom, TTo, TSize>[],
-): FixedSizeCodec<TFrom, TTo, TSize>;
-export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom>(
-    patterns: FixedSizePatternMatchCodecEntry<TFrom, TFrom, TTo>[],
-): FixedSizeCodec<TFrom, TTo>;
+): PatternMatchFixedSizeCodec<TFrom, TTo, TSize>;
 export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom>(
     patterns: VariableSizePatternMatchCodecEntry<TFrom, TFrom, TTo>[],
 ): VariableSizeCodec<TFrom, TTo>;

--- a/packages/codecs-data-structures/src/pattern-match.ts
+++ b/packages/codecs-data-structures/src/pattern-match.ts
@@ -236,7 +236,6 @@ export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom>(
 ): Codec<TFrom, TTo> {
     return combineCodec(
         getPatternMatchEncoder(patterns.map(([valuePredicate, , codec]) => [valuePredicate, codec]) as any),
-
         getPatternMatchDecoder(patterns.map(([, bytesPredicate, codec]) => [bytesPredicate, codec]) as any),
     );
 }

--- a/packages/codecs-data-structures/src/pattern-match.ts
+++ b/packages/codecs-data-structures/src/pattern-match.ts
@@ -1,16 +1,5 @@
-import {
-    Codec,
-    combineCodec,
-    Decoder,
-    Encoder,
-    FixedSizeCodec,
-    FixedSizeDecoder,
-    FixedSizeEncoder,
-    ReadonlyUint8Array,
-    VariableSizeCodec,
-    VariableSizeDecoder,
-    VariableSizeEncoder,
-} from '@solana/codecs-core';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Codec, combineCodec, Decoder, Encoder, ReadonlyUint8Array } from '@solana/codecs-core';
 import {
     SOLANA_ERROR__CODECS__INVALID_PATTERN_MATCH_BYTES,
     SOLANA_ERROR__CODECS__INVALID_PATTERN_MATCH_VALUE,
@@ -18,6 +7,7 @@ import {
 } from '@solana/errors';
 
 import { getUnionDecoder, getUnionEncoder } from './union';
+import { GetEncoderTypeFromVariants, GetUnionCodecType, GetUnionDecoderType, GetUnionEncoderType } from './utils';
 
 type PatternMatchEncoderEntry<TNarrowed, TFrom = TNarrowed> = TNarrowed extends TFrom
     ? // Boolean predicate with original encoder
@@ -26,35 +16,28 @@ type PatternMatchEncoderEntry<TNarrowed, TFrom = TNarrowed> = TNarrowed extends 
           | readonly [(value: TFrom) => value is TNarrowed, Encoder<TNarrowed>]
     : never;
 
-type IsUnion<T, U = T> = [T] extends [never] ? false : T extends unknown ? ([U] extends [T] ? false : true) : false;
+type PatternMatchDecoderEntry<TTo> = readonly [(bytes: ReadonlyUint8Array) => boolean, Decoder<TTo>];
 
-type FixedSizePatternMatchEncoderEntry<
-    TNarrowed,
-    TFrom = TNarrowed,
-    TSize extends number = number,
-> = TNarrowed extends TFrom
-    ?
-          | readonly [(value: TFrom) => boolean, FixedSizeEncoder<TFrom, TSize>]
-          | readonly [(value: TFrom) => value is TNarrowed, FixedSizeEncoder<TNarrowed, TSize>]
-    : never;
+/** Extracts the tuple of variant encoders from a tuple of `[predicate, encoder]` entries. */
+type GetPatternMatchEncoders<TPatterns extends readonly PatternMatchEncoderEntry<any>[]> = {
+    [I in keyof TPatterns]: TPatterns[I] extends readonly [unknown, infer TEncoder extends Encoder<any>]
+        ? TEncoder
+        : never;
+};
 
-type VariableSizePatternMatchEncoderEntry<TNarrowed, TFrom = TNarrowed> = TNarrowed extends TFrom
-    ?
-          | readonly [(value: TFrom) => boolean, VariableSizeEncoder<TFrom>]
-          | readonly [(value: TFrom) => value is TNarrowed, VariableSizeEncoder<TNarrowed>]
-    : never;
+/** Extracts the tuple of variant decoders from a tuple of `[predicate, decoder]` entries. */
+type GetPatternMatchDecoders<TPatterns extends readonly PatternMatchDecoderEntry<any>[]> = {
+    [I in keyof TPatterns]: TPatterns[I] extends readonly [unknown, infer TDecoder extends Decoder<any>]
+        ? TDecoder
+        : never;
+};
 
-type PatternMatchFixedSizeEncoder<TFrom, TSize extends number> = number extends TSize
-    ? Encoder<TFrom>
-    : IsUnion<TSize> extends true
-      ? Encoder<TFrom>
-      : FixedSizeEncoder<TFrom, TSize>;
-
-type PatternMatchFixedSizeDecoder<TTo, TSize extends number> = number extends TSize
-    ? Decoder<TTo>
-    : IsUnion<TSize> extends true
-      ? Decoder<TTo>
-      : FixedSizeDecoder<TTo, TSize>;
+/** Extracts the tuple of variant codecs from a tuple of `[valuePredicate, bytesPredicate, codec]` entries. */
+type GetPatternMatchCodecs<TPatterns extends readonly PatternMatchCodecEntry<any>[]> = {
+    [I in keyof TPatterns]: TPatterns[I] extends readonly [unknown, unknown, infer TCodec extends Codec<any>]
+        ? TCodec
+        : never;
+};
 
 /**
  * Returns an encoder that selects which variant encoder to use based on pattern matching.
@@ -101,13 +84,10 @@ type PatternMatchFixedSizeDecoder<TTo, TSize extends number> = number extends TS
  *
  * @see {@link getPatternMatchCodec}
  */
-export function getPatternMatchEncoder<TFrom, TSize extends number>(
-    patterns: FixedSizePatternMatchEncoderEntry<TFrom, TFrom, TSize>[],
-): PatternMatchFixedSizeEncoder<TFrom, TSize>;
-export function getPatternMatchEncoder<TFrom>(
-    patterns: VariableSizePatternMatchEncoderEntry<TFrom>[],
-): VariableSizeEncoder<TFrom>;
-export function getPatternMatchEncoder<TFrom>(patterns: PatternMatchEncoderEntry<TFrom>[]): Encoder<TFrom>;
+export function getPatternMatchEncoder<const TPatterns extends readonly PatternMatchEncoderEntry<any>[]>(
+    patterns: TPatterns &
+        readonly PatternMatchEncoderEntry<GetEncoderTypeFromVariants<GetPatternMatchEncoders<TPatterns>>>[],
+): GetUnionEncoderType<GetPatternMatchEncoders<TPatterns>>;
 export function getPatternMatchEncoder<TFrom>(patterns: PatternMatchEncoderEntry<TFrom>[]): Encoder<TFrom> {
     return getUnionEncoder(
         patterns.map(([, encoder]) => encoder),
@@ -155,15 +135,9 @@ export function getPatternMatchEncoder<TFrom>(patterns: PatternMatchEncoderEntry
  * @see {@link getPatternMatchCodec}
  * @see {@link getPatternMatchEncoder}
  */
-export function getPatternMatchDecoder<TTo, TSize extends number>(
-    patterns: [(value: ReadonlyUint8Array) => boolean, FixedSizeDecoder<TTo, TSize>][],
-): PatternMatchFixedSizeDecoder<TTo, TSize>;
-export function getPatternMatchDecoder<TTo>(
-    patterns: [(value: ReadonlyUint8Array) => boolean, VariableSizeDecoder<TTo>][],
-): VariableSizeDecoder<TTo>;
-export function getPatternMatchDecoder<TTo>(
-    patterns: [(value: ReadonlyUint8Array) => boolean, Decoder<TTo>][],
-): Decoder<TTo>;
+export function getPatternMatchDecoder<const TPatterns extends readonly PatternMatchDecoderEntry<any>[]>(
+    patterns: TPatterns,
+): GetUnionDecoderType<GetPatternMatchDecoders<TPatterns>>;
 export function getPatternMatchDecoder<TTo>(
     patterns: [(value: ReadonlyUint8Array) => boolean, Decoder<TTo>][],
 ): Decoder<TTo> {
@@ -192,53 +166,6 @@ type PatternMatchCodecEntry<TNarrowedFrom, TFrom = TNarrowedFrom, TTo = TNarrowe
               | readonly [(value: TFrom) => boolean, (bytes: ReadonlyUint8Array) => boolean, Codec<TFrom, TTo>]
         : never
     : never;
-
-type FixedSizePatternMatchCodecEntry<
-    TNarrowedFrom,
-    TFrom = TNarrowedFrom,
-    TTo = TNarrowedFrom,
-    TSize extends number = number,
-> = TNarrowedFrom extends TFrom
-    ? TTo extends TNarrowedFrom
-        ?
-              | readonly [
-                    (value: TFrom) => boolean,
-                    (bytes: ReadonlyUint8Array) => boolean,
-                    FixedSizeCodec<TFrom, TTo, TSize>,
-                ]
-              | readonly [
-                    (value: TFrom) => value is TNarrowedFrom,
-                    (bytes: ReadonlyUint8Array) => boolean,
-                    FixedSizeCodec<TNarrowedFrom, TTo, TSize>,
-                ]
-        : never
-    : never;
-
-type VariableSizePatternMatchCodecEntry<
-    TNarrowedFrom,
-    TFrom = TNarrowedFrom,
-    TTo = TNarrowedFrom,
-> = TNarrowedFrom extends TFrom
-    ? TTo extends TNarrowedFrom
-        ?
-              | readonly [
-                    (value: TFrom) => boolean,
-                    (bytes: ReadonlyUint8Array) => boolean,
-                    VariableSizeCodec<TFrom, TTo>,
-                ]
-              | readonly [
-                    (value: TFrom) => value is TNarrowedFrom,
-                    (bytes: ReadonlyUint8Array) => boolean,
-                    VariableSizeCodec<TNarrowedFrom, TTo>,
-                ]
-        : never
-    : never;
-
-type PatternMatchFixedSizeCodec<TFrom, TTo extends TFrom, TSize extends number> = number extends TSize
-    ? Codec<TFrom, TTo>
-    : IsUnion<TSize> extends true
-      ? Codec<TFrom, TTo>
-      : FixedSizeCodec<TFrom, TTo, TSize>;
 
 /**
  * Returns a codec that selects which variant codec to use based on pattern matching.
@@ -300,22 +227,16 @@ type PatternMatchFixedSizeCodec<TFrom, TTo extends TFrom, TSize extends number> 
  * @see {@link getPatternMatchDecoder}
  * @see {@link getUnionCodec}
  */
-export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom, TSize extends number = number>(
-    patterns: FixedSizePatternMatchCodecEntry<TFrom, TFrom, TTo, TSize>[],
-): PatternMatchFixedSizeCodec<TFrom, TTo, TSize>;
-export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom>(
-    patterns: VariableSizePatternMatchCodecEntry<TFrom, TFrom, TTo>[],
-): VariableSizeCodec<TFrom, TTo>;
-export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom>(
-    patterns: PatternMatchCodecEntry<TFrom, TFrom, TTo>[],
-): Codec<TFrom, TTo>;
+export function getPatternMatchCodec<const TPatterns extends readonly PatternMatchCodecEntry<any>[]>(
+    patterns: TPatterns &
+        readonly PatternMatchCodecEntry<GetEncoderTypeFromVariants<GetPatternMatchCodecs<TPatterns>>>[],
+): GetUnionCodecType<GetPatternMatchCodecs<TPatterns>>;
 export function getPatternMatchCodec<TFrom, TTo extends TFrom = TFrom>(
     patterns: PatternMatchCodecEntry<TFrom, TFrom, TTo>[],
 ): Codec<TFrom, TTo> {
     return combineCodec(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         getPatternMatchEncoder(patterns.map(([valuePredicate, , codec]) => [valuePredicate, codec]) as any),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
         getPatternMatchDecoder(patterns.map(([, bytesPredicate, codec]) => [bytesPredicate, codec]) as any),
     );
 }

--- a/packages/codecs-data-structures/src/predicate.ts
+++ b/packages/codecs-data-structures/src/predicate.ts
@@ -1,17 +1,37 @@
-import {
-    Codec,
-    Decoder,
-    Encoder,
-    FixedSizeCodec,
-    FixedSizeDecoder,
-    FixedSizeEncoder,
-    ReadonlyUint8Array,
-    VariableSizeCodec,
-    VariableSizeDecoder,
-    VariableSizeEncoder,
-} from '@solana/codecs-core';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Codec, Decoder, Encoder, ReadonlyUint8Array } from '@solana/codecs-core';
 
 import { getUnionCodec, getUnionDecoder, getUnionEncoder } from './union';
+import {
+    GetDecoderTypeFromVariants,
+    GetEncoderTypeFromVariants,
+    GetUnionCodecType,
+    GetUnionDecoderType,
+    GetUnionEncoderType,
+} from './utils';
+
+// Keep predicate branches on one value type. Pattern matching supports type guards for narrowed branches.
+type SameType<TExpected, TActual> = [TExpected] extends [TActual]
+    ? [TActual] extends [TExpected]
+        ? unknown
+        : never
+    : never;
+
+type SameEncoderType<TIfTrue extends Encoder<any>, TIfFalse extends Encoder<any>> = SameType<
+    GetEncoderTypeFromVariants<readonly [TIfTrue]>,
+    GetEncoderTypeFromVariants<readonly [TIfFalse]>
+>;
+
+type SameDecoderType<TIfTrue extends Decoder<any>, TIfFalse extends Decoder<any>> = SameType<
+    GetDecoderTypeFromVariants<readonly [TIfTrue]>,
+    GetDecoderTypeFromVariants<readonly [TIfFalse]>
+>;
+
+type SameCodecType<TIfTrue extends Codec<any>, TIfFalse extends Codec<any>> = SameType<
+    GetEncoderTypeFromVariants<readonly [TIfTrue]>,
+    GetEncoderTypeFromVariants<readonly [TIfFalse]>
+> &
+    SameType<GetDecoderTypeFromVariants<readonly [TIfTrue]>, GetDecoderTypeFromVariants<readonly [TIfFalse]>>;
 
 /**
  * Returns an encoder that selects between two encoders based on a predicate.
@@ -47,32 +67,18 @@ import { getUnionCodec, getUnionDecoder, getUnionEncoder } from './union';
  *
  * @see {@link getPredicateCodec}
  */
-export function getPredicateEncoder<TFrom, TSize extends number>(
+export function getPredicateEncoder<
+    TFrom = any,
+    const TIfTrue extends Encoder<TFrom> = Encoder<TFrom>,
+    const TIfFalse extends Encoder<TFrom> = Encoder<TFrom>,
+>(
     predicate: (value: TFrom) => boolean,
-    ifTrue: FixedSizeEncoder<TFrom, TSize>,
-    ifFalse: FixedSizeEncoder<TFrom, TSize>,
-): FixedSizeEncoder<TFrom, TSize>;
-export function getPredicateEncoder<TFrom>(
-    predicate: (value: TFrom) => boolean,
-    ifTrue: FixedSizeEncoder<TFrom>,
-    ifFalse: FixedSizeEncoder<TFrom>,
-): FixedSizeEncoder<TFrom>;
-export function getPredicateEncoder<TFrom>(
-    predicate: (value: TFrom) => boolean,
-    ifTrue: VariableSizeEncoder<TFrom>,
-    ifFalse: VariableSizeEncoder<TFrom>,
-): VariableSizeEncoder<TFrom>;
-export function getPredicateEncoder<TFrom>(
-    predicate: (value: TFrom) => boolean,
-    ifTrue: Encoder<TFrom>,
-    ifFalse: Encoder<TFrom>,
-): Encoder<TFrom>;
-export function getPredicateEncoder<TFrom>(
-    predicate: (value: TFrom) => boolean,
-    ifTrue: Encoder<TFrom>,
-    ifFalse: Encoder<TFrom>,
-): Encoder<TFrom> {
-    return getUnionEncoder([ifTrue, ifFalse], (value: TFrom) => (predicate(value) ? 0 : 1));
+    ifTrue: TIfTrue,
+    ifFalse: SameEncoderType<TIfTrue, TIfFalse> & TIfFalse,
+): GetUnionEncoderType<readonly [TIfTrue, TIfFalse]> {
+    return getUnionEncoder([ifTrue, ifFalse], (value: GetEncoderTypeFromVariants<readonly [TIfTrue, TIfFalse]>) =>
+        predicate(value as TFrom) ? 0 : 1,
+    ) as GetUnionEncoderType<readonly [TIfTrue, TIfFalse]>;
 }
 
 /**
@@ -107,32 +113,18 @@ export function getPredicateEncoder<TFrom>(
  *
  * @see {@link getPredicateCodec}
  */
-export function getPredicateDecoder<TTo, TSize extends number>(
+export function getPredicateDecoder<
+    TTo = any,
+    const TIfTrue extends Decoder<TTo> = Decoder<TTo>,
+    const TIfFalse extends Decoder<TTo> = Decoder<TTo>,
+>(
     predicate: (value: ReadonlyUint8Array) => boolean,
-    ifTrue: FixedSizeDecoder<TTo, TSize>,
-    ifFalse: FixedSizeDecoder<TTo, TSize>,
-): FixedSizeDecoder<TTo, TSize>;
-export function getPredicateDecoder<TTo>(
-    predicate: (value: ReadonlyUint8Array) => boolean,
-    ifTrue: FixedSizeDecoder<TTo>,
-    ifFalse: FixedSizeDecoder<TTo>,
-): FixedSizeDecoder<TTo>;
-export function getPredicateDecoder<TTo>(
-    predicate: (value: ReadonlyUint8Array) => boolean,
-    ifTrue: VariableSizeDecoder<TTo>,
-    ifFalse: VariableSizeDecoder<TTo>,
-): VariableSizeDecoder<TTo>;
-export function getPredicateDecoder<TTo>(
-    predicate: (value: ReadonlyUint8Array) => boolean,
-    ifTrue: Decoder<TTo>,
-    ifFalse: Decoder<TTo>,
-): Decoder<TTo>;
-export function getPredicateDecoder<TTo>(
-    predicate: (value: ReadonlyUint8Array) => boolean,
-    ifTrue: Decoder<TTo>,
-    ifFalse: Decoder<TTo>,
-): Decoder<TTo> {
-    return getUnionDecoder([ifTrue, ifFalse], (value: ReadonlyUint8Array) => (predicate(value) ? 0 : 1));
+    ifTrue: TIfTrue,
+    ifFalse: SameDecoderType<TIfTrue, TIfFalse> & TIfFalse,
+): GetUnionDecoderType<readonly [TIfTrue, TIfFalse]> {
+    return getUnionDecoder([ifTrue, ifFalse], (value: ReadonlyUint8Array) =>
+        predicate(value) ? 0 : 1,
+    ) as GetUnionDecoderType<readonly [TIfTrue, TIfFalse]>;
 }
 
 /**
@@ -176,39 +168,20 @@ export function getPredicateDecoder<TTo>(
  * @see {@link getPredicateEncoder}
  * @see {@link getPredicateDecoder}
  */
-export function getPredicateCodec<TFrom, TTo extends TFrom, TSize extends number>(
+export function getPredicateCodec<
+    TFrom = any,
+    TTo extends TFrom = TFrom,
+    const TIfTrue extends Codec<TFrom, TTo> = Codec<TFrom, TTo>,
+    const TIfFalse extends Codec<TFrom, TTo> = Codec<TFrom, TTo>,
+>(
     encodePredicate: (value: TFrom) => boolean,
     decodePredicate: (value: ReadonlyUint8Array) => boolean,
-    ifTrue: FixedSizeCodec<TFrom, TTo, TSize>,
-    ifFalse: FixedSizeCodec<TFrom, TTo, TSize>,
-): FixedSizeCodec<TFrom, TTo, TSize>;
-export function getPredicateCodec<TFrom, TTo extends TFrom>(
-    encodePredicate: (value: TFrom) => boolean,
-    decodePredicate: (value: ReadonlyUint8Array) => boolean,
-    ifTrue: FixedSizeCodec<TFrom, TTo>,
-    ifFalse: FixedSizeCodec<TFrom, TTo>,
-): FixedSizeCodec<TFrom, TTo>;
-export function getPredicateCodec<TFrom, TTo extends TFrom>(
-    encodePredicate: (value: TFrom) => boolean,
-    decodePredicate: (value: ReadonlyUint8Array) => boolean,
-    ifTrue: VariableSizeCodec<TFrom, TTo>,
-    ifFalse: VariableSizeCodec<TFrom, TTo>,
-): VariableSizeCodec<TFrom, TTo>;
-export function getPredicateCodec<TFrom, TTo extends TFrom>(
-    encodePredicate: (value: TFrom) => boolean,
-    decodePredicate: (value: ReadonlyUint8Array) => boolean,
-    ifTrue: Codec<TFrom, TTo>,
-    ifFalse: Codec<TFrom, TTo>,
-): Codec<TFrom, TTo>;
-export function getPredicateCodec<TFrom, TTo extends TFrom>(
-    encodePredicate: (value: TFrom) => boolean,
-    decodePredicate: (value: ReadonlyUint8Array) => boolean,
-    ifTrue: Codec<TFrom, TTo>,
-    ifFalse: Codec<TFrom, TTo>,
-): Codec<TFrom, TTo> {
+    ifTrue: TIfTrue,
+    ifFalse: SameCodecType<TIfTrue, TIfFalse> & TIfFalse,
+): GetUnionCodecType<readonly [TIfTrue, TIfFalse]> {
     return getUnionCodec(
         [ifTrue, ifFalse],
-        (value: TFrom) => (encodePredicate(value) ? 0 : 1),
+        (value: GetEncoderTypeFromVariants<readonly [TIfTrue, TIfFalse]>) => (encodePredicate(value as TFrom) ? 0 : 1),
         (value: ReadonlyUint8Array) => (decodePredicate(value) ? 0 : 1),
-    );
+    ) as GetUnionCodecType<readonly [TIfTrue, TIfFalse]>;
 }

--- a/packages/codecs-data-structures/src/union.ts
+++ b/packages/codecs-data-structures/src/union.ts
@@ -6,9 +6,6 @@ import {
     createEncoder,
     Decoder,
     Encoder,
-    FixedSizeCodec,
-    FixedSizeDecoder,
-    FixedSizeEncoder,
     getEncodedSize,
     isFixedSize,
     Offset,
@@ -16,47 +13,15 @@ import {
 } from '@solana/codecs-core';
 import { SOLANA_ERROR__CODECS__UNION_VARIANT_OUT_OF_RANGE, SolanaError } from '@solana/errors';
 
-import { DrainOuterGeneric, getMaxSize, maxCodecSizes } from './utils';
-
-/**
- * Infers the TypeScript type for values that can be encoded using a union codec.
- *
- * This type maps the provided variant encoders to their corresponding value types.
- *
- * @typeParam TVariants - An array of encoders, each corresponding to a union variant.
- */
-type GetEncoderTypeFromVariants<TVariants extends readonly Encoder<any>[]> = DrainOuterGeneric<{
-    [I in keyof TVariants]: TVariants[I] extends Encoder<infer TFrom> ? TFrom : never;
-}>[number];
-
-/**
- * Infers the TypeScript type for values that can be decoded using a union codec.
- *
- * This type maps the provided variant decoders to their corresponding value types.
- *
- * @typeParam TVariants - An array of decoders, each corresponding to a union variant.
- */
-type GetDecoderTypeFromVariants<TVariants extends readonly Decoder<any>[]> = DrainOuterGeneric<{
-    [I in keyof TVariants]: TVariants[I] extends Decoder<infer TFrom> ? TFrom : never;
-}>[number];
-
-type UnionEncoder<TVariants extends readonly Encoder<unknown>[]> = TVariants extends readonly FixedSizeEncoder<any>[]
-    ? FixedSizeEncoder<GetEncoderTypeFromVariants<TVariants>>
-    : Encoder<GetEncoderTypeFromVariants<TVariants>>;
-
-type UnionDecoder<TVariants extends readonly Decoder<unknown>[]> = TVariants extends readonly FixedSizeDecoder<any>[]
-    ? FixedSizeDecoder<GetDecoderTypeFromVariants<TVariants>>
-    : Decoder<GetDecoderTypeFromVariants<TVariants>>;
-
-type UnionCodec<TVariants extends readonly Codec<unknown>[]> = TVariants extends readonly FixedSizeCodec<any>[]
-    ? FixedSizeCodec<
-          GetEncoderTypeFromVariants<TVariants>,
-          GetDecoderTypeFromVariants<TVariants> & GetEncoderTypeFromVariants<TVariants>
-      >
-    : Codec<
-          GetEncoderTypeFromVariants<TVariants>,
-          GetDecoderTypeFromVariants<TVariants> & GetEncoderTypeFromVariants<TVariants>
-      >;
+import {
+    GetDecoderTypeFromVariants,
+    GetEncoderTypeFromVariants,
+    getMaxSize,
+    GetUnionCodecType,
+    GetUnionDecoderType,
+    GetUnionEncoderType,
+    maxCodecSizes,
+} from './utils';
 
 /**
  * Returns an encoder for union types.
@@ -97,7 +62,7 @@ type UnionCodec<TVariants extends readonly Codec<unknown>[]> = TVariants extends
 export function getUnionEncoder<const TVariants extends readonly Encoder<any>[]>(
     variants: TVariants,
     getIndexFromValue: (value: GetEncoderTypeFromVariants<TVariants>) => number,
-): UnionEncoder<TVariants> {
+): GetUnionEncoderType<TVariants> {
     type TFrom = GetEncoderTypeFromVariants<TVariants>;
     const fixedSize = getUnionFixedSize(variants);
     const write: Encoder<TFrom>['write'] = (variant, bytes, offset) => {
@@ -107,7 +72,7 @@ export function getUnionEncoder<const TVariants extends readonly Encoder<any>[]>
     };
 
     if (fixedSize !== null) {
-        return createEncoder({ fixedSize, write }) as UnionEncoder<TVariants>;
+        return createEncoder({ fixedSize, write }) as GetUnionEncoderType<TVariants>;
     }
 
     const maxSize = getUnionMaxSize(variants);
@@ -119,7 +84,7 @@ export function getUnionEncoder<const TVariants extends readonly Encoder<any>[]>
             return getEncodedSize(variant, variants[index]);
         },
         write,
-    }) as UnionEncoder<TVariants>;
+    }) as GetUnionEncoderType<TVariants>;
 }
 
 /**
@@ -157,7 +122,7 @@ export function getUnionEncoder<const TVariants extends readonly Encoder<any>[]>
 export function getUnionDecoder<const TVariants extends readonly Decoder<any>[]>(
     variants: TVariants,
     getIndexFromBytes: (bytes: ReadonlyUint8Array, offset: Offset) => number,
-): UnionDecoder<TVariants> {
+): GetUnionDecoderType<TVariants> {
     type TTo = GetDecoderTypeFromVariants<TVariants>;
     const fixedSize = getUnionFixedSize(variants);
     const read: Decoder<TTo>['read'] = (bytes, offset) => {
@@ -167,11 +132,11 @@ export function getUnionDecoder<const TVariants extends readonly Decoder<any>[]>
     };
 
     if (fixedSize !== null) {
-        return createDecoder({ fixedSize, read }) as UnionDecoder<TVariants>;
+        return createDecoder({ fixedSize, read }) as GetUnionDecoderType<TVariants>;
     }
 
     const maxSize = getUnionMaxSize(variants);
-    return createDecoder({ ...(maxSize !== null ? { maxSize } : {}), read }) as UnionDecoder<TVariants>;
+    return createDecoder({ ...(maxSize !== null ? { maxSize } : {}), read }) as GetUnionDecoderType<TVariants>;
 }
 
 /**
@@ -225,13 +190,13 @@ export function getUnionCodec<const TVariants extends readonly Codec<any>[]>(
     variants: TVariants,
     getIndexFromValue: (value: GetEncoderTypeFromVariants<TVariants>) => number,
     getIndexFromBytes: (bytes: ReadonlyUint8Array, offset: Offset) => number,
-): UnionCodec<TVariants> {
+): GetUnionCodecType<TVariants> {
     return combineCodec(
         getUnionEncoder(variants, getIndexFromValue),
         getUnionDecoder(variants as readonly Decoder<any>[], getIndexFromBytes) as Decoder<
             GetDecoderTypeFromVariants<TVariants> & GetEncoderTypeFromVariants<TVariants>
         >,
-    ) as UnionCodec<TVariants>;
+    ) as GetUnionCodecType<TVariants>;
 }
 
 function assertValidVariantIndex(variants: readonly unknown[], index: number) {

--- a/packages/codecs-data-structures/src/utils.ts
+++ b/packages/codecs-data-structures/src/utils.ts
@@ -1,4 +1,16 @@
-import { isFixedSize } from '@solana/codecs-core';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import {
+    Codec,
+    Decoder,
+    Encoder,
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+    isFixedSize,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
+} from '@solana/codecs-core';
 
 /**
  * Functionally, this type helper is equivalent to the identity type — i.e. `type Identity<T> = T`.
@@ -11,6 +23,131 @@ import { isFixedSize } from '@solana/codecs-core';
  * @see https://github.com/kysely-org/kysely/pull/483
  */
 export type DrainOuterGeneric<T> = [T] extends [unknown] ? T : never;
+
+type IsUnion<T, U = T> = [T] extends [never] ? false : T extends unknown ? ([U] extends [T] ? false : true) : false;
+
+type IsPreciseNumberLiteral<TSize extends number> = number extends TSize
+    ? false
+    : IsUnion<TSize> extends true
+      ? false
+      : true;
+
+type ContainsVariableSizeCodec<TItems extends readonly unknown[], TVariableSizeCodec> = number extends TItems['length']
+    ? [TItems[number]] extends [TVariableSizeCodec]
+        ? true
+        : false
+    : TItems extends readonly [infer THead, ...infer TTail]
+      ? [THead] extends [TVariableSizeCodec]
+          ? true
+          : ContainsVariableSizeCodec<TTail, TVariableSizeCodec>
+      : false;
+
+type GetFixedCodecSize<TItem> = TItem extends { readonly fixedSize: infer TSize }
+    ? TSize extends number
+        ? TSize
+        : never
+    : never;
+
+type GetFixedCodecSizeState<TItems extends readonly unknown[]> = TItems extends readonly []
+    ? readonly ['fixed', 0]
+    : TItems extends readonly [infer TOnly]
+      ? readonly ['fixed', GetFixedCodecSize<TOnly>]
+      : number extends TItems['length']
+        ? IsPreciseNumberLiteral<GetFixedCodecSize<TItems[number]>> extends true
+            ? readonly ['fixed', number]
+            : readonly ['unknown']
+        : GetFixedCodecSizeTupleState<TItems>;
+
+type GetFixedCodecSizeTupleState<
+    TItems extends readonly unknown[],
+    TExpectedSize extends number | undefined = undefined,
+> = TItems extends readonly [infer THead, ...infer TTail]
+    ? GetFixedCodecSize<THead> extends infer THeadSize extends number
+        ? IsPreciseNumberLiteral<THeadSize> extends true
+            ? TExpectedSize extends number
+                ? THeadSize extends TExpectedSize
+                    ? GetFixedCodecSizeTupleState<TTail, TExpectedSize>
+                    : readonly ['variable']
+                : GetFixedCodecSizeTupleState<TTail, THeadSize>
+            : readonly ['unknown']
+        : never
+    : TExpectedSize extends number
+      ? readonly ['fixed', TExpectedSize]
+      : readonly ['fixed', 0];
+
+/** Infers the TypeScript type for values that can be encoded using a list of variant encoders. */
+export type GetEncoderTypeFromVariants<TVariants extends readonly Encoder<any>[]> = DrainOuterGeneric<{
+    [I in keyof TVariants]: TVariants[I] extends Encoder<infer TFrom> ? TFrom : never;
+}>[number];
+
+/** Infers the TypeScript type for values that can be decoded using a list of variant decoders. */
+export type GetDecoderTypeFromVariants<TVariants extends readonly Decoder<any>[]> = DrainOuterGeneric<{
+    [I in keyof TVariants]: TVariants[I] extends Decoder<infer TFrom> ? TFrom : never;
+}>[number];
+
+type GetFixedSizeEncoderFromVariants<TVariants extends readonly FixedSizeEncoder<any, any>[]> =
+    GetFixedCodecSizeState<TVariants> extends readonly ['fixed', infer TSize extends number]
+        ? FixedSizeEncoder<GetEncoderTypeFromVariants<TVariants>, TSize>
+        : GetFixedCodecSizeState<TVariants> extends readonly ['variable']
+          ? VariableSizeEncoder<GetEncoderTypeFromVariants<TVariants>>
+          : Encoder<GetEncoderTypeFromVariants<TVariants>>;
+
+type GetFixedSizeDecoderFromVariants<TVariants extends readonly FixedSizeDecoder<any, any>[]> =
+    GetFixedCodecSizeState<TVariants> extends readonly ['fixed', infer TSize extends number]
+        ? FixedSizeDecoder<GetDecoderTypeFromVariants<TVariants>, TSize>
+        : GetFixedCodecSizeState<TVariants> extends readonly ['variable']
+          ? VariableSizeDecoder<GetDecoderTypeFromVariants<TVariants>>
+          : Decoder<GetDecoderTypeFromVariants<TVariants>>;
+
+type GetFixedSizeCodecFromVariants<TVariants extends readonly FixedSizeCodec<any, any, any>[]> =
+    GetFixedCodecSizeState<TVariants> extends readonly ['fixed', infer TSize extends number]
+        ? FixedSizeCodec<
+              GetEncoderTypeFromVariants<TVariants>,
+              GetDecoderTypeFromVariants<TVariants> & GetEncoderTypeFromVariants<TVariants>,
+              TSize
+          >
+        : GetFixedCodecSizeState<TVariants> extends readonly ['variable']
+          ? VariableSizeCodec<
+                GetEncoderTypeFromVariants<TVariants>,
+                GetDecoderTypeFromVariants<TVariants> & GetEncoderTypeFromVariants<TVariants>
+            >
+          : Codec<
+                GetEncoderTypeFromVariants<TVariants>,
+                GetDecoderTypeFromVariants<TVariants> & GetEncoderTypeFromVariants<TVariants>
+            >;
+
+/** Infers whether a union encoder is fixed-size, variable-size, or unknown from its variant encoders. */
+export type GetUnionEncoderType<TVariants extends readonly Encoder<any>[]> =
+    TVariants extends readonly FixedSizeEncoder<any, any>[]
+        ? GetFixedSizeEncoderFromVariants<TVariants>
+        : ContainsVariableSizeCodec<TVariants, VariableSizeEncoder<any>> extends true
+          ? VariableSizeEncoder<GetEncoderTypeFromVariants<TVariants>>
+          : Encoder<GetEncoderTypeFromVariants<TVariants>>;
+
+/** Infers whether a union decoder is fixed-size, variable-size, or unknown from its variant decoders. */
+export type GetUnionDecoderType<TVariants extends readonly Decoder<any>[]> =
+    TVariants extends readonly FixedSizeDecoder<any, any>[]
+        ? GetFixedSizeDecoderFromVariants<TVariants>
+        : ContainsVariableSizeCodec<TVariants, VariableSizeDecoder<any>> extends true
+          ? VariableSizeDecoder<GetDecoderTypeFromVariants<TVariants>>
+          : Decoder<GetDecoderTypeFromVariants<TVariants>>;
+
+/** Infers whether a union codec is fixed-size, variable-size, or unknown from its variant codecs. */
+export type GetUnionCodecType<TVariants extends readonly Codec<any>[]> = TVariants extends readonly FixedSizeCodec<
+    any,
+    any,
+    any
+>[]
+    ? GetFixedSizeCodecFromVariants<TVariants>
+    : ContainsVariableSizeCodec<TVariants, VariableSizeCodec<any>> extends true
+      ? VariableSizeCodec<
+            GetEncoderTypeFromVariants<TVariants>,
+            GetDecoderTypeFromVariants<TVariants> & GetEncoderTypeFromVariants<TVariants>
+        >
+      : Codec<
+            GetEncoderTypeFromVariants<TVariants>,
+            GetDecoderTypeFromVariants<TVariants> & GetEncoderTypeFromVariants<TVariants>
+        >;
 
 export function maxCodecSizes(sizes: (number | null)[]): number | null {
     return sizes.reduce(

--- a/packages/codecs-data-structures/src/utils.ts
+++ b/packages/codecs-data-structures/src/utils.ts
@@ -33,9 +33,10 @@ type IsPreciseNumberLiteral<TSize extends number> = number extends TSize
       : true;
 
 type ContainsVariableSizeCodec<TItems extends readonly unknown[], TVariableSizeCodec> = number extends TItems['length']
-    ? [TItems[number]] extends [TVariableSizeCodec]
-        ? true
-        : false
+    ? // A dynamic array may be empty, in which case the union is fixed-size (`fixedSize: 0`) at
+      // runtime. We therefore cannot promise a variable-size result even if every element is
+      // variable-size, so we widen to the broad codec type instead.
+      false
     : TItems extends readonly [infer THead, ...infer TTail]
       ? [THead] extends [TVariableSizeCodec]
           ? true

--- a/packages/transaction-messages/src/codecs/message.ts
+++ b/packages/transaction-messages/src/codecs/message.ts
@@ -29,13 +29,12 @@ import { getMessageDecoder as getV1MessageDecoder, getMessageEncoder as getV1Mes
 export function getCompiledTransactionMessageEncoder(): VariableSizeEncoder<
     CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime)
 > {
+    type Value = CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime);
     return transformEncoder(
-        getPatternMatchEncoder<
-            CompiledTransactionMessage | (CompiledTransactionMessage & CompiledTransactionMessageWithLifetime)
-        >([
-            [m => m.version === 'legacy', getLegacyMessageEncoder()],
-            [m => m.version === 0, getV0MessageEncoder()],
-            [m => m.version === 1, getV1MessageEncoder()],
+        getPatternMatchEncoder([
+            [(m: Value) => m.version === 'legacy', getLegacyMessageEncoder()],
+            [(m: Value) => m.version === 0, getV0MessageEncoder()],
+            [(m: Value) => m.version === 1, getV1MessageEncoder()],
         ]),
         value => {
             // check version is valid before encoding, so we don't get the generic pattern match error

--- a/packages/transaction-messages/src/codecs/v1/config.ts
+++ b/packages/transaction-messages/src/codecs/v1/config.ts
@@ -1,4 +1,4 @@
-import { transformDecoder, VariableSizeDecoder, VariableSizeEncoder } from '@solana/codecs-core';
+import { transformDecoder, transformEncoder, VariableSizeDecoder, VariableSizeEncoder } from '@solana/codecs-core';
 import {
     getArrayEncoder,
     getPatternMatchEncoder,
@@ -16,16 +16,28 @@ import {
     transactionConfigMaskHasPriorityFee,
 } from '../../v1-transaction-config';
 
-/* TODO issue #1143 - we have a type error on `getPatternMatchEncoder` where it incorrectly
- * types the return as FixedSizeEncoder when used with differently sized FixedSizEencoder
- * inputs. For now we cast to VariableSizeEncoder, which is what the underlying union codec
- * actually returns.
+type U32Value = Extract<CompiledTransactionConfigValue, { kind: 'u32' }>;
+type U64Value = Extract<CompiledTransactionConfigValue, { kind: 'u64' }>;
+
+/* `getPatternMatchEncoder` correctly infers a variable-size encoder when its branches are
+ * fixed-size encoders of *differing* sizes. It cannot do so here, however, because
+ * `getStructEncoder` types its `fixedSize` as the broad `number` rather than a literal (`4` vs
+ * `8`), so the two branches look like identically-sized fixed encoders and the union widens to a
+ * plain `Encoder`. The runtime result is genuinely variable-size, so we cast accordingly. Once
+ * `getStructEncoder` preserves literal sizes, this cast can be removed.
+ * See https://github.com/anza-xyz/kit/issues/1738
  */
 function getCompiledTransactionConfigValueEncoder(): VariableSizeEncoder<CompiledTransactionConfigValue> {
-    return getPatternMatchEncoder<CompiledTransactionConfigValue>([
-        [value => value.kind === 'u32', getStructEncoder([['value', getU32Encoder()]])],
-        [value => value.kind === 'u64', getStructEncoder([['value', getU64Encoder()]])],
-    ]) as unknown as VariableSizeEncoder<CompiledTransactionConfigValue>;
+    return getPatternMatchEncoder([
+        [
+            (value: CompiledTransactionConfigValue) => value.kind === 'u32',
+            transformEncoder(getStructEncoder([['value', getU32Encoder()]]), (value: U32Value) => value),
+        ],
+        [
+            (value: CompiledTransactionConfigValue) => value.kind === 'u64',
+            transformEncoder(getStructEncoder([['value', getU64Encoder()]]), (value: U64Value) => value),
+        ],
+    ]) as VariableSizeEncoder<CompiledTransactionConfigValue>;
 }
 
 /**


### PR DESCRIPTION
#### Problem

`getPredicate*` and `getPatternMatch*` are wrappers over the union codec, but their types were more optimistic than runtime. They could expose `fixedSize` even when the selected branch may have a different size.

The union codec typing had the same missing split: same fixed size, known different fixed sizes, and fixed-size branches where TypeScript can't know if sizes match.

#### Summary of Changes

This follows the feedback on #1541. I fixed the union codec typing first, then aligned predicate and pattern-match with it.

- Same known fixed size stays `FixedSize*<..., S>`.
- Known different fixed sizes become `VariableSize*` where branch sizes are still preserved.
- Unknown or ambiguous sizes fall back to the broader `Encoder` / `Decoder` / `Codec` type.
- Typetests cover same-size branches, different-size branches, dynamic arrays, and ambiguous literal-union sizes.

Fixes #1443
