### PR TITLE
Add AGENTS, gitignore LLM files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ test-ledger/
 
 # ignore JetBrains IDE
 .idea
+
+# LLM files
+.claude/worktrees
+.claude/settings.local.json
+.codex/config.toml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
Small repo tidyups

- AGENTS.md is a symlink to CLAUDE.md, keeping CLAUDE as source of truth for now because it's what we mostly use
- Claude seems to create worktrees at .claude/worktrees, so ignoring that path. Codex seems to create its worktrees outside the repo 
- .claude/settings.local.json and .codex/config.toml copied from https://github.com/anza-xyz/kit/pull/1611/changes