### PR TITLE
Add test coverage to the React example app and align it with the current kit API

### DIFF
--- a/examples/react-app/jest-unit.config.browser.js
+++ b/examples/react-app/jest-unit.config.browser.js
@@ -1,0 +1,21 @@
+import baseConfig from '../../node_modules/@solana/test-config/jest-unit.config.browser.js';
+
+const config = {
+    ...baseConfig,
+    transform: {
+        '^.+\\.(ts|js)x?$': [
+            '@swc/jest',
+            {
+                jsc: {
+                    parser: { syntax: 'typescript', tsx: true },
+                    target: 'es2020',
+                    transform: {
+                        react: { runtime: 'automatic' },
+                    },
+                },
+            },
+        ],
+    },
+};
+
+export default config;

--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -10,7 +10,8 @@
         "style:fix": "pnpm eslint --fix src && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ../../node_modules/@solana/test-config/jest-lint.config.js --rootDir . --silent --testMatch '<rootDir>src/**/*.{ts,tsx}'",
         "test:prettier": "TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ../../node_modules/@solana/test-config/jest-prettier.config.js --rootDir . --silent",
-        "test:typecheck": "tsc"
+        "test:typecheck": "tsc",
+        "test:unit:browser": "NODE_OPTIONS=\"--no-experimental-webstorage\" TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ./jest-unit.config.browser.js --rootDir . --silent"
     },
     "dependencies": {
         "@radix-ui/react-dropdown-menu": "2.1.6",
@@ -30,6 +31,9 @@
         "@solana/eslint-config": "workspace:*",
         "@solana/wallet-standard-features": "^1.4.0",
         "@types/react": "^19.2.17",
+        "@solana/test-config": "workspace:*",
+        "@swc/jest": "^0.2.39",
+        "@testing-library/react": "^16.3.2",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react-swc": "^4.3.1",
         "eslint": "^9.39.2",

--- a/examples/react-app/src/__test-utils__/render.tsx
+++ b/examples/react-app/src/__test-utils__/render.tsx
@@ -1,0 +1,26 @@
+import {
+    render as baseRender,
+    renderHook as baseRenderHook,
+    RenderHookOptions,
+    RenderOptions,
+} from '@testing-library/react';
+import { ComponentType, ReactElement, ReactNode, StrictMode } from 'react';
+
+function composeWithStrictMode(
+    Inner: ComponentType<{ children: ReactNode }> | undefined,
+): ComponentType<{ children: ReactNode }> {
+    return function StrictModeWrapper({ children }) {
+        return <StrictMode>{Inner ? <Inner>{children}</Inner> : children}</StrictMode>;
+    };
+}
+
+export function renderHook<TResult, TProps>(
+    callback: (props: TProps) => TResult,
+    options?: RenderHookOptions<TProps>,
+): ReturnType<typeof baseRenderHook<TResult, TProps>> {
+    return baseRenderHook(callback, { ...options, wrapper: composeWithStrictMode(options?.wrapper) });
+}
+
+export function render(ui: ReactElement, options?: RenderOptions): ReturnType<typeof baseRender> {
+    return baseRender(ui, { ...options, wrapper: composeWithStrictMode(options?.wrapper) });
+}

--- a/examples/react-app/src/__tests__/errors-test.browser.tsx
+++ b/examples/react-app/src/__tests__/errors-test.browser.tsx
@@ -1,0 +1,83 @@
+import { SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,SolanaError } from '@solana/kit';
+import {
+    WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED,
+    WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_FEATURE_UNIMPLEMENTED,
+    WALLET_STANDARD_ERROR__FEATURES__WALLET_FEATURE_UNIMPLEMENTED,
+    WalletStandardError,
+} from '@wallet-standard/core';
+import React from 'react';
+
+import { render } from '../__test-utils__/render';
+import { getErrorMessage } from '../errors';
+
+describe('getErrorMessage', () => {
+    function renderInDocument(node: React.ReactNode): string {
+        const { container } = render(<div>{node}</div>);
+        return container.textContent ?? '';
+    }
+
+    it('extracts `err.message` from a plain error-like object', () => {
+        expect(getErrorMessage({ message: 'bang' }, 'fallback')).toBe('bang');
+    });
+
+    it('coerces non-string `err.message` to a string', () => {
+        expect(getErrorMessage({ message: 42 }, 'fallback')).toBe('42');
+    });
+
+    it('returns the fallback for primitives or objects with no `message`', () => {
+        expect(getErrorMessage('plain string', 'fallback')).toBe('fallback');
+        expect(getErrorMessage(undefined, 'fallback')).toBe('fallback');
+        expect(getErrorMessage(null, 'fallback')).toBe('fallback');
+        expect(getErrorMessage({}, 'fallback')).toBe('fallback');
+    });
+
+    it('renders the unsupported feature name for WALLET_ACCOUNT_FEATURE_UNIMPLEMENTED', () => {
+        const err = new WalletStandardError(WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_FEATURE_UNIMPLEMENTED, {
+            address: 'addr',
+            featureName: 'solana:signMessage',
+            supportedChains: ['solana:devnet'],
+            supportedFeatures: [],
+        });
+        const text = renderInDocument(getErrorMessage(err, 'fallback'));
+        expect(text).toContain('solana:signMessage');
+    });
+
+    it('lists chains and features for WALLET_FEATURE_UNIMPLEMENTED', () => {
+        const err = new WalletStandardError(WALLET_STANDARD_ERROR__FEATURES__WALLET_FEATURE_UNIMPLEMENTED, {
+            featureName: 'solana:signMessage',
+            supportedChains: ['solana:devnet', 'solana:mainnet'],
+            supportedFeatures: ['solana:signTransaction'],
+            walletName: 'TestWallet',
+        });
+        const text = renderInDocument(getErrorMessage(err, 'fallback'));
+        expect(text).toContain('TestWallet');
+        expect(text).toContain('solana:devnet');
+        expect(text).toContain('solana:mainnet');
+        expect(text).toContain('solana:signMessage');
+        expect(text).toContain('solana:signTransaction');
+    });
+
+    it('lists supported chains for WALLET_ACCOUNT_CHAIN_UNSUPPORTED', () => {
+        const err = new WalletStandardError(WALLET_STANDARD_ERROR__FEATURES__WALLET_ACCOUNT_CHAIN_UNSUPPORTED, {
+            address: 'addr',
+            chain: 'solana:mainnet',
+            featureName: 'solana:signMessage',
+            supportedChains: ['solana:devnet'],
+            supportedFeatures: [],
+        });
+        const text = renderInDocument(getErrorMessage(err, 'fallback'));
+        expect(text).toContain('solana:mainnet');
+        expect(text).toContain('solana:devnet');
+    });
+
+    it('renders preflight logs for the JSON-RPC preflight-failure error', () => {
+        // The full preflight context is large; cast through `unknown` since `getErrorMessage`
+        // only reads `err.message` and `err.context.logs`.
+        const err = new SolanaError(SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE, {
+            logs: ['Program log: hello', 'Program log: world'],
+        } as unknown as ConstructorParameters<typeof SolanaError>[1]);
+        const text = renderInDocument(getErrorMessage(err, 'fallback'));
+        expect(text).toContain('Program log: hello');
+        expect(text).toContain('Program log: world');
+    });
+});

--- a/examples/react-app/src/components/AirdropButton.tsx
+++ b/examples/react-app/src/components/AirdropButton.tsx
@@ -8,7 +8,7 @@ import { ErrorDialog } from './ErrorDialog';
 
 export function AirdropButton({ address }: { address: Address }) {
     const { current: NO_ERROR } = useRef<unknown>(Symbol());
-    const { chain } = useContext(ChainContext);
+    const { chain, solanaExplorerClusterName } = useContext(ChainContext);
     const { rpc, rpcSubscriptions } = useContext(RpcContext);
     const [error, setError] = useState(NO_ERROR);
     const [lastSignature, setLastSignature] = useState<Signature | undefined>();

--- a/examples/react-app/src/components/BaseSignMessageFeaturePanel.tsx
+++ b/examples/react-app/src/components/BaseSignMessageFeaturePanel.tsx
@@ -12,7 +12,7 @@ type Props = Readonly<{
 }>;
 
 export function BaseSignMessageFeaturePanel({ signMessage }: Props) {
-    const { current: NO_ERROR } = useRef(Symbol());
+    const { current: NO_ERROR } = useRef<unknown>(Symbol());
     const [isSigningMessage, setIsSigningMessage] = useState(false);
     const [error, setError] = useState(NO_ERROR);
     const [lastSignature, setLastSignature] = useState<ReadonlyUint8Array | undefined>();

--- a/examples/react-app/src/components/DisconnectButton.tsx
+++ b/examples/react-app/src/components/DisconnectButton.tsx
@@ -15,7 +15,7 @@ export function DisconnectButton({
     ...buttonProps
 }: Omit<React.ComponentProps<typeof Button>, 'color' | 'loading' | 'onClick'> & Props) {
     const [isDisconnecting, disconnect] = useDisconnect(wallet);
-    const [lastError, setLastError] = useState(NO_ERROR);
+    const [lastError, setLastError] = useState<unknown>(NO_ERROR);
     return (
         <Tooltip
             content={

--- a/examples/react-app/src/components/SlotIndicator.tsx
+++ b/examples/react-app/src/components/SlotIndicator.tsx
@@ -1,61 +1,34 @@
 import { Link, Text } from '@radix-ui/themes';
-import { useContext, useEffect, useState, useSyncExternalStore } from 'react';
+import { useContext, useEffect, useMemo, useSyncExternalStore } from 'react';
 
 import { ChainContext } from '../context/ChainContext';
 import { RpcContext } from '../context/RpcContext';
-
-type SlotNotification = Readonly<{
-    parent: bigint;
-    root: bigint;
-    slot: bigint;
-}>;
-
-type ReactiveStore<T> = {
-    getError(): unknown;
-    getState(): T | undefined;
-    subscribe(callback: () => void): () => void;
-};
-
-function createNoopStore(error?: unknown): ReactiveStore<SlotNotification> {
-    return {
-        getError: () => error,
-        getState: () => undefined,
-        subscribe: () => () => { },
-    };
-}
 
 const slotFormatter = new Intl.NumberFormat();
 
 export function SlotIndicator() {
     const { rpcSubscriptions } = useContext(RpcContext);
     const { chain, solanaExplorerClusterName } = useContext(ChainContext);
-    const [store, setStore] = useState<ReactiveStore<SlotNotification>>(createNoopStore);
+    const store = useMemo(
+        () => rpcSubscriptions.slotNotifications().reactiveStore(),
+        [rpcSubscriptions, chain],
+    );
 
     useEffect(() => {
-        const abortController = new AbortController();
-        rpcSubscriptions
-            .slotNotifications()
-            .reactive({ abortSignal: abortController.signal })
-            .then(setStore)
-            .catch(e => setStore(createNoopStore(e)));
-        return () => abortController.abort();
-    }, [rpcSubscriptions, chain]);
+        store.connect();
+        return () => store.reset();
+    }, [store]);
 
-    const slot = useSyncExternalStore(store.subscribe, () => {
-        if (store.getError()) throw store.getError();
-        return store.getState();
-    });
-
-    if (!slot) {
-        return <Text>{'\u2013'}</Text>;
-    }
+    const state = useSyncExternalStore(store.subscribe, store.getUnifiedState);
+    if (state.status === 'error') throw state.error;
+    if (state.status !== 'loaded') return <Text>{'\u2013'}</Text>;
 
     return (
         <Link
-            href={`https://explorer.solana.com/block/${slot.slot}?cluster=${solanaExplorerClusterName}`}
+            href={`https://explorer.solana.com/block/${state.data.slot}?cluster=${solanaExplorerClusterName}`}
             target="_blank"
         >
-            {slotFormatter.format(slot.slot)}
+            {slotFormatter.format(state.data.slot)}
         </Link>
     );
 }

--- a/examples/react-app/src/components/SolanaSignAndSendTransactionFeaturePanel.tsx
+++ b/examples/react-app/src/components/SolanaSignAndSendTransactionFeaturePanel.tsx
@@ -41,7 +41,7 @@ function solStringToLamports(solQuantityString: string) {
 
 export function SolanaSignAndSendTransactionFeaturePanel({ account }: Props) {
     const { mutate } = useSWRConfig();
-    const { current: NO_ERROR } = useRef(Symbol());
+    const { current: NO_ERROR } = useRef<unknown>(Symbol());
     const { rpc } = useContext(RpcContext);
     const wallets = useWallets();
     const [isSendingTransaction, setIsSendingTransaction] = useState(false);

--- a/examples/react-app/src/components/__tests__/Balance-test.browser.tsx
+++ b/examples/react-app/src/components/__tests__/Balance-test.browser.tsx
@@ -1,0 +1,179 @@
+import { Theme } from '@radix-ui/themes';
+import type {
+    AccountNotificationsApi,
+    Lamports,
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcApiMainnet,
+    SolanaRpcResponse,
+    SolanaRpcSubscriptionsApi,
+} from '@solana/kit';
+import { createReactiveActionStore, createReactiveStoreFromDataPublisherFactory } from '@solana/kit';
+import { act, waitFor } from '@testing-library/react';
+import type { UiWalletAccount } from '@wallet-standard/react';
+import React from 'react';
+import { SWRConfig } from 'swr';
+
+import { render } from '../../__test-utils__/render';
+import { ChainContext, DEFAULT_CHAIN_CONFIG } from '../../context/ChainContext';
+import { RpcContext } from '../../context/RpcContext';
+import { Balance } from '../Balance';
+
+type LamportsResponse = SolanaRpcResponse<Lamports>;
+type AccountNotification = SolanaRpcResponse<{ lamports: Lamports }>;
+
+const ACCOUNT_ADDRESS = 'So11111111111111111111111111111111111111112';
+
+function makeAccount(): UiWalletAccount {
+    return { address: ACCOUNT_ADDRESS } as UiWalletAccount;
+}
+
+function lamportsResponse(slot: number, lamports: bigint): LamportsResponse {
+    return { context: { slot: BigInt(slot) }, value: lamports as Lamports };
+}
+
+// `Balance` drives `balanceSubscribe`, which consumes the RPC request via its `reactiveStore()`
+// method (not `send()`), so the mock backs `getBalance(...)` with a real `ReactiveActionStore`
+// wrapping a controllable promise. `resolveGetBalance` / `rejectGetBalance` settle the fetch.
+function makeMockRpc() {
+    const { promise, resolve, reject } = Promise.withResolvers<LamportsResponse>();
+    const execute = jest.fn().mockReturnValue(promise);
+    return {
+        rejectGetBalance: reject,
+        resolveGetBalance: resolve,
+        rpc: {
+            getBalance: jest.fn().mockReturnValue({
+                reactiveStore: () => createReactiveActionStore(execute),
+            }),
+        } as unknown as Rpc<SolanaRpcApiMainnet>,
+    };
+}
+
+// The subscription is consumed via its `reactiveStore()` method (not `subscribe()`), so the mock
+// backs `accountNotifications(...)` with a real `ReactiveStreamStore` built from a mock
+// `DataPublisher` factory. `pushNotification` emits onto the most recent connection through the
+// same `'notification'` channel the real RPC uses.
+function makeMockSubscriptions() {
+    const publishers: { publish(channel: string, payload: unknown): void; signal: AbortSignal | undefined }[] = [];
+    const createDataPublisher = jest.fn().mockImplementation((signal?: AbortSignal) => {
+        const on = jest.fn().mockReturnValue(function unsubscribe() {});
+        publishers.push({
+            publish(channel: string, payload: unknown) {
+                on.mock.calls
+                    .filter(
+                        ([actualChannel, , options]: [string, unknown, { signal?: AbortSignal } | undefined]) =>
+                            actualChannel === channel && !options?.signal?.aborted,
+                    )
+                    .forEach(([, listener]) => listener(payload));
+            },
+            signal,
+        });
+        return Promise.resolve({ on });
+    });
+    const rpcSubscriptions = {
+        accountNotifications: jest.fn().mockReturnValue({
+            reactiveStore: () =>
+                createReactiveStoreFromDataPublisherFactory<AccountNotification>({
+                    createDataPublisher,
+                    dataChannelName: 'notification',
+                    errorChannelName: 'error',
+                }),
+        }),
+    } as unknown as RpcSubscriptions<AccountNotificationsApi & SolanaRpcSubscriptionsApi>;
+    return {
+        pushNotification(notification: AccountNotification) {
+            const publisher = publishers[publishers.length - 1];
+            if (!publisher) {
+                throw new Error('No active account-notifications publisher to push a notification through');
+            }
+            publisher.publish('notification', notification);
+        },
+        rpcSubscriptions,
+    };
+}
+
+function makeWrapper({
+    rpc,
+    rpcSubscriptions,
+}: {
+    rpc: Rpc<SolanaRpcApiMainnet>;
+    rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+}) {
+    return function Wrapper({ children }: { children: React.ReactNode }) {
+        return (
+            <Theme>
+                <SWRConfig value={{ provider: () => new Map() }}>
+                    <ChainContext.Provider value={DEFAULT_CHAIN_CONFIG}>
+                        <RpcContext.Provider value={{ rpc, rpcSubscriptions }}>{children}</RpcContext.Provider>
+                    </ChainContext.Provider>
+                </SWRConfig>
+            </Theme>
+        );
+    };
+}
+
+describe('Balance', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('renders an em-dash while the balance is loading', () => {
+        const { rpc } = makeMockRpc();
+        const { rpcSubscriptions } = makeMockSubscriptions();
+        const { container } = render(<Balance account={makeAccount()} />, {
+            wrapper: makeWrapper({ rpc, rpcSubscriptions }),
+        });
+        // En-dash `\u2013` is used in the loading state.
+        expect(container.textContent).toBe('\u2013');
+    });
+
+    it('formats the resolved lamports value as SOL', async () => {
+        const { rpc, resolveGetBalance } = makeMockRpc();
+        const { rpcSubscriptions } = makeMockSubscriptions();
+        const { container } = render(<Balance account={makeAccount()} />, {
+            wrapper: makeWrapper({ rpc, rpcSubscriptions }),
+        });
+        await act(async () => {
+            resolveGetBalance(lamportsResponse(100, 1_500_000_000n));
+            await jest.runAllTimersAsync();
+        });
+        // Allow SWR's cache propagation to flush.
+        await waitFor(() => expect(container.textContent ?? '').toContain('\u25CE'));
+        expect(container.textContent).toBe('1.5 \u25CE');
+    });
+
+    it('reflects a newer account notification over the initial balance', async () => {
+        const { rpc, resolveGetBalance } = makeMockRpc();
+        const { rpcSubscriptions, pushNotification } = makeMockSubscriptions();
+        const { container } = render(<Balance account={makeAccount()} />, {
+            wrapper: makeWrapper({ rpc, rpcSubscriptions }),
+        });
+        await act(async () => {
+            resolveGetBalance(lamportsResponse(100, 1_000_000_000n));
+            await jest.runAllTimersAsync();
+        });
+        await waitFor(() => expect(container.textContent).toBe('1 \u25CE'));
+
+        await act(async () => {
+            pushNotification({ context: { slot: 200n }, value: { lamports: 2_500_000_000n as Lamports } });
+            await jest.runAllTimersAsync();
+        });
+        await waitFor(() => expect(container.textContent).toBe('2.5 \u25CE'));
+    });
+
+    it('shows the error indicator (warning glyph) when the balance fetch fails', async () => {
+        const { rpc, rejectGetBalance } = makeMockRpc();
+        const { rpcSubscriptions } = makeMockSubscriptions();
+        const { container } = render(<Balance account={makeAccount()} />, {
+            wrapper: makeWrapper({ rpc, rpcSubscriptions }),
+        });
+        await act(async () => {
+            rejectGetBalance(new Error('rpc-down'));
+            await jest.runAllTimersAsync();
+        });
+        await waitFor(() => expect(container.querySelector('svg')).not.toBeNull());
+    });
+});

--- a/examples/react-app/src/components/__tests__/SlotIndicator-test.browser.tsx
+++ b/examples/react-app/src/components/__tests__/SlotIndicator-test.browser.tsx
@@ -1,0 +1,123 @@
+import type { Rpc, RpcSubscriptions, SolanaRpcApiMainnet, SolanaRpcSubscriptionsApi } from '@solana/kit';
+import { act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import { render } from '../../__test-utils__/render';
+import { ChainContext, DEFAULT_CHAIN_CONFIG } from '../../context/ChainContext';
+import { RpcContext } from '../../context/RpcContext';
+import { SlotIndicator } from '../SlotIndicator';
+
+type SlotNotification = Readonly<{ parent: bigint; root: bigint; slot: bigint }>;
+type Snapshot =
+    { data: SlotNotification | undefined; error: undefined; status: 'loading' } | { data: SlotNotification | undefined; error: unknown; status: 'error' } | { data: SlotNotification; error: undefined; status: 'loaded' } | { data: undefined; error: undefined; status: 'idle' };
+
+function makeReactiveStreamStore() {
+    const subscribers = new Set<() => void>();
+    let snapshot: Snapshot = { data: undefined, error: undefined, status: 'idle' };
+    const setSnapshot = (next: Snapshot) => {
+        snapshot = next;
+        subscribers.forEach(cb => cb());
+    };
+    const connect = jest.fn(() => {
+        setSnapshot({ data: snapshot.data, error: undefined, status: 'loading' });
+    });
+    const reset = jest.fn(() => {
+        snapshot = { data: undefined, error: undefined, status: 'idle' };
+        subscribers.forEach(cb => cb());
+    });
+    return {
+        connectCalls: () => connect.mock.calls.length,
+        publish(notification: SlotNotification) {
+            setSnapshot({ data: notification, error: undefined, status: 'loaded' });
+        },
+        publishError(error: unknown) {
+            setSnapshot({ data: snapshot.data, error, status: 'error' });
+        },
+        resetCalls: () => reset.mock.calls.length,
+        store: {
+            connect,
+            getUnifiedState: () => snapshot,
+            reset,
+            subscribe: (cb: () => void) => {
+                subscribers.add(cb);
+                return () => {
+                    subscribers.delete(cb);
+                };
+            },
+        },
+    };
+}
+
+function makeMockRpcSubscriptions(reactiveStore: jest.Mock) {
+    const slotNotifications = jest.fn().mockReturnValue({ reactiveStore });
+    return { slotNotifications } as unknown as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+}
+
+function makeWrapper(rpcSubscriptions: RpcSubscriptions<SolanaRpcSubscriptionsApi>) {
+    const rpc = {} as Rpc<SolanaRpcApiMainnet>;
+    return function Wrapper({ children }: { children: React.ReactNode }) {
+        return (
+            <ChainContext.Provider value={DEFAULT_CHAIN_CONFIG}>
+                <RpcContext.Provider value={{ rpc, rpcSubscriptions }}>{children}</RpcContext.Provider>
+            </ChainContext.Provider>
+        );
+    };
+}
+
+describe('SlotIndicator', () => {
+    it('renders an em-dash while the stream is still loading', () => {
+        const harness = makeReactiveStreamStore();
+        const rpcSubscriptions = makeMockRpcSubscriptions(jest.fn().mockReturnValue(harness.store));
+        const { container } = render(<SlotIndicator />, { wrapper: makeWrapper(rpcSubscriptions) });
+        expect(container.textContent).toBe('\u2013');
+    });
+
+    it('calls `connect()` on mount and `reset()` on unmount', () => {
+        const harness = makeReactiveStreamStore();
+        const rpcSubscriptions = makeMockRpcSubscriptions(jest.fn().mockReturnValue(harness.store));
+        const { unmount } = render(<SlotIndicator />, { wrapper: makeWrapper(rpcSubscriptions) });
+        // StrictMode invokes effects twice in dev, so check ≥1 rather than exact equality.
+        expect(harness.connectCalls()).toBeGreaterThan(0);
+        const resetsBeforeUnmount = harness.resetCalls();
+        unmount();
+        expect(harness.resetCalls()).toBeGreaterThan(resetsBeforeUnmount);
+    });
+
+    it('renders the formatted slot number once a notification is loaded', async () => {
+        const harness = makeReactiveStreamStore();
+        const rpcSubscriptions = makeMockRpcSubscriptions(jest.fn().mockReturnValue(harness.store));
+        const { container } = render(<SlotIndicator />, { wrapper: makeWrapper(rpcSubscriptions) });
+
+        act(() => {
+            harness.publish({ parent: 122n, root: 100n, slot: 123n });
+        });
+        await waitFor(() => expect(container.textContent).toContain('123'));
+
+        const link = container.querySelector('a');
+        expect(link).not.toBeNull();
+        expect(link?.getAttribute('href')).toContain('/block/123');
+        expect(link?.getAttribute('href')).toContain('cluster=devnet');
+    });
+
+    it('throws a stream error to the nearest error boundary', async () => {
+        const harness = makeReactiveStreamStore();
+        const rpcSubscriptions = makeMockRpcSubscriptions(jest.fn().mockReturnValue(harness.store));
+        const rpc = {} as Rpc<SolanaRpcApiMainnet>;
+        function Wrapper({ children }: { children: React.ReactNode }) {
+            return (
+                <ChainContext.Provider value={DEFAULT_CHAIN_CONFIG}>
+                    <RpcContext.Provider value={{ rpc, rpcSubscriptions }}>
+                        <ErrorBoundary fallback={<span>boundary-caught</span>}>{children}</ErrorBoundary>
+                    </RpcContext.Provider>
+                </ChainContext.Provider>
+            );
+        }
+        const { container } = render(<SlotIndicator />, { wrapper: Wrapper });
+
+        act(() => {
+            harness.publishError(new Error('slot-stream-down'));
+        });
+        await waitFor(() => expect(container.textContent).toContain('boundary-caught'));
+    });
+});

--- a/examples/react-app/src/functions/__tests__/balance-test.browser.tsx
+++ b/examples/react-app/src/functions/__tests__/balance-test.browser.tsx
@@ -1,0 +1,174 @@
+import type {
+    AccountNotificationsApi,
+    Address,
+    GetBalanceApi,
+    Lamports,
+    Rpc,
+    RpcSubscriptions,
+    SolanaRpcResponse,
+} from '@solana/kit';
+import { createReactiveActionStore, createReactiveStoreFromDataPublisherFactory } from '@solana/kit';
+import { act } from '@testing-library/react';
+
+import { balanceSubscribe } from '../balance';
+
+type LamportsResponse = SolanaRpcResponse<Lamports>;
+type AccountNotification = SolanaRpcResponse<{ lamports: Lamports }>;
+
+function lamportsResponse(slot: number, lamports: bigint): LamportsResponse {
+    return { context: { slot: BigInt(slot) }, value: lamports as Lamports };
+}
+
+function accountNotification(slot: number, lamports: bigint): AccountNotification {
+    return { context: { slot: BigInt(slot) }, value: { lamports: lamports as Lamports } };
+}
+
+// `balanceSubscribe` consumes the RPC request via its `reactiveStore()` method (not `send()`), so
+// the mock backs `getBalance(...)` with a real `ReactiveActionStore` wrapping a controllable
+// promise. `resolveGetBalance` / `rejectGetBalance` settle the initial fetch on demand.
+function createMockRpc() {
+    const { promise, resolve, reject } = Promise.withResolvers<LamportsResponse>();
+    const execute = jest.fn().mockReturnValue(promise);
+    const getBalance = jest.fn().mockReturnValue({
+        reactiveStore: () => createReactiveActionStore(execute),
+    });
+    return {
+        getBalance,
+        rejectGetBalance: reject,
+        resolveGetBalance: resolve,
+        rpc: { getBalance } as unknown as Rpc<GetBalanceApi>,
+    };
+}
+
+// `balanceSubscribe` consumes the subscription via its `reactiveStore()` method (not `subscribe()`),
+// so the mock backs `accountNotifications(...)` with a real `ReactiveStreamStore` built from a mock
+// `DataPublisher` factory. The factory hands out a fresh publisher per connection; `pushNotification`
+// emits onto the most recent one through the same `'notification'` channel the real RPC uses.
+function createMockSubscriptions() {
+    const publishers: { publish(channel: string, payload: unknown): void; signal: AbortSignal | undefined }[] = [];
+    const createDataPublisher = jest.fn().mockImplementation((signal?: AbortSignal) => {
+        const on = jest.fn().mockReturnValue(function unsubscribe() {});
+        publishers.push({
+            publish(channel: string, payload: unknown) {
+                on.mock.calls
+                    .filter(
+                        ([actualChannel, , options]: [string, unknown, { signal?: AbortSignal } | undefined]) =>
+                            actualChannel === channel && !options?.signal?.aborted,
+                    )
+                    .forEach(([, listener]) => listener(payload));
+            },
+            signal,
+        });
+        return Promise.resolve({ on });
+    });
+    const accountNotifications = jest.fn().mockReturnValue({
+        reactiveStore: () =>
+            createReactiveStoreFromDataPublisherFactory<AccountNotification>({
+                createDataPublisher,
+                dataChannelName: 'notification',
+                errorChannelName: 'error',
+            }),
+    });
+    return {
+        accountNotifications,
+        pushNotification(notification: AccountNotification) {
+            const publisher = publishers[publishers.length - 1];
+            if (!publisher) {
+                throw new Error('No active account-notifications publisher to push a notification through');
+            }
+            publisher.publish('notification', notification);
+        },
+        rpcSubscriptions: { accountNotifications } as unknown as RpcSubscriptions<AccountNotificationsApi>,
+    };
+}
+
+const FAKE_ADDRESS = 'So11111111111111111111111111111111111111112' as Address;
+
+function startSubscribe(rpc: Rpc<GetBalanceApi>, rpcSubscriptions: RpcSubscriptions<AccountNotificationsApi>) {
+    const next = jest.fn();
+    const cleanup = balanceSubscribe(rpc, rpcSubscriptions, { address: FAKE_ADDRESS }, { next });
+    return { cleanup, next };
+}
+
+describe('balanceSubscribe', () => {
+    beforeEach(() => {
+        jest.useFakeTimers();
+    });
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('requests `getBalance` with the `confirmed` commitment', () => {
+        const { rpc, getBalance } = createMockRpc();
+        const { rpcSubscriptions } = createMockSubscriptions();
+        startSubscribe(rpc, rpcSubscriptions);
+        expect(getBalance).toHaveBeenCalledWith(FAKE_ADDRESS, { commitment: 'confirmed' });
+    });
+
+    it('opens the account-notifications subscription for the same address', () => {
+        const { rpc } = createMockRpc();
+        const { rpcSubscriptions, accountNotifications } = createMockSubscriptions();
+        startSubscribe(rpc, rpcSubscriptions);
+        expect(accountNotifications).toHaveBeenCalledWith(FAKE_ADDRESS);
+    });
+
+    it('publishes the initial RPC lamports value through `next`', async () => {
+        const { rpc, resolveGetBalance } = createMockRpc();
+        const { rpcSubscriptions } = createMockSubscriptions();
+        const { next } = startSubscribe(rpc, rpcSubscriptions);
+
+        await act(async () => {
+            resolveGetBalance(lamportsResponse(100, 42n));
+            await jest.runAllTimersAsync();
+        });
+        expect(next).toHaveBeenCalledWith(null, 42n);
+    });
+
+    it('promotes a newer subscription notification over the initial RPC value', async () => {
+        const { rpc, resolveGetBalance } = createMockRpc();
+        const { rpcSubscriptions, pushNotification } = createMockSubscriptions();
+        const { next } = startSubscribe(rpc, rpcSubscriptions);
+
+        await act(async () => {
+            resolveGetBalance(lamportsResponse(100, 1n));
+            await jest.runAllTimersAsync();
+        });
+        await act(async () => {
+            pushNotification(accountNotification(200, 2n));
+            await jest.runAllTimersAsync();
+        });
+        expect(next).toHaveBeenLastCalledWith(null, 2n);
+    });
+
+    it('drops a stale subscription notification with an older slot', async () => {
+        const { rpc, resolveGetBalance } = createMockRpc();
+        const { rpcSubscriptions, pushNotification } = createMockSubscriptions();
+        const { next } = startSubscribe(rpc, rpcSubscriptions);
+
+        await act(async () => {
+            resolveGetBalance(lamportsResponse(200, 99n));
+            await jest.runAllTimersAsync();
+        });
+        const callsAfterRpc = next.mock.calls.length;
+        await act(async () => {
+            // Older slot — the store should ignore this and `next` should not fire again.
+            pushNotification(accountNotification(150, 5n));
+            await jest.runAllTimersAsync();
+        });
+        expect(next.mock.calls).toHaveLength(callsAfterRpc);
+        expect(next).toHaveBeenLastCalledWith(null, 99n);
+    });
+
+    it('publishes errors from the initial RPC through `next`', async () => {
+        const { rpc, rejectGetBalance } = createMockRpc();
+        const { rpcSubscriptions } = createMockSubscriptions();
+        const { next } = startSubscribe(rpc, rpcSubscriptions);
+
+        const boom = new Error('rpc-down');
+        await act(async () => {
+            rejectGetBalance(boom);
+            await jest.runAllTimersAsync();
+        });
+        expect(next).toHaveBeenCalledWith(boom);
+    });
+});

--- a/examples/react-app/src/functions/balance.ts
+++ b/examples/react-app/src/functions/balance.ts
@@ -30,7 +30,7 @@ export function balanceSubscribe(
         streamSource: rpcSubscriptions.accountNotifications(address),
         streamValueMapper: ({ lamports }) => lamports,
     });
-    store.subscribe(() => {
+    const unsubscribe = store.subscribe(() => {
         const error = store.getError();
         if (error) {
             next(error as Error);
@@ -40,6 +40,8 @@ export function balanceSubscribe(
     });
     store.withSignal(abortController.signal).connect();
     return () => {
+        unsubscribe();
         abortController.abort();
+        store.reset();
     };
 }

--- a/examples/react-app/src/hooks/__tests__/useStable-test.browser.tsx
+++ b/examples/react-app/src/hooks/__tests__/useStable-test.browser.tsx
@@ -1,0 +1,31 @@
+import { renderHook } from '../../__test-utils__/render';
+import { useStable } from '../useStable';
+
+describe('useStable', () => {
+    it('caches the first computed value and ignores later getter results', () => {
+        let count = 0;
+        const { result, rerender } = renderHook(() => useStable(() => ++count));
+        const first = result.current;
+        rerender();
+        rerender();
+        expect(result.current).toBe(first);
+    });
+
+    it('returns the same reference across renders for an object result', () => {
+        const { result, rerender } = renderHook(() => useStable(() => ({ token: Symbol() })));
+        const first = result.current;
+        rerender();
+        expect(result.current).toBe(first);
+    });
+
+    it('treats `undefined` as a valid cached value (not "unresolved")', () => {
+        const getValue = jest.fn().mockReturnValue(undefined);
+        const { result, rerender } = renderHook(() => useStable(getValue));
+        expect(result.current).toBeUndefined();
+        const callsAfterFirstMount = getValue.mock.calls.length;
+        rerender();
+        rerender();
+        // The getter must not run again on subsequent renders.
+        expect(getValue.mock.calls).toHaveLength(callsAfterFirstMount);
+    });
+});

--- a/examples/react-app/tsconfig.app.json
+++ b/examples/react-app/tsconfig.app.json
@@ -4,7 +4,7 @@
         "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
         "target": "ES2020",
         "useDefineForClassFields": true,
-        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "lib": ["ES2020", "ES2024.Promise", "DOM", "DOM.Iterable"],
         "module": "ESNext",
         "skipLibCheck": true,
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,9 +185,18 @@ importers:
       '@solana/eslint-config':
         specifier: workspace:*
         version: link:../../packages/eslint-config
+      '@solana/test-config':
+        specifier: workspace:*
+        version: link:../../packages/test-config
       '@solana/wallet-standard-features':
         specifier: ^1.4.0
         version: 1.4.0
+      '@swc/jest':
+        specifier: ^0.2.39
+        version: 0.2.39(@swc/core@1.15.33(@swc/helpers@0.5.17))
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17


### PR DESCRIPTION
#### Adding tests for the existing behaviour of the react-app example

This will provide validation when parts of the react-app example are refactored to use the new hooks (and eventually wallet plugin hooks) 