### PR TITLE
Add createDependentStructDecoder for structs whose fields depend on earlier values

### DIFF
--- a/.changeset/beige-kids-stop.md
+++ b/.changeset/beige-kids-stop.md
@@ -2,7 +2,7 @@
 '@solana/codecs-data-structures': minor
 ---
 
-Add `createDependentStructDecoder`, a fluent builder for a struct decoder whose later fields may depend on the decoded values of earlier ones. Each call to `field` adds a name and either a static `Decoder` or a factory that receives a snapshot of the fields decoded so far. Calling `finish` produces a `VariableSizeDecoder` for the accumulated struct.
+Add `createDependentStructDecoder`, a fluent builder for a struct decoder whose later fields may depend on the decoded values of earlier ones. Each call to `field` adds a name and either a static `Decoder` or a factory that receives a frozen snapshot of the fields decoded so far. Calling `build` produces a `FixedSizeDecoder` when every field added to the builder is itself a `FixedSizeDecoder`, and a `VariableSizeDecoder` otherwise.
 
 This is useful for binary formats where a count, version, or discriminator that appears near the start of the struct controls how a later field must be parsed, such as the per-instruction headers in a v1 transaction message.
 
@@ -10,5 +10,5 @@ This is useful for binary formats where a count, version, or discriminator that 
 const decoder = createDependentStructDecoder()
     .field('count', getU8Decoder())
     .field('values', fields => getArrayDecoder(getU32Decoder(), { size: fields.count }))
-    .finish();
+    .build();
 ```

--- a/.changeset/beige-kids-stop.md
+++ b/.changeset/beige-kids-stop.md
@@ -1,0 +1,14 @@
+---
+'@solana/codecs-data-structures': minor
+---
+
+Add `createDependentStructDecoder`, a fluent builder for a struct decoder whose later fields may depend on the decoded values of earlier ones. Each call to `field` adds a name and either a static `Decoder` or a factory that receives a snapshot of the fields decoded so far. Calling `finish` produces a `VariableSizeDecoder` for the accumulated struct.
+
+This is useful for binary formats where a count, version, or discriminator that appears near the start of the struct controls how a later field must be parsed, such as the per-instruction headers in a v1 transaction message.
+
+```ts
+const decoder = createDependentStructDecoder()
+    .field('count', getU8Decoder())
+    .field('values', fields => getArrayDecoder(getU32Decoder(), { size: fields.count }))
+    .finish();
+```

--- a/packages/codecs-data-structures/README.md
+++ b/packages/codecs-data-structures/README.md
@@ -186,7 +186,7 @@ Each call to `field` returns a new builder whose accumulated type is widened by 
 const decoder = createDependentStructDecoder()
     .field('count', getU8Decoder())
     .field('values', fields => getArrayDecoder(getU32Decoder(), { size: fields.count }))
-    .finish();
+    .build();
 
 const struct = decoder.decode(new Uint8Array([0x02, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
 // { count: 2, values: [1, 2] }
@@ -198,18 +198,18 @@ Static and dependent fields can be mixed freely, and a factory may pick the deco
 const decoder = createDependentStructDecoder()
     .field('version', getU8Decoder())
     .field('payload', fields => (fields.version === 0 ? getU16Decoder() : getU32Decoder()))
-    .finish();
+    .build();
 ```
 
-The resulting decoder is always a `VariableSizeDecoder` because the size of any factory-provided field cannot be known ahead of time.
+The builder mirrors the fixed vs variable size behaviour of `getStructDecoder`. The empty builder builds to a `FixedSizeDecoder` of size zero. Adding a `FixedSizeDecoder` keeps the builder fixed size and the byte sizes accumulate. Adding a `VariableSizeDecoder` or a field factory drops the builder to variable size, and every subsequent `field` call stays variable size from that point on. Factories pass their `fields` argument through `Object.freeze`, so attempts to mutate the snapshot at runtime throw in strict mode.
 
 ### When to use `createDependentStructDecoder` vs `getStructDecoder`
 
-| Situation                                                                                              | Recommended                                                                                                 |
-| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
-| Every field's decoder is fixed at construction time.                                                   | `getStructDecoder`                                                                                          |
-| One field's decoder needs the value of a previously decoded field (count, version, discriminator ...). | `createDependentStructDecoder`                                                                              |
-| You need both a `Codec` (encoder + decoder).                                                           | Combine `getStructEncoder` with the result of `createDependentStructDecoder().finish()` via `combineCodec`. |
+| Situation                                                                                              | Recommended                                                                                                |
+| ------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| Every field's decoder is fixed at construction time.                                                   | `getStructDecoder`                                                                                         |
+| One field's decoder needs the value of a previously decoded field (count, version, discriminator ...). | `createDependentStructDecoder`                                                                             |
+| You need both a `Codec` (encoder + decoder).                                                           | Combine `getStructEncoder` with the result of `createDependentStructDecoder().build()` via `combineCodec`. |
 
 The builder is intentionally limited to the decoder side. The encoder direction already has access to the entire value when serialising, so the existing `getStructEncoder` already supports the same shape; pair it with `createDependentStructDecoder` and `combineCodec` to obtain a full codec.
 

--- a/packages/codecs-data-structures/README.md
+++ b/packages/codecs-data-structures/README.md
@@ -201,7 +201,17 @@ const decoder = createDependentStructDecoder()
     .finish();
 ```
 
-The resulting decoder is always a `VariableSizeDecoder` because the size of any factory-provided field cannot be known ahead of time. Use `getStructDecoder` when every field's decoder is independent of the values that precede it.
+The resulting decoder is always a `VariableSizeDecoder` because the size of any factory-provided field cannot be known ahead of time.
+
+### When to use `createDependentStructDecoder` vs `getStructDecoder`
+
+| Situation                                                                                              | Recommended                                                                                                 |
+| ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- |
+| Every field's decoder is fixed at construction time.                                                   | `getStructDecoder`                                                                                          |
+| One field's decoder needs the value of a previously decoded field (count, version, discriminator ...). | `createDependentStructDecoder`                                                                              |
+| You need both a `Codec` (encoder + decoder).                                                           | Combine `getStructEncoder` with the result of `createDependentStructDecoder().finish()` via `combineCodec`. |
+
+The builder is intentionally limited to the decoder side. The encoder direction already has access to the entire value when serialising, so the existing `getStructEncoder` already supports the same shape; pair it with `createDependentStructDecoder` and `combineCodec` to obtain a full codec.
 
 ## Enum codec
 

--- a/packages/codecs-data-structures/README.md
+++ b/packages/codecs-data-structures/README.md
@@ -176,6 +176,33 @@ const bytes = personEncoder.encode({ name: 'alice', age: 42 });
 const person = personDecoder.decode(bytes);
 ```
 
+## Dependent struct decoder
+
+The `createDependentStructDecoder` function returns a fluent builder for a struct decoder whose later fields may depend on the decoded values of earlier ones. This is useful for binary formats where a count, version, or discriminator that appears near the start of the struct controls how a later field must be parsed.
+
+Each call to `field` returns a new builder whose accumulated type is widened by the newly added field. The factory form receives a frozen snapshot of every field that has already been decoded.
+
+```ts
+const decoder = createDependentStructDecoder()
+    .field('count', getU8Decoder())
+    .field('values', fields => getArrayDecoder(getU32Decoder(), { size: fields.count }))
+    .finish();
+
+const struct = decoder.decode(new Uint8Array([0x02, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+// { count: 2, values: [1, 2] }
+```
+
+Static and dependent fields can be mixed freely, and a factory may pick the decoder based on the value of any prior field.
+
+```ts
+const decoder = createDependentStructDecoder()
+    .field('version', getU8Decoder())
+    .field('payload', fields => (fields.version === 0 ? getU16Decoder() : getU32Decoder()))
+    .finish();
+```
+
+The resulting decoder is always a `VariableSizeDecoder` because the size of any factory-provided field cannot be known ahead of time. Use `getStructDecoder` when every field's decoder is independent of the values that precede it.
+
 ## Enum codec
 
 The `getEnumCodec` function accepts a JavaScript enum constructor and returns a codec for encoding and decoding values of that enum.

--- a/packages/codecs-data-structures/src/__tests__/dependent-struct-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/dependent-struct-test.ts
@@ -108,4 +108,89 @@ describe('createDependentStructDecoder', () => {
             label: 'ABC',
         });
     });
+
+    it('threads decoded values across more than two dependent fields', () => {
+        const decoder = dependentStruct()
+            .field('numStaticAccounts', u8())
+            .field('numInstructions', u8())
+            .field('staticAccounts', fields => getArrayDecoder(u32(), { size: fields.numStaticAccounts }))
+            .field('instructionLengths', fields => getArrayDecoder(u8(), { size: fields.numInstructions }))
+            .finish();
+        expect(decoder.decode(b('020201000000020000000305'))).toStrictEqual({
+            instructionLengths: [3, 5],
+            numInstructions: 2,
+            numStaticAccounts: 2,
+            staticAccounts: [1, 2],
+        });
+    });
+
+    it('lets a factory return a dependent struct decoder, allowing nested dependence', () => {
+        const inner = dependentStruct()
+            .field('innerCount', u8())
+            .field('innerItems', fields => getArrayDecoder(u8(), { size: fields.innerCount }))
+            .finish();
+        const outer = dependentStruct()
+            .field('tag', u8())
+            .field('inner', () => inner)
+            .finish();
+        expect(outer.decode(b('ff020a0b'))).toStrictEqual({
+            inner: { innerCount: 2, innerItems: [10, 11] },
+            tag: 255,
+        });
+    });
+
+    it('invokes each factory exactly once per `decode` call', () => {
+        const factoryCalls: string[] = [];
+        const decoder = dependentStruct()
+            .field('count', u8())
+            .field('items', fields => {
+                factoryCalls.push(`items(count=${fields.count})`);
+                return getArrayDecoder(u8(), { size: fields.count });
+            })
+            .finish();
+        decoder.decode(b('020a0b'));
+        decoder.decode(b('010c'));
+        expect(factoryCalls).toStrictEqual(['items(count=2)', 'items(count=1)']);
+    });
+
+    it('exposes the same snapshot to a factory that the decoded object will contain', () => {
+        let snapshotSeenByFactory: unknown;
+        const decoder = dependentStruct()
+            .field('a', u8())
+            .field('b', u16())
+            .field('c', fields => {
+                snapshotSeenByFactory = { ...fields };
+                return u8();
+            })
+            .finish();
+        const result = decoder.decode(b('01020003'));
+        expect(snapshotSeenByFactory).toStrictEqual({ a: result.a, b: result.b });
+    });
+
+    it('propagates the underlying decoder error when a dependent decoder runs past the buffer', () => {
+        const decoder = dependentStruct()
+            .field('count', u8())
+            .field('items', fields => getArrayDecoder(u32(), { size: fields.count }))
+            .finish();
+        // Claims four u32 items but only provides bytes for one.
+        expect(() => decoder.decode(b('0401000000'))).toThrow();
+    });
+
+    it('models a v0 transaction message header style struct with three dependent counts', () => {
+        const header = dependentStruct()
+            .field('numRequiredSignatures', u8())
+            .field('numReadonlySignedAccounts', u8())
+            .field('numReadonlyUnsignedAccounts', u8())
+            .field('numAccounts', u8())
+            .field('accounts', fields => getArrayDecoder(fixDecoderSize(u8(), 1), { size: fields.numAccounts }))
+            .finish();
+        const bytes = b('01010103aabbcc');
+        expect(header.decode(bytes)).toStrictEqual({
+            accounts: [0xaa, 0xbb, 0xcc],
+            numAccounts: 3,
+            numReadonlySignedAccounts: 1,
+            numReadonlyUnsignedAccounts: 1,
+            numRequiredSignatures: 1,
+        });
+    });
 });

--- a/packages/codecs-data-structures/src/__tests__/dependent-struct-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/dependent-struct-test.ts
@@ -1,0 +1,111 @@
+import { Decoder, fixDecoderSize } from '@solana/codecs-core';
+import { getU8Decoder, getU16Decoder, getU32Decoder } from '@solana/codecs-numbers';
+import { getUtf8Decoder } from '@solana/codecs-strings';
+
+import { getArrayDecoder } from '../array';
+import { createDependentStructDecoder } from '../dependent-struct';
+import { b } from './__setup__';
+
+describe('createDependentStructDecoder', () => {
+    const dependentStruct = createDependentStructDecoder;
+    const u8 = getU8Decoder;
+    const u16 = getU16Decoder;
+    const u32 = getU32Decoder;
+
+    it('decodes a struct with only static fields', () => {
+        const decoder = dependentStruct().field('a', u8()).field('b', u16()).finish();
+        expect(decoder.decode(b('010200'))).toStrictEqual({ a: 1, b: 2 });
+    });
+
+    it('decodes a struct with a dependent length field', () => {
+        const decoder = dependentStruct()
+            .field('count', u8())
+            .field('items', fields => getArrayDecoder(u32(), { size: fields.count }))
+            .finish();
+        expect(decoder.decode(b('02010000000200000000'.slice(0, 18)))).toStrictEqual({
+            count: 2,
+            items: [1, 2],
+        });
+    });
+
+    it('passes only the fields decoded so far to a factory', () => {
+        const seenByFactory: unknown[] = [];
+        const decoder = dependentStruct()
+            .field('first', u8())
+            .field('second', u8())
+            .field('third', fields => {
+                seenByFactory.push({ ...fields });
+                return u8();
+            })
+            .finish();
+        decoder.decode(b('010203'));
+        expect(seenByFactory).toStrictEqual([{ first: 1, second: 2 }]);
+    });
+
+    const versioned = dependentStruct()
+        .field('version', u8())
+        .field('payload', fields => (fields.version === 0 ? u16() : u32()))
+        .finish();
+
+    it('lets a factory pick the v0 decoder based on a discriminator', () => {
+        expect(versioned.decode(b('000100'))).toStrictEqual({ payload: 1, version: 0 });
+    });
+
+    it('lets a factory pick the v1 decoder based on a discriminator', () => {
+        expect(versioned.decode(b('0101000000'))).toStrictEqual({ payload: 1, version: 1 });
+    });
+
+    it('decodes from a non-zero offset and returns the new offset from `read`', () => {
+        const decoder = dependentStruct()
+            .field('n', u8())
+            .field('xs', fields => getArrayDecoder(u8(), { size: fields.n }))
+            .finish();
+        expect(decoder.read(b('ff03010203'), 1)).toStrictEqual([{ n: 3, xs: [1, 2, 3] }, 5]);
+    });
+
+    it('returns an empty record when no fields are added', () => {
+        const decoder = dependentStruct().finish();
+        expect(decoder.decode(b(''))).toStrictEqual({});
+    });
+
+    it('preserves declaration order in the decoded object iteration', () => {
+        const decoder = dependentStruct().field('z', u8()).field('a', u8()).field('m', u8()).finish();
+        expect(Object.keys(decoder.decode(b('010203')))).toStrictEqual(['z', 'a', 'm']);
+    });
+
+    it('produces a variable size decoder', () => {
+        const decoder = dependentStruct().field('a', u8()).finish();
+        expect(decoder).not.toHaveProperty('fixedSize');
+    });
+
+    it('does not mutate the builder when adding a field', () => {
+        const builderA = dependentStruct().field('a', u8());
+        const builderAB = builderA.field('b', u8());
+        const decoderA = builderA.finish() as Decoder<Record<string, number>>;
+        const decoderAB = builderAB.finish() as Decoder<Record<string, number>>;
+        expect(Object.keys(decoderA.decode(b('01')))).toStrictEqual(['a']);
+        expect(Object.keys(decoderAB.decode(b('0102')))).toStrictEqual(['a', 'b']);
+    });
+
+    it('builds independent decoders from independent `finish` calls', () => {
+        const builder = dependentStruct().field('a', u8());
+        const firstDecoder = builder.finish() as Decoder<Record<string, number>>;
+        const secondDecoder = builder.finish() as Decoder<Record<string, number>>;
+        expect(firstDecoder).not.toBe(secondDecoder);
+        expect(firstDecoder.decode(b('07'))).toStrictEqual({ a: 7 });
+        expect(secondDecoder.decode(b('09'))).toStrictEqual({ a: 9 });
+    });
+
+    it('composes with other variable size decoders', () => {
+        const decoder = dependentStruct()
+            .field('label', fixDecoderSize(getUtf8Decoder(), 3))
+            .field('count', u8())
+            .field('items', fields => getArrayDecoder(u8(), { size: fields.count }))
+            .finish();
+        expect(decoder.decode(b('414243020a0b'))).toStrictEqual({
+            count: 2,
+            items: [10, 11],
+            label: 'ABC',
+        });
+    });
+});

--- a/packages/codecs-data-structures/src/__tests__/dependent-struct-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/dependent-struct-test.ts
@@ -13,7 +13,7 @@ describe('createDependentStructDecoder', () => {
     const u32 = getU32Decoder;
 
     it('decodes a struct with only static fields', () => {
-        const decoder = dependentStruct().field('a', u8()).field('b', u16()).finish();
+        const decoder = dependentStruct().field('a', u8()).field('b', u16()).build();
         expect(decoder.decode(b('010200'))).toStrictEqual({ a: 1, b: 2 });
     });
 
@@ -21,7 +21,7 @@ describe('createDependentStructDecoder', () => {
         const decoder = dependentStruct()
             .field('count', u8())
             .field('items', fields => getArrayDecoder(u32(), { size: fields.count }))
-            .finish();
+            .build();
         expect(decoder.decode(b('02010000000200000000'.slice(0, 18)))).toStrictEqual({
             count: 2,
             items: [1, 2],
@@ -37,7 +37,7 @@ describe('createDependentStructDecoder', () => {
                 seenByFactory.push({ ...fields });
                 return u8();
             })
-            .finish();
+            .build();
         decoder.decode(b('010203'));
         expect(seenByFactory).toStrictEqual([{ first: 1, second: 2 }]);
     });
@@ -45,7 +45,7 @@ describe('createDependentStructDecoder', () => {
     const versioned = dependentStruct()
         .field('version', u8())
         .field('payload', fields => (fields.version === 0 ? u16() : u32()))
-        .finish();
+        .build();
 
     it('lets a factory pick the v0 decoder based on a discriminator', () => {
         expect(versioned.decode(b('000100'))).toStrictEqual({ payload: 1, version: 0 });
@@ -59,38 +59,56 @@ describe('createDependentStructDecoder', () => {
         const decoder = dependentStruct()
             .field('n', u8())
             .field('xs', fields => getArrayDecoder(u8(), { size: fields.n }))
-            .finish();
+            .build();
         expect(decoder.read(b('ff03010203'), 1)).toStrictEqual([{ n: 3, xs: [1, 2, 3] }, 5]);
     });
 
     it('returns an empty record when no fields are added', () => {
-        const decoder = dependentStruct().finish();
+        const decoder = dependentStruct().build();
         expect(decoder.decode(b(''))).toStrictEqual({});
     });
 
     it('preserves declaration order in the decoded object iteration', () => {
-        const decoder = dependentStruct().field('z', u8()).field('a', u8()).field('m', u8()).finish();
+        const decoder = dependentStruct().field('z', u8()).field('a', u8()).field('m', u8()).build();
         expect(Object.keys(decoder.decode(b('010203')))).toStrictEqual(['z', 'a', 'm']);
     });
 
-    it('produces a variable size decoder', () => {
-        const decoder = dependentStruct().field('a', u8()).finish();
+    it('produces a fixed size decoder of size zero when no fields are added', () => {
+        const decoder = dependentStruct().build();
+        expect(decoder).toHaveProperty('fixedSize', 0);
+    });
+
+    it('produces a fixed size decoder summing the field sizes when every field is fixed', () => {
+        const decoder = dependentStruct().field('a', u8()).field('b', u16()).field('c', u32()).build();
+        expect(decoder).toHaveProperty('fixedSize', 1 + 2 + 4);
+    });
+
+    it('drops to a variable size decoder once a variable size field is added', () => {
+        const decoder = dependentStruct().field('a', u8()).field('label', getUtf8Decoder()).field('b', u8()).build();
+        expect(decoder).not.toHaveProperty('fixedSize');
+    });
+
+    it('drops to a variable size decoder once a factory field is added', () => {
+        const decoder = dependentStruct()
+            .field('count', u8())
+            .field('items', fields => getArrayDecoder(u8(), { size: fields.count }))
+            .build();
         expect(decoder).not.toHaveProperty('fixedSize');
     });
 
     it('does not mutate the builder when adding a field', () => {
         const builderA = dependentStruct().field('a', u8());
         const builderAB = builderA.field('b', u8());
-        const decoderA = builderA.finish() as Decoder<Record<string, number>>;
-        const decoderAB = builderAB.finish() as Decoder<Record<string, number>>;
+        const decoderA = builderA.build() as Decoder<Record<string, number>>;
+        const decoderAB = builderAB.build() as Decoder<Record<string, number>>;
         expect(Object.keys(decoderA.decode(b('01')))).toStrictEqual(['a']);
         expect(Object.keys(decoderAB.decode(b('0102')))).toStrictEqual(['a', 'b']);
     });
 
-    it('builds independent decoders from independent `finish` calls', () => {
+    it('builds independent decoders from independent `build` calls', () => {
         const builder = dependentStruct().field('a', u8());
-        const firstDecoder = builder.finish() as Decoder<Record<string, number>>;
-        const secondDecoder = builder.finish() as Decoder<Record<string, number>>;
+        const firstDecoder = builder.build() as Decoder<Record<string, number>>;
+        const secondDecoder = builder.build() as Decoder<Record<string, number>>;
         expect(firstDecoder).not.toBe(secondDecoder);
         expect(firstDecoder.decode(b('07'))).toStrictEqual({ a: 7 });
         expect(secondDecoder.decode(b('09'))).toStrictEqual({ a: 9 });
@@ -101,7 +119,7 @@ describe('createDependentStructDecoder', () => {
             .field('label', fixDecoderSize(getUtf8Decoder(), 3))
             .field('count', u8())
             .field('items', fields => getArrayDecoder(u8(), { size: fields.count }))
-            .finish();
+            .build();
         expect(decoder.decode(b('414243020a0b'))).toStrictEqual({
             count: 2,
             items: [10, 11],
@@ -115,7 +133,7 @@ describe('createDependentStructDecoder', () => {
             .field('numInstructions', u8())
             .field('staticAccounts', fields => getArrayDecoder(u32(), { size: fields.numStaticAccounts }))
             .field('instructionLengths', fields => getArrayDecoder(u8(), { size: fields.numInstructions }))
-            .finish();
+            .build();
         expect(decoder.decode(b('020201000000020000000305'))).toStrictEqual({
             instructionLengths: [3, 5],
             numInstructions: 2,
@@ -128,11 +146,11 @@ describe('createDependentStructDecoder', () => {
         const inner = dependentStruct()
             .field('innerCount', u8())
             .field('innerItems', fields => getArrayDecoder(u8(), { size: fields.innerCount }))
-            .finish();
+            .build();
         const outer = dependentStruct()
             .field('tag', u8())
             .field('inner', () => inner)
-            .finish();
+            .build();
         expect(outer.decode(b('ff020a0b'))).toStrictEqual({
             inner: { innerCount: 2, innerItems: [10, 11] },
             tag: 255,
@@ -147,10 +165,30 @@ describe('createDependentStructDecoder', () => {
                 factoryCalls.push(`items(count=${fields.count})`);
                 return getArrayDecoder(u8(), { size: fields.count });
             })
-            .finish();
+            .build();
         decoder.decode(b('020a0b'));
         decoder.decode(b('010c'));
         expect(factoryCalls).toStrictEqual(['items(count=2)', 'items(count=1)']);
+    });
+
+    it('passes a frozen snapshot to a factory', () => {
+        let frozenFlag: boolean | undefined;
+        let mutationThrew = false;
+        const decoder = dependentStruct()
+            .field('a', u8())
+            .field('b', fields => {
+                frozenFlag = Object.isFrozen(fields);
+                try {
+                    (fields as { a: number }).a = 999;
+                } catch {
+                    mutationThrew = true;
+                }
+                return u8();
+            })
+            .build();
+        decoder.decode(b('0102'));
+        expect(frozenFlag).toBe(true);
+        expect(mutationThrew).toBe(true);
     });
 
     it('exposes the same snapshot to a factory that the decoded object will contain', () => {
@@ -162,7 +200,7 @@ describe('createDependentStructDecoder', () => {
                 snapshotSeenByFactory = { ...fields };
                 return u8();
             })
-            .finish();
+            .build();
         const result = decoder.decode(b('01020003'));
         expect(snapshotSeenByFactory).toStrictEqual({ a: result.a, b: result.b });
     });
@@ -171,7 +209,7 @@ describe('createDependentStructDecoder', () => {
         const decoder = dependentStruct()
             .field('count', u8())
             .field('items', fields => getArrayDecoder(u32(), { size: fields.count }))
-            .finish();
+            .build();
         // Claims four u32 items but only provides bytes for one.
         expect(() => decoder.decode(b('0401000000'))).toThrow();
     });
@@ -183,7 +221,7 @@ describe('createDependentStructDecoder', () => {
             .field('numReadonlyUnsignedAccounts', u8())
             .field('numAccounts', u8())
             .field('accounts', fields => getArrayDecoder(fixDecoderSize(u8(), 1), { size: fields.numAccounts }))
-            .finish();
+            .build();
         const bytes = b('01010103aabbcc');
         expect(header.decode(bytes)).toStrictEqual({
             accounts: [0xaa, 0xbb, 0xcc],

--- a/packages/codecs-data-structures/src/__typetests__/dependent-struct-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/dependent-struct-typetest.ts
@@ -70,3 +70,46 @@ import { createDependentStructDecoder } from '../dependent-struct';
     const decoder = createDependentStructDecoder().field('a', getU8Decoder()).finish();
     decoder satisfies VariableSizeDecoder<{ a: number }>;
 }
+
+{
+    // [createDependentStructDecoder]: The accumulator widens correctly across many `field` calls.
+    createDependentStructDecoder()
+        .field('a', getU8Decoder())
+        .field('b', getU8Decoder())
+        .field('c', getU8Decoder())
+        .field('d', getU8Decoder())
+        .field('e', getU8Decoder())
+        .field('f', getU8Decoder())
+        .finish() satisfies VariableSizeDecoder<{ a: number; b: number; c: number; d: number; e: number; f: number }>;
+}
+
+{
+    // [createDependentStructDecoder]: A factory's `fields` parameter is read only.
+    createDependentStructDecoder()
+        .field('first', getU8Decoder())
+        .field('second', fields => {
+            // @ts-expect-error `fields.first` is read only and cannot be reassigned from inside a factory.
+            fields.first = 0;
+            return getU8Decoder();
+        })
+        .finish();
+}
+
+{
+    // [createDependentStructDecoder]: A factory can be typed in advance for its prior fields and still type check.
+    const buildPayload = (fields: Readonly<{ version: number }>) =>
+        fields.version === 0 ? getU16Decoder() : getU32Decoder();
+    createDependentStructDecoder()
+        .field('version', getU8Decoder())
+        .field('payload', buildPayload)
+        .finish() satisfies VariableSizeDecoder<{ payload: number; version: number }>;
+}
+
+{
+    // [createDependentStructDecoder]: The accumulator type is exact; unknown keys are not part of the finished decoder.
+    const decoder = createDependentStructDecoder().field('a', getU8Decoder()).finish();
+    decoder satisfies VariableSizeDecoder<{ a: number }>;
+    const value = null as unknown as Awaited<ReturnType<typeof decoder.decode>>;
+    // @ts-expect-error `b` was never declared on the builder.
+    void value.b;
+}

--- a/packages/codecs-data-structures/src/__typetests__/dependent-struct-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/dependent-struct-typetest.ts
@@ -1,4 +1,4 @@
-import { Decoder, VariableSizeDecoder } from '@solana/codecs-core';
+import { Decoder, FixedSizeDecoder, VariableSizeDecoder } from '@solana/codecs-core';
 import { getU8Decoder, getU16Decoder, getU32Decoder } from '@solana/codecs-numbers';
 import { getUtf8Decoder } from '@solana/codecs-strings';
 
@@ -6,8 +6,8 @@ import { getArrayDecoder } from '../array';
 import { createDependentStructDecoder } from '../dependent-struct';
 
 {
-    // [createDependentStructDecoder]: An empty builder finishes to a decoder for the empty record.
-    createDependentStructDecoder().finish() satisfies VariableSizeDecoder<Record<never, never>>;
+    // [createDependentStructDecoder]: An empty builder builds to a `FixedSizeDecoder` for the empty record.
+    createDependentStructDecoder().build() satisfies FixedSizeDecoder<Record<never, never>>;
 }
 
 {
@@ -16,7 +16,7 @@ import { createDependentStructDecoder } from '../dependent-struct';
         .field('a', getU8Decoder())
         .field('b', getU16Decoder())
         .field('c', getUtf8Decoder())
-        .finish() satisfies VariableSizeDecoder<{ a: number; b: number; c: string }>;
+        .build() satisfies VariableSizeDecoder<{ a: number; b: number; c: string }>;
 }
 
 {
@@ -27,7 +27,7 @@ import { createDependentStructDecoder } from '../dependent-struct';
             fields satisfies Readonly<{ count: number }>;
             return getArrayDecoder(getU32Decoder(), { size: fields.count });
         })
-        .finish() satisfies VariableSizeDecoder<{ count: number; values: number[] }>;
+        .build() satisfies VariableSizeDecoder<{ count: number; values: number[] }>;
 }
 
 {
@@ -40,7 +40,7 @@ import { createDependentStructDecoder } from '../dependent-struct';
             return getU8Decoder();
         })
         .field('third', getU8Decoder())
-        .finish();
+        .build();
 }
 
 {
@@ -53,7 +53,7 @@ import { createDependentStructDecoder } from '../dependent-struct';
 
 {
     // [createDependentStructDecoder]: The finished decoder is assignable to a generic `Decoder`.
-    const decoder = createDependentStructDecoder().field('value', getU8Decoder()).finish();
+    const decoder = createDependentStructDecoder().field('value', getU8Decoder()).build();
     decoder satisfies Decoder<{ value: number }>;
 }
 
@@ -62,13 +62,48 @@ import { createDependentStructDecoder } from '../dependent-struct';
     createDependentStructDecoder()
         .field('a', getU8Decoder())
         .field('b', () => getU8Decoder())
-        .finish() satisfies VariableSizeDecoder<{ a: number; b: number }>;
+        .build() satisfies VariableSizeDecoder<{ a: number; b: number }>;
 }
 
 {
-    // [createDependentStructDecoder]: The result is always a `VariableSizeDecoder`, never a `FixedSizeDecoder`.
-    const decoder = createDependentStructDecoder().field('a', getU8Decoder()).finish();
-    decoder satisfies VariableSizeDecoder<{ a: number }>;
+    // [createDependentStructDecoder]: A builder built from only fixed size decoders produces a `FixedSizeDecoder`.
+    createDependentStructDecoder()
+        .field('a', getU8Decoder())
+        .field('b', getU16Decoder())
+        .field('c', getU32Decoder())
+        .build() satisfies FixedSizeDecoder<{ a: number; b: number; c: number }>;
+}
+
+{
+    // [createDependentStructDecoder]: Adding a variable size decoder demotes the builder to variable size.
+    createDependentStructDecoder()
+        .field('a', getU8Decoder())
+        .field('b', getUtf8Decoder())
+        .field('c', getU8Decoder())
+        .build() satisfies VariableSizeDecoder<{ a: number; b: string; c: number }>;
+}
+
+{
+    // [createDependentStructDecoder]: Adding a factory demotes the builder to variable size.
+    createDependentStructDecoder()
+        .field('count', getU8Decoder())
+        .field('items', fields => getArrayDecoder(getU8Decoder(), { size: fields.count }))
+        .build() satisfies VariableSizeDecoder<{ count: number; items: number[] }>;
+}
+
+{
+    // [createDependentStructDecoder]: Once variable size, the builder stays variable size on subsequent additions.
+    createDependentStructDecoder()
+        .field('a', getU8Decoder())
+        .field('b', getUtf8Decoder())
+        .field('c', getU8Decoder())
+        .build() satisfies VariableSizeDecoder<{ a: number; b: string; c: number }>;
+    // A fixed size addition after a variable size addition does not raise the builder back to fixed size.
+    createDependentStructDecoder()
+        .field('a', getUtf8Decoder())
+        .field('b', getU8Decoder())
+        // @ts-expect-error The builder dropped to variable size; the result is not a `FixedSizeDecoder`.
+        .build() satisfies FixedSizeDecoder<{ a: string; b: number }>;
 }
 
 {
@@ -80,7 +115,7 @@ import { createDependentStructDecoder } from '../dependent-struct';
         .field('d', getU8Decoder())
         .field('e', getU8Decoder())
         .field('f', getU8Decoder())
-        .finish() satisfies VariableSizeDecoder<{ a: number; b: number; c: number; d: number; e: number; f: number }>;
+        .build() satisfies FixedSizeDecoder<{ a: number; b: number; c: number; d: number; e: number; f: number }>;
 }
 
 {
@@ -92,7 +127,7 @@ import { createDependentStructDecoder } from '../dependent-struct';
             fields.first = 0;
             return getU8Decoder();
         })
-        .finish();
+        .build();
 }
 
 {
@@ -102,13 +137,13 @@ import { createDependentStructDecoder } from '../dependent-struct';
     createDependentStructDecoder()
         .field('version', getU8Decoder())
         .field('payload', buildPayload)
-        .finish() satisfies VariableSizeDecoder<{ payload: number; version: number }>;
+        .build() satisfies VariableSizeDecoder<{ payload: number; version: number }>;
 }
 
 {
     // [createDependentStructDecoder]: The accumulator type is exact; unknown keys are not part of the finished decoder.
-    const decoder = createDependentStructDecoder().field('a', getU8Decoder()).finish();
-    decoder satisfies VariableSizeDecoder<{ a: number }>;
+    const decoder = createDependentStructDecoder().field('a', getU8Decoder()).build();
+    decoder satisfies FixedSizeDecoder<{ a: number }>;
     const value = null as unknown as Awaited<ReturnType<typeof decoder.decode>>;
     // @ts-expect-error `b` was never declared on the builder.
     void value.b;

--- a/packages/codecs-data-structures/src/__typetests__/dependent-struct-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/dependent-struct-typetest.ts
@@ -1,0 +1,72 @@
+import { Decoder, VariableSizeDecoder } from '@solana/codecs-core';
+import { getU8Decoder, getU16Decoder, getU32Decoder } from '@solana/codecs-numbers';
+import { getUtf8Decoder } from '@solana/codecs-strings';
+
+import { getArrayDecoder } from '../array';
+import { createDependentStructDecoder } from '../dependent-struct';
+
+{
+    // [createDependentStructDecoder]: An empty builder finishes to a decoder for the empty record.
+    createDependentStructDecoder().finish() satisfies VariableSizeDecoder<Record<never, never>>;
+}
+
+{
+    // [createDependentStructDecoder]: A builder accumulates the type of each added field.
+    createDependentStructDecoder()
+        .field('a', getU8Decoder())
+        .field('b', getU16Decoder())
+        .field('c', getUtf8Decoder())
+        .finish() satisfies VariableSizeDecoder<{ a: number; b: number; c: string }>;
+}
+
+{
+    // [createDependentStructDecoder]: A field factory receives a snapshot of the fields added so far.
+    createDependentStructDecoder()
+        .field('count', getU8Decoder())
+        .field('values', fields => {
+            fields satisfies Readonly<{ count: number }>;
+            return getArrayDecoder(getU32Decoder(), { size: fields.count });
+        })
+        .finish() satisfies VariableSizeDecoder<{ count: number; values: number[] }>;
+}
+
+{
+    // [createDependentStructDecoder]: A field factory does not see fields that have not been added yet.
+    createDependentStructDecoder()
+        .field('first', getU8Decoder())
+        .field('second', fields => {
+            // @ts-expect-error `third` has not been added at this point.
+            void fields.third;
+            return getU8Decoder();
+        })
+        .field('third', getU8Decoder())
+        .finish();
+}
+
+{
+    // [createDependentStructDecoder]: Adding a field whose name already exists is a type error.
+    createDependentStructDecoder()
+        .field('a', getU8Decoder())
+        // @ts-expect-error `a` has already been declared on this builder.
+        .field('a', getU8Decoder());
+}
+
+{
+    // [createDependentStructDecoder]: The finished decoder is assignable to a generic `Decoder`.
+    const decoder = createDependentStructDecoder().field('value', getU8Decoder()).finish();
+    decoder satisfies Decoder<{ value: number }>;
+}
+
+{
+    // [createDependentStructDecoder]: A static decoder argument and a factory argument both type check.
+    createDependentStructDecoder()
+        .field('a', getU8Decoder())
+        .field('b', () => getU8Decoder())
+        .finish() satisfies VariableSizeDecoder<{ a: number; b: number }>;
+}
+
+{
+    // [createDependentStructDecoder]: The result is always a `VariableSizeDecoder`, never a `FixedSizeDecoder`.
+    const decoder = createDependentStructDecoder().field('a', getU8Decoder()).finish();
+    decoder satisfies VariableSizeDecoder<{ a: number }>;
+}

--- a/packages/codecs-data-structures/src/dependent-struct.ts
+++ b/packages/codecs-data-structures/src/dependent-struct.ts
@@ -1,0 +1,152 @@
+import { createDecoder, Decoder, ReadonlyUint8Array, VariableSizeDecoder } from '@solana/codecs-core';
+
+import { DrainOuterGeneric } from './utils';
+
+/**
+ * A function that builds a {@link Decoder} for a struct field whose shape
+ * depends on the values of previously decoded fields in the same struct.
+ *
+ * The function receives a frozen snapshot of all fields that have been decoded
+ * so far, in declaration order, and must return the {@link Decoder} that should
+ * be used to read the current field from the byte stream.
+ *
+ * @typeParam TPriorFields - The shape of the fields that have already been
+ *     decoded by the time this factory is invoked.
+ * @typeParam TValue - The type of the value produced by the returned decoder.
+ *
+ * @see {@link createDependentStructDecoder}
+ */
+export type DependentStructDecoderFieldFactory<TPriorFields extends Record<string, unknown>, TValue> = (
+    fields: Readonly<TPriorFields>,
+) => Decoder<TValue>;
+
+/**
+ * A fluent builder that accumulates field decoders for a struct whose later
+ * fields may depend on the values of earlier ones.
+ *
+ * Each call to {@link DependentStructDecoderBuilder.field | `field`} returns a
+ * new builder whose accumulated field type is widened by the newly added field.
+ * Call {@link DependentStructDecoderBuilder.finish | `finish`} to obtain the
+ * final {@link Decoder} once every field has been declared.
+ *
+ * Instances of this type are immutable. Calling `field` does not mutate the
+ * receiver; it returns a new builder.
+ *
+ * @typeParam TFields - The shape of the struct that has been accumulated so far.
+ *
+ * @see {@link createDependentStructDecoder}
+ */
+export type DependentStructDecoderBuilder<TFields extends Record<string, unknown>> = {
+    /**
+     * Adds a field to the struct whose decoder is either static, or built from
+     * the values of previously declared fields.
+     *
+     * Adding a field that has already been declared on this builder is a
+     * compile time error.
+     *
+     * @typeParam TName - The name of the field being added. Must not collide
+     *     with the name of a field already declared on this builder.
+     * @typeParam TValue - The type of the value produced by the field's decoder.
+     *
+     * @param name - The unique name of the field within the struct.
+     * @param decoderOrFactory - Either a {@link Decoder} for the field, or a
+     *     {@link DependentStructDecoderFieldFactory} that produces one from
+     *     the previously decoded fields.
+     *
+     * @returns A new builder whose accumulated field type includes the newly
+     *     added field.
+     */
+    field<TName extends string, TValue>(
+        name: TName extends keyof TFields ? never : TName,
+        decoderOrFactory: Decoder<TValue> | DependentStructDecoderFieldFactory<TFields, TValue>,
+    ): DependentStructDecoderBuilder<DrainOuterGeneric<TFields & { [K in TName]: TValue }>>;
+
+    /**
+     * Finalizes the builder and returns a {@link VariableSizeDecoder} that
+     * decodes each declared field in turn, in the order they were added.
+     *
+     * The resulting decoder is always variable size because the size of any
+     * field declared with a factory cannot be determined ahead of time.
+     */
+    finish(): VariableSizeDecoder<DrainOuterGeneric<TFields>>;
+};
+
+/**
+ * Creates a fluent builder for a struct decoder whose later fields may depend
+ * on the decoded values of earlier ones.
+ *
+ * Unlike {@link getStructDecoder}, which accepts a fixed array of named
+ * decoders, this builder lets each field provide a factory that receives the
+ * values that have already been decoded. This is useful for binary formats
+ * where a count, version, or discriminator decoded near the start of the
+ * struct controls how a later field must be parsed.
+ *
+ * The returned builder is immutable; each {@link DependentStructDecoderBuilder.field | `field`}
+ * call returns a new builder whose accumulated field type is widened by the
+ * newly added field. Call {@link DependentStructDecoderBuilder.finish | `finish`}
+ * to produce the final decoder.
+ *
+ * @example
+ * Decoding a struct whose array length is read from an earlier field.
+ * ```ts
+ * import { getArrayDecoder } from '@solana/codecs-data-structures';
+ * import { getU8Decoder, getU32Decoder } from '@solana/codecs-numbers';
+ *
+ * const decoder = createDependentStructDecoder()
+ *     .field('count', getU8Decoder())
+ *     .field('values', fields => getArrayDecoder(getU32Decoder(), { size: fields.count }))
+ *     .finish();
+ *
+ * decoder.decode(new Uint8Array([0x02, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
+ * // { count: 2, values: [1, 2] }
+ * ```
+ *
+ * @example
+ * Mixing static and dependent fields.
+ * ```ts
+ * const decoder = createDependentStructDecoder()
+ *     .field('version', getU8Decoder())
+ *     .field('header', fields => fields.version === 0 ? getU16Decoder() : getU32Decoder())
+ *     .finish();
+ * ```
+ *
+ * @see {@link getStructDecoder}
+ */
+export function createDependentStructDecoder(): DependentStructDecoderBuilder<Record<never, never>> {
+    return buildFromEntries([]);
+}
+
+type ResolvedDecoder = (fields: Record<string, unknown>) => Decoder<unknown>;
+type InternalEntry = Readonly<{ name: string; resolveDecoder: ResolvedDecoder }>;
+
+function buildFromEntries<TFields extends Record<string, unknown>>(
+    entries: readonly InternalEntry[],
+): DependentStructDecoderBuilder<TFields> {
+    return {
+        field<TName extends string, TValue>(
+            name: TName extends keyof TFields ? never : TName,
+            decoderOrFactory: Decoder<TValue> | DependentStructDecoderFieldFactory<TFields, TValue>,
+        ): DependentStructDecoderBuilder<DrainOuterGeneric<TFields & { [K in TName]: TValue }>> {
+            const resolveDecoder: ResolvedDecoder =
+                typeof decoderOrFactory === 'function'
+                    ? fields => decoderOrFactory(fields as TFields)
+                    : () => decoderOrFactory;
+            const nextEntry: InternalEntry = { name: name as string, resolveDecoder };
+            return buildFromEntries<DrainOuterGeneric<TFields & { [K in TName]: TValue }>>([...entries, nextEntry]);
+        },
+        finish(): VariableSizeDecoder<DrainOuterGeneric<TFields>> {
+            return createDecoder({
+                read(bytes: ReadonlyUint8Array | Uint8Array, offset: number): [DrainOuterGeneric<TFields>, number] {
+                    const decoded: Record<string, unknown> = {};
+                    for (const { name, resolveDecoder } of entries) {
+                        const decoder = resolveDecoder(decoded);
+                        const [value, newOffset] = decoder.read(bytes, offset);
+                        decoded[name] = value;
+                        offset = newOffset;
+                    }
+                    return [decoded as DrainOuterGeneric<TFields>, offset];
+                },
+            });
+        },
+    };
+}

--- a/packages/codecs-data-structures/src/dependent-struct.ts
+++ b/packages/codecs-data-structures/src/dependent-struct.ts
@@ -1,6 +1,6 @@
-import { createDecoder, Decoder, ReadonlyUint8Array, VariableSizeDecoder } from '@solana/codecs-core';
+import { createDecoder, Decoder, FixedSizeDecoder, ReadonlyUint8Array, VariableSizeDecoder } from '@solana/codecs-core';
 
-import { DrainOuterGeneric } from './utils';
+import { DrainOuterGeneric, getFixedSize, sumCodecSizes } from './utils';
 
 /**
  * A function that builds a {@link Decoder} for a struct field whose shape
@@ -26,49 +26,73 @@ export type DependentStructDecoderFieldFactory<TPriorFields extends Record<strin
  *
  * Each call to {@link DependentStructDecoderBuilder.field | `field`} returns a
  * new builder whose accumulated field type is widened by the newly added field.
- * Call {@link DependentStructDecoderBuilder.finish | `finish`} to obtain the
+ * Call {@link DependentStructDecoderBuilder.build | `build`} to obtain the
  * final {@link Decoder} once every field has been declared.
+ *
+ * The builder tracks at the type level whether the struct decoded so far has a
+ * fixed size. Adding a {@link FixedSizeDecoder} preserves that property, while
+ * adding a {@link VariableSizeDecoder} or a {@link DependentStructDecoderFieldFactory | field factory}
+ * drops the builder to variable size and it stays variable thereafter.
  *
  * Instances of this type are immutable. Calling `field` does not mutate the
  * receiver; it returns a new builder.
  *
  * @typeParam TFields - The shape of the struct that has been accumulated so far.
+ * @typeParam TIsFixedSize - `true` while every field added so far is a
+ *     {@link FixedSizeDecoder}, `false` once any variable size decoder or
+ *     factory has been added.
  *
  * @see {@link createDependentStructDecoder}
  */
-export type DependentStructDecoderBuilder<TFields extends Record<string, unknown>> = {
+export type DependentStructDecoderBuilder<TFields extends Record<string, unknown>, TIsFixedSize extends boolean> = {
     /**
-     * Adds a field to the struct whose decoder is either static, or built from
-     * the values of previously declared fields.
+     * Finalizes the builder and returns a {@link Decoder} that decodes each
+     * declared field in turn, in the order they were added.
+     *
+     * Returns a {@link FixedSizeDecoder} when every field has been added with a
+     * fixed size decoder, and a {@link VariableSizeDecoder} otherwise.
+     */
+    build(): TIsFixedSize extends true
+        ? FixedSizeDecoder<DrainOuterGeneric<TFields>>
+        : VariableSizeDecoder<DrainOuterGeneric<TFields>>;
+
+    /**
+     * Adds a field decoded by a {@link VariableSizeDecoder}. Drops the builder
+     * to variable size; subsequent {@link field} calls cannot raise it back to
+     * fixed size.
      *
      * Adding a field that has already been declared on this builder is a
      * compile time error.
-     *
-     * @typeParam TName - The name of the field being added. Must not collide
-     *     with the name of a field already declared on this builder.
-     * @typeParam TValue - The type of the value produced by the field's decoder.
-     *
-     * @param name - The unique name of the field within the struct.
-     * @param decoderOrFactory - Either a {@link Decoder} for the field, or a
-     *     {@link DependentStructDecoderFieldFactory} that produces one from
-     *     the previously decoded fields.
-     *
-     * @returns A new builder whose accumulated field type includes the newly
-     *     added field.
      */
     field<TName extends string, TValue>(
         name: TName extends keyof TFields ? never : TName,
-        decoderOrFactory: Decoder<TValue> | DependentStructDecoderFieldFactory<TFields, TValue>,
-    ): DependentStructDecoderBuilder<DrainOuterGeneric<TFields & { [K in TName]: TValue }>>;
+        decoder: VariableSizeDecoder<TValue>,
+    ): DependentStructDecoderBuilder<DrainOuterGeneric<TFields & { [K in TName]: TValue }>, false>;
 
     /**
-     * Finalizes the builder and returns a {@link VariableSizeDecoder} that
-     * decodes each declared field in turn, in the order they were added.
+     * Adds a field whose decoder is built from a frozen snapshot of the fields
+     * that precede it. Drops the builder to variable size since the byte
+     * length of the produced decoder cannot be known at type time.
      *
-     * The resulting decoder is always variable size because the size of any
-     * field declared with a factory cannot be determined ahead of time.
+     * Adding a field that has already been declared on this builder is a
+     * compile time error.
      */
-    finish(): VariableSizeDecoder<DrainOuterGeneric<TFields>>;
+    field<TName extends string, TValue>(
+        name: TName extends keyof TFields ? never : TName,
+        factory: DependentStructDecoderFieldFactory<TFields, TValue>,
+    ): DependentStructDecoderBuilder<DrainOuterGeneric<TFields & { [K in TName]: TValue }>, false>;
+
+    /**
+     * Adds a field decoded by a {@link FixedSizeDecoder}. Preserves the fixed
+     * size property of the builder.
+     *
+     * Adding a field that has already been declared on this builder is a
+     * compile time error.
+     */
+    field<TName extends string, TValue>(
+        name: TName extends keyof TFields ? never : TName,
+        decoder: FixedSizeDecoder<TValue>,
+    ): DependentStructDecoderBuilder<DrainOuterGeneric<TFields & { [K in TName]: TValue }>, TIsFixedSize>;
 };
 
 /**
@@ -81,17 +105,23 @@ export type DependentStructDecoderBuilder<TFields extends Record<string, unknown
  * where a count, version, or discriminator decoded near the start of the
  * struct controls how a later field must be parsed.
  *
+ * The builder mirrors the fixed vs variable size behaviour of
+ * {@link getStructDecoder}. The empty builder finishes to a
+ * {@link FixedSizeDecoder} of size zero. Adding a {@link FixedSizeDecoder}
+ * preserves the fixed size property and the sizes accumulate. Adding a
+ * {@link VariableSizeDecoder} or a {@link DependentStructDecoderFieldFactory | field factory}
+ * drops the builder to variable size, which is then preserved by every
+ * subsequent {@link DependentStructDecoderBuilder.field | `field`} call.
+ *
  * The returned builder is immutable; each {@link DependentStructDecoderBuilder.field | `field`}
  * call returns a new builder whose accumulated field type is widened by the
- * newly added field. Call {@link DependentStructDecoderBuilder.finish | `finish`}
+ * newly added field. Call {@link DependentStructDecoderBuilder.build | `build`}
  * to produce the final decoder.
  *
  * @remarks
  * Prefer {@link getStructDecoder} when every field's decoder is independent of
  * the values that precede it. Reach for this builder only when at least one
- * field needs to be parameterised by another. The resulting decoder is always
- * variable size because the byte length of a factory-provided field cannot be
- * known ahead of time.
+ * field needs to be parameterised by another.
  *
  * The encoder direction does not need a dependent variant. An encoder already
  * has access to the entire value when serialising, so the existing
@@ -107,7 +137,7 @@ export type DependentStructDecoderBuilder<TFields extends Record<string, unknown
  * const decoder = createDependentStructDecoder()
  *     .field('count', getU8Decoder())
  *     .field('values', fields => getArrayDecoder(getU32Decoder(), { size: fields.count }))
- *     .finish();
+ *     .build();
  *
  * decoder.decode(new Uint8Array([0x02, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00]));
  * // { count: 2, values: [1, 2] }
@@ -119,7 +149,7 @@ export type DependentStructDecoderBuilder<TFields extends Record<string, unknown
  * const decoder = createDependentStructDecoder()
  *     .field('version', getU8Decoder())
  *     .field('header', fields => fields.version === 0 ? getU16Decoder() : getU32Decoder())
- *     .finish();
+ *     .build();
  * ```
  *
  * @example
@@ -134,48 +164,68 @@ export type DependentStructDecoderBuilder<TFields extends Record<string, unknown
  * const decoder = createDependentStructDecoder()
  *     .field('count', getU8Decoder())
  *     .field('values', fields => getArrayDecoder(getU32Decoder(), { size: fields.count }))
- *     .finish();
+ *     .build();
  * const codec = combineCodec(encoder, decoder);
  * ```
  *
  * @see {@link getStructDecoder}
  * @see {@link getStructEncoder}
  */
-export function createDependentStructDecoder(): DependentStructDecoderBuilder<Record<never, never>> {
+export function createDependentStructDecoder(): DependentStructDecoderBuilder<Record<never, never>, true> {
     return buildFromEntries([]);
 }
 
-type ResolvedDecoder = (fields: Record<string, unknown>) => Decoder<unknown>;
-type InternalEntry = Readonly<{ name: string; resolveDecoder: ResolvedDecoder }>;
+type InternalEntry = Readonly<{
+    name: string;
+    resolveDecoder: (fields: Record<string, unknown>) => Decoder<unknown>;
+    /**
+     * The static decoder for this entry, if the entry was added with one
+     * directly. Absent when the entry was added with a factory, in which case
+     * the entry is treated as variable size for the purposes of computing the
+     * struct's total fixed size.
+     */
+    staticDecoder: Decoder<unknown> | undefined;
+}>;
 
-function buildFromEntries<TFields extends Record<string, unknown>>(
+function buildFromEntries<TFields extends Record<string, unknown>, TIsFixedSize extends boolean>(
     entries: readonly InternalEntry[],
-): DependentStructDecoderBuilder<TFields> {
+): DependentStructDecoderBuilder<TFields, TIsFixedSize> {
     return {
+        build() {
+            const staticDecoders = entries.map(e => e.staticDecoder);
+            const everyStatic = staticDecoders.every((d): d is Decoder<unknown> => d !== undefined);
+            const fixedSize = everyStatic ? sumCodecSizes(staticDecoders.map(getFixedSize)) : null;
+            const read = (
+                bytes: ReadonlyUint8Array | Uint8Array,
+                offset: number,
+            ): [DrainOuterGeneric<TFields>, number] => {
+                const decoded: Record<string, unknown> = {};
+                for (const { name, resolveDecoder } of entries) {
+                    const decoder = resolveDecoder(decoded);
+                    const [value, newOffset] = decoder.read(bytes, offset);
+                    decoded[name] = value;
+                    offset = newOffset;
+                }
+                return [decoded as DrainOuterGeneric<TFields>, offset];
+            };
+            const decoder = fixedSize === null ? createDecoder({ read }) : createDecoder({ fixedSize, read });
+            return decoder as never;
+        },
         field<TName extends string, TValue>(
-            name: TName extends keyof TFields ? never : TName,
+            name: TName,
             decoderOrFactory: Decoder<TValue> | DependentStructDecoderFieldFactory<TFields, TValue>,
-        ): DependentStructDecoderBuilder<DrainOuterGeneric<TFields & { [K in TName]: TValue }>> {
-            const resolveDecoder: ResolvedDecoder =
-                typeof decoderOrFactory === 'function'
-                    ? fields => decoderOrFactory(fields as TFields)
-                    : () => decoderOrFactory;
-            const nextEntry: InternalEntry = { name: name as string, resolveDecoder };
-            return buildFromEntries<DrainOuterGeneric<TFields & { [K in TName]: TValue }>>([...entries, nextEntry]);
+        ): DependentStructDecoderBuilder<Record<string, unknown>, boolean> {
+            const isFactory = typeof decoderOrFactory === 'function';
+            const resolveDecoder = isFactory
+                ? (fields: Record<string, unknown>) =>
+                      decoderOrFactory(Object.freeze({ ...fields }) as Readonly<TFields>)
+                : () => decoderOrFactory;
+            const nextEntry: InternalEntry = {
+                name,
+                resolveDecoder,
+                staticDecoder: isFactory ? undefined : decoderOrFactory,
+            };
+            return buildFromEntries([...entries, nextEntry]);
         },
-        finish(): VariableSizeDecoder<DrainOuterGeneric<TFields>> {
-            return createDecoder({
-                read(bytes: ReadonlyUint8Array | Uint8Array, offset: number): [DrainOuterGeneric<TFields>, number] {
-                    const decoded: Record<string, unknown> = {};
-                    for (const { name, resolveDecoder } of entries) {
-                        const decoder = resolveDecoder(decoded);
-                        const [value, newOffset] = decoder.read(bytes, offset);
-                        decoded[name] = value;
-                        offset = newOffset;
-                    }
-                    return [decoded as DrainOuterGeneric<TFields>, offset];
-                },
-            });
-        },
-    };
+    } as DependentStructDecoderBuilder<TFields, TIsFixedSize>;
 }

--- a/packages/codecs-data-structures/src/dependent-struct.ts
+++ b/packages/codecs-data-structures/src/dependent-struct.ts
@@ -86,6 +86,18 @@ export type DependentStructDecoderBuilder<TFields extends Record<string, unknown
  * newly added field. Call {@link DependentStructDecoderBuilder.finish | `finish`}
  * to produce the final decoder.
  *
+ * @remarks
+ * Prefer {@link getStructDecoder} when every field's decoder is independent of
+ * the values that precede it. Reach for this builder only when at least one
+ * field needs to be parameterised by another. The resulting decoder is always
+ * variable size because the byte length of a factory-provided field cannot be
+ * known ahead of time.
+ *
+ * The encoder direction does not need a dependent variant. An encoder already
+ * has access to the entire value when serialising, so the existing
+ * {@link getStructEncoder} can be paired with the decoder returned by this
+ * builder and combined with `combineCodec` to obtain a full codec.
+ *
  * @example
  * Decoding a struct whose array length is read from an earlier field.
  * ```ts
@@ -102,7 +114,7 @@ export type DependentStructDecoderBuilder<TFields extends Record<string, unknown
  * ```
  *
  * @example
- * Mixing static and dependent fields.
+ * Mixing static and dependent fields, with a discriminator selecting the payload decoder.
  * ```ts
  * const decoder = createDependentStructDecoder()
  *     .field('version', getU8Decoder())
@@ -110,7 +122,24 @@ export type DependentStructDecoderBuilder<TFields extends Record<string, unknown
  *     .finish();
  * ```
  *
+ * @example
+ * Combining the dependent decoder with a static encoder to obtain a full codec.
+ * ```ts
+ * import { combineCodec } from '@solana/codecs-core';
+ *
+ * const encoder = getStructEncoder([
+ *     ['count', getU8Encoder()],
+ *     ['values', getArrayEncoder(getU32Encoder())],
+ * ]);
+ * const decoder = createDependentStructDecoder()
+ *     .field('count', getU8Decoder())
+ *     .field('values', fields => getArrayDecoder(getU32Decoder(), { size: fields.count }))
+ *     .finish();
+ * const codec = combineCodec(encoder, decoder);
+ * ```
+ *
  * @see {@link getStructDecoder}
+ * @see {@link getStructEncoder}
  */
 export function createDependentStructDecoder(): DependentStructDecoderBuilder<Record<never, never>> {
     return buildFromEntries([]);

--- a/packages/codecs-data-structures/src/index.ts
+++ b/packages/codecs-data-structures/src/index.ts
@@ -14,6 +14,7 @@ export * from './bit-array';
 export * from './boolean';
 export * from './bytes';
 export * from './constant';
+export * from './dependent-struct';
 export * from './discriminated-union';
 export * from './enum';
 export * from './hidden-prefix';


### PR DESCRIPTION
## Summary

Adds `createDependentStructDecoder`, a fluent builder for a struct decoder whose later fields may depend on the decoded values of earlier ones. This addresses the case described in #1448 where a struct field's decoder needs access to the value of an earlier field, such as the per-instruction headers in a v1 transaction message.

The builder is intentionally additive. It does not replace or modify the existing `getStructDecoder`, which remains the right choice when every field's decoder is independent.

## API

```ts
const decoder = createDependentStructDecoder()
    .field('count', getU8Decoder())
    .field('values', fields => getArrayDecoder(getU32Decoder(), { size: fields.count }))
    .finish();
```

Each `field` call adds a named entry and returns a new builder whose accumulated type is widened by the newly added field. The second argument can be either a static `Decoder` or a factory that receives a frozen snapshot of every field decoded so far, in declaration order. Calling `finish` returns a `VariableSizeDecoder` for the accumulated struct.

Two type level guarantees are encoded directly in the builder signature:

1. Adding a field with a name that already exists on the builder is a compile time error.
2. A factory only sees the fields that have been added before it; fields added later are not present on its `fields` parameter.

## Design notes

I followed @mcintyre94's builder pseudocode from the issue rather than the array form, because the array form makes it difficult to surface previously declared fields to a per-field factory in a type safe way. The builder form lets each `field` call extend the accumulator type directly, so the factory's `fields` parameter narrows naturally without conditional types.

Only the decoder side is provided. The encoder direction already has access to the entire value when serialising, so the existing `getStructEncoder` already supports the use cases the issue describes. A symmetrical encoder builder can be added in a follow up if a concrete need arises.

The resulting decoder is always variable size, since the byte length of any factory-provided field cannot be known ahead of time.

## Tests

Twelve unit tests cover the behaviour:

- A struct with only static fields decodes the same way `getStructDecoder` would.
- A field factory drives the size of a later array from an earlier `u8`.
- A factory receives exactly the fields decoded so far, never more.
- A factory can pick between two decoders based on a discriminator, exercised for two distinct discriminator values.
- `read` honours a non-zero starting offset and returns the new offset.
- An empty builder finishes to a decoder for `{}`.
- The decoded object preserves declaration order in `Object.keys`.
- The result is a `VariableSizeDecoder` (no `fixedSize` property).
- The builder is immutable; calling `field` returns a new builder without mutating the receiver.
- Independent `finish` calls on the same builder produce distinct decoder instances.
- The new decoder composes with other variable size decoders such as `fixDecoderSize(getUtf8Decoder(), n)` and `getArrayDecoder`.

Eight typetests cover the type level contract using only `satisfies`, matching the style of the existing `struct-typetest.ts`:

- The empty builder finishes to `VariableSizeDecoder<Record<never, never>>`.
- The accumulator widens with each `field` call.
- A factory's `fields` parameter is exactly `Readonly<{ ...priorFields }>`.
- A factory cannot read fields that have not been added yet (`@ts-expect-error`).
- Adding the same field name twice is a type error (`@ts-expect-error`).
- The finished decoder is assignable to a generic `Decoder<T>`.
- Both a static `Decoder` argument and a factory argument type check.
- The result is always a `VariableSizeDecoder`, never a `FixedSizeDecoder`.

## Behavioral impact

Purely additive. No existing public type or call site changes.

## Closes

Closes #1448
