### PR TITLE
Migrate `@solana/react` to import from `@solana/kit`

### DIFF
--- a/.changeset/purple-readers-obey.md
+++ b/.changeset/purple-readers-obey.md
@@ -1,0 +1,14 @@
+---
+'@solana/react': patch
+'@solana/kit': minor
+---
+
+Migrate `@solana/react` to depend on `@solana/kit` as a peer dependency (replacing its individual workspace sub-package deps) and re-export `@solana/subscribable` from `@solana/kit` so React consumers have a single import root. `@solana/promises` remains as a direct dep — it's a small utility that isn't part of Kit's public surface.
+
+For `@solana/react` users:
+- `@solana/kit` must now be installed alongside `@solana/react`.
+- Apps that already use both get a single deduplicated `@solana/kit` instance — important for anything relying on shared types or `instanceof SolanaError` checks.
+- Kit can be bumped independently of React within the peer range.
+
+For `@solana/kit` users:
+- `ReactiveStreamSource`, `ReactiveStreamStore`, `ReactiveActionSource`, `ReactiveActionStore`, `ReactiveState`, `createReactiveActionStore`, `createReactiveStoreFromDataPublisherFactory`, `DataPublisher` and the rest of `@solana/subscribable`'s surface are now reachable directly through `@solana/kit`.

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -23,6 +23,7 @@ export * from '@solana/rpc-parsed-types';
 export * from '@solana/rpc-subscriptions';
 export * from '@solana/rpc-types';
 export * from '@solana/signers';
+export * from '@solana/subscribable';
 export * from '@solana/transaction-introspection';
 export * from '@solana/transaction-messages';
 export * from '@solana/transactions';

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -74,10 +74,6 @@
         "maintained node versions"
     ],
     "dependencies": {
-        "@solana/addresses": "workspace:*",
-        "@solana/errors": "workspace:*",
-        "@solana/keys": "workspace:*",
-        "@solana/plugin-core": "workspace:*",
         "@solana/promises": "workspace:*",
         "@solana/signers": "workspace:*",
         "@solana/subscribable": "workspace:*",
@@ -91,9 +87,8 @@
         "@wallet-standard/ui-registry": "^1.0.1"
     },
     "devDependencies": {
-        "@solana/codecs-core": "workspace:*",
         "@solana/eslint-config": "workspace:*",
-        "@solana/rpc-types": "workspace:*",
+        "@solana/kit": "workspace:*",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -104,6 +99,7 @@
         "react-test-renderer": "^19.2.7"
     },
     "peerDependencies": {
+        "@solana/kit": "workspace:*",
         "react": ">=18"
     },
     "peerDependenciesMeta": {

--- a/packages/react/src/ClientProvider.tsx
+++ b/packages/react/src/ClientProvider.tsx
@@ -1,4 +1,4 @@
-import type { Client } from '@solana/plugin-core';
+import type { Client } from '@solana/kit';
 import React from 'react';
 
 import { usePromise } from './usePromise';

--- a/packages/react/src/__tests__/ClientProvider-test.browser.tsx
+++ b/packages/react/src/__tests__/ClientProvider-test.browser.tsx
@@ -1,12 +1,11 @@
-import { isSolanaError, SOLANA_ERROR__REACT__MISSING_PROVIDER } from '@solana/errors';
-import { Client, createClient } from '@solana/plugin-core';
+import { Client, createClient, isSolanaError, SOLANA_ERROR__REACT__MISSING_PROVIDER } from '@solana/kit';
 import { act } from '@testing-library/react';
 import React, { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
+import { render, renderHook } from '../__test-utils__/render';
 import { ClientProvider } from '../ClientProvider';
 import { useClient } from '../useClient';
-import { render, renderHook } from '../__test-utils__/render';
 
 describe('ClientProvider + useClient', () => {
     it('publishes the client to descendants and returns the same reference across renders', () => {
@@ -110,7 +109,7 @@ describe('ClientProvider + useClient', () => {
             const clientPromise = Promise.reject<Client<object>>(boom);
             // Pre-attach a catch so the rejection isn't flagged as unhandled before React's
             // error-boundary subscription runs.
-            clientPromise.catch(() => {});
+            clientPromise.catch(() => { });
             const onError = jest.fn();
             function Probe() {
                 useClient();

--- a/packages/react/src/__tests__/useAction-test.browser.tsx
+++ b/packages/react/src/__tests__/useAction-test.browser.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { renderToString } from 'react-dom/server';
 
 import { renderHook } from '../__test-utils__/render';
-
 import { useAction } from '../useAction';
 
 describe('useAction', () => {

--- a/packages/react/src/__tests__/useClientCapability-test.browser.tsx
+++ b/packages/react/src/__tests__/useClientCapability-test.browser.tsx
@@ -1,15 +1,15 @@
 import {
+    createClient,
     isSolanaError,
     SOLANA_ERROR__REACT__MISSING_CAPABILITY,
     SOLANA_ERROR__REACT__MISSING_PROVIDER,
-} from '@solana/errors';
-import { createClient } from '@solana/plugin-core';
+} from '@solana/kit';
 import React from 'react';
 
+import { renderHook } from '../__test-utils__/render';
 import { ClientProvider } from '../ClientProvider';
 import { useClient } from '../useClient';
 import { useClientCapability } from '../useClientCapability';
-import { renderHook } from '../__test-utils__/render';
 
 type ClientWithFoo = { foo: { hello(): string } };
 

--- a/packages/react/src/__tests__/useRequest-test.browser.tsx
+++ b/packages/react/src/__tests__/useRequest-test.browser.tsx
@@ -1,4 +1,4 @@
-import { createReactiveActionStore, ReactiveActionSource } from '@solana/subscribable';
+import { createReactiveActionStore, ReactiveActionSource } from '@solana/kit';
 import { act } from '@testing-library/react';
 import React from 'react';
 import { renderToString } from 'react-dom/server';

--- a/packages/react/src/__tests__/useSubscription-test.browser.tsx
+++ b/packages/react/src/__tests__/useSubscription-test.browser.tsx
@@ -1,5 +1,9 @@
-import { SolanaRpcResponse } from '@solana/rpc-types';
-import { createReactiveStoreFromDataPublisherFactory, DataPublisher, ReactiveStreamSource } from '@solana/subscribable';
+import {
+    createReactiveStoreFromDataPublisherFactory,
+    DataPublisher,
+    ReactiveStreamSource,
+    SolanaRpcResponse,
+} from '@solana/kit';
 import { act } from '@testing-library/react';
 import React from 'react';
 import { renderToString } from 'react-dom/server';

--- a/packages/react/src/__tests__/useWalletAccountMessageSigner-test.ts
+++ b/packages/react/src/__tests__/useWalletAccountMessageSigner-test.ts
@@ -1,5 +1,4 @@
-import { SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED, SolanaError } from '@solana/errors';
-import { SignatureBytes } from '@solana/keys';
+import { SignatureBytes, SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED, SolanaError } from '@solana/kit';
 import type { UiWalletAccount } from '@wallet-standard/ui';
 
 import { renderHook } from '../test-renderer';

--- a/packages/react/src/__tests__/useWalletAccountTransactionSendingSigner-test.ts
+++ b/packages/react/src/__tests__/useWalletAccountTransactionSendingSigner-test.ts
@@ -1,16 +1,23 @@
-import { Address } from '@solana/addresses';
-import type { VariableSizeEncoder } from '@solana/codecs-core';
-import { SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED, SolanaError } from '@solana/errors';
-import { SignatureBytes } from '@solana/keys';
-import { Transaction, TransactionMessageBytes } from '@solana/transactions';
-import { getTransactionEncoder } from '@solana/transactions';
+import {
+    Address,
+    getTransactionEncoder,
+    SignatureBytes,
+    SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED,
+    SolanaError,
+    Transaction,
+    TransactionMessageBytes,
+    type VariableSizeEncoder,
+} from '@solana/kit';
 import type { UiWalletAccount } from '@wallet-standard/ui';
 
 import { renderHook } from '../test-renderer';
 import { useSignAndSendTransaction } from '../useSignAndSendTransaction';
 import { useWalletAccountTransactionSendingSigner } from '../useWalletAccountTransactionSendingSigner';
 
-jest.mock('@solana/transactions');
+jest.mock('@solana/kit', () => ({
+    ...jest.requireActual('@solana/kit'),
+    getTransactionEncoder: jest.fn(),
+}));
 jest.mock('../useSignAndSendTransaction');
 
 describe('useWalletAccountTransactionSendingSigner', () => {

--- a/packages/react/src/__tests__/useWalletAccountTransactionSigner-test.ts
+++ b/packages/react/src/__tests__/useWalletAccountTransactionSigner-test.ts
@@ -1,31 +1,33 @@
-import { Address } from '@solana/addresses';
-import type { VariableSizeCodec, VariableSizeDecoder } from '@solana/codecs-core';
 import {
-    SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED,
-    SOLANA_ERROR__TRANSACTION__NONCE_ACCOUNT_CANNOT_BE_IN_LOOKUP_TABLE,
-    SolanaError,
-} from '@solana/errors';
-import { SignatureBytes } from '@solana/keys';
-import { Blockhash } from '@solana/rpc-types';
-import {
+    Address,
+    Blockhash,
     CompiledTransactionMessage,
     CompiledTransactionMessageWithLifetime,
     getCompiledTransactionMessageDecoder,
-} from '@solana/transaction-messages';
-import {
+    getTransactionCodec,
     getTransactionLifetimeConstraintFromCompiledTransactionMessage,
+    SignatureBytes,
+    SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED,
+    SOLANA_ERROR__TRANSACTION__NONCE_ACCOUNT_CANNOT_BE_IN_LOOKUP_TABLE,
+    SolanaError,
     Transaction,
     TransactionMessageBytes,
-} from '@solana/transactions';
-import { getTransactionCodec } from '@solana/transactions';
+    type VariableSizeCodec,
+    type VariableSizeDecoder,
+} from '@solana/kit';
 import type { UiWalletAccount } from '@wallet-standard/ui';
 
 import { renderHook } from '../test-renderer';
 import { useSignTransaction } from '../useSignTransaction';
 import { useWalletAccountTransactionSigner } from '../useWalletAccountTransactionSigner';
 
-jest.mock('@solana/transaction-messages');
-jest.mock('@solana/transactions');
+jest.mock('@solana/kit', () => ({
+    ...jest.requireActual('@solana/kit'),
+    assertIsTransactionWithinSizeLimit: jest.fn(),
+    getCompiledTransactionMessageDecoder: jest.fn(),
+    getTransactionCodec: jest.fn(),
+    getTransactionLifetimeConstraintFromCompiledTransactionMessage: jest.fn(),
+}));
 jest.mock('../useSignTransaction');
 
 describe('useWalletAccountTransactionSigner', () => {

--- a/packages/react/src/__typetests__/useClient-typetest.ts
+++ b/packages/react/src/__typetests__/useClient-typetest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import type { Client } from '@solana/plugin-core';
+import type { Client } from '@solana/kit';
 
 import { useClient } from '../useClient';
 

--- a/packages/react/src/__typetests__/useClientCapability-typetest.ts
+++ b/packages/react/src/__typetests__/useClientCapability-typetest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import type { Client } from '@solana/plugin-core';
+import type { Client } from '@solana/kit';
 
 import { useClientCapability } from '../useClientCapability';
 

--- a/packages/react/src/__typetests__/useRequest-typetest.ts
+++ b/packages/react/src/__typetests__/useRequest-typetest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import { ReactiveActionSource } from '@solana/subscribable';
+import { ReactiveActionSource } from '@solana/kit';
 
 import { RequestResult, useRequest } from '../useRequest';
 

--- a/packages/react/src/__typetests__/useSignAndSendTransaction-typetest.ts
+++ b/packages/react/src/__typetests__/useSignAndSendTransaction-typetest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import { address } from '@solana/addresses';
+import { address } from '@solana/kit';
 import { UiWalletAccount } from '@wallet-standard/ui';
 
 import { useSignAndSendTransaction, useSignAndSendTransactions } from '../useSignAndSendTransaction';

--- a/packages/react/src/__typetests__/useSignIn-typetest.ts
+++ b/packages/react/src/__typetests__/useSignIn-typetest.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import { address } from '@solana/addresses';
+import { address } from '@solana/kit';
 import { WalletVersion } from '@wallet-standard/base';
 import { UiWalletAccount } from '@wallet-standard/ui';
 

--- a/packages/react/src/__typetests__/useSignTransaction-typetest.ts
+++ b/packages/react/src/__typetests__/useSignTransaction-typetest.ts
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import { address } from '@solana/addresses';
+import { address } from '@solana/kit';
 import { UiWalletAccount } from '@wallet-standard/ui';
 
 import { useSignTransaction, useSignTransactions } from '../useSignTransaction';

--- a/packages/react/src/__typetests__/useSubscription-typetest.ts
+++ b/packages/react/src/__typetests__/useSubscription-typetest.ts
@@ -1,7 +1,6 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 
-import { SolanaRpcResponse } from '@solana/rpc-types';
-import { ReactiveStreamSource } from '@solana/subscribable';
+import { ReactiveStreamSource, SolanaRpcResponse } from '@solana/kit';
 
 import { SubscriptionResult, useSubscription } from '../useSubscription';
 

--- a/packages/react/src/staticStores.ts
+++ b/packages/react/src/staticStores.ts
@@ -1,4 +1,4 @@
-import { ReactiveActionStore, ReactiveState, ReactiveStreamStore } from '@solana/subscribable';
+import { ReactiveActionStore, ReactiveState, ReactiveStreamStore } from '@solana/kit';
 
 const DISABLED_ACTION_STATE = Object.freeze({
     data: undefined,

--- a/packages/react/src/useAction.ts
+++ b/packages/react/src/useAction.ts
@@ -1,4 +1,4 @@
-import { createReactiveActionStore } from '@solana/subscribable';
+import { createReactiveActionStore } from '@solana/kit';
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 
 import { useIsomorphicLayoutEffect } from './useIsomorphicLayoutEffect';

--- a/packages/react/src/useClient.ts
+++ b/packages/react/src/useClient.ts
@@ -1,5 +1,4 @@
-import { SOLANA_ERROR__REACT__MISSING_PROVIDER, SolanaError } from '@solana/errors';
-import type { Client } from '@solana/plugin-core';
+import { type Client, SOLANA_ERROR__REACT__MISSING_PROVIDER, SolanaError } from '@solana/kit';
 import React from 'react';
 
 import { ClientContext } from './ClientProvider';

--- a/packages/react/src/useClientCapability.ts
+++ b/packages/react/src/useClientCapability.ts
@@ -1,5 +1,4 @@
-import { SOLANA_ERROR__REACT__MISSING_CAPABILITY, SolanaError } from '@solana/errors';
-import type { Client } from '@solana/plugin-core';
+import { type Client, SOLANA_ERROR__REACT__MISSING_CAPABILITY, SolanaError } from '@solana/kit';
 
 import { useClient } from './useClient';
 

--- a/packages/react/src/useRequest.ts
+++ b/packages/react/src/useRequest.ts
@@ -1,4 +1,4 @@
-import { createReactiveActionStore, ReactiveActionSource, ReactiveActionStore } from '@solana/subscribable';
+import { createReactiveActionStore, ReactiveActionSource, ReactiveActionStore } from '@solana/kit';
 import { useMemo } from 'react';
 
 import { disabledActionStore } from './staticStores';

--- a/packages/react/src/useRequestResult.ts
+++ b/packages/react/src/useRequestResult.ts
@@ -1,4 +1,4 @@
-import { ReactiveActionStore } from '@solana/subscribable';
+import { ReactiveActionStore } from '@solana/kit';
 import { useMemo, useSyncExternalStore } from 'react';
 
 import { RequestResult } from './useRequest';

--- a/packages/react/src/useSignIn.ts
+++ b/packages/react/src/useSignIn.ts
@@ -1,4 +1,4 @@
-import { Address } from '@solana/addresses';
+import { Address } from '@solana/kit';
 import {
     SolanaSignIn,
     SolanaSignInFeature,

--- a/packages/react/src/useSubscription.ts
+++ b/packages/react/src/useSubscription.ts
@@ -1,4 +1,4 @@
-import { ReactiveStreamSource, ReactiveStreamStore } from '@solana/subscribable';
+import { ReactiveStreamSource, ReactiveStreamStore } from '@solana/kit';
 import { useMemo } from 'react';
 
 import { disabledStreamStore } from './staticStores';

--- a/packages/react/src/useSubscriptionResult.ts
+++ b/packages/react/src/useSubscriptionResult.ts
@@ -1,4 +1,4 @@
-import { ReactiveStreamStore } from '@solana/subscribable';
+import { ReactiveStreamStore } from '@solana/kit';
 import { useMemo, useSyncExternalStore } from 'react';
 
 import { SubscriptionResult } from './useSubscription';

--- a/packages/react/src/useWalletAccountMessageSigner.ts
+++ b/packages/react/src/useWalletAccountMessageSigner.ts
@@ -1,9 +1,14 @@
-import { Address, address } from '@solana/addresses';
-import { bytesEqual } from '@solana/codecs-core';
-import { SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED, SolanaError } from '@solana/errors';
-import { SignatureBytes } from '@solana/keys';
+import {
+    Address,
+    address,
+    bytesEqual,
+    MessageModifyingSigner,
+    SignableMessage,
+    SignatureBytes,
+    SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED,
+    SolanaError,
+} from '@solana/kit';
 import { getAbortablePromise } from '@solana/promises';
-import { MessageModifyingSigner, SignableMessage } from '@solana/signers';
 import type { UiWalletAccount } from '@wallet-standard/ui';
 import { useMemo } from 'react';
 
@@ -21,7 +26,7 @@ import { useSignMessage } from './useSignMessage';
  * @example
  * ```tsx
  * import { useWalletAccountMessageSigner } from '@solana/react';
- * import { createSignableMessage } from '@solana/signers';
+ * import { createSignableMessage } from '@solana/kit';
  *
  * function SignMessageButton({ account, text }) {
  *     const messageSigner = useWalletAccountMessageSigner(account);

--- a/packages/react/src/useWalletAccountTransactionSendingSigner.ts
+++ b/packages/react/src/useWalletAccountTransactionSendingSigner.ts
@@ -1,9 +1,12 @@
-import { address } from '@solana/addresses';
-import { SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED, SolanaError } from '@solana/errors';
-import { SignatureBytes } from '@solana/keys';
+import {
+    address,
+    getTransactionEncoder,
+    SignatureBytes,
+    SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED,
+    SolanaError,
+    TransactionSendingSigner,
+} from '@solana/kit';
 import { getAbortablePromise } from '@solana/promises';
-import { TransactionSendingSigner } from '@solana/signers';
-import { getTransactionEncoder } from '@solana/transactions';
 import { UiWalletAccount } from '@wallet-standard/ui';
 import { useMemo, useRef } from 'react';
 

--- a/packages/react/src/useWalletAccountTransactionSigner.ts
+++ b/packages/react/src/useWalletAccountTransactionSigner.ts
@@ -1,17 +1,18 @@
-import { address } from '@solana/addresses';
-import { bytesEqual } from '@solana/codecs-core';
-import { SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED, SolanaError } from '@solana/errors';
-import { getAbortablePromise } from '@solana/promises';
-import { TransactionModifyingSigner } from '@solana/signers';
-import { getCompiledTransactionMessageDecoder } from '@solana/transaction-messages';
 import {
+    address,
     assertIsTransactionWithinSizeLimit,
+    bytesEqual,
+    getCompiledTransactionMessageDecoder,
     getTransactionCodec,
     getTransactionLifetimeConstraintFromCompiledTransactionMessage,
+    SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED,
+    SolanaError,
     Transaction,
+    TransactionModifyingSigner,
     TransactionWithinSizeLimit,
     TransactionWithLifetime,
-} from '@solana/transactions';
+} from '@solana/kit';
+import { getAbortablePromise } from '@solana/promises';
 import { UiWalletAccount } from '@wallet-standard/ui';
 import { useMemo, useRef } from 'react';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -947,18 +947,6 @@ importers:
 
   packages/react:
     dependencies:
-      '@solana/addresses':
-        specifier: workspace:*
-        version: link:../addresses
-      '@solana/errors':
-        specifier: workspace:*
-        version: link:../errors
-      '@solana/keys':
-        specifier: workspace:*
-        version: link:../keys
-      '@solana/plugin-core':
-        specifier: workspace:*
-        version: link:../plugin-core
       '@solana/promises':
         specifier: workspace:*
         version: link:../promises
@@ -993,15 +981,12 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
     devDependencies:
-      '@solana/codecs-core':
-        specifier: workspace:*
-        version: link:../codecs-core
       '@solana/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
-      '@solana/rpc-types':
+      '@solana/kit':
         specifier: workspace:*
-        version: link:../rpc-types
+        version: link:../kit
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
#### Summary of Changes

This PR changes the imports of `@solana/react` to use `@solana/kit` instead of the individual sub-packages (addresses, transactions, etc) wherever possible

This explicitly makes `@solana/kit` a dependency of `@solana/react`. This is ok because we will never want to export `@solana/react` from `@solana/kit` because of its react dependency.

We do this because a following PR will use `createReactiveStoreWithInitialValueAndSlotTracking` from `@solana/kit`. This is a separate PR to make reviewing easier and keep that one focused.

We also export `@solana/subscribable` from Kit. I think the new types (ReactiveActionStore etc) justify this. 