### PR TITLE
Refactor createReactiveStoreWithInitialValueAndSlotTracking to use store inputs

### DIFF
--- a/.changeset/empty-deserts-happen.md
+++ b/.changeset/empty-deserts-happen.md
@@ -1,0 +1,17 @@
+---
+'@solana/kit': major
+---
+
+`createReactiveStoreWithInitialValueAndSlotTracking` now consumes its two inputs as reactive sources rather than as request objects it calls `send()` / `subscribe()` on directly. The `rpcRequest` / `rpcSubscriptionRequest` config fields (and their `rpcValueMapper` / `rpcSubscriptionValueMapper`) are replaced by `initialValueSource: ReactiveActionSource<...>` / `streamSource: ReactiveStreamSource<...>` (with `initialValueMapper` / `streamValueMapper`).
+
+Each source is consumed via its `reactiveStore()` method, so the helper reuses `ReactiveActionStore` / `ReactiveStreamStore` primitives. `PendingRpcRequest` satisfies `ReactiveActionSource` and `PendingRpcSubscriptionsRequest` satisfies `ReactiveStreamSource`, so callers can still pass eg. `rpc.getBalance(addr)` / `rpcSubscriptions.accountNotifications(addr)` results directly.
+
+```ts
+const balanceStore = createReactiveStoreWithInitialValueAndSlotTracking({
+    initialValueSource: rpc.getBalance(myAddress, { commitment: 'confirmed' }),
+    initialValueMapper: lamports => lamports,
+    streamSource: rpcSubscriptions.accountNotifications(myAddress),
+    streamValueMapper: ({ lamports }) => lamports,
+});
+balanceStore.withSignal(AbortSignal.timeout(60_000)).connect();
+```

--- a/examples/react-app/src/functions/balance.ts
+++ b/examples/react-app/src/functions/balance.ts
@@ -25,11 +25,10 @@ export function balanceSubscribe(
     const [{ address }, { next }] = subscriptionArgs;
     const abortController = new AbortController();
     const store = createReactiveStoreWithInitialValueAndSlotTracking({
-        abortSignal: abortController.signal,
-        rpcRequest: rpc.getBalance(address, { commitment: 'confirmed' }),
-        rpcSubscriptionRequest: rpcSubscriptions.accountNotifications(address),
-        rpcSubscriptionValueMapper: ({ lamports }) => lamports,
-        rpcValueMapper: lamports => lamports,
+        initialValueMapper: lamports => lamports,
+        initialValueSource: rpc.getBalance(address, { commitment: 'confirmed' }),
+        streamSource: rpcSubscriptions.accountNotifications(address),
+        streamValueMapper: ({ lamports }) => lamports,
     });
     store.subscribe(() => {
         const error = store.getError();
@@ -39,6 +38,7 @@ export function balanceSubscribe(
             next(null, store.getState()?.value);
         }
     });
+    store.withSignal(abortController.signal).connect();
     return () => {
         abortController.abort();
     };

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -40,7 +40,7 @@ await airdrop({
 
 ### `createReactiveStoreWithInitialValueAndSlotTracking(config)`
 
-Creates a `ReactiveStreamStore` that combines an initial RPC fetch with an ongoing subscription to keep its state up to date. Uses slot-based comparison to ensure only the most recent value is kept, regardless of whether it came from the RPC response or a subscription notification.
+Creates a `ReactiveStreamStore` that combines an initial-value source with an ongoing stream source to keep its state up to date. Uses slot-based comparison to ensure only the most recent value is kept, regardless of whether it came from the initial value or a stream notification.
 
 The returned store is compatible with React's `useSyncExternalStore`, Svelte stores, Solid's `from()`, and any other reactive primitive that expects a `{ subscribe, getState }` contract.
 
@@ -57,18 +57,20 @@ const rpcSubscriptions = createSolanaRpcSubscriptions('ws://127.0.0.1:8900');
 const myAddress = address('FnHyam9w4NZoWR6mKN1CuGBritdsEWZQa4Z4oawLZGxa');
 
 const balanceStore = createReactiveStoreWithInitialValueAndSlotTracking({
-    abortSignal: AbortSignal.timeout(60_000),
-    rpcRequest: rpc.getBalance(myAddress, { commitment: 'confirmed' }),
-    rpcValueMapper: lamports => lamports,
-    rpcSubscriptionRequest: rpcSubscriptions.accountNotifications(myAddress),
-    rpcSubscriptionValueMapper: ({ lamports }) => lamports,
+    initialValueSource: rpc.getBalance(myAddress, { commitment: 'confirmed' }),
+    initialValueMapper: lamports => lamports,
+    streamSource: rpcSubscriptions.accountNotifications(myAddress),
+    streamValueMapper: ({ lamports }) => lamports,
 });
 
 const unsubscribe = balanceStore.subscribe(() => {
-    const error = balanceStore.getError();
-    if (error) console.error('Error:', error);
-    else console.log('Balance:', balanceStore.getState());
+    const state = balanceStore.getUnifiedState();
+    if (state.status === 'error') console.error('Error:', state.error);
+    else if (state.status === 'loaded') console.log('Balance:', state.data.value);
 });
+
+// Start fetching, cancelling after 60 seconds:
+balanceStore.withSignal(AbortSignal.timeout(60_000)).connect();
 ```
 
 ### `decompileTransactionMessageFetchingLookupTables(compiledTransactionMessage, rpc, config)`

--- a/packages/kit/src/__tests__/create-reactive-store-with-initial-value-and-slot-tracking-test.ts
+++ b/packages/kit/src/__tests__/create-reactive-store-with-initial-value-and-slot-tracking-test.ts
@@ -1,109 +1,94 @@
-import type { PendingRpcRequest } from '@solana/rpc';
-import type { PendingRpcSubscriptionsRequest } from '@solana/rpc-subscriptions';
 import type { SolanaRpcResponse } from '@solana/rpc-types';
+import {
+    createReactiveActionStore,
+    createReactiveStoreFromDataPublisherFactory,
+    ReactiveActionSource,
+    ReactiveStreamSource,
+} from '@solana/subscribable';
 
 import { createReactiveStoreWithInitialValueAndSlotTracking } from '../create-reactive-store-with-initial-value-and-slot-tracking';
 
 type TestValue = { count: number };
 
-function createMockRpcRequest(): {
-    mockRequest: PendingRpcRequest<SolanaRpcResponse<TestValue>>;
-    reject(error: unknown): void;
-    resolve(response: SolanaRpcResponse<TestValue>): void;
+// Backs the `initialValueSource` with a real `ReactiveActionStore`. The wrapped function hands out
+// a fresh controllable promise on every dispatch, so a retry (which builds a new store and
+// dispatches again) gets its own instance. `instances[i]` captures the resolve/reject and the
+// per-dispatch signal for the i-th dispatch.
+function createMockInitialValueSource(): {
+    fn: jest.Mock;
+    instances: {
+        reject(error: unknown): void;
+        resolve(response: SolanaRpcResponse<TestValue>): void;
+        signal: AbortSignal | undefined;
+    }[];
+    source: ReactiveActionSource<SolanaRpcResponse<TestValue>>;
 } {
-    const { promise, resolve, reject } = Promise.withResolvers<SolanaRpcResponse<TestValue>>();
-    return {
-        mockRequest: {
-            reactiveStore: jest.fn().mockImplementation(() => {
-                throw new Error('not implemented');
-            }),
-            send: jest.fn().mockReturnValue(promise),
-        },
-        reject,
-        resolve,
+    const instances: {
+        reject(error: unknown): void;
+        resolve(response: SolanaRpcResponse<TestValue>): void;
+        signal: AbortSignal | undefined;
+    }[] = [];
+    const fn = jest.fn().mockImplementation((signal?: AbortSignal) => {
+        const { promise, resolve, reject } = Promise.withResolvers<SolanaRpcResponse<TestValue>>();
+        instances.push({ reject, resolve, signal });
+        return promise;
+    });
+    const source: ReactiveActionSource<SolanaRpcResponse<TestValue>> = {
+        reactiveStore: () => createReactiveActionStore(fn),
     };
+    return { fn, instances, source };
 }
 
-function createMockSubscriptionRequest(): {
-    complete(): void;
-    error(err: unknown): void;
-    mockRequest: PendingRpcSubscriptionsRequest<SolanaRpcResponse<TestValue>>;
-    pushNotification(notification: SolanaRpcResponse<TestValue>): void;
+// Backs the `streamSource` with a real `ReactiveStreamStore` built from a mock `DataPublisher`
+// factory. The factory hands out a fresh publisher per connection, so a retry gets its own
+// instance. `publishers[i]` lets the test publish data/error onto the i-th connection and exposes
+// the per-connection signal.
+function createMockStreamSource(): {
+    createDataPublisher: jest.Mock;
+    publishers: { publish(channel: string, payload: unknown): void; signal: AbortSignal | undefined }[];
+    source: ReactiveStreamSource<SolanaRpcResponse<TestValue>>;
 } {
-    const notifications: SolanaRpcResponse<TestValue>[] = [];
-    let waitingResolve: ((value: IteratorResult<SolanaRpcResponse<TestValue>>) => void) | null = null;
-    let waitingReject: ((reason: unknown) => void) | null = null;
-    let done = false;
-    let errorValue: unknown;
-    let hasError = false;
-
-    const asyncIterable: AsyncIterable<SolanaRpcResponse<TestValue>> = {
-        [Symbol.asyncIterator]() {
-            return {
-                next() {
-                    if (notifications.length > 0) {
-                        return Promise.resolve({ done: false, value: notifications.shift()! } as const);
-                    }
-                    if (done) {
-                        return Promise.resolve({ done: true, value: undefined } as const);
-                    }
-                    if (hasError) {
-                        return Promise.reject(errorValue as Error);
-                    }
-                    return new Promise<IteratorResult<SolanaRpcResponse<TestValue>>>((resolve, reject) => {
-                        waitingResolve = resolve;
-                        waitingReject = reject;
-                    });
-                },
-            };
-        },
-    };
-
-    const pushNotification = (notification: SolanaRpcResponse<TestValue>) => {
-        if (waitingResolve) {
-            const resolve = waitingResolve;
-            waitingResolve = null;
-            resolve({ done: false, value: notification });
-        } else {
-            notifications.push(notification);
-        }
-    };
-
-    const error = (err: unknown) => {
-        hasError = true;
-        errorValue = err;
-        if (waitingReject) {
-            const reject = waitingReject;
-            waitingResolve = null;
-            waitingReject = null;
-            reject(err);
-        }
-    };
-
-    const complete = () => {
-        done = true;
-        if (waitingResolve) {
-            const resolve = waitingResolve;
-            waitingResolve = null;
-            resolve({ done: true, value: undefined });
-        }
-    };
-
-    return {
-        complete,
-        error,
-        mockRequest: {
-            reactiveStore: jest.fn().mockImplementation(() => {
-                throw new Error('not implemented');
+    const publishers: { publish(channel: string, payload: unknown): void; signal: AbortSignal | undefined }[] = [];
+    const createDataPublisher = jest.fn().mockImplementation((signal?: AbortSignal) => {
+        const mockOn = jest.fn().mockReturnValue(function unsubscribe() {});
+        publishers.push({
+            publish(channel: string, payload: unknown) {
+                mockOn.mock.calls
+                    .filter(
+                        ([actualChannel, , options]: [string, unknown, { signal?: AbortSignal } | undefined]) =>
+                            actualChannel === channel && !options?.signal?.aborted,
+                    )
+                    .forEach(([, listener]) => listener(payload));
+            },
+            signal,
+        });
+        return Promise.resolve({ on: mockOn });
+    });
+    const source: ReactiveStreamSource<SolanaRpcResponse<TestValue>> = {
+        reactiveStore: () =>
+            createReactiveStoreFromDataPublisherFactory<SolanaRpcResponse<TestValue>>({
+                createDataPublisher,
+                dataChannelName: 'data',
+                errorChannelName: 'error',
             }),
-            subscribe: jest.fn().mockResolvedValue(asyncIterable),
-        },
-        pushNotification,
     };
+    return { createDataPublisher, publishers, source };
 }
 
 function rpcResponse(slot: number, value: TestValue): SolanaRpcResponse<TestValue> {
     return { context: { slot: BigInt(slot) }, value };
+}
+
+function createStore(
+    initialValueSource: ReactiveActionSource<SolanaRpcResponse<TestValue>>,
+    streamSource: ReactiveStreamSource<SolanaRpcResponse<TestValue>>,
+) {
+    return createReactiveStoreWithInitialValueAndSlotTracking({
+        initialValueMapper: (v: TestValue) => v.count,
+        initialValueSource,
+        streamSource,
+        streamValueMapper: (v: TestValue) => v.count,
+    });
 }
 
 jest.useFakeTimers();
@@ -121,98 +106,68 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
 
     describe('getState()', () => {
         it('returns `undefined` before any data arrives', () => {
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             expect(store.getState()).toBeUndefined();
         });
-        it('updates with the RPC response value', async () => {
+        it('updates with the initial-value source response', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
-            resolve(rpcResponse(100, { count: 42 }));
+            instances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             expect(store.getState()).toEqual({ context: { slot: 100n }, value: 42 });
         });
-        it('updates with a subscription notification value', async () => {
+        it('updates with a stream notification value', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             await jest.runAllTimersAsync();
-            pushNotification(rpcResponse(100, { count: 99 }));
+            publishers[0].publish('data', rpcResponse(100, { count: 99 }));
             await jest.runAllTimersAsync();
             expect(store.getState()).toEqual({ context: { slot: 100n }, value: 99 });
         });
-        it('ignores the RPC response when a newer subscription notification has already arrived', async () => {
+        it('ignores the initial value when a newer stream notification has already arrived', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             await jest.runAllTimersAsync();
-            pushNotification(rpcResponse(200, { count: 99 }));
+            publishers[0].publish('data', rpcResponse(200, { count: 99 }));
             await jest.runAllTimersAsync();
-            // RPC response arrives later at an older slot
-            resolve(rpcResponse(100, { count: 42 }));
+            // Initial value arrives later at an older slot
+            instances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             expect(store.getState()).toEqual({ context: { slot: 200n }, value: 99 });
         });
-        it('ignores a subscription notification when the RPC response was at a newer slot', async () => {
+        it('ignores a stream notification when the initial value was at a newer slot', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
-            resolve(rpcResponse(200, { count: 42 }));
+            instances[0].resolve(rpcResponse(200, { count: 42 }));
             await jest.runAllTimersAsync();
-            pushNotification(rpcResponse(100, { count: 99 }));
+            publishers[0].publish('data', rpcResponse(100, { count: 99 }));
             await jest.runAllTimersAsync();
             expect(store.getState()).toEqual({ context: { slot: 200n }, value: 42 });
         });
         it('preserves the last known value after an error', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
-            resolve(rpcResponse(100, { count: 42 }));
+            instances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
-            error(new Error('subscription failed'));
+            publishers[0].publish('error', new Error('stream failed'));
             await jest.runAllTimersAsync();
             expect(store.getState()).toEqual({ context: { slot: 100n }, value: 42 });
         });
@@ -220,208 +175,147 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
 
     describe('getError()', () => {
         it('returns `undefined` before any error', () => {
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             expect(store.getError()).toBeUndefined();
         });
-        it('captures an error from the RPC request', async () => {
+        it('captures an error from the initial-value source', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, reject } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
-            const error = new Error('rpc failed');
-            reject(error);
+            const error = new Error('initial value failed');
+            instances[0].reject(error);
             await jest.runAllTimersAsync();
             expect(store.getError()).toBe(error);
         });
-        it('captures an error from the subscription', async () => {
+        it('captures an error from the stream', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             await jest.runAllTimersAsync();
-            const subscriptionError = new Error('subscription failed');
-            error(subscriptionError);
+            const streamError = new Error('stream failed');
+            publishers[0].publish('error', streamError);
             await jest.runAllTimersAsync();
-            expect(store.getError()).toBe(subscriptionError);
+            expect(store.getError()).toBe(streamError);
         });
-        it('only captures the first error when RPC fails then subscription fails', async () => {
+        it('only captures the first error when the initial value fails then the stream fails', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, reject: rejectRpc } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, error: errorSubscription } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             await jest.runAllTimersAsync();
-            rejectRpc(new Error('rpc error'));
+            instances[0].reject(new Error('initial value error'));
             await jest.runAllTimersAsync();
-            errorSubscription(new Error('subscription error'));
+            publishers[0].publish('error', new Error('stream error'));
             await jest.runAllTimersAsync();
-            expect(store.getError()).toEqual(new Error('rpc error'));
+            expect(store.getError()).toEqual(new Error('initial value error'));
         });
-        it('only captures the first error when subscription fails then RPC fails', async () => {
+        it('only captures the first error when the stream fails then the initial value fails', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, reject: rejectRpc } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, error: errorSubscription } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             await jest.runAllTimersAsync();
-            errorSubscription(new Error('subscription error'));
+            publishers[0].publish('error', new Error('stream error'));
             await jest.runAllTimersAsync();
-            rejectRpc(new Error('rpc error'));
+            instances[0].reject(new Error('initial value error'));
             await jest.runAllTimersAsync();
-            expect(store.getError()).toEqual(new Error('subscription error'));
+            expect(store.getError()).toEqual(new Error('stream error'));
         });
     });
 
     describe('subscribe()', () => {
-        it('calls the subscriber when the RPC response arrives', async () => {
+        it('calls the subscriber when the initial value arrives', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             const subscriber = jest.fn();
             store.subscribe(subscriber);
-            resolve(rpcResponse(100, { count: 42 }));
+            instances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             expect(subscriber).toHaveBeenCalledTimes(1);
         });
-        it('calls the subscriber when a subscription notification arrives', async () => {
+        it('calls the subscriber when a stream notification arrives', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             const subscriber = jest.fn();
             store.subscribe(subscriber);
             await jest.runAllTimersAsync();
-            pushNotification(rpcResponse(100, { count: 99 }));
+            publishers[0].publish('data', rpcResponse(100, { count: 99 }));
             await jest.runAllTimersAsync();
             expect(subscriber).toHaveBeenCalledTimes(1);
         });
         it('does not call the subscriber when an out-of-order notification is skipped', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             const subscriber = jest.fn();
             store.subscribe(subscriber);
-            resolve(rpcResponse(200, { count: 42 }));
+            instances[0].resolve(rpcResponse(200, { count: 42 }));
             await jest.runAllTimersAsync();
             subscriber.mockClear();
-            await jest.runAllTimersAsync();
             // This notification is at an older slot and should be skipped
-            pushNotification(rpcResponse(100, { count: 99 }));
+            publishers[0].publish('data', rpcResponse(100, { count: 99 }));
             await jest.runAllTimersAsync();
             expect(subscriber).not.toHaveBeenCalled();
         });
         it('calls the subscriber when an error occurs', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, reject } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             const subscriber = jest.fn();
             store.subscribe(subscriber);
-            reject(new Error('fail'));
+            instances[0].reject(new Error('fail'));
             await jest.runAllTimersAsync();
             expect(subscriber).toHaveBeenCalledTimes(1);
         });
-        it('calls the subscriber when a subscription error occurs', async () => {
+        it('calls the subscriber when a stream error occurs', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             const subscriber = jest.fn();
             store.subscribe(subscriber);
             await jest.runAllTimersAsync();
-            error(new Error('fail'));
+            publishers[0].publish('error', new Error('fail'));
             await jest.runAllTimersAsync();
             expect(subscriber).toHaveBeenCalledTimes(1);
         });
         it('stops calling the subscriber after unsubscribe', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             const subscriber = jest.fn();
             const unsubscribe = store.subscribe(subscriber);
             unsubscribe();
-            resolve(rpcResponse(100, { count: 42 }));
+            instances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             expect(subscriber).not.toHaveBeenCalled();
         });
         it('the unsubscribe function is idempotent', () => {
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             const unsubscribe = store.subscribe(jest.fn());
             expect(() => {
@@ -432,47 +326,32 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
     });
 
     describe('withSignal()', () => {
-        it('forwards the composed signal to the RPC request', () => {
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+        it('forwards the composed signal to the initial-value source', () => {
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.withSignal(abortController.signal).connect();
-            const rpcSignal = (rpcRequest.send as jest.Mock).mock.calls[0][0].abortSignal;
-            expect(rpcSignal.aborted).toBe(false);
+            const signal = instances[0].signal!;
+            expect(signal.aborted).toBe(false);
             abortController.abort('test reason');
-            expect(rpcSignal.aborted).toBe(true);
-            expect(rpcSignal.reason).toBe('test reason');
+            expect(signal.aborted).toBe(true);
+            expect(signal.reason).toBe('test reason');
         });
-        it('forwards the composed signal to the subscription request', () => {
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+        it('forwards the composed signal to the stream source', () => {
+            const { source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.withSignal(abortController.signal).connect();
-            const subscriptionSignal = (rpcSubscriptionRequest.subscribe as jest.Mock).mock.calls[0][0].abortSignal;
-            expect(subscriptionSignal.aborted).toBe(false);
+            const signal = publishers[0].signal!;
+            expect(signal.aborted).toBe(false);
             abortController.abort('test reason');
-            expect(subscriptionSignal.aborted).toBe(true);
-            expect(subscriptionSignal.reason).toBe('test reason');
+            expect(signal.aborted).toBe(true);
+            expect(signal.reason).toBe('test reason');
         });
         it('transitions to `error` with the caller signal abort reason', () => {
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.withSignal(abortController.signal).connect();
             const reason = new Error('timed out');
             abortController.abort(reason);
@@ -482,53 +361,38 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 status: 'error',
             });
         });
-        it('does not overwrite the abort-reason error with a late RPC rejection', async () => {
+        it('does not overwrite the abort-reason error with a late initial-value rejection', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, reject } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.withSignal(abortController.signal).connect();
             const reason = new Error('cancelled');
             abortController.abort(reason);
-            reject(new Error('rpc-late'));
+            instances[0].reject(new Error('late'));
             await jest.runAllTimersAsync();
             expect(store.getError()).toBe(reason);
         });
-        it('does not update state when the RPC response arrives after abort', async () => {
+        it('does not update state when the initial value arrives after abort', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.withSignal(abortController.signal).connect();
             abortController.abort();
-            resolve(rpcResponse(100, { count: 42 }));
+            instances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             expect(store.getState()).toBeUndefined();
         });
-        it('does not update state when a subscription notification arrives after abort', async () => {
+        it('does not update state when a stream notification arrives after abort', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, pushNotification } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.withSignal(abortController.signal).connect();
             await jest.runAllTimersAsync();
             abortController.abort();
-            pushNotification(rpcResponse(100, { count: 99 }));
+            publishers[0].publish('data', rpcResponse(100, { count: 99 }));
             await jest.runAllTimersAsync();
             expect(store.getState()).toBeUndefined();
         });
@@ -536,14 +400,9 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
 
     describe('getUnifiedState()', () => {
         it('starts in `loading` status', () => {
-            const { mockRequest: rpcRequest } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             expect(store.getUnifiedState()).toStrictEqual({
                 data: undefined,
@@ -551,18 +410,13 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 status: 'loading',
             });
         });
-        it('transitions to `loaded` after the RPC response arrives', async () => {
+        it('transitions to `loaded` after the initial value arrives', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
-            resolve(rpcResponse(100, { count: 42 }));
+            instances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             expect(store.getUnifiedState()).toStrictEqual({
                 data: { context: { slot: 100n }, value: 42 },
@@ -570,19 +424,14 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 status: 'loaded',
             });
         });
-        it('transitions to `error` on RPC failure, preserving nothing (no prior data)', async () => {
+        it('transitions to `error` on initial-value failure, preserving nothing (no prior data)', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, reject } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
-            const failure = new Error('rpc failed');
-            reject(failure);
+            const failure = new Error('initial value failed');
+            instances[0].reject(failure);
             await jest.runAllTimersAsync();
             expect(store.getUnifiedState()).toStrictEqual({
                 data: undefined,
@@ -590,21 +439,16 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 status: 'error',
             });
         });
-        it('transitions to `error` on subscription failure, preserving the RPC value', async () => {
+        it('transitions to `error` on stream failure, preserving the initial value', async () => {
             expect.assertions(1);
-            const { mockRequest: rpcRequest, resolve } = createMockRpcRequest();
-            const { mockRequest: rpcSubscriptionRequest, error } = createMockSubscriptionRequest();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
-            resolve(rpcResponse(100, { count: 42 }));
+            instances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
-            const failure = new Error('subscription failed');
-            error(failure);
+            const failure = new Error('stream failed');
+            publishers[0].publish('error', failure);
             await jest.runAllTimersAsync();
             expect(store.getUnifiedState()).toStrictEqual({
                 data: { context: { slot: 100n }, value: 42 },
@@ -612,75 +456,115 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 status: 'error',
             });
         });
+        it('transitions to `loaded` after a stream notification arrives', async () => {
+            expect.assertions(1);
+            const { source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
+            store.connect();
+            await jest.runAllTimersAsync();
+            publishers[0].publish('data', rpcResponse(100, { count: 99 }));
+            await jest.runAllTimersAsync();
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: { context: { slot: 100n }, value: 99 },
+                error: undefined,
+                status: 'loaded',
+            });
+        });
+        it('keeps the newer stream value when an older initial value arrives later', async () => {
+            expect.assertions(1);
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
+            store.connect();
+            await jest.runAllTimersAsync();
+            publishers[0].publish('data', rpcResponse(200, { count: 99 }));
+            await jest.runAllTimersAsync();
+            // Initial value arrives later at an older slot and should be ignored
+            instances[0].resolve(rpcResponse(100, { count: 42 }));
+            await jest.runAllTimersAsync();
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: { context: { slot: 200n }, value: 99 },
+                error: undefined,
+                status: 'loaded',
+            });
+        });
+        it('keeps the newer initial value when an older stream notification arrives later', async () => {
+            expect.assertions(1);
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
+            store.connect();
+            instances[0].resolve(rpcResponse(200, { count: 42 }));
+            await jest.runAllTimersAsync();
+            // Stream notification arrives at an older slot and should be ignored
+            publishers[0].publish('data', rpcResponse(100, { count: 99 }));
+            await jest.runAllTimersAsync();
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: { context: { slot: 200n }, value: 42 },
+                error: undefined,
+                status: 'loaded',
+            });
+        });
+        it('captures only the first error when the initial value fails then the stream fails', async () => {
+            expect.assertions(1);
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
+            store.connect();
+            await jest.runAllTimersAsync();
+            const firstError = new Error('initial value error');
+            instances[0].reject(firstError);
+            await jest.runAllTimersAsync();
+            publishers[0].publish('error', new Error('stream error'));
+            await jest.runAllTimersAsync();
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: undefined,
+                error: firstError,
+                status: 'error',
+            });
+        });
+        it('captures only the first error when the stream fails then the initial value fails', async () => {
+            expect.assertions(1);
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
+            store.connect();
+            await jest.runAllTimersAsync();
+            const firstError = new Error('stream error');
+            publishers[0].publish('error', firstError);
+            await jest.runAllTimersAsync();
+            instances[0].reject(new Error('initial value error'));
+            await jest.runAllTimersAsync();
+            expect(store.getUnifiedState()).toStrictEqual({
+                data: undefined,
+                error: firstError,
+                status: 'error',
+            });
+        });
     });
 
     describe('retry()', () => {
-        // Helper: returns mocks where each invocation of rpcRequest.send() /
-        // rpcSubscriptionRequest.subscribe() yields a fresh controllable instance — needed to
-        // exercise retry, which re-invokes both.
-        function createRetryableMocks() {
-            const rpcInstances: {
-                reject(error: unknown): void;
-                resolve(response: SolanaRpcResponse<TestValue>): void;
-            }[] = [];
-            const subscriptionInstances: {
-                error(err: unknown): void;
-                pushNotification(notification: SolanaRpcResponse<TestValue>): void;
-            }[] = [];
-            const rpcRequest: PendingRpcRequest<SolanaRpcResponse<TestValue>> = {
-                reactiveStore: jest.fn().mockImplementation(() => {
-                    throw new Error('not implemented');
-                }),
-                send: jest.fn().mockImplementation(() => {
-                    const { promise, resolve, reject } = Promise.withResolvers<SolanaRpcResponse<TestValue>>();
-                    rpcInstances.push({ reject, resolve });
-                    return promise;
-                }),
-            };
-            const rpcSubscriptionRequest: PendingRpcSubscriptionsRequest<SolanaRpcResponse<TestValue>> = {
-                reactiveStore: jest.fn().mockImplementation(() => {
-                    throw new Error('not implemented');
-                }),
-                subscribe: jest.fn().mockImplementation(() => {
-                    const instance = createMockSubscriptionRequest();
-                    subscriptionInstances.push({
-                        error: instance.error,
-                        pushNotification: instance.pushNotification,
-                    });
-                    return (instance.mockRequest.subscribe as jest.Mock)();
-                }),
-            };
-            return { rpcInstances, rpcRequest, rpcSubscriptionRequest, subscriptionInstances };
-        }
-
         it('is a no-op when the store is not in error state', async () => {
             expect.assertions(1);
-            const { rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { fn, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
             await jest.runAllTimersAsync();
             store.retry();
-            expect(rpcRequest.send).toHaveBeenCalledTimes(1);
+            expect(fn).toHaveBeenCalledTimes(1);
         });
         it('transitions back to `loading` with preserved data AND error (SWR)', async () => {
             expect.assertions(1);
-            const { rpcInstances, rpcRequest, rpcSubscriptionRequest, subscriptionInstances } = createRetryableMocks();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { publishers, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
-            rpcInstances[0].resolve(rpcResponse(100, { count: 42 }));
+            instances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
             const fail = new Error('stream died');
-            subscriptionInstances[0].error(fail);
+            publishers[0].publish('error', fail);
             await jest.runAllTimersAsync();
             store.retry();
             expect(store.getUnifiedState()).toStrictEqual({
@@ -689,38 +573,30 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 status: 'loading',
             });
         });
-        it('re-invokes the RPC request and subscription on retry', async () => {
+        it('re-builds both inner stores on retry', async () => {
             expect.assertions(2);
-            const { rpcInstances, rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { fn, instances, source: initialValueSource } = createMockInitialValueSource();
+            const { createDataPublisher, source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
-            rpcInstances[0].reject(new Error('boom'));
+            instances[0].reject(new Error('boom'));
             await jest.runAllTimersAsync();
             store.retry();
             await jest.runAllTimersAsync();
-            expect(rpcRequest.send).toHaveBeenCalledTimes(2);
-            expect(rpcSubscriptionRequest.subscribe).toHaveBeenCalledTimes(2);
+            expect(fn).toHaveBeenCalledTimes(2);
+            expect(createDataPublisher).toHaveBeenCalledTimes(2);
         });
-        it('recovers to `loaded` when the retried RPC succeeds', async () => {
+        it('recovers to `loaded` when the retried initial value succeeds', async () => {
             expect.assertions(1);
-            const { rpcInstances, rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
-            rpcInstances[0].reject(new Error('first failure'));
+            instances[0].reject(new Error('first failure'));
             await jest.runAllTimersAsync();
             store.retry();
             await jest.runAllTimersAsync();
-            rpcInstances[1].resolve(rpcResponse(200, { count: 99 }));
+            instances[1].resolve(rpcResponse(200, { count: 99 }));
             await jest.runAllTimersAsync();
             expect(store.getUnifiedState()).toStrictEqual({
                 data: { context: { slot: 200n }, value: 99 },
@@ -728,22 +604,18 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
                 status: 'loaded',
             });
         });
-        it('transitions to `error` again when the retried RPC also fails', async () => {
+        it('transitions to `error` again when the retried initial value also fails', async () => {
             expect.assertions(1);
-            const { rpcInstances, rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
-            rpcInstances[0].reject(new Error('first'));
+            instances[0].reject(new Error('first'));
             await jest.runAllTimersAsync();
             store.retry();
             await jest.runAllTimersAsync();
             const secondFailure = new Error('second');
-            rpcInstances[1].reject(secondFailure);
+            instances[1].reject(secondFailure);
             await jest.runAllTimersAsync();
             expect(store.getUnifiedState()).toStrictEqual({
                 data: undefined,
@@ -753,15 +625,11 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
         });
         it('notifies subscribers on the error → loading transition after retry', async () => {
             expect.assertions(1);
-            const { rpcInstances, rpcRequest, rpcSubscriptionRequest } = createRetryableMocks();
-            const store = createReactiveStoreWithInitialValueAndSlotTracking({
-                rpcRequest,
-                rpcSubscriptionRequest,
-                rpcSubscriptionValueMapper: v => v.count,
-                rpcValueMapper: v => v.count,
-            });
+            const { instances, source: initialValueSource } = createMockInitialValueSource();
+            const { source: streamSource } = createMockStreamSource();
+            const store = createStore(initialValueSource, streamSource);
             store.connect();
-            rpcInstances[0].reject(new Error('fail'));
+            instances[0].reject(new Error('fail'));
             await jest.runAllTimersAsync();
             const subscriber = jest.fn();
             store.subscribe(subscriber);

--- a/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
+++ b/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
@@ -1,40 +1,44 @@
-import type { PendingRpcRequest } from '@solana/rpc';
-import type { PendingRpcSubscriptionsRequest } from '@solana/rpc-subscriptions';
 import type { SolanaRpcResponse } from '@solana/rpc-types';
-import type { ReactiveState, ReactiveStreamStore } from '@solana/subscribable';
+import type {
+    ReactiveActionSource,
+    ReactiveState,
+    ReactiveStreamSource,
+    ReactiveStreamStore,
+} from '@solana/subscribable';
 
 /**
  * Configuration for {@link createReactiveStoreWithInitialValueAndSlotTracking}. Pairs a one-shot
- * RPC fetch with an ongoing subscription so the resulting store can hydrate from the initial
- * response and keep up to date with notifications, slot-deduplicating the two streams.
+ * initial-value source with an ongoing stream source so the resulting store can hydrate from the
+ * initial response and keep up to date with notifications, slot-deduplicating the two sources.
  *
- * @typeParam TRpcValue - The value type returned by `rpcRequest` (inside the {@link SolanaRpcResponse} envelope).
- * @typeParam TSubscriptionValue - The value type emitted by `rpcSubscriptionRequest` (inside the {@link SolanaRpcResponse} envelope).
+ * @typeParam TInitialValue - The value type produced by `initialValueSource` (inside the {@link SolanaRpcResponse} envelope).
+ * @typeParam TStreamValue - The value type emitted by `streamSource` (inside the {@link SolanaRpcResponse} envelope).
  * @typeParam TItem - The unified item type the store holds, produced by the two value mappers.
  *
  * @see {@link createReactiveStoreWithInitialValueAndSlotTracking}
  */
-export type CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscriptionValue, TItem> = Readonly<{
+export type CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TInitialValue, TStreamValue, TItem> = Readonly<{
     /**
-     * A pending RPC request whose response will be used to set the store's initial state.
-     * The response must be a {@link SolanaRpcResponse} so that its slot can be compared with
-     * subscription notifications.
+     * Maps the value from the initial-value source's response to the item type stored in the
+     * reactive store.
      */
-    rpcRequest: PendingRpcRequest<SolanaRpcResponse<TRpcValue>>;
+    initialValueMapper: (value: TInitialValue) => TItem;
     /**
-     * A pending RPC subscription request whose notifications will be used to keep the store
-     * up to date. Each notification must be a {@link SolanaRpcResponse} so that its slot can be
-     * compared with the initial RPC response and other notifications.
+     * A reactive action source whose dispatched value will be used to set the store's initial
+     * state. The value must be a {@link SolanaRpcResponse} so that its slot can be compared with
+     * stream notifications. Satisfied by `PendingRpcRequest`.
      */
-    rpcSubscriptionRequest: PendingRpcSubscriptionsRequest<SolanaRpcResponse<TSubscriptionValue>>;
+    initialValueSource: ReactiveActionSource<SolanaRpcResponse<TInitialValue>>;
     /**
-     * Maps the value from a subscription notification to the item type stored in the reactive store.
+     * A reactive stream source whose notifications will be used to keep the store up to date. Each
+     * notification must be a {@link SolanaRpcResponse} so that its slot can be compared with the
+     * initial value and with other notifications. Satisfied by `PendingRpcSubscriptionsRequest`.
      */
-    rpcSubscriptionValueMapper: (value: TSubscriptionValue) => TItem;
+    streamSource: ReactiveStreamSource<SolanaRpcResponse<TStreamValue>>;
     /**
-     * Maps the value from the RPC response to the item type stored in the reactive store.
+     * Maps the value from a stream notification to the item type stored in the reactive store.
      */
-    rpcValueMapper: (value: TRpcValue) => TItem;
+    streamValueMapper: (value: TStreamValue) => TItem;
 }>;
 
 const IDLE_STATE: ReactiveState<never> = Object.freeze({
@@ -44,27 +48,31 @@ const IDLE_STATE: ReactiveState<never> = Object.freeze({
 });
 
 /**
- * Creates a {@link ReactiveStreamStore} that combines an initial RPC fetch with an ongoing subscription
- * to keep its state up to date.
+ * Creates a {@link ReactiveStreamStore} that combines an initial one-shot fetch with an ongoing
+ * stream to keep its state up to date.
  *
  * The store uses slot-based comparison to ensure that only the most recent value is kept,
- * regardless of whether it came from the initial RPC response or a subscription notification.
- * This prevents stale data from overwriting newer data when the RPC response and subscription
- * notifications arrive out of order.
+ * regardless of whether it came from the initial value source or a stream notification. This
+ * prevents stale data from overwriting newer data when the two sources arrive out of order.
+ *
+ * The two sources are consumed via their {@link ReactiveActionSource.reactiveStore | `reactiveStore()`}
+ * methods rather than by calling `send()` / `subscribe()` directly, so any object satisfying the
+ * {@link ReactiveActionSource} / {@link ReactiveStreamSource} duck-types works — including
+ * `PendingRpcRequest` / `PendingRpcSubscriptionsRequest` and plugin-authored wrappers.
  *
  * Things to note:
  *
  * - The returned store starts in `status: 'idle'`. Call
- *   {@link ReactiveStreamStore.connect | `connect()`} to fire the RPC request and open the
- *   subscription.
- * - The store transitions through `loading` until the first response or notification arrives,
+ *   {@link ReactiveStreamStore.connect | `connect()`} to dispatch the initial-value source and open
+ *   the stream.
+ * - The store transitions through `loading` until the first value or notification arrives,
  *   then to `loaded` with a {@link SolanaRpcResponse} containing the value and the slot context
  *   at which it was observed.
  * - On error from either source, the store transitions to `status: 'error'` preserving the last
  *   known value. Only the first error per connection window is captured.
  * - A subsequent `connect()` aborts the current connection, transitions back to
  *   `status: 'loading'` (preserving the last known `data` and `error` for stale-while-revalidate),
- *   and re-fires the RPC request and subscription with a fresh inner abort signal.
+ *   and re-builds both inner stores with a fresh inner abort signal.
  * - {@link ReactiveStreamStore.reset | `reset()`} aborts the current connection and returns the
  *   store to `idle`, clearing `data` and `error`.
  * - Attach a caller-provided cancellation source via
@@ -88,10 +96,10 @@ const IDLE_STATE: ReactiveState<never> = Object.freeze({
  * const myAddress = address('FnHyam9w4NZoWR6mKN1CuGBritdsEWZQa4Z4oawLZGxa');
  *
  * const balanceStore = createReactiveStoreWithInitialValueAndSlotTracking({
- *     rpcRequest: rpc.getBalance(myAddress, { commitment: 'confirmed' }),
- *     rpcValueMapper: lamports => lamports,
- *     rpcSubscriptionRequest: rpcSubscriptions.accountNotifications(myAddress),
- *     rpcSubscriptionValueMapper: ({ lamports }) => lamports,
+ *     initialValueSource: rpc.getBalance(myAddress, { commitment: 'confirmed' }),
+ *     initialValueMapper: lamports => lamports,
+ *     streamSource: rpcSubscriptions.accountNotifications(myAddress),
+ *     streamValueMapper: ({ lamports }) => lamports,
  * });
  *
  * const unsubscribe = balanceStore.subscribe(() => {
@@ -108,12 +116,12 @@ const IDLE_STATE: ReactiveState<never> = Object.freeze({
  *
  * @see {@link ReactiveStreamStore}
  */
-export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TSubscriptionValue, TItem>({
-    rpcRequest,
-    rpcValueMapper,
-    rpcSubscriptionRequest,
-    rpcSubscriptionValueMapper,
-}: CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TRpcValue, TSubscriptionValue, TItem>): ReactiveStreamStore<
+export function createReactiveStoreWithInitialValueAndSlotTracking<TInitialValue, TStreamValue, TItem>({
+    initialValueMapper,
+    initialValueSource,
+    streamSource,
+    streamValueMapper,
+}: CreateReactiveStoreWithInitialValueAndSlotTrackingConfig<TInitialValue, TStreamValue, TItem>): ReactiveStreamStore<
     SolanaRpcResponse<TItem>
 > {
     let currentState: ReactiveState<SolanaRpcResponse<TItem>> = IDLE_STATE;
@@ -175,37 +183,55 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TRpcValue, TS
             innerController.abort(err);
         }
 
-        function handleValue(value: SolanaRpcResponse<TItem>) {
-            setState({ data: value, error: undefined, status: 'loaded' });
+        // `lastUpdateSlot` persists across reconnects so the store never regresses. If a source
+        // delivers a value at a slot older than one we've already seen, we keep waiting for
+        // something newer before leaving `loading`.
+        function handleSlottedValue({ context: { slot }, value }: SolanaRpcResponse<TItem>) {
+            if (signal.aborted) return;
+            if (slot < lastUpdateSlot) return;
+            lastUpdateSlot = slot;
+            setState({ data: { context: { slot }, value }, error: undefined, status: 'loaded' });
         }
 
-        rpcRequest
-            .send({ abortSignal: signal })
-            .then(({ context: { slot }, value }) => {
-                if (signal.aborted) return;
-                // `lastUpdateSlot` persists across reconnects so the store never regresses. If
-                // the re-fetched RPC returns a slot older than one we've already seen, we wait
-                // for the subscription to deliver something newer before leaving `loading`.
-                if (slot < lastUpdateSlot) return;
-                lastUpdateSlot = slot;
-                handleValue({ context: { slot }, value: rpcValueMapper(value) });
-            })
-            .catch(handleError);
+        // Build fresh inner stores for this connection window and forward their state into the
+        // unified store. Drive both with the composed signal so they tear down when this connection
+        // window does.
+        const actionStore = initialValueSource.reactiveStore();
+        const streamStore = streamSource.reactiveStore();
 
-        rpcSubscriptionRequest
-            .subscribe({ abortSignal: signal })
-            .then(async notifications => {
-                for await (const {
-                    context: { slot },
-                    value,
-                } of notifications) {
-                    if (signal.aborted) return;
-                    if (slot < lastUpdateSlot) continue;
-                    lastUpdateSlot = slot;
-                    handleValue({ context: { slot }, value: rpcSubscriptionValueMapper(value) });
-                }
-            })
-            .catch(handleError);
+        const unsubscribeAction = actionStore.subscribe(() => {
+            const state = actionStore.getState();
+            if (state.status === 'success') {
+                const { context, value } = state.data;
+                handleSlottedValue({ context, value: initialValueMapper(value) });
+            } else if (state.status === 'error') {
+                handleError(state.error);
+            }
+        });
+        const unsubscribeStream = streamStore.subscribe(() => {
+            const state = streamStore.getUnifiedState();
+            if (state.status === 'loaded') {
+                const { context, value } = state.data;
+                handleSlottedValue({ context, value: streamValueMapper(value) });
+            } else if (state.status === 'error') {
+                handleError(state.error);
+            }
+        });
+
+        // Stop observing this connection's inner stores once it is superseded or the caller
+        // aborts.
+        // Note: don't call reset here, causes a race with the abort reason
+        innerSignal.addEventListener(
+            'abort',
+            () => {
+                unsubscribeAction();
+                unsubscribeStream();
+            },
+            { once: true },
+        );
+
+        streamStore.withSignal(signal).connect();
+        actionStore.withSignal(signal).dispatch();
     }
 
     function performReset() {


### PR DESCRIPTION
Note: this PR has been rewritten, first review comments refer to an old version

#### Problem

`createReactiveStoreWithInitialValueAndSlotTracking` currently takes as input a `PendingRpcRequest` and a `PendingRpcSubscriptionsRequest`. Internally it is using the `send()` and `subscribe()` functions, and not the `reactiveStore()` that is used by the react hooks. 

#### Summary of Changes

`createReactiveStoreWithInitialValueAndSlotTracking` is refactored to take a `ReactiveActionStore` and a `ReactiveStreamStore`, and its internals are rewritten to produce its store from these inputs.

Its config now has the shape:

```ts
{
    initialValueSource: ReactiveActionSource<SolanaRpcResponse<TInitialValue>>;
    initialValueMapper: (value: TInitialValue) => TItem;
    streamSource: ReactiveStreamSource<SolanaRpcResponse<TStreamValue>>;
    streamValueMapper: (value: TStreamValue) => TItem;
}
```

Its behaviour is unchanged - it combines the initial value and the stream and always provides the latest available data (based on slot) from either source

The following PR adds a react hook that exposes `createReactiveStoreWithInitialValueAndSlotTracking`, and it will now share the same input types with the other react hooks.