### PR TITLE
Adds support for retrieving the slot in which migration to alpenglow happened

### DIFF
--- a/packages/rpc-api/src/getAlpenglowMigrationSlot.ts
+++ b/packages/rpc-api/src/getAlpenglowMigrationSlot.ts
@@ -1,0 +1,12 @@
+import type { Slot } from '@solana/rpc-types';
+
+type GetAlpenglowMigrationSlotApiResponse = Slot | null;
+
+export type GetAlpenglowMigrationSlotApi = {
+    /**
+     * Returns the slot in which the cluster will migrate to Alpenglow.
+     *
+     * @see https://solana.com/docs/rpc/http/getalpenglowmigrationslot
+     */
+    getAlpenglowMigrationSlot(config?: Readonly<object>): GetAlpenglowMigrationSlotApiResponse;
+};

--- a/packages/rpc-api/src/index.ts
+++ b/packages/rpc-api/src/index.ts
@@ -37,6 +37,7 @@ import {
 } from '@solana/rpc-transformers';
 
 import { GetAccountInfoApi } from './getAccountInfo';
+import { GetAlpenglowMigrationSlotApi } from './getAlpenglowMigrationSlot';
 import { GetBalanceApi } from './getBalance';
 import { GetBlockApi } from './getBlock';
 import { GetBlockCommitmentApi } from './getBlockCommitment';
@@ -90,6 +91,7 @@ import { SendTransactionApi } from './sendTransaction';
 import { SimulateTransactionApi } from './simulateTransaction';
 
 type SolanaRpcApiForAllClusters = GetAccountInfoApi &
+    GetAlpenglowMigrationSlotApi &
     GetBalanceApi &
     GetBlockApi &
     GetBlockCommitmentApi &
@@ -169,6 +171,7 @@ export type SolanaRpcApiMainnet = SolanaRpcApiForAllClusters;
 
 export type {
     GetAccountInfoApi,
+    GetAlpenglowMigrationSlotApi,
     GetBalanceApi,
     GetBlockApi,
     GetBlockCommitmentApi,


### PR DESCRIPTION
#### Problem

In https://github.com/anza-xyz/agave/pull/12735, we are introducing a new rpc endpoint to retrieve the slot in which migration to alpenglow took place.


#### Summary of Changes

This adds support for the endpoint in this repo
