### PR TITLE
Add useSubscriptionQuery to react/query subpath

### DIFF
--- a/.changeset/tame-islands-buy.md
+++ b/.changeset/tame-islands-buy.md
@@ -1,0 +1,13 @@
+---
+'@solana/react': minor
+---
+
+Add `useSubscriptionQuery(key, source, options?)` to the `@solana/react/query` subpath — the TanStack Query-backed counterpart to `useSubscription`, for streams with no one-shot RPC fetch. It routes a long-lived stream through TanStack Query's cache via `experimental_streamedQuery`, so components reading the same `key` share one connection and the stream shows up in TanStack Query's devtools.
+
+```tsx
+import { useSubscriptionQuery } from '@solana/react/query';
+
+const { data, error } = useSubscriptionQuery(['slot'], client.rpcSubscriptions.slotNotifications());
+```
+
+The source matches `useSubscription`: a `ReactiveStreamSource<T>`. The hook also accepts a raw `(signal: AbortSignal) => AsyncIterable<T>` factory, as `experimental_streamedQuery` is built on `AsyncIterable`. `data` is the raw notification — the `SolanaRpcResponse` envelope is not unwrapped — matching `useSubscription`. Pass `null` for `source` to disable (TanStack's `enabled: false`); call `result.refetch()` to reconnect. Defaults `retry: false`, `staleTime: Infinity`, and `refetchOnWindowFocus: false` so a focus revalidation doesn't tear down and re-open the connection.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -454,6 +454,41 @@ function Profile({ userId }: { userId: string }) {
 
 The function source is held in a ref synced to the latest render, so an inline closure recreated each render is fine — no `useCallback` needed. TanStack keys the cache off `key`, not the queryFn identity.
 
+### `useSubscriptionQuery(key, source, options?)`
+
+TanStack Query-backed counterpart to `useSubscription`, for streams that have no one-shot RPC fetch. This hook is built on `experimental_streamedQuery`: a long-lived query that stays `fetching` for the subscription's whole life, writing each notification to the cache as it arrives. Components reading the same `key` share one underlying connection and the stream shows up in TanStack Query's devtools.
+
+Returns TanStack's native `UseQueryResult<T>`. `data` is the raw notification, exactly as the source emits it, so for RPC subscriptions read `data.value` and `data.context.slot`. Pass `null` for `source` to disable (TanStack's `enabled: false`).
+
+```tsx
+import { useClient } from '@solana/react';
+import { useSubscriptionQuery } from '@solana/react/query';
+import type { ClientWithRpcSubscriptions, SlotNotificationsApi } from '@solana/kit';
+
+function SlotHeight() {
+    const client = useClient<ClientWithRpcSubscriptions<SlotNotificationsApi>>();
+    const { data, error } = useSubscriptionQuery(['slot'], client.rpcSubscriptions.slotNotifications());
+    if (error) return <p>Disconnected.</p>;
+    if (!data) return <p>Connecting…</p>;
+    return <p>Slot {String(data.slot)}</p>;
+}
+```
+
+Because the stream never settles, the query sits in `fetchStatus: 'fetching'` for the subscription's whole life — `isFetching` is permanently `true`, and `isLoading` flips false after the first notification. Read `data` / `error` / `status` and ignore `isFetching` for subscriptions. Note that `isLoading` only reports the _initial_ connect — it stays false across reconnects. `result.refetch()` is the reconnect verb: it aborts the current connection (resetting its store) and opens a fresh one. Fire and forget — for a never-ending stream the returned promise never resolves, so don't `await refetch()` or it will hang forever. Sensible defaults are applied and all overridable: `retry: false` (the underlying reactive store owns retry/backoff), and `staleTime: Infinity` + `refetchOnWindowFocus: false` so a focus revalidation doesn't tear down and re-open the socket — the subscription is what keeps the data fresh.
+
+The source matches `useSubscription`: a `ReactiveStreamSource<T>`. This hook also accepts a raw `(signal: AbortSignal) => AsyncIterable<T>` factory, as `experimental_streamedQuery` is built on `AsyncIterable`.
+
+```tsx
+function Ticker() {
+    const { data } = useSubscriptionQuery(['ticker'], (signal: AbortSignal) => streamPrices(signal));
+    return <p>{data ?? '…'}</p>;
+}
+```
+
+### Why no `useActionQuery`?
+
+It would just be a wrapper around Tanstack's built-in [`useMutation`](https://tanstack.com/query/latest/docs/framework/react/guides/mutations) with no additional functionality. Either use `useMutation` or, if you don't need the Tanstack integration, use `useAction`.
+
 ## Hooks
 
 ### `useSignIn(uiWalletAccount, chain)`

--- a/packages/react/src/query.ts
+++ b/packages/react/src/query.ts
@@ -11,3 +11,4 @@
  * @packageDocumentation
  */
 export * from './query/useRequestQuery';
+export * from './query/useSubscriptionQuery';

--- a/packages/react/src/query/__tests__/bridgeStoreToAsyncIterable-test.ts
+++ b/packages/react/src/query/__tests__/bridgeStoreToAsyncIterable-test.ts
@@ -1,0 +1,197 @@
+import {
+    isSolanaError,
+    type ReactiveState,
+    type ReactiveStreamStore,
+    SOLANA_ERROR__REACT__SUBSCRIPTION_CLOSED_WITHOUT_ERROR,
+} from '@solana/kit';
+
+import { bridgeStoreToAsyncIterable } from '../bridgeStoreToAsyncIterable';
+
+function createFakeStore<T>(): {
+    connectCount: () => number;
+    emit: (state: ReactiveState<T>) => void;
+    listenerCount: () => number;
+    resetCount: () => number;
+    store: ReactiveStreamStore<T>;
+    withSignalArg: () => AbortSignal | undefined;
+} {
+    let state: ReactiveState<T> = { data: undefined, error: undefined, status: 'idle' };
+    const listeners = new Set<() => void>();
+    let connects = 0;
+    let resets = 0;
+    let withSignalArg: AbortSignal | undefined;
+    const store: ReactiveStreamStore<T> = {
+        // The bridge connects via `withSignal(signal).connect()`, never the bare `connect()` — fail
+        // loudly if it reaches for the unbound one.
+        connect: jest.fn().mockImplementation(() => {
+            throw new Error('not implemented');
+        }),
+        getError: jest.fn().mockImplementation(() => {
+            throw new Error('not implemented');
+        }),
+        getState: jest.fn().mockImplementation(() => {
+            throw new Error('not implemented');
+        }),
+        getUnifiedState: () => state,
+        reset: () => {
+            resets++;
+        },
+        retry: jest.fn().mockImplementation(() => {
+            throw new Error('not implemented');
+        }),
+        subscribe: (callback: () => void) => {
+            listeners.add(callback);
+            return () => {
+                listeners.delete(callback);
+            };
+        },
+        withSignal: (signal: AbortSignal) => {
+            withSignalArg = signal;
+            return {
+                connect: () => {
+                    connects++;
+                },
+            };
+        },
+    };
+    return {
+        connectCount: () => connects,
+        emit: (next: ReactiveState<T>) => {
+            state = next;
+            listeners.forEach(l => l());
+        },
+        listenerCount: () => listeners.size,
+        resetCount: () => resets,
+        store,
+        withSignalArg: () => withSignalArg,
+    };
+}
+
+describe('bridgeStoreToAsyncIterable', () => {
+    it('subscribes to and connects the store bound to the signal', () => {
+        const fake = createFakeStore<number>();
+        const ctrl = new AbortController();
+        const it = bridgeStoreToAsyncIterable(fake.store, ctrl.signal)[Symbol.asyncIterator]();
+        // The generator body runs synchronously up to its first `await`, so subscribe + connect have
+        // happened by the time `next()` returns its (still-pending) promise.
+        void it.next();
+        expect(fake.listenerCount()).toBe(1);
+        expect(fake.connectCount()).toBe(1);
+        expect(fake.withSignalArg()).toBe(ctrl.signal);
+    });
+
+    it('yields a loaded value', async () => {
+        expect.assertions(1);
+        const fake = createFakeStore<number>();
+        const it = bridgeStoreToAsyncIterable(fake.store, new AbortController().signal)[Symbol.asyncIterator]();
+        const pull = it.next();
+        fake.emit({ data: 42, error: undefined, status: 'loaded' });
+        await expect(pull).resolves.toEqual({ done: false, value: 42 });
+    });
+
+    it('yields successive loaded values across pulls', async () => {
+        expect.assertions(2);
+        const fake = createFakeStore<number>();
+        const it = bridgeStoreToAsyncIterable(fake.store, new AbortController().signal)[Symbol.asyncIterator]();
+
+        const first = it.next();
+        fake.emit({ data: 1, error: undefined, status: 'loaded' });
+        await expect(first).resolves.toEqual({ done: false, value: 1 });
+
+        const second = it.next();
+        fake.emit({ data: 2, error: undefined, status: 'loaded' });
+        await expect(second).resolves.toEqual({ done: false, value: 2 });
+    });
+
+    it('drops intermediate values (latest-wins) when several land between pulls', async () => {
+        expect.assertions(1);
+        const fake = createFakeStore<number>();
+        const it = bridgeStoreToAsyncIterable(fake.store, new AbortController().signal)[Symbol.asyncIterator]();
+        const pull = it.next();
+        // Three notifications arrive before the consumer pulls — only the freshest survives.
+        fake.emit({ data: 1, error: undefined, status: 'loaded' });
+        fake.emit({ data: 2, error: undefined, status: 'loaded' });
+        fake.emit({ data: 3, error: undefined, status: 'loaded' });
+        await expect(pull).resolves.toEqual({ done: false, value: 3 });
+    });
+
+    it('ignores idle and loading states', async () => {
+        expect.assertions(1);
+        const fake = createFakeStore<number>();
+        const it = bridgeStoreToAsyncIterable(fake.store, new AbortController().signal)[Symbol.asyncIterator]();
+        const pull = it.next();
+        fake.emit({ data: undefined, error: undefined, status: 'loading' });
+        fake.emit({ data: undefined, error: undefined, status: 'idle' });
+        // Neither carried a value; the first *loaded* is what the consumer sees.
+        fake.emit({ data: 7, error: undefined, status: 'loaded' });
+        await expect(pull).resolves.toEqual({ done: false, value: 7 });
+    });
+
+    it('throws on a store error and resets the store', async () => {
+        expect.assertions(2);
+        const fake = createFakeStore<number>();
+        const it = bridgeStoreToAsyncIterable(fake.store, new AbortController().signal)[Symbol.asyncIterator]();
+        const pull = it.next();
+        const boom = new Error('boom');
+        fake.emit({ data: undefined, error: boom, status: 'error' });
+        await expect(pull).rejects.toBe(boom);
+        expect(fake.resetCount()).toBe(1);
+    });
+
+    it('drops a buffered value when an error arrives before the next pull', async () => {
+        expect.assertions(2);
+        const fake = createFakeStore<number>();
+        const it = bridgeStoreToAsyncIterable(fake.store, new AbortController().signal)[Symbol.asyncIterator]();
+        const pull = it.next();
+        // A value lands, then an error arrives before the consumer pulls again. Error wins: the
+        // buffered value is dropped (once errored, stop yielding). Pins the failure-before-latest
+        // precedence so a refactor can't silently invert it.
+        const boom = new Error('boom');
+        fake.emit({ data: 1, error: undefined, status: 'loaded' });
+        fake.emit({ data: undefined, error: boom, status: 'error' });
+        await expect(pull).rejects.toBe(boom);
+        expect(fake.resetCount()).toBe(1);
+    });
+
+    it('substitutes a sentinel when the store errors with a nullish payload', async () => {
+        expect.assertions(1);
+        const fake = createFakeStore<number>();
+        const it = bridgeStoreToAsyncIterable(fake.store, new AbortController().signal)[Symbol.asyncIterator]();
+        const pull = it.next();
+        fake.emit({ data: undefined, error: undefined, status: 'error' });
+        await pull.then(
+            () => {
+                throw new Error('expected the pull to reject');
+            },
+            error => {
+                expect(isSolanaError(error, SOLANA_ERROR__REACT__SUBSCRIPTION_CLOSED_WITHOUT_ERROR)).toBe(true);
+            },
+        );
+    });
+
+    it('ends cleanly and resets the store when the signal aborts', async () => {
+        expect.assertions(3);
+        const fake = createFakeStore<number>();
+        const ctrl = new AbortController();
+        const it = bridgeStoreToAsyncIterable(fake.store, ctrl.signal)[Symbol.asyncIterator]();
+        const pull = it.next();
+        ctrl.abort();
+        // An abort is teardown, not failure: the iterable completes (`done`) rather than rejecting.
+        await expect(pull).resolves.toEqual({ done: true, value: undefined });
+        expect(fake.resetCount()).toBe(1);
+        expect(fake.listenerCount()).toBe(0);
+    });
+
+    it('unsubscribes and resets the store when the consumer stops early', async () => {
+        expect.assertions(2);
+        const fake = createFakeStore<number>();
+        const it = bridgeStoreToAsyncIterable(fake.store, new AbortController().signal)[Symbol.asyncIterator]();
+        const pull = it.next();
+        fake.emit({ data: 1, error: undefined, status: 'loaded' });
+        await pull;
+
+        await it.return!(undefined);
+        expect(fake.resetCount()).toBe(1);
+        expect(fake.listenerCount()).toBe(0);
+    });
+});

--- a/packages/react/src/query/__tests__/useSubscriptionQuery-test.browser.tsx
+++ b/packages/react/src/query/__tests__/useSubscriptionQuery-test.browser.tsx
@@ -1,0 +1,416 @@
+import { type ReactiveState, type ReactiveStreamSource, type ReactiveStreamStore } from '@solana/kit';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+import { render, renderHook } from '../../__test-utils__/render';
+import { useSubscriptionQuery } from '../useSubscriptionQuery';
+
+// A fresh `QueryClient` per render so cache state never leaks between tests. `gcTime` defaults to 0
+// so an unmounted query is collected immediately; the focus/reconnect refetch triggers are off so
+// the test environment doesn't accidentally re-fire queries during assertions.
+function createWrapper(gcTime = 0) {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: {
+                gcTime,
+                refetchOnReconnect: false,
+                refetchOnWindowFocus: false,
+                retry: false,
+            },
+        },
+    });
+    return function wrapper({ children }: { children: React.ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    };
+}
+
+// A controllable push-based async iterable: values pushed before a pull are buffered, and `fail`
+// makes the iterator throw. Used to stand in for an arbitrary `(signal) => AsyncIterable<T>` source.
+function makePushStream<T>() {
+    const buffer: T[] = [];
+    let failure: { readonly error: unknown } | undefined;
+    let ended = false;
+    let waiter: PromiseWithResolvers<void> | undefined;
+    const wake = () => waiter?.resolve();
+    return {
+        end() {
+            ended = true;
+            wake();
+        },
+        fail(error: unknown) {
+            failure = { error };
+            wake();
+        },
+        iterable: {
+            async *[Symbol.asyncIterator]() {
+                while (true) {
+                    while (buffer.length) yield buffer.shift()!;
+                    if (failure) throw failure.error;
+                    if (ended) return;
+                    waiter = Promise.withResolvers<void>();
+                    await waiter.promise;
+                }
+            },
+        } as AsyncIterable<T>,
+        push(value: T) {
+            buffer.push(value);
+            wake();
+        },
+    };
+}
+
+// Wraps `makePushStream` in a `jest.fn` factory that mints a fresh stream per invocation (so a
+// StrictMode double-mount's discarded stream never steals values from the live one) and records the
+// latest stream + signal for the test to drive.
+function makeStreamFactory<T>() {
+    let latest: ReturnType<typeof makePushStream<T>> | undefined;
+    let latestSignal: AbortSignal | undefined;
+    const factory = jest.fn((signal: AbortSignal): AsyncIterable<T> => {
+        const stream = makePushStream<T>();
+        latest = stream;
+        latestSignal = signal;
+        // End the stream when its signal aborts so a discarded iterator tears down cleanly.
+        signal.addEventListener('abort', () => stream.end(), { once: true });
+        return stream.iterable;
+    });
+    return {
+        factory,
+        fail: (error: unknown) => latest!.fail(error),
+        push: (value: T) => latest!.push(value),
+        signal: () => latestSignal,
+    };
+}
+
+function createFakeStore<T>(): {
+    connectCount: () => number;
+    emit: (state: ReactiveState<T>) => void;
+    resetCount: () => number;
+    store: ReactiveStreamStore<T>;
+    withSignalArg: () => AbortSignal | undefined;
+} {
+    let state: ReactiveState<T> = { data: undefined, error: undefined, status: 'idle' };
+    const listeners = new Set<() => void>();
+    let connects = 0;
+    let resets = 0;
+    let withSignalArg: AbortSignal | undefined;
+    const store: ReactiveStreamStore<T> = {
+        connect: jest.fn().mockImplementation(() => {
+            throw new Error('not implemented');
+        }),
+        getError: jest.fn().mockImplementation(() => {
+            throw new Error('not implemented');
+        }),
+        getState: jest.fn().mockImplementation(() => {
+            throw new Error('not implemented');
+        }),
+        getUnifiedState: () => state,
+        reset: () => {
+            resets++;
+        },
+        retry: jest.fn().mockImplementation(() => {
+            throw new Error('not implemented');
+        }),
+        subscribe: (callback: () => void) => {
+            listeners.add(callback);
+            return () => {
+                listeners.delete(callback);
+            };
+        },
+        withSignal: (signal: AbortSignal) => {
+            withSignalArg = signal;
+            return {
+                connect: () => {
+                    connects++;
+                },
+            };
+        },
+    };
+    return {
+        connectCount: () => connects,
+        emit: (next: ReactiveState<T>) => {
+            state = next;
+            listeners.forEach(l => l());
+        },
+        resetCount: () => resets,
+        store,
+        withSignalArg: () => withSignalArg,
+    };
+}
+
+// Mints a fresh fake store per `reactiveStore()` call (mirroring the real one-store-per-connect
+// model) and exposes the latest store so the test can emit into the live subscription.
+function makeStoreSource<T>() {
+    let latest: ReturnType<typeof createFakeStore<T>> | undefined;
+    const source: ReactiveStreamSource<T> = {
+        reactiveStore() {
+            latest = createFakeStore<T>();
+            return latest.store;
+        },
+    };
+    return {
+        emit: (state: ReactiveState<T>) => latest!.emit(state),
+        resetCount: () => latest!.resetCount(),
+        source,
+        withSignalArg: () => latest!.withSignalArg(),
+    };
+}
+
+describe('useSubscriptionQuery', () => {
+    // The "never fires" tests opt into fake timers so the negative assertion can flush async
+    // scheduling exhaustively via `jest.runAllTimersAsync()` rather than relying on a fixed number
+    // of microtask ticks. Reset to real timers after each test so the `waitFor`-driven tests in the
+    // sibling describes aren't left on fake timers.
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    describe('with a function (AsyncIterable) source', () => {
+        it('flows each notification through to `data`', async () => {
+            const f = makeStreamFactory<number>();
+            const { result } = renderHook(() => useSubscriptionQuery(['fn-flow'], f.factory), {
+                wrapper: createWrapper(),
+            });
+            await waitFor(() => expect(f.factory).toHaveBeenCalled());
+
+            await act(async () => f.push(1));
+            await waitFor(() => expect(result.current.data).toBe(1));
+
+            await act(async () => f.push(2));
+            await waitFor(() => expect(result.current.data).toBe(2));
+            expect(result.current.error).toBeNull();
+        });
+
+        it('surfaces the notification verbatim without unwrapping the envelope', async () => {
+            const notification = { context: { slot: 7n }, value: { lamports: 5n } };
+            const f = makeStreamFactory<typeof notification>();
+            const { result } = renderHook(() => useSubscriptionQuery(['fn-raw'], f.factory), {
+                wrapper: createWrapper(),
+            });
+            await waitFor(() => expect(f.factory).toHaveBeenCalled());
+
+            await act(async () => f.push(notification));
+            // `data` is the raw notification object (identity), not `notification.value`.
+            await waitFor(() => expect(result.current.data).toBe(notification));
+        });
+
+        it('surfaces an error thrown by the iterable', async () => {
+            const boom = new Error('boom');
+            const f = makeStreamFactory<number>();
+            const { result } = renderHook(() => useSubscriptionQuery(['fn-error'], f.factory), {
+                wrapper: createWrapper(),
+            });
+            await waitFor(() => expect(f.factory).toHaveBeenCalled());
+
+            await act(async () => f.fail(boom));
+            await waitFor(() => expect(result.current.error).toBe(boom));
+        });
+
+        it('threads an `AbortSignal` into the factory', async () => {
+            const f = makeStreamFactory<number>();
+            renderHook(() => useSubscriptionQuery(['fn-signal'], f.factory), { wrapper: createWrapper() });
+            await waitFor(() => expect(f.factory).toHaveBeenCalled());
+            const signal = f.signal();
+            expect(signal).toBeInstanceOf(AbortSignal);
+            expect(signal!.aborted).toBe(false);
+        });
+
+        it('combines a `getAbortSignal`-supplied signal so aborting it aborts the threaded signal', async () => {
+            const f = makeStreamFactory<number>();
+            const ctrl = new AbortController();
+            const getAbortSignal = jest.fn(() => ctrl.signal);
+            renderHook(() => useSubscriptionQuery(['fn-user-signal'], f.factory, { getAbortSignal }), {
+                wrapper: createWrapper(),
+            });
+            await waitFor(() => expect(f.factory).toHaveBeenCalled());
+            expect(getAbortSignal).toHaveBeenCalled();
+            const signal = f.signal()!;
+            expect(signal.aborted).toBe(false);
+
+            await act(async () => ctrl.abort());
+            await waitFor(() => expect(signal.aborted).toBe(true));
+        });
+
+        it('does not fire when the source is null', async () => {
+            // A null source maps to `enabled: false`, so the query stays idle and never opens a
+            // stream. The "fires once a non-null source is supplied" path is covered by the tests
+            // above that pass a factory directly.
+            jest.useFakeTimers();
+            const initialProps: { source: ((signal: AbortSignal) => AsyncIterable<number>) | null } = {
+                source: null,
+            };
+            const { result } = renderHook(({ source }) => useSubscriptionQuery(['fn-null'], source), {
+                initialProps,
+                wrapper: createWrapper(),
+            });
+            await act(async () => {
+                await jest.runAllTimersAsync();
+            });
+            expect(result.current.fetchStatus).toBe('idle');
+            expect(result.current.data).toBeUndefined();
+        });
+
+        it('reconnects via `refetch()`, re-invoking the factory', async () => {
+            const f = makeStreamFactory<number>();
+            const { result } = renderHook(() => useSubscriptionQuery(['fn-refetch'], f.factory), {
+                wrapper: createWrapper(),
+            });
+            await waitFor(() => expect(f.factory).toHaveBeenCalled());
+            await act(async () => f.push(1));
+            await waitFor(() => expect(result.current.data).toBe(1));
+
+            const callsBefore = f.factory.mock.calls.length;
+            // Don't await `refetch()`: a streamedQuery never settles, so its promise never resolves.
+            // Firing it cancels the running stream (aborting the old signal) and opens a fresh one.
+            await act(async () => {
+                void result.current.refetch();
+                await Promise.resolve();
+            });
+            await waitFor(() => expect(f.factory.mock.calls.length).toBeGreaterThan(callsBefore));
+
+            // The fresh connection keeps flowing notifications.
+            await act(async () => f.push(2));
+            await waitFor(() => expect(result.current.data).toBe(2));
+        });
+
+        // Rendered through a component (not `renderHook`) and asserted against the DOM. On the
+        // error → refetch → reconnect path the final success render commits via the streamedQuery's
+        // async generator, outside the triggering `act`; `renderHook`'s `result.current` is set in a
+        // passive effect that doesn't flush there, so it reads stale even though the query state is
+        // correct. A DOM assertion reflects the actual committed render — the consumer-facing value —
+        // and `findByText` polling drives the commit deterministically.
+        it('reconnects via `refetch()` after an error, clearing the error on the next notification', async () => {
+            const boom = new Error('boom');
+            const f = makeStreamFactory<number>();
+            // Trigger `refetch` from a button rather than capturing it during render (which the
+            // react-hooks lint forbids). Don't await the click handler: a streamedQuery never
+            // settles, so `refetch()`'s promise never resolves.
+            function Probe() {
+                const query = useSubscriptionQuery(['fn-refetch-after-error'], f.factory);
+                return (
+                    <div>
+                        <button
+                            onClick={() => {
+                                void query.refetch();
+                            }}
+                        >
+                            refetch
+                        </button>
+                        data:{query.data ?? 'none'} err:{(query.error as Error | null)?.message ?? 'none'}
+                    </div>
+                );
+            }
+            render(<Probe />, { wrapper: createWrapper() });
+            await waitFor(() => expect(f.factory).toHaveBeenCalled());
+
+            // Error the stream; the query surfaces the error and the old store is torn down.
+            await act(async () => f.fail(boom));
+            await screen.findByText('data:none err:boom');
+
+            // Refetch reconnects from the error state, re-invoking the factory on a fresh stream.
+            const callsBefore = f.factory.mock.calls.length;
+            await act(async () => {
+                screen.getByRole('button').click();
+                await Promise.resolve();
+            });
+            await waitFor(() => expect(f.factory.mock.calls.length).toBeGreaterThan(callsBefore));
+
+            // The first notification on the reconnected stream populates `data` and clears `error`.
+            await act(async () => f.push(1));
+            await screen.findByText('data:1 err:none');
+        });
+    });
+
+    describe('with a ReactiveStreamSource', () => {
+        it('connects the store bound to a signal and flows notifications through to `data`', async () => {
+            const src = makeStoreSource<number>();
+            const { result } = renderHook(() => useSubscriptionQuery(['store-flow'], src.source), {
+                wrapper: createWrapper(),
+            });
+            await waitFor(() => expect(src.withSignalArg()).toBeInstanceOf(AbortSignal));
+
+            await act(async () => src.emit({ data: 9, error: undefined, status: 'loaded' }));
+            await waitFor(() => expect(result.current.data).toBe(9));
+        });
+
+        it('surfaces a store error', async () => {
+            const boom = new Error('store-boom');
+            const src = makeStoreSource<number>();
+            const { result } = renderHook(() => useSubscriptionQuery(['store-error'], src.source), {
+                wrapper: createWrapper(),
+            });
+            await waitFor(() => expect(src.withSignalArg()).toBeInstanceOf(AbortSignal));
+
+            await act(async () => src.emit({ data: undefined, error: boom, status: 'error' }));
+            await waitFor(() => expect(result.current.error).toBe(boom));
+        });
+
+        it('resets the store on unmount', async () => {
+            const src = makeStoreSource<number>();
+            const { unmount } = renderHook(() => useSubscriptionQuery(['store-teardown'], src.source), {
+                wrapper: createWrapper(),
+            });
+            await waitFor(() => expect(src.withSignalArg()).toBeInstanceOf(AbortSignal));
+
+            unmount();
+            await waitFor(() => expect(src.resetCount()).toBeGreaterThan(0));
+        });
+
+        it('does not connect when the source is null', async () => {
+            // A null source maps to `enabled: false`, so the query stays idle and never connects a
+            // store.
+            jest.useFakeTimers();
+            const initialProps: { source: ReactiveStreamSource<number> | null } = { source: null };
+            const { result } = renderHook(({ source }) => useSubscriptionQuery(['store-null'], source), {
+                initialProps,
+                wrapper: createWrapper(),
+            });
+            await act(async () => {
+                await jest.runAllTimersAsync();
+            });
+            expect(result.current.fetchStatus).toBe('idle');
+            expect(result.current.data).toBeUndefined();
+        });
+    });
+
+    describe('teardown timing', () => {
+        it('aborts the stream signal on unmount even when gcTime has not elapsed', async () => {
+            // Regression pin for `experimental_streamedQuery`'s teardown: TanStack cancels the
+            // in-flight stream the instant the last observer unmounts — independent of `gcTime`
+            // (which governs cache eviction, not fetch cancellation). With `gcTime: Infinity` the
+            // cache entry is never collected, yet the signal must still abort promptly so the socket
+            // closes. This behavior backs the `experimental_` API; pin it so a TanStack bump can't
+            // regress it silently.
+            const f = makeStreamFactory<number>();
+            const { unmount } = renderHook(() => useSubscriptionQuery(['teardown-timing'], f.factory), {
+                wrapper: createWrapper(Infinity),
+            });
+            await waitFor(() => expect(f.factory).toHaveBeenCalled());
+            const signal = f.signal()!;
+            expect(signal.aborted).toBe(false);
+
+            unmount();
+            await waitFor(() => expect(signal.aborted).toBe(true));
+        });
+    });
+
+    describe('SSR', () => {
+        it('renders without firing the stream', () => {
+            const f = makeStreamFactory<number>();
+            function Component() {
+                const { data } = useSubscriptionQuery(['ssr'], f.factory);
+                return <p>{data ?? 'no-data'}</p>;
+            }
+            const html = renderToString(
+                <QueryClientProvider client={new QueryClient()}>
+                    <Component />
+                </QueryClientProvider>,
+            );
+            expect(html).toBe('<p>no-data</p>');
+            // On the server, no observer subscribes during renderToString, so TanStack never
+            // schedules the queryFn.
+            expect(f.factory).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/react/src/query/__typetests__/useSubscriptionQuery-typetest.ts
+++ b/packages/react/src/query/__typetests__/useSubscriptionQuery-typetest.ts
@@ -1,0 +1,127 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import type { ReactiveStreamSource } from '@solana/kit';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+import { useSubscriptionQuery } from '../useSubscriptionQuery';
+
+type Notification = { context: { slot: bigint }; value: { lamports: bigint } };
+
+const fnSource = null as unknown as (signal: AbortSignal) => AsyncIterable<Notification>;
+const reactiveSource = null as unknown as ReactiveStreamSource<Notification>;
+
+// [DESCRIBE] useSubscriptionQuery
+{
+    // Function (AsyncIterable) source — returns UseQueryResult with the notification type.
+    {
+        useSubscriptionQuery(['slot'], fnSource) satisfies UseQueryResult<Notification>;
+    }
+
+    // ReactiveStreamSource — returns UseQueryResult with the source's notification type.
+    {
+        useSubscriptionQuery(['account'], reactiveSource) satisfies UseQueryResult<Notification>;
+    }
+
+    // `data` is the raw notification (envelope NOT unwrapped) and is `T | undefined` until the first
+    // notification arrives.
+    {
+        const { data } = useSubscriptionQuery(['account'], reactiveSource);
+        data satisfies Notification | undefined;
+        // @ts-expect-error - `data` is the raw notification, not the unwrapped `value`.
+        data satisfies { lamports: bigint } | undefined;
+    }
+
+    // Null source is accepted (disables the query, mapping to TanStack's `enabled: false`). Explicit
+    // `T` is required — there's no source value for inference to pick `T` up from.
+    {
+        useSubscriptionQuery<Notification>(['account'], null) satisfies UseQueryResult<Notification, unknown>;
+    }
+
+    // Default error type is unknown; TanStack surfaces `TError | null`.
+    {
+        const { error } = useSubscriptionQuery(['slot'], fnSource);
+        error satisfies unknown;
+        // @ts-expect-error - errors default to unknown, not Error.
+        error satisfies Error | null;
+    }
+
+    // `TError` is overridable via the generic.
+    {
+        useSubscriptionQuery<Notification, string>(['slot'], fnSource).error satisfies string | null;
+    }
+
+    // `select` transforms `data`, and `TData` is inferred from its return type.
+    {
+        const { data } = useSubscriptionQuery(['account'], reactiveSource, {
+            select: ({ value }) => value.lamports,
+        });
+        data satisfies bigint | undefined;
+        // @ts-expect-error - after `select`, `data` is the projected type, not the source type.
+        data satisfies Notification | undefined;
+    }
+
+    // `select`'s input is the source's notification type.
+    {
+        useSubscriptionQuery(['account'], reactiveSource, {
+            select: data => {
+                data satisfies Notification;
+                return data.value.lamports;
+            },
+        });
+    }
+
+    // `TData` is overridable via the third generic (e.g. for a null source where there's nothing to
+    // infer `select`'s input from).
+    {
+        useSubscriptionQuery<Notification, unknown, bigint>(['account'], null, {
+            select: ({ value }) => value.lamports,
+        }).data satisfies bigint | undefined;
+    }
+
+    // Options are forwarded to TanStack's configuration.
+    {
+        useSubscriptionQuery(['slot'], fnSource, {
+            enabled: false,
+            // @ts-expect-error - TanStack doesn't accept arbitrary keys.
+            notARealOption: true,
+        });
+    }
+
+    // `queryKey` and `queryFn` are owned by the hook and cannot be overridden via options.
+    {
+        useSubscriptionQuery(['slot'], fnSource, {
+            // @ts-expect-error - the hook owns queryFn.
+            queryFn: () => Promise.resolve({} as Notification),
+        });
+    }
+
+    // Kit-specific options merge into the TanStack options bag.
+    {
+        useSubscriptionQuery(['slot'], fnSource, {
+            enabled: true,
+            getAbortSignal: () => AbortSignal.timeout(30_000),
+        });
+    }
+
+    // `getAbortSignal` must return an AbortSignal (or undefined when omitted).
+    {
+        useSubscriptionQuery(['slot'], fnSource, {
+            // @ts-expect-error - factory must return AbortSignal.
+            getAbortSignal: () => 'not a signal',
+        });
+    }
+
+    // Function source must return `AsyncIterable<T>` and accept an AbortSignal.
+    {
+        useSubscriptionQuery(['slot'], (signal: AbortSignal) => {
+            signal satisfies AbortSignal;
+            return null as unknown as AsyncIterable<Notification>;
+        });
+    }
+
+    // A function source returning a non-iterable is rejected.
+    {
+        // @ts-expect-error - must return an AsyncIterable, not a bare value.
+        useSubscriptionQuery(['slot'], (_signal: AbortSignal) => ({ lamports: 1n }));
+    }
+}

--- a/packages/react/src/query/bridgeStoreToAsyncIterable.ts
+++ b/packages/react/src/query/bridgeStoreToAsyncIterable.ts
@@ -1,0 +1,97 @@
+import {
+    type ReactiveStreamStore,
+    SOLANA_ERROR__REACT__SUBSCRIPTION_CLOSED_WITHOUT_ERROR,
+    SolanaError,
+} from '@solana/kit';
+
+/**
+ * Bridges a {@link ReactiveStreamStore} into the `AsyncIterable` contract that TanStack Query's
+ * `experimental_streamedQuery` consumes. The TanStack twin of `bridgeStoreToSwr`: where the SWR
+ * bridge pushes each store update into a `next` callback, this one exposes a *pull*-based async
+ * iterable, since `streamedQuery` drives the stream by `for await`-ing it.
+ *
+ * Subscribes to the store, `connect()`s it bound to `signal`, and yields its unified lifecycle:
+ * - `loaded` → yields the value. Latest-wins: if several notifications land between pulls, only the
+ *   most recent unconsumed value is yielded (a subscription consumer wants the freshest state, not a
+ *   backlog).
+ * - `error` → throws, so the `streamedQuery` queryFn rejects and the query surfaces `error`.
+ *   Substitutes a {@link SOLANA_ERROR__REACT__SUBSCRIPTION_CLOSED_WITHOUT_ERROR} sentinel when the
+ *   store reports an error with a nullish payload (mirrors `bridgeStoreToSwr`). An error takes
+ *   precedence over a buffered value: if a `loaded` value is still pending when an `error` arrives,
+ *   that value is dropped and the error propagates (once errored, stop yielding).
+ * - `signal` aborts → ends the iterable cleanly (no error). An abort means teardown — unmount, a
+ *   superseding refetch, or a caller-supplied deadline — so the subscription stops rather than
+ *   failing.
+ *
+ * Whichever way the iterable ends — value exhaustion, error, or abort — the `finally` block
+ * unsubscribes and `reset()`s the store, aborting the active connection. The store the caller hands
+ * in is owned by this bridge for the iterable's lifetime.
+ *
+ * @typeParam T - The notification type emitted by the store.
+ *
+ * @param store - An idle stream store to drive.
+ * @param signal - The abort signal to bind the connection to (TanStack's query-cancellation signal,
+ *   optionally combined with a caller-supplied one). Aborting it tears the stream down.
+ *
+ * @returns An `AsyncIterable<T>` that yields each store value until the store errors or `signal`
+ *   aborts.
+ *
+ * @internal
+ */
+export function bridgeStoreToAsyncIterable<T>(store: ReactiveStreamStore<T>, signal: AbortSignal): AsyncIterable<T> {
+    return {
+        async *[Symbol.asyncIterator](): AsyncIterator<T> {
+            // Latest-wins single-slot buffer plus a one-shot "something changed" deferred the loop
+            // parks on. `wake()` resolves the current deferred and arms a fresh one for the next park.
+            let latest: { readonly value: T } | undefined;
+            let failure: { readonly error: unknown } | undefined;
+            let deferred = Promise.withResolvers<void>();
+            const wake = () => {
+                const { resolve } = deferred;
+                deferred = Promise.withResolvers<void>();
+                resolve();
+            };
+
+            const onChange = () => {
+                const state = store.getUnifiedState();
+                if (state.status === 'loaded') {
+                    latest = { value: state.data };
+                    wake();
+                } else if (state.status === 'error') {
+                    // A nullish error would otherwise surface as a value-less success; substitute a
+                    // sentinel so the failure propagates, matching `bridgeStoreToSwr`.
+                    failure = {
+                        error: state.error ?? new SolanaError(SOLANA_ERROR__REACT__SUBSCRIPTION_CLOSED_WITHOUT_ERROR),
+                    };
+                    wake();
+                }
+                // `idle` / `loading` carry no value and no error — nothing to yield.
+            };
+
+            const onAbort = () => wake();
+            signal.addEventListener('abort', onAbort, { once: true });
+            const unsubscribe = store.subscribe(onChange);
+            // Bind the connection to `signal` so an abort tears down the underlying stream too.
+            store.withSignal(signal).connect();
+            try {
+                while (true) {
+                    // Abort wins over everything: an abort is teardown, so end cleanly without
+                    // surfacing the store's incidental abort-driven error state.
+                    if (signal.aborted) return;
+                    if (failure) throw failure.error;
+                    if (latest) {
+                        const { value } = latest;
+                        latest = undefined;
+                        yield value;
+                        continue;
+                    }
+                    await deferred.promise;
+                }
+            } finally {
+                signal.removeEventListener('abort', onAbort);
+                unsubscribe();
+                store.reset();
+            }
+        },
+    };
+}

--- a/packages/react/src/query/useSubscriptionQuery.ts
+++ b/packages/react/src/query/useSubscriptionQuery.ts
@@ -1,0 +1,154 @@
+import type { ReactiveStreamSource } from '@solana/kit';
+import {
+    experimental_streamedQuery,
+    type QueryFunction,
+    type QueryFunctionContext,
+    type QueryKey,
+    useQuery,
+    type UseQueryOptions,
+    type UseQueryResult,
+} from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useLatest } from '../useLatest';
+import type { UseRequestOptions } from '../useRequest';
+import { bridgeStoreToAsyncIterable } from './bridgeStoreToAsyncIterable';
+
+/**
+ * Options accepted by {@link useSubscriptionQuery}: every option `@tanstack/react-query`'s `useQuery`
+ * takes (minus `queryKey` and `queryFn`, which this hook owns) plus the Kit-specific
+ * {@link UseRequestOptions}.
+ *
+ * @typeParam T - The notification type emitted by the source.
+ * @typeParam TError - The error type TanStack Query will surface on failure.
+ * @typeParam TData - The shape of `data` after any `select` transform. Defaults to `T` when no
+ * `select` is supplied.
+ */
+export type UseSubscriptionQueryOptions<T, TError = unknown, TData = T> = Omit<
+    UseQueryOptions<T, TError, TData, QueryKey>,
+    'queryFn' | 'queryKey'
+> &
+    UseRequestOptions;
+
+/**
+ * TanStack Query-backed counterpart to core's `useSubscription`, for streams that have no one-shot
+ * RPC fetch counterpart. Routes a long-lived stream through TanStack Query's cache via
+ * `experimental_streamedQuery`, so components reading the same `key` share one underlying connection
+ * and the stream participates in TanStack Query's cache and devtools.
+ *
+ * The source has the same two shapes as {@link useRequestQuery}, the pull-based analog of its
+ * `(signal) => Promise<T>` arm: a {@link ReactiveStreamSource} (satisfied by an RPC subscription) or
+ * a raw `(signal: AbortSignal) => AsyncIterable<T>` factory. `streamedQuery` is itself built on
+ * `AsyncIterable`, so the factory's iterable is consumed directly; a `ReactiveStreamSource` is
+ * adapted to one internally. The factory receives TanStack's query-cancellation signal (combined
+ * with any `getAbortSignal` you supply) so a `fetch`- or socket-backed generator can bind
+ * cancellation to it.
+ *
+ * `data` is the raw notification, exactly as the source emits it. For RPC subscriptions read
+ * `data.value` and `data.context.slot` yourself.
+ *
+ * Because the stream never settles, the query stays in `fetchStatus: 'fetching'` for the
+ * subscription's whole life — `isFetching` is permanently `true` and `isLoading` flips false
+ * after the first notification. Read `data` / `error` / `status` and ignore `isFetching` for
+ * subscriptions. `result.refetch()` reconnects: TanStack aborts the old signal (ending the prior
+ * iterable, which resets its store) and opens a fresh stream. Fire and forget — for a never-ending
+ * stream the returned promise never resolves, so don't `await refetch()` (a click handler that does
+ * will hang forever).
+ *
+ * Defaults, all overridable: `retry: false` (the underlying reactive store owns retry/backoff),
+ * `staleTime: Infinity` and `refetchOnWindowFocus: false` (a focus revalidation must not tear down
+ * and re-open the socket — the subscription is what keeps data fresh). The internal `refetchMode` is
+ * `'append'` paired with a replace-latest reducer: every notification is written to the cache live,
+ * and the prior value stays visible across a reconnect (stale-while-revalidate).
+ *
+ * Pass `null` for `source` to disable — maps to TanStack's `enabled: false` and combines with any
+ * `enabled` you pass (the query runs only when the source is non-null *and* your `enabled` is not
+ * `false`).
+ *
+ * @typeParam T - The notification type emitted by the source.
+ * @typeParam TError - The error type TanStack Query will surface on failure.
+ * @typeParam TData - The shape of `data` after any `select` transform. Defaults to `T` when no
+ * `select` is supplied; pass a `select: (data: T) => TData` option to project each notification into
+ * a different shape and `result.data` narrows accordingly.
+ *
+ * @example
+ * ```tsx
+ * function SlotHeight() {
+ *     const client = useClient<ClientWithRpcSubscriptions<SlotNotificationsApi>>();
+ *     const { data, error } = useSubscriptionQuery(['slot'], client.rpcSubscriptions.slotNotifications());
+ *     if (error) return <p>Disconnected.</p>;
+ *     if (!data) return <p>Connecting…</p>;
+ *     return <p>Slot {String(data.slot)}</p>;
+ * }
+ *
+ * // Function shape — wraps an arbitrary async iterable, threading the cancellation signal in.
+ * function Ticker() {
+ *     const { data } = useSubscriptionQuery(['ticker'], (signal: AbortSignal) => streamPrices(signal));
+ *     return <p>{data ?? '…'}</p>;
+ * }
+ * ```
+ *
+ * @see {@link UseSubscriptionQueryOptions}
+ * @see {@link useRequestQuery}
+ */
+export function useSubscriptionQuery<T, TError = unknown, TData = T>(
+    key: QueryKey,
+    source: ReactiveStreamSource<T> | ((signal: AbortSignal) => AsyncIterable<T>) | null,
+    options?: UseSubscriptionQueryOptions<T, TError, TData>,
+): UseQueryResult<TData, TError> {
+    // Split our option off the TanStack config so we can hand the rest to `useQuery` cleanly.
+    const { getAbortSignal, ...queryOptions } = options ?? {};
+
+    // Ref-sync the source and the abort-signal factory so an inline value passed each render doesn't
+    // change the streamFn's identity. The streamFn reads the latest values from the refs when it
+    // fires; TanStack uses the key (not the queryFn identity) for cache lookup.
+    const sourceRef = useLatest(source);
+    const getAbortSignalRef = useLatest(getAbortSignal);
+
+    const queryFn = useCallback<QueryFunction<T, QueryKey>>(
+        context =>
+            // `streamedQuery`'s generics default to array accumulation (`TData = Array<TQueryFnData>`).
+            // The explicit `<T, T>` plus a replace-latest reducer types the cache value as the latest
+            // scalar notification rather than `T[]`. `initialValue` only seeds the (ignored) reducer
+            // accumulator before the first chunk, so its value is irrelevant — only its type matters.
+            experimental_streamedQuery<T, T>({
+                initialValue: undefined as T,
+                reducer: (_previous, chunk) => chunk,
+                // `'append'` is the only mode that writes every chunk to the cache live while leaving
+                // the prior value in place across a refetch. `'reset'` would flash to pending on each
+                // reconnect; `'replace'` only flushes once at stream end — which for a never-ending
+                // subscription never happens (an abort skips the final write), freezing the value.
+                refetchMode: 'append',
+                streamFn: ({ signal }: QueryFunctionContext) => {
+                    const current = sourceRef.current;
+                    if (current == null) {
+                        // Defensive: a null source forces `enabled: false` below, so TanStack won't
+                        // schedule this queryFn. This branch should be unreachable.
+                        throw new Error('useSubscriptionQuery: the streamFn ran with a null source');
+                    }
+                    const userSignal = getAbortSignalRef.current?.();
+                    // `signal` is TanStack's query-cancellation signal. Combine it with the caller's
+                    // signal (when present) so aborting either tears the stream down.
+                    const combinedSignal = userSignal ? AbortSignal.any([signal, userSignal]) : signal;
+                    if (typeof current === 'function') {
+                        return current(combinedSignal);
+                    }
+                    return bridgeStoreToAsyncIterable(current.reactiveStore(), combinedSignal);
+                },
+            })(context),
+        [getAbortSignalRef, sourceRef],
+    );
+
+    return useQuery<T, TError, TData, QueryKey>({
+        // Sensible defaults for a long-lived stream; all overridable by `queryOptions` below.
+        refetchOnWindowFocus: false,
+        retry: false,
+        staleTime: Infinity,
+        ...queryOptions,
+        // A null source disables the query (TanStack's `enabled: false`). Combine with the caller's
+        // own `enabled` so the query runs only when the source is present *and* not disabled.
+        enabled: source != null && (queryOptions.enabled ?? true),
+        queryFn,
+        queryKey: key,
+    });
+}


### PR DESCRIPTION
#### Summary of Changes

This PR adds `useSubscriptionQuery`, the Tanstack Query shaped version of `useSubscription`.

```tsx
function SlotHeight() {
    const client = useClient<ClientWithRpcSubscriptions<SlotNotificationsApi>>();
    const { data, error } = useSubscriptionQuery(['slot'], client.rpcSubscriptions.slotNotifications());
    if (error) return <p>Disconnected.</p>;
    if (!data) return <p>Connecting…</p>;
    return <p>Slot {String(data.slot)}</p>;
}
```

Similarly to `useRequestQuery` the third param is an `UseQueryOptions`, with our usual `getAbortSignal` factory to add a custom signal. It also disables when either key or source are null.

Note that under the hood this uses [`experimental_streamedQuery`](https://tanstack.com/query/latest/docs/reference/streamedQuery), which allows `useQuery` to work with a `queryFn` that streams an `AsyncIterable`. Unlike SWR this does not use a different subscription type, so we expose the same API as any other `useQuery`. Most notably this means that we have `refetch` which is missing from `useSubscriptionSWR`. 

We use a bridge function to bridge from our `ReactiveStreamStore` into an `AsyncIterable`, in the same way that we bridged to SWR's custom subscription interface.

As this hook does work with `AsyncIterable`, I've also made it accept a `signal => AsyncIterable` function, so that it can be used without wrapping an `AsyncIterable` in a store, just for us to bridge it back. Note that our other `useSubscription` hooks still don't work with `AsyncIterable` though and continue to require our store.