### PR TITLE
Remove redundant bigint downcast from the default Solana RPC request transformer

### DIFF
--- a/.changeset/cyan-phones-joke.md
+++ b/.changeset/cyan-phones-joke.md
@@ -1,0 +1,7 @@
+---
+'@solana/rpc-transformers': patch
+---
+
+Stop downcasting `bigint` request params to `number` in the default Solana RPC request transformer
+
+`getDefaultRequestTransformerForSolanaRpc` no longer runs `getBigIntDowncastRequestTransformer`. The Solana RPC transport already serializes `bigint` values losslessly as large integer literals (via `stringifyJsonWithBigInts`), and Agave parses JSON integers across the full `u64` range without precision loss, so the lossy `bigint`->`number` downcast was redundant. Removing it also fixes silent truncation for RPC APIs configured without an `onIntegerOverflow` handler. `getBigIntDowncastRequestTransformer` is now deprecated and slated for removal in a future major version.

--- a/packages/rpc-api/src/__tests__/get-block-production-test.ts
+++ b/packages/rpc-api/src/__tests__/get-block-production-test.ts
@@ -79,7 +79,7 @@ describe('getBlockProduction', () => {
                 ),
                 expect(blockProductionPromise).rejects.toHaveProperty(
                     'context.__serverMessage',
-                    expect.stringMatching(/lastSlot, 9223372036854776000, is too large; max \d+/),
+                    expect.stringMatching(/lastSlot, 9223372036854775807, is too large; max \d+/),
                 ),
             ]);
         });

--- a/packages/rpc-api/src/__tests__/get-block-time-test.ts
+++ b/packages/rpc-api/src/__tests__/get-block-time-test.ts
@@ -34,7 +34,7 @@ describe('getBlockTime', () => {
             const blockTimePromise = rpc.getBlockTime(blockNumber).send();
             await expect(blockTimePromise).rejects.toThrow(
                 new SolanaError(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_BLOCK_NOT_AVAILABLE, {
-                    __serverMessage: 'Block not available for slot 9223372036854776000',
+                    __serverMessage: 'Block not available for slot 9223372036854775807',
                 }),
             );
         });

--- a/packages/rpc-api/src/index.ts
+++ b/packages/rpc-api/src/index.ts
@@ -228,8 +228,6 @@ type Config = RequestTransformerConfig;
  * Creates a {@link RpcApi} implementation of the Solana JSON RPC API with some default behaviours.
  *
  * The default behaviours include:
- * - A transform that converts `bigint` inputs to `number` for compatibility with version 1.0 of the
- *   Solana JSON RPC.
  * - A transform that calls the config's {@link Config.onIntegerOverflow | onIntegerOverflow}
  *   handler whenever a `bigint` input would overflow a JavaScript IEEE 754 number. See
  *   [this](https://github.com/solana-labs/solana-web3.js/issues/1116) GitHub issue for more

--- a/packages/rpc-transformers/README.md
+++ b/packages/rpc-transformers/README.md
@@ -17,7 +17,7 @@ This package contains helpers for transforming Solana JSON RPC and RPC Subscript
 
 ### `getDefaultRequestTransformerForSolanaRpc(config)`
 
-Returns the default request transformer for the Solana RPC API. Under the hood, this function composes multiple `RpcRequestTransformers` together such as the `getDefaultCommitmentTransformer`, the `getIntegerOverflowRequestTransformer` and the `getBigIntDowncastRequestTransformer`.
+Returns the default request transformer for the Solana RPC API. Under the hood, this function composes multiple `RpcRequestTransformers` together such as the `getDefaultCommitmentTransformer` and the `getIntegerOverflowRequestTransformer`.
 
 ```ts
 import { getDefaultRequestTransformerForSolanaRpc } from '@solana/rpc-transformers';
@@ -56,6 +56,8 @@ const requestTransformer = getIntegerOverflowRequestTransformer((request, keyPat
 ```
 
 ### `getBigIntDowncastRequestTransformer()`
+
+> **Deprecated.** No longer used by the default Solana RPC request transformer — the transport serializes `bigint`s losslessly and Agave parses the full `u64` range. Slated for removal in a future major version.
 
 Creates a transformer that downcasts all `BigInt` values to `Number`.
 

--- a/packages/rpc-transformers/src/__tests__/request-transformer-test.ts
+++ b/packages/rpc-transformers/src/__tests__/request-transformer-test.ts
@@ -14,25 +14,23 @@ describe('getDefaultRequestTransformerForSolanaRpc', () => {
         });
         describe('given an array as input', () => {
             const input = [10n, 10, '10', ['10', [10, 10n], 10n]] as const;
-            it('casts the bigints in the array to a `number`, recursively', () => {
+            it('leaves bigints in the array untouched, to be serialized losslessly downstream', () => {
                 const request = createRequest(input);
-                expect(requestTransformer(request).params).toStrictEqual([
-                    Number(input[0]),
-                    input[1],
-                    input[2],
-                    [input[3][0], [input[3][1][0], Number(input[3][1][0])], Number(input[3][2])],
-                ]);
+                expect(requestTransformer(request).params).toStrictEqual(input);
             });
         });
         describe('given an object as input', () => {
             const input = { a: 10n, b: 10, c: { c1: '10', c2: 10n } } as const;
-            it('casts the bigints in the array to a `number`, recursively', () => {
+            it('leaves bigints in the object untouched, to be serialized losslessly downstream', () => {
                 const request = createRequest(input);
-                expect(requestTransformer(request).params).toStrictEqual({
-                    a: Number(input.a),
-                    b: input.b,
-                    c: { c1: input.c.c1, c2: Number(input.c.c2) },
-                });
+                expect(requestTransformer(request).params).toStrictEqual(input);
+            });
+        });
+        describe('given a `bigint` larger than `Number.MAX_SAFE_INTEGER` and no overflow handler', () => {
+            it('preserves the `bigint` losslessly rather than downcasting it to a `number`', () => {
+                const input = BigInt(Number.MAX_SAFE_INTEGER) + 2n; // 9007199254740993
+                const request = createRequest([input]);
+                expect((requestTransformer(request).params as readonly unknown[])[0]).toBe(input);
             });
         });
     });

--- a/packages/rpc-transformers/src/request-transformer-bigint-downcast.ts
+++ b/packages/rpc-transformers/src/request-transformer-bigint-downcast.ts
@@ -4,6 +4,12 @@ import { getTreeWalkerRequestTransformer } from './tree-traversal';
 /**
  * Creates a transformer that downcasts all `BigInt` values to `Number`.
  *
+ * @deprecated This transformer is no longer used by the default Solana RPC request transformer
+ * ({@link getDefaultRequestTransformerForSolanaRpc}). The Solana RPC transport serializes `bigint`
+ * values losslessly as large integer literals (via `stringifyJsonWithBigInts`), and Agave parses
+ * JSON integers across the full `u64` range without precision loss, so downcasting `bigint`s to
+ * (potentially lossy) `number`s is unnecessary. It is slated for removal in a future major version.
+ *
  * @example
  * ```ts
  * import { getBigIntDowncastRequestTransformer } from '@solana/rpc-transformers';

--- a/packages/rpc-transformers/src/request-transformer.ts
+++ b/packages/rpc-transformers/src/request-transformer.ts
@@ -2,7 +2,6 @@ import { pipe } from '@solana/functional';
 import { RpcRequest, RpcRequestTransformer } from '@solana/rpc-spec-types';
 import { Commitment } from '@solana/rpc-types';
 
-import { getBigIntDowncastRequestTransformer } from './request-transformer-bigint-downcast';
 import { getDefaultCommitmentRequestTransformer } from './request-transformer-default-commitment';
 import { getIntegerOverflowRequestTransformer, IntegerOverflowHandler } from './request-transformer-integer-overflow';
 import { OPTIONS_OBJECT_POSITION_BY_METHOD } from './request-transformer-options-object-position-config';
@@ -28,8 +27,7 @@ export type RequestTransformerConfig = Readonly<{
  *
  * Under the hood, this function composes multiple
  * {@link RpcRequestTransformer | RpcRequestTransformers} together such as the
- * {@link getDefaultCommitmentTransformer}, the {@link getIntegerOverflowRequestTransformer} and the
- * {@link getBigIntDowncastRequestTransformer}.
+ * {@link getDefaultCommitmentTransformer} and the {@link getIntegerOverflowRequestTransformer}.
  *
  * @example
  * ```ts
@@ -49,7 +47,6 @@ export function getDefaultRequestTransformerForSolanaRpc(config?: RequestTransfo
         return pipe(
             request,
             handleIntegerOverflow ? getIntegerOverflowRequestTransformer(handleIntegerOverflow) : r => r,
-            getBigIntDowncastRequestTransformer(),
             getDefaultCommitmentRequestTransformer({
                 defaultCommitment: config?.defaultCommitment,
                 optionsObjectPositionByMethod: OPTIONS_OBJECT_POSITION_BY_METHOD,


### PR DESCRIPTION
As #366 asked, I checked what Agave's RPC does with a JSON number above Number.MAX_SAFE_INTEGER. The downcast turns out to be unnecessary: the transport already serializes bigints losslessly via stringifyJsonWithBigInts, and a local solana-test-validator parses the full u64 range without loss — 2^53 and 2^53+1 echo back distinct (no precision loss), and only values past u64::MAX are rejected, cleanly:

| slot sent | Agave response |
| --- | --- |
| 9007199254740992 (2^53) | Block not available for slot 9007199254740992 |
| 9007199254740993 (2^53 + 1) | Block not available for slot 9007199254740993 |
| 18446744073709551616 (u64::MAX + 1) | Invalid params: invalid type: floating point, expected u64 |

So this removes getBigIntDowncastRequestTransformer from the default request transformer and adds a regression test; the export is deprecated rather than deleted to stay non-breaking.

Fixes #366
