### PR TITLE
Add a /query subpath to react, add useRequestQuery

### DIFF
--- a/.changeset/shy-rats-live.md
+++ b/.changeset/shy-rats-live.md
@@ -1,0 +1,5 @@
+---
+'@solana/react': minor
+---
+
+Add a `@solana/react/query` subpath that bridges Kit's reactive primitives into [TanStack Query](https://tanstack.com/query). The new `useRequestQuery(key, source, options?)` hook is the TanStack Query-backed counterpart to `useRequest` — it accepts the same `ReactiveActionSource<T>` or `(signal: AbortSignal) => Promise<T>` source shape, routes it through TanStack's cache, and threads the query's cancellation signal (combined with the optional `getAbortSignal` factory) into the source. Pass a `null` source to disable the query (mapped to TanStack's `enabled: false`). `@tanstack/react-query@^5` is an optional peer dependency.

--- a/packages/build-scripts/getBaseConfig.ts
+++ b/packages/build-scripts/getBaseConfig.ts
@@ -21,7 +21,7 @@ export function getBaseConfig(platform: Platform, formats: Format[], _options: O
         env.npm_package_name === '@solana/kit'
             ? ['./src/index.ts', './src/program-client-core.ts']
             : env.npm_package_name === '@solana/react'
-              ? ['./src/index.ts', './src/swr.ts']
+              ? ['./src/index.ts', './src/swr.ts', './src/query.ts']
               : ['./src/index.ts'];
 
     return [true, false]

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -339,18 +339,18 @@ For any one-shot async work that isn't a `ReactiveActionSource` — `fetch`, a t
 
 ```tsx
 function Profile({ userId }: { userId: string }) {
-    const fetcher = useCallback(
+    const { data, error, isLoading, mutate } = useRequestSWR(
+        ['users', userId],
         (signal: AbortSignal) => fetch(`/api/users/${userId}`, { signal }).then(r => r.json()),
-        [userId],
+        { getAbortSignal: () => AbortSignal.timeout(5_000) },
     );
-    const { data, error, isLoading, mutate } = useRequestSWR(['users', userId], fetcher, {
-        getAbortSignal: () => AbortSignal.timeout(5_000),
-    });
     if (error) return <button onClick={() => mutate()}>Retry</button>;
     if (isLoading) return <p>Loading…</p>;
     return <p>{data!.name}</p>;
 }
 ```
+
+The function source is held in a ref synced to the latest render, so an inline closure recreated each render is fine — no `useCallback` needed. SWR keys the cache off `key`, not the fetcher identity.
 
 When `getAbortSignal` isn't configured the signal is a fresh never-aborting `AbortSignal` (so the function's signature is satisfied) — it does **not** fire on unmount or when SWR supersedes the request. SWR's model is to discard the stale result rather than cancel the network call.
 
@@ -406,6 +406,53 @@ If the `spec` changes (new mappers, new source) but the SWR `key` is stable, the
 ### Why no `useActionSWR`?
 
 It would just be a wrapper around SWR's built-in [`useSWRMutation`](https://swr.vercel.app/docs/mutation#useswrmutation) with no additional functionality. Either use `useSWRMutation` or, if you don't need the SWR integration, use `useAction`.
+
+## TanStack Query adapter (`@solana/react/query`)
+
+Opt-in subpath that bridges Kit's reactive primitives into [TanStack Query](https://tanstack.com/query)'s cache. Import from `@solana/react/query`; `@tanstack/react-query@^5` is an optional peer dependency, and your tree must be wrapped in a `QueryClientProvider`. Hooks carry the `Query` suffix to keep the cache backing visible at the call site.
+
+### `useRequestQuery(key, source, options?)`
+
+TanStack Query-backed counterpart to `useRequest`. Same `source` shape (a `ReactiveActionSource<T>` or `(signal: AbortSignal) => Promise<T>`). Returns TanStack's native `UseQueryResult<T>`. Pass `null` for `source` to disable — useful when one of the source's inputs isn't yet known. This maps to TanStack's `enabled: false`. Unlike SWR there is no nullable `key`, disable via a `null` source (or `enabled`) instead.
+
+```tsx
+import { useClient } from '@solana/react';
+import { useRequestQuery } from '@solana/react/query';
+import type { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+
+function LatestBlockhash() {
+    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+    const { data, error, isLoading, refetch } = useRequestQuery(['latestBlockhash'], client.rpc.getLatestBlockhash());
+    if (error) return <button onClick={() => refetch()}>Retry</button>;
+    if (isLoading) return <p>Loading…</p>;
+    return <p>Blockhash: {data!.value.blockhash}</p>;
+}
+```
+
+`refetch()` is TanStack's revalidate verb — call it to re-fire the request manually (the equivalent of `refresh()` from `useRequest`).
+
+Pass any TanStack `useQuery` option in the options bag (e.g. `enabled`, `staleTime`, `refetchInterval`) — `queryKey` and `queryFn` are owned by the hook. The query's `queryFn` is handed TanStack's own `AbortSignal`, which aborts when the query is cancelled (unmount, garbage collection, or a superseding refetch), and that signal is threaded into the source so cancellation propagates all the way down. The Kit-only `getAbortSignal: () => AbortSignal` factory adds a second signal (typically a per-attempt timeout); when supplied, it is combined with TanStack's signal via `AbortSignal.any`, so aborting either one cancels the attempt and the rejection surfaces via `error`.
+
+```tsx
+useRequestQuery(['latestBlockhash'], source, {
+    getAbortSignal: () => AbortSignal.timeout(5_000),
+});
+```
+
+For any one-shot async work that isn't a `ReactiveActionSource` — `fetch`, a third-party SDK call, etc. — you can pass an async function instead of a source. This can be any function of shape `(signal: AbortSignal) => Promise<T>`, and the combined abort signal is passed to it on each request. Other than that signal, this is the equivalent of `useQuery({ queryKey, queryFn })` and both are interoperable.
+
+```tsx
+function Profile({ userId }: { userId: string }) {
+    const { data, error, isLoading, refetch } = useRequestQuery(['users', userId], (signal: AbortSignal) =>
+        fetch(`/api/users/${userId}`, { signal }).then(r => r.json()),
+    );
+    if (error) return <button onClick={() => refetch()}>Retry</button>;
+    if (isLoading) return <p>Loading…</p>;
+    return <p>{data!.name}</p>;
+}
+```
+
+The function source is held in a ref synced to the latest render, so an inline closure recreated each render is fine — no `useCallback` needed. TanStack keys the cache off `key`, not the queryFn identity.
 
 ## Hooks
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -43,13 +43,35 @@
             },
             "react-native": "./dist/swr.native.mjs",
             "types": "./dist/types/swr.d.ts"
+        },
+        "./query": {
+            "edge-light": {
+                "import": "./dist/query.node.mjs",
+                "require": "./dist/query.node.cjs"
+            },
+            "workerd": {
+                "import": "./dist/query.node.mjs",
+                "require": "./dist/query.node.cjs"
+            },
+            "browser": {
+                "import": "./dist/query.browser.mjs",
+                "require": "./dist/query.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/query.node.mjs",
+                "require": "./dist/query.node.cjs"
+            },
+            "react-native": "./dist/query.native.mjs",
+            "types": "./dist/types/query.d.ts"
         }
     },
     "browser": {
         "./dist/index.node.cjs": "./dist/index.browser.cjs",
         "./dist/index.node.mjs": "./dist/index.browser.mjs",
         "./dist/swr.node.cjs": "./dist/swr.browser.cjs",
-        "./dist/swr.node.mjs": "./dist/swr.browser.mjs"
+        "./dist/swr.node.mjs": "./dist/swr.browser.mjs",
+        "./dist/query.node.cjs": "./dist/query.browser.cjs",
+        "./dist/query.node.mjs": "./dist/query.browser.mjs"
     },
     "main": "./dist/index.node.cjs",
     "module": "./dist/index.node.mjs",
@@ -77,9 +99,9 @@
         "style:fix": "pnpm eslint --fix src && pnpm prettier --log-level warn --ignore-unknown --write ./*",
         "test:lint": "TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ../../node_modules/@solana/test-config/jest-lint.config.js --rootDir . --silent",
         "test:prettier": "TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ../../node_modules/@solana/test-config/jest-prettier.config.js --rootDir . --silent",
-        "test:treeshakability:browser": "agadoo dist/index.browser.mjs && agadoo dist/swr.browser.mjs",
-        "test:treeshakability:native": "agadoo dist/index.native.mjs && agadoo dist/swr.native.mjs",
-        "test:treeshakability:node": "agadoo dist/index.node.mjs && agadoo dist/swr.node.mjs",
+        "test:treeshakability:browser": "agadoo dist/index.browser.mjs && agadoo dist/swr.browser.mjs && agadoo dist/query.browser.mjs",
+        "test:treeshakability:native": "agadoo dist/index.native.mjs && agadoo dist/swr.native.mjs && agadoo dist/query.native.mjs",
+        "test:treeshakability:node": "agadoo dist/index.node.mjs && agadoo dist/swr.node.mjs && agadoo dist/query.node.mjs",
         "test:typecheck": "tsc --noEmit",
         "test:unit:browser": "NODE_OPTIONS=\"--no-experimental-webstorage\" TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ../../node_modules/@solana/test-config/jest-unit.config.browser.js --rootDir . --silent",
         "test:unit:node": "NODE_OPTIONS=\"--no-experimental-webstorage\" TERM_OVERRIDE=\"${TURBO_HASH:+dumb}\" TERM=${TERM_OVERRIDE:-$TERM} jest -c ../../node_modules/@solana/test-config/jest-unit.config.node.js --rootDir . --silent"
@@ -113,6 +135,7 @@
     "devDependencies": {
         "@solana/eslint-config": "workspace:*",
         "@solana/kit": "workspace:*",
+        "@tanstack/react-query": "^5.0.0",
         "@testing-library/react": "^16.3.2",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -125,10 +148,14 @@
     },
     "peerDependencies": {
         "@solana/kit": "workspace:*",
+        "@tanstack/react-query": "^5.0.0",
         "react": ">=18",
         "swr": "^2.0.0"
     },
     "peerDependenciesMeta": {
+        "@tanstack/react-query": {
+            "optional": true
+        },
         "react": {
             "optional": true
         },

--- a/packages/react/src/query.ts
+++ b/packages/react/src/query.ts
@@ -1,0 +1,13 @@
+/**
+ * TanStack Query-backed adapter for `@solana/react`. Bridges Kit's reactive primitives into
+ * TanStack Query's cache so multiple components reading the same key share a single in-flight
+ * request, participate in TanStack's revalidation triggers (focus, reconnect, polling), become
+ * Suspense-capable, and show up in TanStack Query's devtools.
+ *
+ * Import from `@solana/react/query` — the subpath requires `@tanstack/react-query` as a peer dep
+ * but is otherwise isolated from the core export so consumers who don't use TanStack Query aren't
+ * forced to install it.
+ *
+ * @packageDocumentation
+ */
+export * from './query/useRequestQuery';

--- a/packages/react/src/query/__tests__/useRequestQuery-test.browser.tsx
+++ b/packages/react/src/query/__tests__/useRequestQuery-test.browser.tsx
@@ -1,0 +1,371 @@
+import { createReactiveActionStore, type ReactiveActionSource, type ReactiveActionStore } from '@solana/kit';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+import { renderHook } from '../../__test-utils__/render';
+import { useRequestQuery } from '../useRequestQuery';
+
+// A fresh `QueryClient` per render so cache state never leaks between tests. Retries are disabled
+// so a rejected fetch surfaces as `error` immediately instead of triggering TanStack's backoff, and
+// the focus/reconnect refetch triggers are off so the test environment doesn't accidentally re-fire
+// queries during assertions.
+function createWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                gcTime: 0,
+                refetchOnReconnect: false,
+                refetchOnWindowFocus: false,
+                retry: false,
+                staleTime: 0,
+            },
+        },
+    });
+    return function wrapper({ children }: { children: React.ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    };
+}
+
+// Recursive `Partial` that also descends into function return types — needed so a stubbed
+// `withSignal: () => ({ dispatchAsync })` type-checks against `withSignal`'s actual return shape
+// (the full `ReactiveActionStore`).
+type DeepPartial<T> = T extends (...args: infer A) => infer R
+    ? (...args: A) => DeepPartial<R>
+    : T extends object
+    ? { [K in keyof T]?: DeepPartial<T[K]> }
+    : T;
+
+// Wraps a partial `ReactiveActionStore` stub into a `ReactiveActionSource`, isolating the
+// type-narrowing cast to one place so spy-on-store tests stay legible.
+function stubActionSource<T>(store: DeepPartial<ReactiveActionStore<[], T>>): ReactiveActionSource<T> {
+    return {
+        reactiveStore: () => store as ReactiveActionStore<[], T>,
+    };
+}
+
+function makeFakeSource<T>(): {
+    fn: jest.Mock<Promise<T>, [AbortSignal]>;
+    rejectLatest: (err: unknown) => void;
+    resolveLatest: (value: T) => void;
+    source: ReactiveActionSource<T>;
+} {
+    let latest: PromiseWithResolvers<T> | null = null;
+    const fn = jest.fn<Promise<T>, [AbortSignal]>(() => {
+        latest = Promise.withResolvers<T>();
+        return latest.promise;
+    });
+    return {
+        fn,
+        rejectLatest(err) {
+            latest!.reject(err);
+        },
+        resolveLatest(value) {
+            latest!.resolve(value);
+        },
+        source: {
+            reactiveStore() {
+                return createReactiveActionStore<[], T>(fn);
+            },
+        },
+    };
+}
+
+describe('useRequestQuery', () => {
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    describe('with a function source', () => {
+        it('auto-fires the queryFn on mount and transitions to data on success', async () => {
+            const { promise, resolve } = Promise.withResolvers<string>();
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => promise);
+            const { result } = renderHook(() => useRequestQuery(['fn-success'], fn), { wrapper: createWrapper() });
+            await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+            expect(result.current.data).toBeUndefined();
+
+            await act(async () => resolve('hi'));
+            await waitFor(() => expect(result.current.data).toBe('hi'));
+            expect(result.current.error).toBeNull();
+        });
+
+        it('surfaces the rejection as `error`', async () => {
+            const boom = new Error('boom');
+            const { promise, reject } = Promise.withResolvers<string>();
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => promise);
+            const { result } = renderHook(() => useRequestQuery(['fn-error'], fn), { wrapper: createWrapper() });
+            await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+            expect(result.current.error).toBeNull();
+
+            await act(async () => reject(boom));
+            await waitFor(() => expect(result.current.error).toBe(boom));
+        });
+
+        it('threads an `AbortSignal` into the function', async () => {
+            const { promise, resolve } = Promise.withResolvers<string>();
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => promise);
+            renderHook(() => useRequestQuery(['signal-threaded'], fn), { wrapper: createWrapper() });
+            await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+            const signal = fn.mock.calls[0][0];
+            expect(signal).toBeInstanceOf(AbortSignal);
+            expect(signal.aborted).toBe(false);
+            await act(async () => resolve('ok'));
+        });
+
+        it('invokes the user-supplied `getAbortSignal` factory', async () => {
+            const { promise, resolve } = Promise.withResolvers<string>();
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => promise);
+            const ctrl = new AbortController();
+            const getAbortSignal = jest.fn(() => ctrl.signal);
+            renderHook(() => useRequestQuery(['user-signal'], fn, { getAbortSignal }), { wrapper: createWrapper() });
+            await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+            expect(getAbortSignal).toHaveBeenCalledTimes(1);
+            const signal = fn.mock.calls[0][0];
+            expect(signal).toBeInstanceOf(AbortSignal);
+            expect(signal.aborted).toBe(false);
+            await act(async () => resolve('ok'));
+        });
+
+        it('surfaces a `getAbortSignal`-driven abort as `result.error`', async () => {
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(
+                signal =>
+                    new Promise((_, reject) => {
+                        signal.addEventListener('abort', () => reject(signal.reason));
+                    }),
+            );
+            const ctrl = new AbortController();
+            const { result } = renderHook(
+                () => useRequestQuery(['user-signal-abort'], fn, { getAbortSignal: () => ctrl.signal }),
+                { wrapper: createWrapper() },
+            );
+            await waitFor(() => expect(fn).toHaveBeenCalledTimes(1));
+            expect(result.current.error).toBeNull();
+
+            const reason = new Error('timeout');
+            await act(async () => ctrl.abort(reason));
+            await waitFor(() => expect(result.current.error).toBe(reason));
+        });
+
+        it('does not fire the queryFn while disabled via `enabled: false`', async () => {
+            jest.useFakeTimers();
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => Promise.resolve('never'));
+            const { result } = renderHook(() => useRequestQuery(['disabled'], fn, { enabled: false }), {
+                wrapper: createWrapper(),
+            });
+            await act(async () => {
+                await jest.runAllTimersAsync();
+            });
+            expect(fn).not.toHaveBeenCalled();
+            expect(result.current.fetchStatus).toBe('idle');
+        });
+
+        it('starts firing once `enabled` transitions from false to true', async () => {
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => Promise.resolve('value'));
+            const initialProps: { enabled: boolean } = { enabled: false };
+            const { result, rerender } = renderHook(({ enabled }) => useRequestQuery(['toggle'], fn, { enabled }), {
+                initialProps,
+                wrapper: createWrapper(),
+            });
+            expect(fn).not.toHaveBeenCalled();
+
+            rerender({ enabled: true });
+            await waitFor(() => expect(result.current.data).toBe('value'));
+        });
+
+        it('does not fire the queryFn when the source is null', async () => {
+            // A null source maps to `enabled: false`, so the query stays idle (it never schedules a
+            // queryFn to fire). The "fires once the source is set" path is covered by the next test.
+            jest.useFakeTimers();
+            const initialProps: { source: ((signal: AbortSignal) => Promise<string>) | null } = { source: null };
+            const { result } = renderHook(({ source }) => useRequestQuery(['null-source'], source), {
+                initialProps,
+                wrapper: createWrapper(),
+            });
+            await act(async () => {
+                await jest.runAllTimersAsync();
+            });
+            expect(result.current.fetchStatus).toBe('idle');
+            expect(result.current.data).toBeUndefined();
+        });
+
+        it('starts firing once the source transitions from null to non-null', async () => {
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => Promise.resolve('value'));
+            const initialProps: { source: ((signal: AbortSignal) => Promise<string>) | null } = { source: null };
+            const { result, rerender } = renderHook(({ source }) => useRequestQuery(['null-to-source'], source), {
+                initialProps,
+                wrapper: createWrapper(),
+            });
+            expect(fn).not.toHaveBeenCalled();
+
+            rerender({ source: fn });
+            await waitFor(() => expect(result.current.data).toBe('value'));
+        });
+
+        it('respects `enabled: false` even when the source is non-null', async () => {
+            jest.useFakeTimers();
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => Promise.resolve('never'));
+            const { result } = renderHook(() => useRequestQuery(['both-channels'], fn, { enabled: false }), {
+                wrapper: createWrapper(),
+            });
+            await act(async () => {
+                await jest.runAllTimersAsync();
+            });
+            expect(fn).not.toHaveBeenCalled();
+            expect(result.current.fetchStatus).toBe('idle');
+        });
+
+        it('uses the latest source closure when `refetch()` is called', async () => {
+            // TanStack keys cache lookup on `queryKey` — if the key is stable, a source-identity
+            // change alone won't refetch. But the next fetch (e.g. via `refetch()`) should run the
+            // latest source.
+            const { result, rerender } = renderHook(
+                ({ value }: { value: string }) => useRequestQuery(['latest-closure'], () => Promise.resolve(value)),
+                { initialProps: { value: 'a' }, wrapper: createWrapper() },
+            );
+            await waitFor(() => expect(result.current.data).toBe('a'));
+
+            rerender({ value: 'b' });
+            await act(async () => {
+                await result.current.refetch();
+            });
+            await waitFor(() => expect(result.current.data).toBe('b'));
+        });
+    });
+
+    describe('with a ReactiveActionSource (PendingRpc-like)', () => {
+        it('builds a store per fetch and resolves through `dispatchAsync()`', async () => {
+            const req = makeFakeSource<string>();
+            const { result } = renderHook(() => useRequestQuery(['source-success'], req.source), {
+                wrapper: createWrapper(),
+            });
+            await waitFor(() => expect(req.fn).toHaveBeenCalledTimes(1));
+            expect(result.current.data).toBeUndefined();
+
+            await act(async () => req.resolveLatest('value'));
+            await waitFor(() => expect(result.current.data).toBe('value'));
+        });
+
+        it('surfaces the rejection as `error`', async () => {
+            const boom = new Error('boom');
+            const req = makeFakeSource<string>();
+            const { result } = renderHook(() => useRequestQuery(['source-error'], req.source), {
+                wrapper: createWrapper(),
+            });
+            await waitFor(() => expect(req.fn).toHaveBeenCalledTimes(1));
+            expect(result.current.error).toBeNull();
+
+            await act(async () => req.rejectLatest(boom));
+            await waitFor(() => expect(result.current.error).toBe(boom));
+        });
+
+        it('dispatches through `withSignal` so the threaded signal reaches the store', async () => {
+            const dispatchAsync = jest.fn(() => Promise.resolve('value'));
+            const withSignal = jest.fn((_signal: AbortSignal) => ({ dispatchAsync }));
+            const source = stubActionSource<string>({ dispatchAsync, withSignal });
+            const { result } = renderHook(() => useRequestQuery(['source-signal'], source), {
+                wrapper: createWrapper(),
+            });
+            await waitFor(() => expect(result.current.data).toBe('value'));
+            expect(withSignal).toHaveBeenCalledTimes(1);
+            expect(withSignal.mock.calls[0][0]).toBeInstanceOf(AbortSignal);
+        });
+
+        it('surfaces a `getAbortSignal`-driven abort as `result.error`', async () => {
+            const req = makeFakeSource<string>();
+            const ctrl = new AbortController();
+            const { result } = renderHook(
+                () => useRequestQuery(['source-user-signal'], req.source, { getAbortSignal: () => ctrl.signal }),
+                { wrapper: createWrapper() },
+            );
+            await waitFor(() => expect(req.fn).toHaveBeenCalledTimes(1));
+            expect(result.current.error).toBeNull();
+
+            const reason = new Error('timeout');
+            await act(async () => ctrl.abort(reason));
+            await waitFor(() => expect(result.current.error).toBe(reason));
+        });
+
+        it('does not fire the queryFn while disabled via `enabled: false`', async () => {
+            jest.useFakeTimers();
+            const req = makeFakeSource<string>();
+            const { result } = renderHook(() => useRequestQuery(['source-disabled'], req.source, { enabled: false }), {
+                wrapper: createWrapper(),
+            });
+            await act(async () => {
+                await jest.runAllTimersAsync();
+            });
+            expect(req.fn).not.toHaveBeenCalled();
+            expect(result.current.fetchStatus).toBe('idle');
+        });
+
+        it('does not fire the queryFn when the source is null', async () => {
+            // A null source maps to `enabled: false`, so the query stays idle. The "fires once the
+            // source is set" path is covered by the next test.
+            jest.useFakeTimers();
+            const initialProps: { source: ReactiveActionSource<string> | null } = { source: null };
+            const { result } = renderHook(({ source }) => useRequestQuery(['source-null'], source), {
+                initialProps,
+                wrapper: createWrapper(),
+            });
+            await act(async () => {
+                await jest.runAllTimersAsync();
+            });
+            expect(result.current.fetchStatus).toBe('idle');
+            expect(result.current.data).toBeUndefined();
+        });
+
+        it('starts firing once the source transitions from null to non-null', async () => {
+            const req = makeFakeSource<string>();
+            const initialProps: { source: ReactiveActionSource<string> | null } = { source: null };
+            const { result, rerender } = renderHook(({ source }) => useRequestQuery(['source-null-to-set'], source), {
+                initialProps,
+                wrapper: createWrapper(),
+            });
+            expect(req.fn).not.toHaveBeenCalled();
+
+            rerender({ source: req.source });
+            await waitFor(() => expect(req.fn).toHaveBeenCalledTimes(1));
+            await act(async () => req.resolveLatest('value'));
+            await waitFor(() => expect(result.current.data).toBe('value'));
+        });
+
+        it('uses the latest source when `refetch()` is called', async () => {
+            const sourceFor = (value: string): ReactiveActionSource<string> => ({
+                reactiveStore: () => createReactiveActionStore<[], string>(() => Promise.resolve(value)),
+            });
+            const { result, rerender } = renderHook(
+                ({ source }: { source: ReactiveActionSource<string> }) => useRequestQuery(['source-latest'], source),
+                { initialProps: { source: sourceFor('a') }, wrapper: createWrapper() },
+            );
+            await waitFor(() => expect(result.current.data).toBe('a'));
+
+            // Source identity changes but the key is stable — TanStack doesn't auto-refetch.
+            rerender({ source: sourceFor('b') });
+
+            // `refetch()` re-fires; the ref-sync picks up the latest source.
+            await act(async () => {
+                await result.current.refetch();
+            });
+            await waitFor(() => expect(result.current.data).toBe('b'));
+        });
+    });
+
+    describe('SSR', () => {
+        it('renders without firing the queryFn', () => {
+            const fn = jest.fn<Promise<string>, [AbortSignal]>(() => Promise.resolve('never'));
+            function Component() {
+                const { data } = useRequestQuery(['ssr'], fn);
+                return <p>{data ?? 'no-data'}</p>;
+            }
+            const html = renderToString(
+                <QueryClientProvider client={new QueryClient()}>
+                    <Component />
+                </QueryClientProvider>,
+            );
+            expect(html).toBe('<p>no-data</p>');
+            // TanStack fires the queryFn inside an effect — on the server, effects don't run.
+            expect(fn).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/react/src/query/__typetests__/useRequestQuery-typetest.ts
+++ b/packages/react/src/query/__typetests__/useRequestQuery-typetest.ts
@@ -1,0 +1,117 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import type { ReactiveActionSource } from '@solana/kit';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+import { useRequestQuery } from '../useRequestQuery';
+
+const fnSource = null as unknown as (signal: AbortSignal) => Promise<{ slot: bigint }>;
+const reactiveSource = null as unknown as ReactiveActionSource<{ slot: bigint }>;
+
+// [DESCRIBE] useRequestQuery
+{
+    // Function source — returns UseQueryResult with the resolved type.
+    {
+        useRequestQuery(['epochInfo'], fnSource) satisfies UseQueryResult<{ slot: bigint }>;
+    }
+
+    // ReactiveActionSource — returns UseQueryResult with the source's value type.
+    {
+        useRequestQuery(['balance'], reactiveSource) satisfies UseQueryResult<{ slot: bigint }>;
+    }
+
+    // `data` is `T | undefined` until the first successful fetch.
+    {
+        const { data } = useRequestQuery(['epochInfo'], fnSource);
+        data satisfies { slot: bigint } | undefined;
+    }
+
+    // Null source is accepted (disables the query, mapping to TanStack's `enabled: false`).
+    // Explicit `T` is required here — there's no source value for inference to pick `T` up from.
+    // `TError` defaults to `unknown` (not TanStack's `Error`), matching the rest of the family.
+    {
+        useRequestQuery<{ slot: bigint }>(['epochInfo'], null) satisfies UseQueryResult<{ slot: bigint }, unknown>;
+    }
+
+    // Default error type is unknown; TanStack surfaces `TError | null`.
+    {
+        const { error } = useRequestQuery(['epochInfo'], fnSource);
+        error satisfies unknown;
+        // @ts-expect-error - errors default to unknown, not Error.
+        error satisfies Error | null;
+    }
+
+    // `TError` is overridable via the generic.
+    {
+        useRequestQuery<{ slot: bigint }, string>(['epochInfo'], fnSource).error satisfies string | null;
+    }
+
+    // `select` transforms `data`, and `TData` is inferred from its return type.
+    {
+        const { data } = useRequestQuery(['epochInfo'], fnSource, {
+            select: ({ slot }) => slot,
+        });
+        data satisfies bigint | undefined;
+        // @ts-expect-error - after `select`, `data` is the projected type, not the source type.
+        data satisfies { slot: bigint } | undefined;
+    }
+
+    // `select`'s input is the source's resolved value type.
+    {
+        useRequestQuery(['epochInfo'], fnSource, {
+            select: data => {
+                data satisfies { slot: bigint };
+                return data.slot;
+            },
+        });
+    }
+
+    // `TData` is overridable via the third generic (e.g. for a null source where there's nothing to
+    // infer `select`'s input from).
+    {
+        useRequestQuery<{ slot: bigint }, unknown, bigint>(['epochInfo'], null, {
+            select: ({ slot }) => slot,
+        }).data satisfies bigint | undefined;
+    }
+
+    // Options are forwarded to TanStack's configuration.
+    {
+        useRequestQuery(['epochInfo'], fnSource, {
+            enabled: false,
+            // @ts-expect-error - TanStack doesn't accept arbitrary keys.
+            notARealOption: true,
+        });
+    }
+
+    // `queryKey` and `queryFn` are owned by the hook and cannot be overridden via options.
+    {
+        useRequestQuery(['epochInfo'], fnSource, {
+            // @ts-expect-error - the hook owns queryFn.
+            queryFn: () => Promise.resolve({ slot: 1n }),
+        });
+    }
+
+    // Kit-specific options merge into the TanStack options bag.
+    {
+        useRequestQuery(['epochInfo'], fnSource, {
+            enabled: true,
+            getAbortSignal: () => AbortSignal.timeout(5_000),
+        });
+    }
+
+    // `getAbortSignal` must return an AbortSignal (or undefined when omitted).
+    {
+        useRequestQuery(['epochInfo'], fnSource, {
+            // @ts-expect-error - factory must return AbortSignal.
+            getAbortSignal: () => 'not a signal',
+        });
+    }
+
+    // Function source must return `Promise<T>` and accept an AbortSignal.
+    {
+        useRequestQuery(['epochInfo'], (signal: AbortSignal) => {
+            signal satisfies AbortSignal;
+            return Promise.resolve({ slot: 1n });
+        });
+    }
+}

--- a/packages/react/src/query/useRequestQuery.ts
+++ b/packages/react/src/query/useRequestQuery.ts
@@ -1,0 +1,130 @@
+import type { ReactiveActionSource } from '@solana/kit';
+import {
+    type QueryFunctionContext,
+    type QueryKey,
+    useQuery,
+    type UseQueryOptions,
+    type UseQueryResult,
+} from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useLatest } from '../useLatest';
+import type { UseRequestOptions } from '../useRequest';
+
+/**
+ * Options accepted by {@link useRequestQuery}: every option `@tanstack/react-query`'s `useQuery`
+ * takes (minus `queryKey` and `queryFn`, which this hook owns) plus the Kit-specific
+ * {@link UseRequestOptions}.
+ *
+ * @typeParam T - The value the underlying request resolves to.
+ * @typeParam TError - The error type TanStack Query will surface on failure.
+ * @typeParam TData - The shape of `data` after any `select` transform. Defaults to `T` when no
+ * `select` is supplied.
+ */
+export type UseRequestQueryOptions<T, TError = unknown, TData = T> = Omit<
+    UseQueryOptions<T, TError, TData, QueryKey>,
+    'queryFn' | 'queryKey'
+> &
+    UseRequestOptions;
+
+/**
+ * TanStack Query-backed counterpart to core's `useRequest`. Accepts the same source shape — a
+ * {@link ReactiveActionSource} (satisfied by `PendingRpcRequest<T>`) or a
+ * `(signal: AbortSignal) => Promise<T>` function — and routes it through TanStack Query's cache, so
+ * components reading the same `key` dedupe into one in-flight request and the result becomes
+ * Suspense-capable and visible in TanStack Query's devtools.
+ *
+ * The query's `queryFn` is handed TanStack Query's own `AbortSignal`, which aborts when the query
+ * is cancelled (unmount, garbage collection, or a superseding refetch). That signal is threaded
+ * into the source so cancellation propagates all the way down. When a `getAbortSignal` factory is
+ * also supplied (e.g. for a per-attempt timeout), the two signals are combined via
+ * {@link AbortSignal.any} — aborting either one cancels the attempt.
+ *
+ * Pass `null` for `source` to disable — useful when one of the source's inputs isn't yet known.
+ * This maps to TanStack's `enabled: false` and combines with any `enabled` you pass yourself (the
+ * query runs only when the source is non-null *and* your `enabled` is not `false`). Use
+ * `result.refetch()` to refresh.
+ *
+ * @typeParam T - The value the underlying request resolves to.
+ * @typeParam TError - The error type TanStack Query will surface on failure.
+ * @typeParam TData - The shape of `data` after any `select` transform. Defaults to `T` when no
+ * `select` is supplied; pass a `select: (data: T) => TData` option to project the cached value into
+ * a different shape and `result.data` narrows accordingly.
+ *
+ * @example
+ * ```tsx
+ * function LatestBlockhash() {
+ *     const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+ *     const { data, error, isLoading, refetch } = useRequestQuery(
+ *         ['latestBlockhash'],
+ *         client.rpc.getLatestBlockhash(),
+ *         { getAbortSignal: () => AbortSignal.timeout(5_000) },
+ *     );
+ *     if (error) return <button onClick={() => refetch()}>Retry</button>;
+ *     if (isLoading) return <p>Loading…</p>;
+ *     return <p>Blockhash: {data!.value.blockhash}</p>;
+ * }
+ *
+ * // Function shape — wraps an arbitrary async call. The source can be an inline closure recreated
+ * // each render; the hook reads the latest one when the query fires and keys the cache off `key`,
+ * // so there's no need to memoize it.
+ * function Profile({ userId }: { userId: string }) {
+ *     const { data, error, isLoading, refetch } = useRequestQuery(
+ *         ['users', userId],
+ *         (signal: AbortSignal) => fetch(`/api/users/${userId}`, { signal }).then(r => r.json()),
+ *     );
+ *     if (error) return <button onClick={() => refetch()}>Retry</button>;
+ *     if (isLoading) return <p>Loading…</p>;
+ *     return <p>{data!.name}</p>;
+ * }
+ * ```
+ *
+ * @see {@link UseRequestQueryOptions}
+ */
+export function useRequestQuery<T, TError = unknown, TData = T>(
+    key: QueryKey,
+    source: ReactiveActionSource<T> | ((signal: AbortSignal) => Promise<T>) | null,
+    options?: UseRequestQueryOptions<T, TError, TData>,
+): UseQueryResult<TData, TError> {
+    // Split our option off the TanStack config so we can hand the rest to `useQuery` cleanly.
+    const { getAbortSignal, ...queryOptions } = options ?? {};
+
+    // Ref-sync the source and the abort-signal factory so an inline closure passed each render
+    // doesn't change the queryFn's identity. The queryFn reads the latest values from the refs when
+    // it fires; TanStack uses the key (not the queryFn identity) for cache lookup.
+    const sourceRef = useLatest(source);
+    const getAbortSignalRef = useLatest(getAbortSignal);
+
+    const queryFn = useCallback(
+        async ({ signal }: QueryFunctionContext): Promise<T> => {
+            const current = sourceRef.current;
+            if (current == null) {
+                // Defensive: a null source forces `enabled: false` below, so TanStack won't schedule
+                // this queryFn. This branch should be unreachable.
+                throw new Error('useRequestQuery: the queryFn ran with a null source');
+            }
+            const userSignal = getAbortSignalRef.current?.();
+            // `signal` is TanStack's query-cancellation signal. Combine it with the caller's signal
+            // (when present) so aborting either cancels the attempt.
+            const combinedSignal = userSignal ? AbortSignal.any([signal, userSignal]) : signal;
+            if (typeof current === 'function') {
+                return await current(combinedSignal);
+            }
+            return await current.reactiveStore().withSignal(combinedSignal).dispatchAsync();
+            // `sourceRef` and `getAbortSignalRef` are stable refs from `useLatest`, so listing them
+            // leaves `queryFn` referentially stable across renders — TanStack keys off `key`, not
+            // the queryFn identity, but a stable queryFn avoids needless churn.
+        },
+        [getAbortSignalRef, sourceRef],
+    );
+
+    return useQuery<T, TError, TData, QueryKey>({
+        ...queryOptions,
+        // A null source disables the query (TanStack's `enabled: false`). Combine with the caller's
+        // own `enabled` so the query runs only when the source is present *and* the caller hasn't
+        // disabled it.
+        enabled: source != null && (queryOptions.enabled ?? true),
+        queryFn,
+        queryKey: key,
+    });
+}

--- a/packages/react/src/swr/useRequestSWR.ts
+++ b/packages/react/src/swr/useRequestSWR.ts
@@ -39,13 +39,12 @@ function getNeverAbortedSignal(): AbortSignal {
  *     return <p>Blockhash: {data!.value.blockhash}</p>;
  * }
  *
- * // Function shape — wraps an arbitrary async call:
+ * // Function shape — wraps an arbitrary async call.
  * function Profile({ userId }: { userId: string }) {
- *     const fetcher = useCallback(
+ *     const { data, error, isLoading, mutate } = useRequestSWR(
+ *         ['users', userId],
  *         (signal: AbortSignal) => fetch(`/api/users/${userId}`, { signal }).then(r => r.json()),
- *         [userId],
  *     );
- *     const { data, error, isLoading, mutate } = useRequestSWR(['users', userId], fetcher);
  *     if (error) return <button onClick={() => mutate()}>Retry</button>;
  *     if (isLoading) return <p>Loading…</p>;
  *     return <p>{data!.name}</p>;

--- a/packages/react/tsconfig.declarations.json
+++ b/packages/react/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts", "src/swr.ts"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts", "src/swr.ts", "src/query.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -996,6 +996,9 @@ importers:
       '@solana/kit':
         specifier: workspace:*
         version: link:../kit
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.101.0(react@19.2.7)
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -5117,6 +5120,14 @@ packages:
 
   '@swc/types@0.1.26':
     resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
+
+  '@tanstack/query-core@5.101.0':
+    resolution: {integrity: sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==}
+
+  '@tanstack/react-query@5.101.0':
+    resolution: {integrity: sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -13720,6 +13731,13 @@ snapshots:
   '@swc/types@0.1.26':
     dependencies:
       '@swc/counter': 0.1.3
+
+  '@tanstack/query-core@5.101.0': {}
+
+  '@tanstack/react-query@5.101.0(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-core': 5.101.0
+      react: 19.2.7
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
#### Summary of Changes

This PR adds the `@solana/react/query` subpath, with an optional `@tanstack/react-query` dependency.

We add the first hook to this subpath, `useRequestQuery`. This mirrors `useRequest` and `useRequestSWR` but provides the shape of `useQuery`:

```tsx
function LatestBlockhash() {
    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
    const { data, error, isLoading, refetch } = useRequestQuery(
        ['latestBlockhash'],
        client.rpc.getLatestBlockhash(),
    );
    if (error) return <button onClick={() => refetch()}>Retry</button>;
    if (isLoading) return <p>Loading…</p>;
    return <p>Blockhash: {data!.value.blockhash}</p>;
}
```

This enables all the niceties of Tanstack Query: shared cache (based on key) across components, dedupe, automatic refetching, global config, etc

A third optional param allows passing any Tansatck Query configuration (same as `useQuery`), as well as the `getAbortSignal(): AbortSignal` factory supported by `useRequest`. Query handles signals, so if passed this is combined with the Tanstack Query signal using `AbortSignal.any`. Note that Query config passed will be merged (by Query) with any global config in the normal way.

Like `useRequest` it can take either a `ReactiveActionSource` such as `PendingRpcRequest`, or an async function `(signal: AbortSignal) => Promise<T>`.

Like `useRequest` it does not fetch when the source is null. We treat a null source the same as passing `enabled: false` in the Query options. This removes the need to test against null too. 

Following PRs will add Tanstack Query versions of `useSubscription` and `useTrackedData`. 