### PR TITLE
Stop sending a manual Content-Length from the HTTP transport

### DIFF
--- a/.changeset/social-carpets-worry.md
+++ b/.changeset/social-carpets-worry.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-transport-http': patch
+---
+
+Stop sending a manual `Content-Length` header from the HTTP transport. The value came from `body.length` — the JavaScript string's UTF-16 code-unit count — which is smaller than the body's actual UTF-8 byte length whenever the payload contains non-ASCII characters. For such payloads the server would respect the header, read only that many bytes off the socket, and stall waiting for a request that the client believed it had already finished sending. The symptom is a hung request rather than a thrown error, and it has been latent since the line was introduced; recent undici versions surface it more readily. The fix is to let `fetch` derive `Content-Length` from the body itself, which it always did anyway. The transport's TypeScript surface and dev-mode runtime check continue to disallow `Content-Length` as a caller-supplied header.

--- a/packages/rpc-transport-http/src/__tests__/http-transport-content-length-test.node.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-content-length-test.node.ts
@@ -1,0 +1,72 @@
+import { createServer, IncomingMessage, Server, ServerResponse } from 'node:http';
+import { AddressInfo } from 'node:net';
+
+import { createHttpTransport } from '../http-transport';
+
+// Integration test exercising the real `fetch` (undici on Node, wired up by setup-undici-fetch.ts)
+// rather than a mocked spy. The bug being guarded against is that the transport used to send a
+// manual `Content-Length` header equal to `body.length` (the JS string's UTF-16 code-unit count),
+// which underreports the byte count for any payload containing non-ASCII characters. Servers then
+// read only that many bytes from the socket and stall waiting for the rest of the request, hanging
+// the client until a timeout fires.
+
+describe('createHttpTransport (real fetch against a local server)', () => {
+    // Short per-request abort timeout so the test fails fast and cleanly (with an AbortError) if
+    // a regression makes the request hang. Comfortably long for a localhost roundtrip.
+    const REQUEST_TIMEOUT_MS = 2_000;
+
+    let server: Server;
+    let receivedHeaders: IncomingMessage['headers'] | undefined;
+    let receivedBody: string | undefined;
+    let url: string;
+    beforeEach(async () => {
+        receivedHeaders = undefined;
+        receivedBody = undefined;
+        server = createServer((req: IncomingMessage, res: ServerResponse) => {
+            receivedHeaders = req.headers;
+            const chunks: Buffer[] = [];
+            req.on('data', (chunk: Buffer) => chunks.push(chunk));
+            req.on('end', () => {
+                receivedBody = Buffer.concat(chunks).toString('utf8');
+                res.writeHead(200, { 'content-type': 'application/json' });
+                res.end(JSON.stringify({ id: 1, jsonrpc: '2.0', result: 'ok' }));
+            });
+        });
+        await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+        const { address, port } = server.address() as AddressInfo;
+        url = `http://${address}:${port}`;
+    });
+    afterEach(async () => {
+        await new Promise<void>(resolve => server.close(() => resolve()));
+    });
+    it('completes a request with an ASCII payload', async () => {
+        expect.assertions(1);
+        const transport = createHttpTransport({ url });
+        await expect(
+            transport({
+                payload: { id: 1, jsonrpc: '2.0', method: 'getSlot' },
+                signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+            }),
+        ).resolves.toBeDefined();
+    });
+    it('lets fetch compute the correct UTF-8 byte length on the wire', async () => {
+        // Regression for `body.length.toString()`: with a multi-byte UTF-8 payload the old manual
+        // header understated the body size. Servers stall reading the socket, and the request
+        // hangs until our AbortSignal trips below — which is what makes this test fail fast on
+        // the regression instead of waiting out Jest's default 5s test timeout.
+        expect.assertions(2);
+        const transport = createHttpTransport({ url });
+        await transport({
+            payload: {
+                id: 1,
+                jsonrpc: '2.0',
+                method: 'getSlot',
+                params: ['\u{1F44B}\u{1F3FD} \u{1F469}\u{1F3FB}‍❤️‍\u{1F469}\u{1F3FF}'],
+            },
+            signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        });
+        expect(receivedBody).toBeDefined();
+        const sentBodyByteLength = Buffer.byteLength(receivedBody as string, 'utf8');
+        expect(receivedHeaders?.['content-length']).toBe(String(sentBodyByteLength));
+    });
+});

--- a/packages/rpc-transport-http/src/__tests__/http-transport-headers-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-headers-test.ts
@@ -111,21 +111,6 @@ describe('createHttpRequest with custom headers', () => {
             }),
         );
     });
-    it('is impossible to override the `Content-Length` header', () => {
-        const makeHttpRequest = createHttpTransport({
-            headers: { 'cOnTeNt-LeNgTh': '420' },
-            url: 'http://localhost',
-        });
-        makeHttpRequest({ payload: 123 }).catch(() => {});
-        expect(fetchSpy).toHaveBeenCalledWith(
-            expect.anything(),
-            expect.objectContaining({
-                headers: expect.objectContaining({
-                    'content-length': '3',
-                }),
-            }),
-        );
-    });
     it('is impossible to override the `Content-Type` header', () => {
         const makeHttpRequest = createHttpTransport({
             headers: { 'cOnTeNt-TyPe': 'text/html' },

--- a/packages/rpc-transport-http/src/__tests__/http-transport-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/http-transport-test.ts
@@ -126,26 +126,21 @@ describe('createHttpTransport', () => {
                 }),
             );
         });
-        it('sets the content length header to the length of the JSON-stringified payload', () => {
+        it('does not set a `content-length` header (fetch derives it from the body)', () => {
+            // Regression test: undici 8.3+ rejects requests that include a `content-length` header
+            // because it computes one from the body itself. The transport must not emit one.
             makeHttpRequest({
                 payload:
-                    // Shruggie: https://emojipedia.org/person-shrugging/
+                    // A payload containing multi-byte UTF-8 sequences (`body.length` would have
+                    // returned a wrong byte count for these): Shruggie + waving hand + family ZWJ.
                     '\xAF\\\x5F\x28\u30C4\x29\x5F\x2F\xAF' +
                     ' ' +
-                    // https://emojipedia.org/waving-hand-medium-skin-tone/
                     '\u{1F44B}\u{1F3FD}' +
                     ' ' +
-                    // https://tinyurl.com/bdemuf3r
                     '\u{1F469}\u{1F3FB}\u200D\u2764\uFE0F\u200D\u{1F469}\u{1F3FF}',
             }).catch(() => {});
-            expect(fetchSpy).toHaveBeenCalledWith(
-                expect.anything(),
-                expect.objectContaining({
-                    headers: expect.objectContaining({
-                        'content-length': '30',
-                    }),
-                }),
-            );
+            const [, requestInfo] = fetchSpy.mock.calls[0];
+            expect(requestInfo.headers).not.toHaveProperty('content-length');
         });
         it('sets the `method` to `POST`', () => {
             makeHttpRequest({ payload: 123 }).catch(() => {});

--- a/packages/rpc-transport-http/src/http-transport.ts
+++ b/packages/rpc-transport-http/src/http-transport.ts
@@ -60,7 +60,6 @@ export function createHttpTransport(config: Config): RpcTransport {
                 ...customHeaders,
                 // Keep these headers lowercase so they will override any user-supplied headers above.
                 accept: 'application/json',
-                'content-length': body.length.toString(),
                 'content-type': 'application/json; charset=utf-8',
             },
             method: 'POST',


### PR DESCRIPTION
#### Problem

undici fetch already sets `content-length` headers, and this library's content-length headers had the incorrect values. This mismatch caused this to break on undici.

#### Summary of Changes

The fix removes the manual header.