### PR TITLE
Add `useTrackedData` for an RPC subscription seeded by an RPC fetch

### DIFF
--- a/.changeset/moody-heads-design.md
+++ b/.changeset/moody-heads-design.md
@@ -1,0 +1,31 @@
+---
+'@solana/react': minor
+---
+
+Add `useTrackedData` — a React hook for an RPC subscription seeded by a one-shot RPC fetch, slot-deduped. The subscription (e.g. `accountNotifications`) is the primary source of live updates; the initial fetch (e.g. `getBalance`, `getAccountInfo`) provides a value to surface as soon as it resolves — typically before the first subscription notification arrives — so the `loading` paint is shorter than subscription-only would give you. Surfaces a unified `{ data, error, refresh, status }` view where `data` is the `SolanaRpcResponse<TItem>` envelope that the underlying kit primitive emits — the primitive's type guarantees the envelope shape, so callers can read `data.value` and `data.context.slot` directly without a runtime check. The underlying store slot-dedupes between the two sources — out-of-order arrivals never regress the surfaced value (older slots are dropped silently, so a stale RPC response can't overwrite a fresher subscription notification).
+
+```tsx
+function AccountBalance({ address }: { address: Address }) {
+    const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const spec = useMemo(
+        () => ({
+            rpcRequest: client.rpc.getBalance(address),
+            rpcSubscriptionRequest: client.rpcSubscriptions.accountNotifications(address),
+            rpcValueMapper: (lamports: bigint) => lamports,
+            rpcSubscriptionValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
+        }),
+        [client, address],
+    );
+    const { data, error, refresh } = useTrackedData(spec);
+    if (error) return <button onClick={refresh}>Retry</button>;
+    return <p>{data ? `${data.value} lamports at slot ${data.context.slot}` : 'Loading…'}</p>;
+}
+```
+
+The result reports `status` as one of `loading | loaded | error | disabled`. Pass `null` for the spec to gate the work off — useful while inputs aren't yet known (e.g. an `address` that hasn't been selected). After a notification arrives, an error transitions to `status: 'error'` while preserving the stale `data` (envelope intact); `refresh()` re-runs both the initial RPC and the subscription, returns `status` to `loading` (preserving stale `data` and `error` for stale-while-revalidate), and settles on `loaded` or a fresh `error`.
+
+Optional `getAbortSignal: () => AbortSignal` is a factory invoked on every attempt (initial run + every `refresh()`). Each attempt gets a fresh signal that the underlying store composes with its per-attempt controller via `AbortSignal.any`. The natural use is per-attempt timeouts: `getAbortSignal: () => AbortSignal.timeout(30_000)` gives every attempt its own 30-second clock that resets on refresh. The factory is held in a ref synced to the latest render, so inline closures are fine — no `useCallback` needed. `refresh()` also accepts an optional `{ abortSignal }` override to replace the factory for one specific attempt (presence-based: omit to use the factory, `{ abortSignal: signal }` to override, `{ abortSignal: undefined }` to opt out).
+
+The hook is built on `createReactiveStoreWithInitialValueAndSlotTracking` from `@solana/kit` — the slot tracking, abort plumbing, and stale-while-revalidate behaviour live one layer down. The React surface reduces to `useSyncExternalStore` glue plus the per-attempt signal API. The Kit primitive's config type is re-shaped as `TrackedDataSpec<TRpcValue, TSubscriptionValue, TItem>` for friendlier use-site naming; the two are mutually assignable. SSR-safe — on the server the connect effect doesn't run, so the store stays `idle` and the hook reports `status: 'loading'`; first client render hydrates from the same paint and commits the connect.
+
+`TrackedDataResult<T>`, `TrackedDataSpec<TRpc, TSub, T>`, and `UseTrackedDataOptions` are exported alongside the hook for plugin hooks built on top.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -244,6 +244,63 @@ reconnect({ abortSignal: undefined }); // no abort signal for this attempt
 reconnect(); // omit the key to use the factory (default)
 ```
 
+### `useTrackedData(spec, options?)`
+
+Render reactive state for an RPC subscription seeded by a one-shot RPC fetch, slot-deduped. The subscription (e.g. `accountNotifications`) is the primary source of live updates; the initial fetch (e.g. `getBalance`, `getAccountInfo`) provides a value to surface as soon as it resolves — typically before the first subscription notification arrives — so the `loading` paint is shorter than subscription-only would give you. Surfaces a unified `{ data, error, refresh, status }` view where `data` is the underlying kit primitive's `SolanaRpcResponse<TItem>` envelope (the primitive's type guarantees the shape, so callers can read `data.value` and `data.context.slot` directly) and `status` is one of `'loading' | 'loaded' | 'error' | 'disabled'`. The underlying store slot-dedupes between the two sources — out-of-order arrivals never regress the surfaced value.
+
+`spec` is a `TrackedDataSpec<TRpcValue, TSubscriptionValue, TItem>` with four fields: a pending RPC request, a pending RPC subscription request, and two mappers that unify their value shapes into a common `TItem`. Both RPC responses and subscription notifications must have shape `SolanaRpcResponse` for slot de-dupe. Pass `null` to disable (the result reports `status: 'disabled'`). Memoize the spec with `useMemo` keyed on its inputs — stable identity is how the hook knows when to tear down and re-run.
+
+```tsx
+import { useClient, useTrackedData } from '@solana/react';
+import type {
+    Address,
+    AccountNotificationsApi,
+    ClientWithRpc,
+    ClientWithRpcSubscriptions,
+    GetBalanceApi,
+} from '@solana/kit';
+
+function AccountBalance({ address }: { address: Address }) {
+    const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const spec = useMemo(
+        () => ({
+            rpcRequest: client.rpc.getBalance(address),
+            rpcSubscriptionRequest: client.rpcSubscriptions.accountNotifications(address),
+            rpcValueMapper: (lamports: bigint) => lamports,
+            rpcSubscriptionValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
+        }),
+        [client, address],
+    );
+    const { data, error, refresh } = useTrackedData(spec);
+    if (error) return <button onClick={refresh}>Retry</button>;
+    return <p>{data ? `${data.value} lamports at slot ${data.context.slot}` : 'Loading…'}</p>;
+}
+```
+
+`refresh()` re-runs both the initial RPC and the subscription. While a refresh is in flight, `status` returns to `'loading'` and `data` / `error` from the prior outcome stay populated until the new attempt resolves (stale-while-revalidate). `data.context.slot` is the slot the underlying store dedup'd on and stays paired with `data.value` across status transitions — useful for "data as of slot X" UIs.
+
+#### Per-attempt cancellation
+
+Pass `getAbortSignal` to attach a cancellation signal to each attempt — initial run plus every `refresh()`. The natural use is per-attempt timeouts:
+
+```tsx
+const { data, error, refresh } = useTrackedData(spec, {
+    // Each attempt gets a fresh 30-second clock. `refresh()` resets it.
+    getAbortSignal: () => AbortSignal.timeout(30_000),
+});
+```
+
+The factory is held in a ref synced to the latest render, so inline closures are fine — no `useCallback` needed. To kill the hook entirely (e.g. on a route change), set the memoized spec to `null` (the result reports `disabled`), or let the component unmount.
+
+`refresh()` accepts an optional `{ abortSignal }` override that replaces the configured factory for just that attempt:
+
+```tsx
+const userInitiatedCtrl = new AbortController();
+refresh({ abortSignal: userInitiatedCtrl.signal }); // override: use this signal, ignore the factory
+refresh({ abortSignal: undefined }); // no abort signal for this attempt
+refresh(); // omit the key to use the factory (default)
+```
+
 ## Hooks
 
 ### `useSignIn(uiWalletAccount, chain)`

--- a/packages/react/src/__tests__/useTrackedData-test.browser.tsx
+++ b/packages/react/src/__tests__/useTrackedData-test.browser.tsx
@@ -1,0 +1,432 @@
+import {
+    createReactiveActionStore,
+    createReactiveStoreFromDataPublisherFactory,
+    type ReactiveActionSource,
+    type ReactiveStreamSource,
+    type SolanaRpcResponse,
+} from '@solana/kit';
+import { act } from '@testing-library/react';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+import { renderHook } from '../__test-utils__/render';
+import { TrackedDataSpec, useTrackedData } from '../useTrackedData';
+
+type TestValue = { count: number };
+
+function rpcResponse(slot: number, value: TestValue): SolanaRpcResponse<TestValue> {
+    return { context: { slot: BigInt(slot) }, value };
+}
+
+// Backs `initialValueSource` with a real `ReactiveActionStore`. The wrapped function hands out a
+// fresh controllable promise per dispatch (so a `refresh()` gets its own) and captures the
+// per-dispatch signal so tests can assert it is forwarded and aborted.
+function createMockInitialValueSource(): {
+    fn: jest.Mock;
+    reject(error: unknown): void;
+    resolve(response: SolanaRpcResponse<TestValue>): void;
+    signals: (AbortSignal | undefined)[];
+    source: ReactiveActionSource<SolanaRpcResponse<TestValue>>;
+} {
+    const instances: { reject(error: unknown): void; resolve(response: SolanaRpcResponse<TestValue>): void }[] = [];
+    const signals: (AbortSignal | undefined)[] = [];
+    const fn = jest.fn().mockImplementation((signal?: AbortSignal) => {
+        const { promise, resolve, reject } = Promise.withResolvers<SolanaRpcResponse<TestValue>>();
+        instances.push({ reject, resolve });
+        signals.push(signal);
+        return promise;
+    });
+    return {
+        fn,
+        reject(error) {
+            instances[instances.length - 1]?.reject(error);
+        },
+        resolve(response) {
+            instances[instances.length - 1]?.resolve(response);
+        },
+        signals,
+        source: { reactiveStore: () => createReactiveActionStore(fn) },
+    };
+}
+
+// Backs `streamSource` with a real `ReactiveStreamStore` built from a mock `DataPublisher` factory.
+// The publisher buffers events delivered before the store subscribes (mirroring the previous
+// async-iterable mock) so notifications are never dropped on a timing technicality.
+function createMockStreamSource(): {
+    createDataPublisher: jest.Mock;
+    error(err: unknown): void;
+    pushNotification(notification: SolanaRpcResponse<TestValue>): void;
+    source: ReactiveStreamSource<SolanaRpcResponse<TestValue>>;
+} {
+    const publishers: { publish(channel: string, payload: unknown): void }[] = [];
+    const createDataPublisher = jest.fn().mockImplementation(() => {
+        const listeners: {
+            channel: string;
+            listener: (payload: unknown) => void;
+            options?: { signal?: AbortSignal };
+        }[] = [];
+        const buffered: { channel: string; payload: unknown }[] = [];
+        const publisher = {
+            on(channel: string, listener: (payload: unknown) => void, options?: { signal?: AbortSignal }) {
+                listeners.push({ channel, listener, options });
+                buffered
+                    .filter(b => b.channel === channel)
+                    .forEach(b => {
+                        if (!options?.signal?.aborted) listener(b.payload);
+                    });
+                return function unsubscribe() {};
+            },
+        };
+        publishers.push({
+            publish(channel, payload) {
+                const matched = listeners.filter(l => l.channel === channel && !l.options?.signal?.aborted);
+                if (matched.length === 0) {
+                    buffered.push({ channel, payload });
+                } else {
+                    matched.forEach(l => l.listener(payload));
+                }
+            },
+        });
+        return Promise.resolve(publisher);
+    });
+    return {
+        createDataPublisher,
+        error(err) {
+            publishers[publishers.length - 1]?.publish('error', err);
+        },
+        pushNotification(notification) {
+            publishers[publishers.length - 1]?.publish('data', notification);
+        },
+        source: {
+            reactiveStore: () =>
+                createReactiveStoreFromDataPublisherFactory<SolanaRpcResponse<TestValue>>({
+                    createDataPublisher,
+                    dataChannelName: 'data',
+                    errorChannelName: 'error',
+                }),
+        },
+    };
+}
+
+type Spec = TrackedDataSpec<TestValue, TestValue, number>;
+function makeSpec(): {
+    error: (err: unknown) => void;
+    initialValueSignals: () => (AbortSignal | undefined)[];
+    pushNotification: (notification: SolanaRpcResponse<TestValue>) => void;
+    rejectRpc: (error: unknown) => void;
+    resolveRpc: (response: SolanaRpcResponse<TestValue>) => void;
+    rpcSendCalls: () => number;
+    spec: Spec;
+    subscribeCalls: () => number;
+} {
+    const initialValue = createMockInitialValueSource();
+    const stream = createMockStreamSource();
+    return {
+        error: stream.error,
+        initialValueSignals: () => initialValue.signals,
+        pushNotification: stream.pushNotification,
+        rejectRpc: initialValue.reject,
+        resolveRpc: initialValue.resolve,
+        rpcSendCalls: () => initialValue.fn.mock.calls.length,
+        spec: {
+            initialValueMapper: v => v.count,
+            initialValueSource: initialValue.source,
+            streamSource: stream.source,
+            streamValueMapper: v => v.count,
+        },
+        subscribeCalls: () => stream.createDataPublisher.mock.calls.length,
+    };
+}
+
+describe('useTrackedData', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('starts in loading, transitions to loaded with the initial RPC value', async () => {
+        const { spec, resolveRpc } = makeSpec();
+        const { result } = renderHook(() => useTrackedData(spec));
+
+        expect(result.current.status).toBe('loading');
+        expect(result.current.data).toBeUndefined();
+
+        await act(async () => {
+            resolveRpc(rpcResponse(100, { count: 42 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.status).toBe('loaded');
+        expect(result.current.data).toStrictEqual({ context: { slot: 100n }, value: 42 });
+    });
+
+    it('promotes a subscription notification over the initial RPC when the slot is newer', async () => {
+        const { spec, resolveRpc, pushNotification } = makeSpec();
+        const { result } = renderHook(() => useTrackedData(spec));
+        await act(async () => {
+            resolveRpc(rpcResponse(100, { count: 1 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 100n }, value: 1 });
+
+        await act(async () => {
+            pushNotification(rpcResponse(200, { count: 2 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 200n }, value: 2 });
+    });
+
+    it('drops a stale subscription notification with a slot older than the current value', async () => {
+        const { spec, resolveRpc, pushNotification } = makeSpec();
+        const { result } = renderHook(() => useTrackedData(spec));
+        await act(async () => {
+            resolveRpc(rpcResponse(200, { count: 99 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 200n }, value: 99 });
+
+        // Older slot — store ignores; UI keeps the newer value.
+        await act(async () => {
+            pushNotification(rpcResponse(150, { count: 7 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 200n }, value: 99 });
+    });
+
+    it('drops the initial RPC value when a newer subscription notification arrived first', async () => {
+        const { spec, resolveRpc, pushNotification } = makeSpec();
+        const { result } = renderHook(() => useTrackedData(spec));
+        // Subscription arrives first at a newer slot.
+        await act(async () => {
+            pushNotification(rpcResponse(300, { count: 5 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 300n }, value: 5 });
+
+        // Then the initial RPC resolves with an older slot — must NOT regress the value.
+        await act(async () => {
+            resolveRpc(rpcResponse(200, { count: 99 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 300n }, value: 5 });
+    });
+
+    it('transitions to error when the initial RPC rejects, preserving stale data if any', async () => {
+        const { spec, rejectRpc, pushNotification } = makeSpec();
+        const { result } = renderHook(() => useTrackedData(spec));
+        // Subscription delivers a value first.
+        await act(async () => {
+            pushNotification(rpcResponse(100, { count: 1 }));
+            await jest.runAllTimersAsync();
+        });
+        const boom = new Error('boom');
+        await act(async () => {
+            rejectRpc(boom);
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.status).toBe('error');
+        expect(result.current.error).toBe(boom);
+        expect(result.current.data).toStrictEqual({ context: { slot: 100n }, value: 1 }); // stale preserved
+    });
+
+    it('transitions to error when the subscription throws, preserving stale data if any', async () => {
+        const { spec, resolveRpc, error } = makeSpec();
+        const { result } = renderHook(() => useTrackedData(spec));
+        // Initial RPC delivers a value first.
+        await act(async () => {
+            resolveRpc(rpcResponse(100, { count: 1 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.status).toBe('loaded');
+
+        const boom = new Error('subscription failed');
+        await act(async () => {
+            error(boom);
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.status).toBe('error');
+        expect(result.current.error).toBe(boom);
+        expect(result.current.data).toStrictEqual({ context: { slot: 100n }, value: 1 }); // stale preserved
+    });
+
+    it('refresh() re-runs the pair and returns to loading with stale data preserved', async () => {
+        const { spec, resolveRpc, pushNotification, rpcSendCalls, subscribeCalls } = makeSpec();
+        const { result } = renderHook(() => useTrackedData(spec));
+        await act(async () => {
+            resolveRpc(rpcResponse(100, { count: 1 }));
+            await jest.runAllTimersAsync();
+        });
+        await act(async () => {
+            pushNotification(rpcResponse(150, { count: 2 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(rpcSendCalls()).toBe(1);
+        expect(subscribeCalls()).toBe(1);
+
+        act(() => result.current.refresh());
+        // Both sources re-fire.
+        expect(rpcSendCalls()).toBe(2);
+        expect(subscribeCalls()).toBe(2);
+        // Status returns to loading with stale data preserved.
+        expect(result.current.status).toBe('loading');
+        expect(result.current.data).toStrictEqual({ context: { slot: 150n }, value: 2 });
+    });
+
+    it('reports status: disabled when the spec is null', () => {
+        const { result } = renderHook(() => useTrackedData<TestValue, TestValue, number>(null));
+        expect(result.current.status).toBe('disabled');
+        expect(result.current.data).toBeUndefined();
+    });
+
+    it('starts running when the spec transitions from null to a real one', async () => {
+        const fake = makeSpec();
+        const initialProps: { spec: Spec | null } = { spec: null };
+        const { result, rerender } = renderHook(({ spec }) => useTrackedData(spec), { initialProps });
+        expect(result.current.status).toBe('disabled');
+        expect(fake.rpcSendCalls()).toBe(0);
+
+        rerender({ spec: fake.spec });
+        expect(result.current.status).toBe('loading');
+        await act(async () => {
+            fake.resolveRpc(rpcResponse(100, { count: 1 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.status).toBe('loaded');
+        expect(result.current.data).toStrictEqual({ context: { slot: 100n }, value: 1 });
+    });
+
+    it('returns to disabled when the spec transitions to null', async () => {
+        const fake = makeSpec();
+        const initialProps: { spec: Spec | null } = { spec: fake.spec };
+        const { result, rerender } = renderHook(({ spec }) => useTrackedData(spec), { initialProps });
+        await act(async () => {
+            fake.resolveRpc(rpcResponse(100, { count: 1 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.status).toBe('loaded');
+
+        rerender({ spec: null });
+        expect(result.current.status).toBe('disabled');
+        expect(result.current.data).toBeUndefined();
+    });
+
+    it('rebuilds the store when the spec identity changes', async () => {
+        const a = makeSpec();
+        const b = makeSpec();
+        const { result, rerender } = renderHook(({ spec }: { spec: Spec }) => useTrackedData(spec), {
+            initialProps: { spec: a.spec },
+        });
+        await act(async () => {
+            a.resolveRpc(rpcResponse(100, { count: 1 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 100n }, value: 1 });
+
+        rerender({ spec: b.spec });
+        expect(result.current.status).toBe('loading');
+        await act(async () => {
+            b.resolveRpc(rpcResponse(50, { count: 2 }));
+            await jest.runAllTimersAsync();
+        });
+        // Fresh store → slot tracking resets, so 50 is accepted as the new baseline.
+        expect(result.current.data).toStrictEqual({ context: { slot: 50n }, value: 2 });
+    });
+
+    it('keeps a stable refresh reference across re-renders', () => {
+        const { spec } = makeSpec();
+        const { result, rerender } = renderHook(() => useTrackedData(spec));
+        const { refresh } = result.current;
+        rerender();
+        expect(result.current.refresh).toBe(refresh);
+    });
+
+    it('invokes `getAbortSignal` on every attempt with a fresh signal', async () => {
+        const fake = makeSpec();
+        const signals: AbortSignal[] = [];
+        const getAbortSignal = jest.fn(() => {
+            const ctrl = new AbortController();
+            signals.push(ctrl.signal);
+            return ctrl.signal;
+        });
+        const { result } = renderHook(() => useTrackedData(fake.spec, { getAbortSignal }));
+        await act(async () => {
+            fake.resolveRpc(rpcResponse(100, { count: 1 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(getAbortSignal).toHaveBeenCalledTimes(1);
+
+        act(() => result.current.refresh());
+        expect(getAbortSignal).toHaveBeenCalledTimes(2);
+        expect(signals[1]).not.toBe(signals[0]);
+    });
+
+    it('refresh({ abortSignal }) overrides the factory for that attempt', async () => {
+        const fake = makeSpec();
+        const getAbortSignal = jest.fn(() => new AbortController().signal);
+        const { result } = renderHook(() => useTrackedData(fake.spec, { getAbortSignal }));
+        await act(async () => {
+            fake.resolveRpc(rpcResponse(100, { count: 1 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(getAbortSignal).toHaveBeenCalledTimes(1);
+
+        const overrideCtrl = new AbortController();
+        act(() => result.current.refresh({ abortSignal: overrideCtrl.signal }));
+        expect(getAbortSignal).toHaveBeenCalledTimes(1); // factory NOT called
+
+        await act(async () => {
+            overrideCtrl.abort(new Error('overridden'));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.status).toBe('error');
+    });
+
+    it('refresh({ abortSignal: undefined }) opts out of the factory for that attempt', async () => {
+        const fake = makeSpec();
+        const getAbortSignal = jest.fn(() => new AbortController().signal);
+        const { result } = renderHook(() => useTrackedData(fake.spec, { getAbortSignal }));
+        await act(async () => {
+            fake.resolveRpc(rpcResponse(100, { count: 1 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(getAbortSignal).toHaveBeenCalledTimes(1);
+
+        act(() => result.current.refresh({ abortSignal: undefined }));
+        expect(getAbortSignal).toHaveBeenCalledTimes(1); // factory NOT called
+        expect(fake.rpcSendCalls()).toBe(2);
+    });
+
+    it('aborts the in-flight attempt when the component unmounts', () => {
+        const { spec, rpcSendCalls, initialValueSignals } = makeSpec();
+        const { unmount } = renderHook(() => useTrackedData(spec));
+        expect(rpcSendCalls()).toBe(1);
+        const abortSignal = initialValueSignals()[0]!;
+        expect(abortSignal.aborted).toBe(false);
+        unmount();
+        expect(abortSignal.aborted).toBe(true);
+    });
+
+    describe('SSR', () => {
+        it('renders `loading` on the server without firing the RPC or subscription', () => {
+            const fake = makeSpec();
+            function Component() {
+                const { status } = useTrackedData(fake.spec);
+                return <p>{status}</p>;
+            }
+            const html = renderToString(<Component />);
+            expect(html).toBe('<p>loading</p>');
+            expect(fake.rpcSendCalls()).toBe(0);
+            expect(fake.subscribeCalls()).toBe(0);
+        });
+
+        it('renders `disabled` on the server when the spec is null', () => {
+            function Component() {
+                const { status } = useTrackedData<TestValue, TestValue, number>(null);
+                return <p>{status}</p>;
+            }
+            const html = renderToString(<Component />);
+            expect(html).toBe('<p>disabled</p>');
+        });
+    });
+});

--- a/packages/react/src/__typetests__/useTrackedData-typetest.ts
+++ b/packages/react/src/__typetests__/useTrackedData-typetest.ts
@@ -1,0 +1,66 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import type { CreateReactiveStoreWithInitialValueAndSlotTrackingConfig, Slot, SolanaRpcResponse } from '@solana/kit';
+
+import { TrackedDataResult, TrackedDataSpec, useTrackedData } from '../useTrackedData';
+
+const spec = null as unknown as TrackedDataSpec<{ a: number }, { b: number }, number>;
+
+// [DESCRIBE] TrackedDataSpec
+{
+    // `TrackedDataSpec` is the React-local alias of the Kit primitive's config — same shape.
+    {
+        null as unknown as TrackedDataSpec<
+            { a: number },
+            { b: number },
+            number
+        > satisfies CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<{ a: number }, { b: number }, number>;
+        null as unknown as CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<
+            { a: number },
+            { b: number },
+            number
+        > satisfies TrackedDataSpec<{ a: number }, { b: number }, number>;
+    }
+}
+
+// [DESCRIBE] useTrackedData
+{
+    // Infers `TItem` from the spec's mappers and surfaces `data` as the primitive's guaranteed
+    // `SolanaRpcResponse<TItem>` envelope.
+    {
+        const result = useTrackedData(spec);
+        result satisfies TrackedDataResult<number>;
+        result.data satisfies SolanaRpcResponse<number> | undefined;
+        result.data?.value satisfies number | undefined;
+        result.data?.context.slot satisfies Slot | undefined;
+    }
+
+    // Spec accepts null (disabled)
+    {
+        useTrackedData<{ a: number }, { b: number }, number>(null) satisfies TrackedDataResult<number>;
+    }
+
+    // Options accept a `getAbortSignal` factory
+    {
+        useTrackedData(spec, { getAbortSignal: () => AbortSignal.timeout(30_000) });
+    }
+
+    // `refresh` accepts no args (uses factory), an `{ abortSignal }` override, or
+    // `{ abortSignal: undefined }` to opt out of the factory entirely.
+    {
+        const { refresh } = useTrackedData(spec);
+        refresh();
+        refresh({ abortSignal: AbortSignal.timeout(1_000) });
+        refresh({ abortSignal: undefined });
+        // @ts-expect-error - abortSignal must be an AbortSignal (or undefined)
+        refresh({ abortSignal: 'nope' });
+    }
+
+    // Status is a discriminated string literal
+    {
+        const { status } = useTrackedData(spec);
+        status satisfies 'disabled' | 'error' | 'loaded' | 'loading';
+        // @ts-expect-error - 'success' is the action-store vocabulary, not stream
+        status satisfies 'success';
+    }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -13,6 +13,7 @@ export * from './useSubscription';
 export * from './useSignIn';
 export * from './useSignMessage';
 export * from './useSignTransaction';
+export * from './useTrackedData';
 export * from './useWalletAccountMessageSigner';
 export * from './useWalletAccountTransactionSigner';
 export * from './useWalletAccountTransactionSendingSigner';

--- a/packages/react/src/useTrackedData.ts
+++ b/packages/react/src/useTrackedData.ts
@@ -1,0 +1,167 @@
+import {
+    createReactiveStoreWithInitialValueAndSlotTracking,
+    type CreateReactiveStoreWithInitialValueAndSlotTrackingConfig,
+    type ReactiveStreamStore,
+    type SolanaRpcResponse,
+} from '@solana/kit';
+import { useMemo } from 'react';
+
+import { disabledStreamStore } from './staticStores';
+import { useReactiveStoreLifecycle } from './useReactiveStoreLifecycle';
+import { useTrackedDataResult } from './useTrackedDataResult';
+
+// Module-level so it's a stable reference — keeps the `refresh` callback from
+// `useReactiveStoreLifecycle` referentially stable across renders.
+function fireConnect<T>(store: ReactiveStreamStore<T>, signal: AbortSignal | undefined): void {
+    if (signal) store.withSignal(signal).connect();
+    else store.connect();
+}
+
+/**
+ * React-local alias for the Kit primitive's config. Lets the call site name the input shape as
+ * `TrackedDataSpec<TInitialValue, TStreamValue, TItem>` instead of the verbose
+ * `CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<...>`.
+ *
+ * @typeParam TInitialValue - The value inside the initial RPC `SolanaRpcResponse` envelope.
+ * @typeParam TStreamValue - The value inside subscription `SolanaRpcResponse` notifications.
+ * @typeParam TItem - The unified item type produced by the two mappers and stored in the result.
+ */
+export type TrackedDataSpec<TInitialValue, TStreamValue, TItem> =
+    CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TInitialValue, TStreamValue, TItem>;
+
+/**
+ * Reactive state for tracked data managed by {@link useTrackedData}.
+ *
+ * Lifecycle: starts at `loading` (or `disabled` when the spec is `null`) and fires both the
+ * initial RPC request and the subscription on mount; transitions to `loaded` on the first
+ * value (from either source — the underlying store slot-dedupes so out-of-order arrivals never
+ * regress) or `error` on failure. `refresh()` re-runs the whole pair — while a refresh is in
+ * flight, `status` returns to `loading` and the stale `data` and/or `error` from the prior
+ * outcome remain populated (stale-while-revalidate).
+ *
+ * @typeParam T - The unified item type held by the store, produced by the two mappers in the
+ *   spec.
+ */
+export type TrackedDataResult<T> = {
+    /**
+     * The latest value, slot-deduped across the initial RPC and the subscription, exactly as the
+     * underlying kit primitive emits it: a `SolanaRpcResponse<T>` envelope (`{ context: { slot },
+     * value }`). The primitive guarantees the envelope shape, so callers can read `data.value`
+     * and `data.context.slot` directly without a runtime check. `undefined` on the first load
+     * and while disabled. On `loading` after a prior outcome, on `error`, and on a subsequent
+     * refresh, holds the last received envelope so UIs can show stale data rather than flashing
+     * to blank.
+     */
+    data: SolanaRpcResponse<T> | undefined;
+    /**
+     * Error from either source, or `undefined`. Only the first error per connection window is
+     * captured (the underlying store drops subsequent errors until the next `refresh()` /
+     * connect). On `loading` after a prior `error`, holds the stale error so UIs can keep
+     * showing the failure context while the refresh is in flight. A subsequent `loaded` clears
+     * it.
+     */
+    error: unknown;
+    /**
+     * Re-run both the initial RPC request and the subscription. By default each call mints a
+     * fresh signal from `getAbortSignal` (if configured) and threads it through the underlying
+     * store's `withSignal(signal).connect()`. Pass `{ abortSignal }` to override the configured
+     * factory for just this attempt. Pass `{ abortSignal: undefined }` to opt out of the
+     * factory entirely for this attempt and run with no caller-provided signal.
+     *
+     * Stable reference. Safe to put in `onClick` handlers or effect deps — typically wired up
+     * to a "Refresh" or "Retry" button. Calls `store.connect()` under the hood, so it always
+     * (re)runs the pair regardless of current status; the bridge transitions back through
+     * `loading` while preserving stale `data` and `error`.
+     */
+    refresh: (options?: { abortSignal?: AbortSignal | undefined }) => void;
+    /**
+     * Lifecycle status as a discriminated string:
+     * - `loading`: an attempt is in progress. On the first attempt, `data` and `error` are
+     *   `undefined`. After a refresh, `data` and `error` hold the last known values from the
+     *   previous attempt (stale-while-revalidate).
+     * - `loaded`: a value has arrived from either source and `error` is `undefined`.
+     * - `error`: the attempt failed; `data` holds the last known value (if any).
+     * - `disabled`: spec was `null` — no work was started.
+     */
+    status: 'disabled' | 'error' | 'loaded' | 'loading';
+};
+
+/** Options accepted by {@link useTrackedData}. */
+export type UseTrackedDataOptions = {
+    /**
+     * Factory invoked on every attempt (initial run + every `refresh()`). The returned signal is
+     * attached to that attempt via the underlying store's `withSignal(signal).connect()`, so
+     * aborting it tears down both the in-flight RPC request and the subscription for that
+     * attempt.
+     *
+     * The most common use is per-attempt timeouts:
+     * `getAbortSignal: () => AbortSignal.timeout(30_000)` gives every attempt its own
+     * 30-second clock that resets on `refresh()`.
+     *
+     * Held in a ref synced to the latest render's closure — there is no need to memoize an
+     * inline factory.
+     */
+    getAbortSignal?: () => AbortSignal;
+};
+
+/**
+ * Render reactive state for an RPC subscription seeded by a one-shot RPC fetch, slot-deduped.
+ * The subscription (e.g. `accountNotifications`) is the primary source of live updates; the
+ * initial fetch (e.g. `getBalance`) provides a value to surface as soon as it resolves —
+ * typically before the first subscription notification arrives — so the `loading` paint is
+ * shorter than subscription-only would give you. The underlying store slot-dedupes between the
+ * two sources — out-of-order arrivals never regress the surfaced value.
+ *
+ * Pass a memoized {@link TrackedDataSpec} keyed on whatever inputs it depends on; stable identity
+ * is how the hook knows when to tear down and re-run. Pass `null` to gate the work off — the
+ * result reports `status: 'disabled'`.
+ *
+ * SSR-safe — on the server the connect effect doesn't run, so the store stays `idle` and the
+ * hook reports `status: 'loading'`. The first client render hydrates from that same `loading`
+ * paint, then commits the connect effect.
+ *
+ * @typeParam TInitialValue - The value inside the initial RPC `SolanaRpcResponse` envelope.
+ * @typeParam TStreamValue - The value inside subscription `SolanaRpcResponse` notifications.
+ * @typeParam TItem - The unified item type produced by the two mappers and stored in the result.
+ *
+ * @example
+ * ```tsx
+ * function AccountBalance({ address }: { address: Address }) {
+ *     const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+ *     const spec = useMemo(() => ({
+ *         initialValueSource: client.rpc.getBalance(address),
+ *         initialValueMapper: (lamports: bigint) => lamports,
+ *         streamSource: client.rpcSubscriptions.accountNotifications(address),
+ *         streamValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
+ *     }), [client, address]);
+ *     const { data, error, refresh } = useTrackedData(spec);
+ *     if (error) return <button onClick={refresh}>Retry</button>;
+ *     return <p>{data ? `${data.value} lamports at slot ${data.context.slot}` : 'Loading…'}</p>;
+ * }
+ * ```
+ *
+ * @see {@link TrackedDataResult}
+ * @see {@link UseTrackedDataOptions}
+ */
+export function useTrackedData<TInitialValue, TStreamValue, TItem>(
+    spec: TrackedDataSpec<TInitialValue, TStreamValue, TItem> | null,
+    options?: UseTrackedDataOptions,
+): TrackedDataResult<TItem> {
+    // One store per `spec`. Both creation paths return an `idle` store; the initial connect
+    // lives in the lifecycle effect below so the memo body stays pure (StrictMode's dev
+    // double-render, and any future render-discard, won't fire a network request from a
+    // discarded render).
+    const store = useMemo(() => {
+        if (spec == null) return disabledStreamStore<SolanaRpcResponse<TItem>>();
+        return createReactiveStoreWithInitialValueAndSlotTracking(spec);
+    }, [spec]);
+
+    // Connect on commit, reset on store change / unmount, and expose the stable `refresh`
+    // callback. `store.reset()` aborts the active attempt via the store's internal controller, so
+    // under StrictMode's mount → cleanup → mount sequence the first connect is properly aborted
+    // before the second one fires. `disabledStreamStore` returns a store whose `connect`/`reset`
+    // are no-ops, so the null-spec case needs no explicit gate.
+    const refresh = useReactiveStoreLifecycle(store, fireConnect, options?.getAbortSignal);
+
+    return useTrackedDataResult(store, refresh, spec == null);
+}

--- a/packages/react/src/useTrackedDataResult.ts
+++ b/packages/react/src/useTrackedDataResult.ts
@@ -1,0 +1,40 @@
+import type { ReactiveStreamStore, SolanaRpcResponse } from '@solana/kit';
+import { useMemo, useSyncExternalStore } from 'react';
+
+import type { TrackedDataResult } from './useTrackedData';
+
+/**
+ * Subscribes to a {@link ReactiveStreamStore} whose value is always shaped as
+ * `SolanaRpcResponse<TItem>` (which is what `createReactiveStoreWithInitialValueAndSlotTracking`
+ * produces) and maps its `idle | loading | loaded | error` lifecycle onto the
+ * {@link TrackedDataResult} shape consumed by `useTrackedData`. The envelope passes through
+ * unchanged — callers read `data.value` and `data.context.slot` directly.
+ *
+ * `idle` is ambiguous on its own: it covers both "no spec — store is disabled" and "real spec,
+ * connect effect hasn't fired yet on the current render." The `disabled` flag disambiguates:
+ * disabled → `status: 'disabled'`, enabled → `status: 'loading'` (the connect is about to fire
+ * on commit; consumers see a single `loading` paint rather than briefly flashing `disabled`).
+ *
+ * Stale-while-revalidate flows naturally through `state.data` / `state.error`, which the store
+ * preserves across `loading` transitions, so the bridge doesn't need to mirror them.
+ *
+ * @param store - The store to subscribe to.
+ * @param refresh - A stable callback that re-runs the initial RPC and the subscription.
+ *   Forwarded to the result so call sites have a single, hook-owned recovery affordance.
+ * @param disabled - When `true`, the result reports `status: 'disabled'`. Used by
+ *   `useTrackedData` to signal the null-spec case.
+ *
+ * @internal
+ */
+export function useTrackedDataResult<TItem>(
+    store: ReactiveStreamStore<SolanaRpcResponse<TItem>>,
+    refresh: (options?: { abortSignal?: AbortSignal | undefined }) => void,
+    disabled: boolean,
+): TrackedDataResult<TItem> {
+    const state = useSyncExternalStore(store.subscribe, store.getUnifiedState, store.getUnifiedState);
+    return useMemo(() => {
+        const status: TrackedDataResult<TItem>['status'] =
+            state.status === 'idle' ? (disabled ? 'disabled' : 'loading') : state.status;
+        return { data: state.data, error: state.error, refresh, status };
+    }, [state, refresh, disabled]);
+}


### PR DESCRIPTION
#### Summary of Changes

This PR adds the `useTrackedData` react hook. This is similar to `useSubscription`, but its reactive stream store is constructed using `createReactiveStoreWithInitialValueAndSlotTracking`. This means that it combines a `RpcSendable` and a `RpcSubscribable` and provides the latest value based on slot. In practice the usual behaviour will be that an RPC request provides an initial value before a subscription, but later messages from the subscription update the value.

Examples where this is useful are things like displaying an account's balance, or its latest data. RPC subscriptions don't vend data immediately on subscribing, so they need to be paired with a request for the initial value. This is what `createReactiveStoreWithInitialValueAndSlotTracking` handles, this hook just exposes it for react. 

```tsx
function AccountBalance({ address }: { address: Address }) {
    const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
    const spec = useMemo(
        () => ({
            rpcRequest: client.rpc.getBalance(address),
            rpcSubscriptionRequest: client.rpcSubscriptions.accountNotifications(address),
            rpcValueMapper: (lamports: bigint) => lamports,
            rpcSubscriptionValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
        }),
        [client, address],
    );
    const { data, slot, error, refresh } = useTrackedData(spec);
    if (error) return <button onClick={refresh}>Retry</button>;
    return <p>{data !== undefined ? `${data} lamports at slot ${slot}` : 'Loading…'}</p>;
}
```

This hook is more opinionated than the others - both the request and subscription must use the `SolanaRpcResponse` shape so that the slot is known. 