### PR TITLE
Add `@solana/react/swr` subpath with `useRequestSWR`

### DIFF
--- a/.changeset/mighty-clouds-admire.md
+++ b/.changeset/mighty-clouds-admire.md
@@ -1,0 +1,13 @@
+---
+'@solana/react': minor
+---
+
+Add `@solana/react/swr` subpath with `useRequestSWR(key, source, options?)` — the SWR-backed counterpart to `useRequest`. Same source shape (`ReactiveActionSource<T>` or `(signal) => Promise<T>`); returns SWR's native `SWRResponse<T>`. Pass `null` for either `key` or `source` to disable. Requires `swr@^2` as an optional peer dependency.
+
+```tsx
+import { useRequestSWR } from '@solana/react/swr';
+
+const { data } = useRequestSWR(['epochInfo'], client.rpc.getEpochInfo());
+```
+
+Options accept any `SWRConfiguration` field plus the Kit-only `getAbortSignal: () => AbortSignal` (same option as `useRequest`), which threads a per-attempt signal into the source — typically a timeout via `AbortSignal.timeout()`. Use SWR's `result.mutate()` to re-fire on demand.

--- a/packages/build-scripts/getBaseConfig.ts
+++ b/packages/build-scripts/getBaseConfig.ts
@@ -14,11 +14,15 @@ type Platform =
 const BROWSERSLIST_TARGETS = browsersListToEsBuild();
 
 export function getBaseConfig(platform: Platform, formats: Format[], _options: Options): Options[] {
-    // `@solana/kit` has an additional subpath entry point that should be published separately.
+    // Packages with additional subpath entry points list them here so each subpath gets its own
+    // platform-specific bundle (`dist/<entry>.<platform>.<format>`). Consumers import the subpath
+    // via the package.json `exports` map.
     const moduleEntry =
         env.npm_package_name === '@solana/kit'
             ? ['./src/index.ts', './src/program-client-core.ts']
-            : ['./src/index.ts'];
+            : env.npm_package_name === '@solana/react'
+              ? ['./src/index.ts', './src/swr.ts']
+              : ['./src/index.ts'];
 
     return [true, false]
         .flatMap<Options | null>(isDebugBuild =>

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -301,6 +301,63 @@ refresh({ abortSignal: undefined }); // no abort signal for this attempt
 refresh(); // omit the key to use the factory (default)
 ```
 
+## SWR adapter (`@solana/react/swr`)
+
+Opt-in subpath that bridges Kit's reactive primitives into SWR's cache. Import from `@solana/react/swr`; `swr@^2` is an optional peer dependency. Hooks carry the `Swr` suffix to keep the cache backing visible at the call site.
+
+### `useRequestSWR(key, source, options?)`
+
+SWR-backed counterpart to `useRequest`. Same `source` shape (a `ReactiveActionSource<T>` or `(signal: AbortSignal) => Promise<T>`). Returns SWR's native `SWRResponse<T>`. Pass `null` for either `key` or `source` to disable — useful when one of the source's inputs isn't yet known.
+
+```tsx
+import { useClient } from '@solana/react';
+import { useRequestSWR } from '@solana/react/swr';
+import type { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+
+function LatestBlockhash() {
+    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+    const { data, error, isLoading, mutate } = useRequestSWR(['latestBlockhash'], client.rpc.getLatestBlockhash());
+    if (error) return <button onClick={() => mutate()}>Retry</button>;
+    if (isLoading) return <p>Loading…</p>;
+    return <p>Blockhash: {data!.value.blockhash}</p>;
+}
+```
+
+`mutate()` is SWR's revalidate verb — call it to re-fire the request manually (the equivalent of `refresh()` from `useRequest`).
+
+Pass any SWR `SWRConfiguration` field in options. The Kit-only `getAbortSignal: () => AbortSignal` factory is invoked on every attempt SWR makes — initial fire, focus / reconnect / poll revalidation, and `mutate()` — and the returned signal is threaded into the source. Typically a per-attempt timeout. SWR won't specifically handle the abort but will surface the rejection via `error`.
+
+```tsx
+useRequestSWR(['latestBlockhash'], source, {
+    getAbortSignal: () => AbortSignal.timeout(5_000),
+});
+```
+
+Unlike `useRequest.refresh({ abortSignal })`, SWR's `mutate()` has no per-attempt override for the abort signal so `getAbortSignal` will be used on every call.
+
+For any one-shot async work that isn't a `ReactiveActionSource` — `fetch`, a third-party SDK call, etc. — you can pass an async function instead of a source. This can be any function of shape `(signal: AbortSignal) => Promise<T>`. The signal from `getAbortSignal` is passed to this function on each request. Other than this signal, this is the equivalent of `useSWR(key, fetcher)` and both are interoperable.
+
+```tsx
+function Profile({ userId }: { userId: string }) {
+    const fetcher = useCallback(
+        (signal: AbortSignal) => fetch(`/api/users/${userId}`, { signal }).then(r => r.json()),
+        [userId],
+    );
+    const { data, error, isLoading, mutate } = useRequestSWR(['users', userId], fetcher, {
+        getAbortSignal: () => AbortSignal.timeout(5_000),
+    });
+    if (error) return <button onClick={() => mutate()}>Retry</button>;
+    if (isLoading) return <p>Loading…</p>;
+    return <p>{data!.name}</p>;
+}
+```
+
+When `getAbortSignal` isn't configured the signal is a fresh never-aborting `AbortSignal` (so the function's signature is satisfied) — it does **not** fire on unmount or when SWR supersedes the request. SWR's model is to discard the stale result rather than cancel the network call.
+
+### Why no `useActionSWR`?
+
+It would just be a wrapper around SWR's built-in [`useSWRMutation`](https://swr.vercel.app/docs/mutation#useswrmutation) with no additional functionality. Either use `useSWRMutation` or, if you don't need the SWR integration, use `useAction`.
+
 ## Hooks
 
 ### `useSignIn(uiWalletAccount, chain)`

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -4,28 +4,52 @@
     "description": "React hooks for building Solana apps",
     "homepage": "https://www.solanakit.com/api#solanareact",
     "exports": {
-        "edge-light": {
-            "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs"
+        ".": {
+            "edge-light": {
+                "import": "./dist/index.node.mjs",
+                "require": "./dist/index.node.cjs"
+            },
+            "workerd": {
+                "import": "./dist/index.node.mjs",
+                "require": "./dist/index.node.cjs"
+            },
+            "browser": {
+                "import": "./dist/index.browser.mjs",
+                "require": "./dist/index.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/index.node.mjs",
+                "require": "./dist/index.node.cjs"
+            },
+            "react-native": "./dist/index.native.mjs",
+            "types": "./dist/types/index.d.ts"
         },
-        "workerd": {
-            "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs"
-        },
-        "browser": {
-            "import": "./dist/index.browser.mjs",
-            "require": "./dist/index.browser.cjs"
-        },
-        "node": {
-            "import": "./dist/index.node.mjs",
-            "require": "./dist/index.node.cjs"
-        },
-        "react-native": "./dist/index.native.mjs",
-        "types": "./dist/types/index.d.ts"
+        "./swr": {
+            "edge-light": {
+                "import": "./dist/swr.node.mjs",
+                "require": "./dist/swr.node.cjs"
+            },
+            "workerd": {
+                "import": "./dist/swr.node.mjs",
+                "require": "./dist/swr.node.cjs"
+            },
+            "browser": {
+                "import": "./dist/swr.browser.mjs",
+                "require": "./dist/swr.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/swr.node.mjs",
+                "require": "./dist/swr.node.cjs"
+            },
+            "react-native": "./dist/swr.native.mjs",
+            "types": "./dist/types/swr.d.ts"
+        }
     },
     "browser": {
         "./dist/index.node.cjs": "./dist/index.browser.cjs",
-        "./dist/index.node.mjs": "./dist/index.browser.mjs"
+        "./dist/index.node.mjs": "./dist/index.browser.mjs",
+        "./dist/swr.node.cjs": "./dist/swr.browser.cjs",
+        "./dist/swr.node.mjs": "./dist/swr.browser.mjs"
     },
     "main": "./dist/index.node.cjs",
     "module": "./dist/index.node.mjs",
@@ -53,9 +77,9 @@
         "style:fix": "pnpm eslint --fix src && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ../../node_modules/@solana/test-config/jest-lint.config.js --rootDir . --silent",
         "test:prettier": "TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ../../node_modules/@solana/test-config/jest-prettier.config.js --rootDir . --silent",
-        "test:treeshakability:browser": "agadoo dist/index.browser.mjs",
-        "test:treeshakability:native": "agadoo dist/index.native.mjs",
-        "test:treeshakability:node": "agadoo dist/index.node.mjs",
+        "test:treeshakability:browser": "agadoo dist/index.browser.mjs && agadoo dist/swr.browser.mjs",
+        "test:treeshakability:native": "agadoo dist/index.native.mjs && agadoo dist/swr.native.mjs",
+        "test:treeshakability:node": "agadoo dist/index.node.mjs && agadoo dist/swr.node.mjs",
         "test:typecheck": "tsc --noEmit",
         "test:unit:browser": "NODE_OPTIONS=\"--no-experimental-webstorage\" TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ../../node_modules/@solana/test-config/jest-unit.config.browser.js --rootDir . --silent",
         "test:unit:node": "NODE_OPTIONS=\"--no-experimental-webstorage\" TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ../../node_modules/@solana/test-config/jest-unit.config.node.js --rootDir . --silent"
@@ -96,14 +120,19 @@
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-error-boundary": "^5.0.0",
-        "react-test-renderer": "^19.2.7"
+        "react-test-renderer": "^19.2.7",
+        "swr": "^2.0.0"
     },
     "peerDependencies": {
         "@solana/kit": "workspace:*",
-        "react": ">=18"
+        "react": ">=18",
+        "swr": "^2.0.0"
     },
     "peerDependenciesMeta": {
         "react": {
+            "optional": true
+        },
+        "swr": {
             "optional": true
         }
     },

--- a/packages/react/src/swr.ts
+++ b/packages/react/src/swr.ts
@@ -1,0 +1,12 @@
+/**
+ * SWR-backed adapter for `@solana/react`. Bridges Kit's reactive primitives into SWR's
+ * cache so multiple components reading the same key share a single in-flight request,
+ * participate in SWR's revalidation triggers (focus, reconnect, polling), and show up in
+ * SWR's devtools.
+ *
+ * Import from `@solana/react/swr` — the subpath requires `swr` as a peer dep but is otherwise
+ * isolated from the core export so consumers who don't use SWR aren't forced to install it.
+ *
+ * @packageDocumentation
+ */
+export * from './swr/useRequestSWR';

--- a/packages/react/src/swr/__tests__/useRequestSWR-test.browser.tsx
+++ b/packages/react/src/swr/__tests__/useRequestSWR-test.browser.tsx
@@ -1,0 +1,358 @@
+import { createReactiveActionStore, type ReactiveActionSource, type ReactiveActionStore } from '@solana/kit';
+import { act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { SWRConfig } from 'swr';
+
+import { renderHook } from '../../__test-utils__/render';
+import { useRequestSWR } from '../useRequestSWR';
+
+// Wrap every render in an SWRConfig that:
+// - Uses a fresh provider Map so cache state never leaks between tests.
+// - Disables retries so a rejected fetch surfaces as `error` immediately instead of triggering
+//   SWR's exponential backoff.
+// - Disables window-focus / network-reconnect revalidation so the test environment doesn't
+//   accidentally re-fire fetches during assertions.
+function wrapper({ children }: { children: React.ReactNode }) {
+    return (
+        <SWRConfig
+            value={{
+                errorRetryCount: 0,
+                provider: () => new Map(),
+                revalidateOnFocus: false,
+                revalidateOnReconnect: false,
+            }}
+        >
+            {children}
+        </SWRConfig>
+    );
+}
+
+// Recursive `Partial` that also descends into function return types — needed so a stubbed
+// `withSignal: () => ({ dispatchAsync })` type-checks against `withSignal`'s actual return shape
+// (the full `ReactiveActionStore`).
+type DeepPartial<T> = T extends (...args: infer A) => infer R
+    ? (...args: A) => DeepPartial<R>
+    : T extends object
+      ? { [K in keyof T]?: DeepPartial<T[K]> }
+      : T;
+
+// Wraps a partial `ReactiveActionStore` stub into a `ReactiveActionSource`, isolating the
+// type-narrowing cast to one place so spy-on-store tests stay legible. The `DeepPartial`
+// parameter gives the test author keyname autocomplete and catches typos, while leaving them
+// free to stub only the fields the code path under exercise actually reads.
+function stubActionSource<T>(store: DeepPartial<ReactiveActionStore<[], T>>): ReactiveActionSource<T> {
+    return {
+        reactiveStore: () => store as ReactiveActionStore<[], T>,
+    };
+}
+
+function makeFakeSource<T>(): {
+    fn: jest.Mock<Promise<T>, [AbortSignal]>;
+    rejectLatest: (err: unknown) => void;
+    resolveLatest: (value: T) => void;
+    source: ReactiveActionSource<T>;
+} {
+    let latest: PromiseWithResolvers<T> | null = null;
+    const fn = jest.fn<Promise<T>, [AbortSignal]>(() => {
+        latest = Promise.withResolvers<T>();
+        return latest.promise;
+    });
+    return {
+        fn,
+        rejectLatest(err) {
+            latest!.reject(err);
+        },
+        resolveLatest(value) {
+            latest!.resolve(value);
+        },
+        source: {
+            reactiveStore() {
+                return createReactiveActionStore<[], T>(fn);
+            },
+        },
+    };
+}
+
+describe('useRequestSWR', () => {
+    describe('with a function source', () => {
+        it('auto-fires the fetcher on mount and transitions to data on success', async () => {
+            const { promise, resolve } = Promise.withResolvers<string>();
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => promise);
+            const { result } = renderHook(() => useRequestSWR(['fn-success'], fn), { wrapper });
+            await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+            // Sync point — under SWR + jsdom, the cache entry needs to settle between the
+            // fetcher being invoked and the deferred promise being resolved. Accessing
+            // `result.current` here lets React commit the loading state before we trigger the
+            // resolution.
+            expect(result.current.data).toBeUndefined();
+
+            await act(async () => resolve('hi'));
+            await waitFor(() => expect(result.current.data).toBe('hi'));
+            expect(result.current.error).toBeUndefined();
+        });
+
+        it('surfaces the rejection as `error`', async () => {
+            const boom = new Error('boom');
+            const { promise, reject } = Promise.withResolvers<string>();
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => promise);
+            const { result } = renderHook(() => useRequestSWR(['fn-error'], fn), { wrapper });
+            await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+            expect(result.current.error).toBeUndefined();
+
+            await act(async () => reject(boom));
+            await waitFor(() => expect(result.current.error).toBe(boom));
+        });
+
+        it('threads an `AbortSignal` into the function', async () => {
+            const { promise, resolve } = Promise.withResolvers<string>();
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => promise);
+            renderHook(() => useRequestSWR(['signal-threaded'], fn), { wrapper });
+            await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+            const signal = fn.mock.calls[0][0];
+            expect(signal).toBeInstanceOf(AbortSignal);
+            expect(signal.aborted).toBe(false);
+            await act(async () => resolve('ok'));
+        });
+
+        it('passes the user-supplied `getAbortSignal` signal through to the function', async () => {
+            const { promise, resolve } = Promise.withResolvers<string>();
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => promise);
+            const ctrl = new AbortController();
+            const getAbortSignal = jest.fn(() => ctrl.signal);
+            renderHook(() => useRequestSWR(['user-signal'], fn, { getAbortSignal }), { wrapper });
+            await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+            expect(getAbortSignal).toHaveBeenCalledTimes(1);
+            expect(fn.mock.calls[0][0]).toBe(ctrl.signal);
+            await act(async () => resolve('ok'));
+        });
+
+        it('surfaces a `getAbortSignal`-driven abort as `result.error`', async () => {
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(
+                signal =>
+                    new Promise((_, reject) => {
+                        signal.addEventListener('abort', () => reject(signal.reason));
+                    }),
+            );
+            const ctrl = new AbortController();
+            const { result } = renderHook(
+                () => useRequestSWR(['user-signal-abort'], fn, { getAbortSignal: () => ctrl.signal }),
+                { wrapper },
+            );
+            await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+            expect(result.current.error).toBeUndefined();
+
+            const reason = new Error('timeout');
+            await act(async () => ctrl.abort(reason));
+            await waitFor(() => expect(result.current.error).toBe(reason));
+        });
+
+        it('skips the fetch when the key is null', async () => {
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => Promise.resolve('never'));
+            const { result } = renderHook(() => useRequestSWR(null, fn), { wrapper });
+            // Wait a tick to be sure SWR hasn't queued a fetch.
+            await act(async () => {
+                await Promise.resolve();
+            });
+            expect(fn).not.toHaveBeenCalled();
+            expect(result.current.data).toBeUndefined();
+        });
+
+        it('skips the fetch when the source is null (even if the key is non-null)', async () => {
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => Promise.resolve('never'));
+            const initialProps: { source: ((signal: AbortSignal) => Promise<string>) | null } = { source: null };
+            const { result, rerender } = renderHook(({ source }) => useRequestSWR(['key-set'], source), {
+                initialProps,
+                wrapper,
+            });
+            await act(async () => {
+                await Promise.resolve();
+            });
+            expect(fn).not.toHaveBeenCalled();
+            expect(result.current.data).toBeUndefined();
+
+            // Transition to a real source — fetch fires.
+            rerender({ source: fn });
+            await waitFor(() => expect(result.current.data).toBe('never'));
+        });
+
+        it('starts firing once the key transitions from null to non-null', async () => {
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => Promise.resolve('value'));
+            const initialProps: { key: string | null } = { key: null };
+            const { result, rerender } = renderHook(({ key }) => useRequestSWR(key, fn), { initialProps, wrapper });
+            expect(fn).not.toHaveBeenCalled();
+
+            rerender({ key: 'now-enabled' });
+            await waitFor(() => expect(result.current.data).toBe('value'));
+        });
+
+        it('uses the latest source closure when `mutate()` is called', async () => {
+            // SWR keys cache lookup — if the key is stable, a source-identity change alone won't
+            // refetch. But the next fetch (e.g. via `mutate()`) should run the latest source. This
+            // mirrors how SWR users normally encode source-dependent inputs in the key.
+            const { result, rerender } = renderHook(
+                ({ value }: { value: string }) => useRequestSWR(['latest-closure'], () => Promise.resolve(value)),
+                { initialProps: { value: 'a' }, wrapper },
+            );
+            await waitFor(() => expect(result.current.data).toBe('a'));
+
+            rerender({ value: 'b' });
+            await act(async () => {
+                await result.current.mutate();
+            });
+            await waitFor(() => expect(result.current.data).toBe('b'));
+        });
+    });
+
+    describe('with a ReactiveActionSource (PendingRpc-like)', () => {
+        it('builds a store per fetch and resolves through `dispatchAsync()`', async () => {
+            const req = makeFakeSource<string>();
+            const { result } = renderHook(() => useRequestSWR(['source-success'], req.source), { wrapper });
+            await waitFor(() => expect(req.fn).toHaveBeenCalledTimes(1));
+            expect(result.current.data).toBeUndefined();
+
+            await act(async () => req.resolveLatest('value'));
+            await waitFor(() => expect(result.current.data).toBe('value'));
+        });
+
+        it('surfaces the rejection as `error`', async () => {
+            const boom = new Error('boom');
+            const req = makeFakeSource<string>();
+            const { result } = renderHook(() => useRequestSWR(['source-error'], req.source), { wrapper });
+            await waitFor(() => expect(req.fn).toHaveBeenCalledTimes(1));
+            expect(result.current.error).toBeUndefined();
+
+            await act(async () => req.rejectLatest(boom));
+            await waitFor(() => expect(result.current.error).toBe(boom));
+        });
+
+        it('dispatches without `withSignal` when no `getAbortSignal` is configured', async () => {
+            // Parallel to the function-source "threads an AbortSignal into the function" — for the
+            // reactive path, the absence of a user signal means the implementation should call
+            // `store.dispatchAsync()` directly, not route through `withSignal`.
+            const dispatchAsync = jest.fn(() => Promise.resolve('value'));
+            const withSignal = jest.fn();
+            const source = stubActionSource<string>({ dispatchAsync, withSignal });
+            const { result } = renderHook(() => useRequestSWR(['source-no-signal'], source), { wrapper });
+            await waitFor(() => expect(result.current.data).toBe('value'));
+            expect(dispatchAsync).toHaveBeenCalled();
+            expect(withSignal).not.toHaveBeenCalled();
+        });
+
+        it('passes the user-supplied `getAbortSignal` signal through to `withSignal`', async () => {
+            // Parallel to the function-source identity check — verifies the signal handed to the
+            // store is the exact one returned by `getAbortSignal`, not a wrapped or copied signal.
+            const dispatchAsync = jest.fn(() => Promise.resolve('value'));
+            const withSignal = jest.fn(() => ({ dispatchAsync }));
+            const source = stubActionSource<string>({ dispatchAsync, withSignal });
+            const ctrl = new AbortController();
+            renderHook(
+                () => useRequestSWR(['source-signal-identity'], source, { getAbortSignal: () => ctrl.signal }),
+                { wrapper },
+            );
+            await waitFor(() => expect(withSignal).toHaveBeenCalledWith(ctrl.signal));
+        });
+
+        it('surfaces a `getAbortSignal`-driven abort as `result.error`', async () => {
+            const req = makeFakeSource<string>();
+            const ctrl = new AbortController();
+            const { result } = renderHook(
+                () => useRequestSWR(['source-user-signal'], req.source, { getAbortSignal: () => ctrl.signal }),
+                { wrapper },
+            );
+            await waitFor(() => expect(req.fn).toHaveBeenCalledTimes(1));
+            expect(result.current.error).toBeUndefined();
+
+            const reason = new Error('timeout');
+            await act(async () => ctrl.abort(reason));
+            await waitFor(() => expect(result.current.error).toBe(reason));
+        });
+
+        it('skips the fetch when the key is null', async () => {
+            const req = makeFakeSource<string>();
+            const { result } = renderHook(() => useRequestSWR(null, req.source), { wrapper });
+            await act(async () => {
+                await Promise.resolve();
+            });
+            expect(req.fn).not.toHaveBeenCalled();
+            expect(result.current.data).toBeUndefined();
+        });
+
+        it('skips the fetch when the source is null (even if the key is non-null)', async () => {
+            const req = makeFakeSource<string>();
+            const initialProps: { source: ReactiveActionSource<string> | null } = { source: null };
+            const { result, rerender } = renderHook(({ source }) => useRequestSWR(['source-key-set'], source), {
+                initialProps,
+                wrapper,
+            });
+            await act(async () => {
+                await Promise.resolve();
+            });
+            expect(req.fn).not.toHaveBeenCalled();
+            expect(result.current.data).toBeUndefined();
+
+            // Transition to a real source — fetch fires.
+            rerender({ source: req.source });
+            await waitFor(() => expect(req.fn).toHaveBeenCalledTimes(1));
+            await act(async () => req.resolveLatest('value'));
+            await waitFor(() => expect(result.current.data).toBe('value'));
+        });
+
+        it('starts firing once the key transitions from null to non-null', async () => {
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => Promise.resolve('value'));
+            const source: ReactiveActionSource<string> = {
+                reactiveStore: () => createReactiveActionStore<[], string>(fn),
+            };
+            const initialProps: { key: string | null } = { key: null };
+            const { result, rerender } = renderHook(({ key }) => useRequestSWR(key, source), {
+                initialProps,
+                wrapper,
+            });
+            expect(fn).not.toHaveBeenCalled();
+
+            rerender({ key: 'source-now-enabled' });
+            await waitFor(() => expect(result.current.data).toBe('value'));
+        });
+
+        it('uses the latest source when `mutate()` is called', async () => {
+            // SWR keys cache lookup — if the key is stable, a source-identity change alone won't
+            // refetch. But the next fetch (e.g. via `mutate()`) should run the latest source.
+            const sourceFor = (value: string): ReactiveActionSource<string> => ({
+                reactiveStore: () => createReactiveActionStore<[], string>(() => Promise.resolve(value)),
+            });
+            const { result, rerender } = renderHook(
+                ({ source }: { source: ReactiveActionSource<string> }) =>
+                    useRequestSWR(['source-latest'], source),
+                { initialProps: { source: sourceFor('a') }, wrapper },
+            );
+            await waitFor(() => expect(result.current.data).toBe('a'));
+
+            // Source identity changes but the key is stable — SWR doesn't auto-refetch.
+            rerender({ source: sourceFor('b') });
+
+            // `mutate()` re-fires; the ref-sync picks up the latest source.
+            await act(async () => {
+                await result.current.mutate();
+            });
+            await waitFor(() => expect(result.current.data).toBe('b'));
+        });
+    });
+
+    describe('SSR', () => {
+        it('renders without firing the fetcher', () => {
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => Promise.resolve('never'));
+            function Component() {
+                const { data } = useRequestSWR(['ssr'], fn);
+                return <p>{data ?? 'no-data'}</p>;
+            }
+            const html = renderToString(
+                <SWRConfig value={{ provider: () => new Map() }}>
+                    <Component />
+                </SWRConfig>,
+            );
+            expect(html).toBe('<p>no-data</p>');
+            // SWR fires the fetcher inside an effect — on the server, effects don't run.
+            expect(fn).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/react/src/swr/__typetests__/useRequestSWR-typetest.ts
+++ b/packages/react/src/swr/__typetests__/useRequestSWR-typetest.ts
@@ -1,0 +1,85 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import type { ReactiveActionSource } from '@solana/kit';
+import type { SWRResponse } from 'swr';
+
+import { useRequestSWR } from '../useRequestSWR';
+
+const fnSource = null as unknown as (signal: AbortSignal) => Promise<{ slot: bigint }>;
+const reactiveSource = null as unknown as ReactiveActionSource<{ slot: bigint }>;
+
+// [DESCRIBE] useRequestSWR
+{
+    // Function source — returns SWRResponse with the resolved type.
+    {
+        useRequestSWR(['epochInfo'], fnSource) satisfies SWRResponse<{ slot: bigint }>;
+    }
+
+    // ReactiveActionSource — returns SWRResponse with the source's value type.
+    {
+        useRequestSWR(['balance'], reactiveSource) satisfies SWRResponse<{ slot: bigint }>;
+    }
+
+    // `data` is `T | undefined` until the first successful fetch.
+    {
+        const { data } = useRequestSWR(['epochInfo'], fnSource);
+        data satisfies { slot: bigint } | undefined;
+    }
+
+    // Null key is accepted (disables the fetch).
+    {
+        useRequestSWR(null, fnSource) satisfies SWRResponse<{ slot: bigint }>;
+    }
+
+    // Null source is accepted (also disables the fetch). Explicit `T` is required here — there's
+    // no source value for inference to pick `T` up from.
+    {
+        useRequestSWR<{ slot: bigint }>(['epochInfo'], null) satisfies SWRResponse<{ slot: bigint }>;
+    }
+
+    // Default error type is unknown.
+    {
+        const { error } = useRequestSWR(['epochInfo'], fnSource);
+        error satisfies unknown;
+        // @ts-expect-error - errors default to unknown, not Error.
+        error satisfies Error | undefined;
+    }
+
+    // `TError` is overridable via the generic.
+    {
+        useRequestSWR<{ slot: bigint }, string>(['epochInfo'], fnSource).error satisfies string | undefined;
+    }
+
+    // Options are forwarded to SWR's configuration.
+    {
+        useRequestSWR(['epochInfo'], fnSource, {
+            // @ts-expect-error - SWR doesn't accept arbitrary keys.
+            notARealOption: true,
+            revalidateOnFocus: false,
+        });
+    }
+
+    // Kit-specific options merge into the SWR options bag.
+    {
+        useRequestSWR(['epochInfo'], fnSource, {
+            getAbortSignal: () => AbortSignal.timeout(5_000),
+            revalidateOnFocus: false,
+        });
+    }
+
+    // `getAbortSignal` must return an AbortSignal (or undefined when omitted).
+    {
+        useRequestSWR(['epochInfo'], fnSource, {
+            // @ts-expect-error - factory must return AbortSignal.
+            getAbortSignal: () => 'not a signal',
+        });
+    }
+
+    // Function source must return `Promise<T>` and accept an AbortSignal.
+    {
+        useRequestSWR(['epochInfo'], (signal: AbortSignal) => {
+            signal satisfies AbortSignal;
+            return Promise.resolve({ slot: 1n });
+        });
+    }
+}

--- a/packages/react/src/swr/useRequestSWR.ts
+++ b/packages/react/src/swr/useRequestSWR.ts
@@ -1,0 +1,93 @@
+import type { ReactiveActionSource } from '@solana/kit';
+import { useCallback } from 'react';
+import useSWR, { type Key as SWRKey, type SWRConfiguration, type SWRResponse } from 'swr';
+
+import { useLatest } from '../useLatest';
+import type { UseRequestOptions } from '../useRequest';
+
+let neverAbortedSignal: AbortSignal | undefined;
+
+function getNeverAbortedSignal(): AbortSignal {
+    // Reused for function sources when no `getAbortSignal` factory is configured. The function's
+    // signature requires an `AbortSignal`; this one is intentionally never aborted (it is NOT wired
+    // to component unmount or SWR supersession because SWR discards stale results instead).
+    return (neverAbortedSignal ||= new AbortController().signal);
+}
+
+/**
+ * SWR-backed counterpart to core's `useRequest`. Accepts the same source shape — a
+ * {@link ReactiveActionSource} (satisfied by `PendingRpcRequest<T>`) or a
+ * `(signal: AbortSignal) => Promise<T>` function — and routes it through SWR's cache.
+ *
+ * Pass `null` for `key` or `source` to disable — useful when one of the source's inputs isn't
+ * yet known. Use `result.mutate()` to refresh.
+ *
+ * @typeParam T - The value the underlying request resolves to.
+ * @typeParam TError - The error type SWR will surface on failure.
+ *
+ * @example
+ * ```tsx
+ * function LatestBlockhash() {
+ *     const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+ *     const { data, error, isLoading, mutate } = useRequestSWR(
+ *         ['latestBlockhash'],
+ *         client.rpc.getLatestBlockhash(),
+ *         { getAbortSignal: () => AbortSignal.timeout(5_000) },
+ *     );
+ *     if (error) return <button onClick={() => mutate()}>Retry</button>;
+ *     if (isLoading) return <p>Loading…</p>;
+ *     return <p>Blockhash: {data!.value.blockhash}</p>;
+ * }
+ *
+ * // Function shape — wraps an arbitrary async call:
+ * function Profile({ userId }: { userId: string }) {
+ *     const fetcher = useCallback(
+ *         (signal: AbortSignal) => fetch(`/api/users/${userId}`, { signal }).then(r => r.json()),
+ *         [userId],
+ *     );
+ *     const { data, error, isLoading, mutate } = useRequestSWR(['users', userId], fetcher);
+ *     if (error) return <button onClick={() => mutate()}>Retry</button>;
+ *     if (isLoading) return <p>Loading…</p>;
+ *     return <p>{data!.name}</p>;
+ * }
+ * ```
+ */
+export function useRequestSWR<T, TError = unknown>(
+    key: SWRKey,
+    source: ReactiveActionSource<T> | ((signal: AbortSignal) => Promise<T>) | null,
+    options?: SWRConfiguration<T, TError> & UseRequestOptions,
+): SWRResponse<T, TError> {
+    // Split our option off the SWR config so we can hand the rest to `useSWR` cleanly.
+    const { getAbortSignal, ...swrConfig } = options ?? {};
+
+    // Ref-sync the source and the abort-signal factory so an inline closure passed each render
+    // doesn't change the fetcher's identity. The fetcher reads the latest values from the refs
+    // when it fires; SWR uses the key (not the fetcher identity) for cache lookup.
+    const sourceRef = useLatest(source);
+    const getAbortSignalRef = useLatest(getAbortSignal);
+
+    const fetcher = useCallback(async (): Promise<T> => {
+        const userSignal = getAbortSignalRef.current?.();
+        const current = sourceRef.current;
+        if (current == null) {
+            // The source was nulled out between SWR firing this fetch and the body running.
+            // SWR will settle into the disabled state on the next render; bail with `undefined`
+            // (matches SWR's `data` shape while loading) so we don't synthesize a spurious error.
+            return undefined as T;
+        }
+        if (typeof current === 'function') {
+            return await current(userSignal ?? getNeverAbortedSignal());
+        }
+        if (userSignal) {
+            return await current.reactiveStore().withSignal(userSignal).dispatchAsync();
+        }
+        return await current.reactiveStore().dispatchAsync();
+        // `sourceRef` and `getAbortSignalRef` are stable refs from `useLatest`, so listing them
+        // leaves `fetcher` referentially stable across renders — SWR keys off `key`, not the
+        // fetcher identity, but a stable fetcher avoids needless re-subscription churn.
+    }, [getAbortSignalRef, sourceRef]);
+
+    // When `source` is null, force the SWR key to null so the fetch is disabled regardless of
+    // whether the caller passed a non-null key.
+    return useSWR<T, TError>(source == null ? null : key, fetcher, swrConfig);
+}

--- a/packages/react/tsconfig.declarations.json
+++ b/packages/react/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts", "src/swr.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1011,6 +1011,9 @@ importers:
       react-test-renderer:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      swr:
+        specifier: ^2.0.0
+        version: 2.4.1(react@19.2.7)
 
   packages/rpc:
     dependencies:


### PR DESCRIPTION
#### Summary of Changes

This PR adds the `@solana/react/swr` subpath, with an optional `swr` dependency.

We add the first hook to this subpath, `useRequestSWR`. This mirrors `useRequest` but provides the shape of `useSWR`:

```tsx
function LatestBlockhash() {
    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
    const { data, error, isLoading, mutate } = useRequestSWR(['latestBlockhash'], client.rpc.getLatestBlockhash());
    if (error) return <button onClick={() => mutate()}>Retry</button>;
    if (isLoading) return <p>Loading…</p>;
    return <p>Blockhash: {data!.value.blockhash}</p>;
}
```

This enables all the niceties of SWR: shared cache (based on key) across components, dedupe, automatic refetching, global config, etc

A third optional param allows passing any SWR configuration (same as `useSWR`), as well as the `getAbortSignal(): AbortSignal` factory supported by `useRequest`. While SWR doesn't have specific abort signal handling, the signal is passed to each fetch. Note that SWR config passed will be merged (by SWR) with any global config in the normal way.

Like `useRequest` it can take either a `ReactiveActionSource` such as `PendingRpcRequest`, or an async function `(signal: AbortSignal) => Promise<T>`. The function version is included for symmetry with `useRequest`, but other than when used with `getAbortSignal` is identical to (and is interoperable with) plain `useSWR`.

Like `useRequest` it does not fetch when the source is null. SWR disables automatically if the key is null, so we disable by setting the key to null. This removes the need to test against null too. 

I've included a note in the readme that we will not have a `useActionSWR` hook. This would provide nothing over `useSWRMutation` and I think it'd be confusing.

Following PRs will add SWR versions of `useSubscription` and `useTrackedData`. 