### PR TITLE
Infer a literal fixedSize for struct codecs

### DIFF
--- a/.changeset/struct-codec-literal-fixed-size.md
+++ b/.changeset/struct-codec-literal-fixed-size.md
@@ -1,0 +1,7 @@
+---
+'@solana/codecs-data-structures': patch
+---
+
+Infer a literal `fixedSize` for `getStructEncoder`, `getStructDecoder`, and `getStructCodec`
+
+When every field is fixed-size, the struct codecs now type their `fixedSize` as the literal sum of the field sizes (for example `5`) instead of the broad `number`. This lets size-aware combinators such as `getUnion*`, `getPredicate*`, and `getPatternMatch*` tell struct branches of different sizes apart. Structs whose fields sum to more than 512 bytes, or that contain a single field larger than that, keep the `number` size so the type-level addition can never exceed TypeScript's recursion limit. This is a type-only change; the runtime is unchanged.

--- a/packages/codecs-data-structures/src/__typetests__/struct-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/struct-typetest.ts
@@ -6,7 +6,14 @@ import {
     VariableSizeDecoder,
     VariableSizeEncoder,
 } from '@solana/codecs-core';
-import { getU32Codec, getU32Decoder, getU32Encoder } from '@solana/codecs-numbers';
+import {
+    getU8Codec,
+    getU8Decoder,
+    getU8Encoder,
+    getU32Codec,
+    getU32Decoder,
+    getU32Encoder,
+} from '@solana/codecs-numbers';
 import { getUtf8Codec, getUtf8Decoder, getUtf8Encoder } from '@solana/codecs-strings';
 
 import { getStructCodec, getStructDecoder, getStructEncoder } from '../struct';
@@ -118,4 +125,37 @@ import { getStructCodec, getStructDecoder, getStructEncoder } from '../struct';
             name: string;
         }
     >;
+}
+
+{
+    // [getStructEncoder]: It infers a literal `fixedSize` from fixed-size fields (issue #1738).
+    getStructEncoder([
+        ['a', getU32Encoder()],
+        ['b', getU8Encoder()],
+    ]) satisfies FixedSizeEncoder<{ a: number; b: number }, 5>;
+    getStructEncoder([['age', getU32Encoder()]]) satisfies FixedSizeEncoder<{ age: number }, 4>;
+    // It falls back to a `number` size when a field's size is not a literal.
+    getStructEncoder([['a', {} as FixedSizeEncoder<number>]]) satisfies FixedSizeEncoder<{ a: number }, number>;
+    // @ts-expect-error It does not claim a literal size when a field's size is not a literal.
+    getStructEncoder([['a', {} as FixedSizeEncoder<number>]]) satisfies FixedSizeEncoder<{ a: number }, 4>;
+    // It falls back to a `number` size when the total exceeds the inference cap (no TS2589).
+    getStructEncoder([['a', {} as FixedSizeEncoder<number, 1000>]]) satisfies FixedSizeEncoder<{ a: number }, number>;
+    // @ts-expect-error It does not infer a literal size beyond the cap.
+    getStructEncoder([['a', {} as FixedSizeEncoder<number, 1000>]]) satisfies FixedSizeEncoder<{ a: number }, 1000>;
+}
+
+{
+    // [getStructDecoder]: It infers a literal `fixedSize` from fixed-size fields (issue #1738).
+    getStructDecoder([
+        ['a', getU32Decoder()],
+        ['b', getU8Decoder()],
+    ]) satisfies FixedSizeDecoder<{ a: number; b: number }, 5>;
+}
+
+{
+    // [getStructCodec]: It infers a literal `fixedSize` from fixed-size fields (issue #1738).
+    getStructCodec([
+        ['a', getU32Codec()],
+        ['b', getU8Codec()],
+    ]) satisfies FixedSizeCodec<{ a: number; b: number }, { a: number; b: number }, 5>;
 }

--- a/packages/codecs-data-structures/src/struct.ts
+++ b/packages/codecs-data-structures/src/struct.ts
@@ -29,6 +29,58 @@ import { DrainOuterGeneric, getFixedSize, getMaxSize, sumCodecSizes } from './ut
  */
 type Fields<T> = readonly (readonly [string, T])[];
 
+/**
+ * The maximum total byte size for which {@link getStructEncoder}, {@link getStructDecoder} and
+ * {@link getStructCodec} infer a *literal* `fixedSize` from their fields. Structs whose fields sum
+ * to more than this (or that contain a single field larger than this) keep the broad `number` size.
+ * The cap keeps the type-level addition below TypeScript's recursion ceiling, so it can never
+ * surface as a compile error in a consumer's code.
+ */
+type MaxInferredStructSize = 512;
+
+// Builds a tuple of length `TLength` (tail-recursive accumulator).
+type BuildTuple<TLength extends number, TTuple extends unknown[] = []> = TTuple['length'] extends TLength
+    ? TTuple
+    : BuildTuple<TLength, [...TTuple, unknown]>;
+
+type StructSizeCapTuple = BuildTuple<MaxInferredStructSize>;
+
+// True when `0 <= TSize <= MaxInferredStructSize`. Walks the cap tuple down rather than
+// materialising `BuildTuple<TSize>`, which would blow the recursion limit for a large `TSize`.
+type IsStructSizeInRange<TSize extends number, TCap extends unknown[] = StructSizeCapTuple> = number extends TSize
+    ? false
+    : TSize extends TCap['length']
+      ? true
+      : TCap extends readonly [unknown, ...infer TRest]
+        ? IsStructSizeInRange<TSize, TRest>
+        : false;
+
+// The literal byte size of each field, in declaration order.
+type FieldFixedSizes<TFields extends Fields<{ readonly fixedSize: number }>> = {
+    [I in keyof TFields]: TFields[I][1] extends { readonly fixedSize: infer TSize extends number } ? TSize : never;
+};
+
+// Sums the field sizes into a literal, falling back to `number` if any field (or the running
+// total) is non-literal or exceeds the cap.
+type SumFieldSizes<TSizes extends readonly number[], TAcc extends unknown[] = []> = TSizes extends readonly [
+    infer THead extends number,
+    ...infer TTail extends readonly number[],
+]
+    ? IsStructSizeInRange<THead> extends true
+        ? [...TAcc, ...BuildTuple<THead>] extends infer TNext extends unknown[]
+            ? IsStructSizeInRange<TNext['length']> extends true
+                ? SumFieldSizes<TTail, TNext>
+                : number
+            : number
+        : number
+    : TAcc['length'];
+
+/**
+ * Infers the literal `fixedSize` of a struct as the sum of its fields' sizes, when that sum is
+ * statically known and within {@link MaxInferredStructSize}; otherwise resolves to `number`.
+ */
+type StructFixedSize<TFields extends Fields<{ readonly fixedSize: number }>> = SumFieldSizes<FieldFixedSizes<TFields>>;
+
 type ArrayIndices<T extends readonly unknown[]> = Exclude<Partial<T>['length'], T['length']> & number;
 
 /**
@@ -84,7 +136,7 @@ type GetDecoderTypeFromFields<TFields extends Fields<Decoder<any>>> = DrainOuter
  */
 export function getStructEncoder<const TFields extends Fields<FixedSizeEncoder<any>>>(
     fields: TFields,
-): FixedSizeEncoder<GetEncoderTypeFromFields<TFields>>;
+): FixedSizeEncoder<GetEncoderTypeFromFields<TFields>, StructFixedSize<TFields>>;
 export function getStructEncoder<const TFields extends Fields<Encoder<any>>>(
     fields: TFields,
 ): VariableSizeEncoder<GetEncoderTypeFromFields<TFields>>;
@@ -146,7 +198,7 @@ export function getStructEncoder<const TFields extends Fields<Encoder<any>>>(
  */
 export function getStructDecoder<const TFields extends Fields<FixedSizeDecoder<any>>>(
     fields: TFields,
-): FixedSizeDecoder<GetDecoderTypeFromFields<TFields>>;
+): FixedSizeDecoder<GetDecoderTypeFromFields<TFields>, StructFixedSize<TFields>>;
 export function getStructDecoder<const TFields extends Fields<Decoder<any>>>(
     fields: TFields,
 ): VariableSizeDecoder<GetDecoderTypeFromFields<TFields>>;
@@ -221,7 +273,8 @@ export function getStructCodec<const TFields extends Fields<FixedSizeCodec<any>>
     fields: TFields,
 ): FixedSizeCodec<
     GetEncoderTypeFromFields<TFields>,
-    GetDecoderTypeFromFields<TFields> & GetEncoderTypeFromFields<TFields>
+    GetDecoderTypeFromFields<TFields> & GetEncoderTypeFromFields<TFields>,
+    StructFixedSize<TFields>
 >;
 export function getStructCodec<const TFields extends Fields<Codec<any>>>(
     fields: TFields,


### PR DESCRIPTION
Closes #1738.

Made `getStructEncoder`/`Decoder`/`Codec` infer a literal `fixedSize` from their fields instead of just falling back to `number`:

```ts
getStructEncoder([
  ['a', getU32Encoder()],
  ['b', getU8Encoder()],
]) satisfies FixedSizeEncoder<{ a: number; b: number }, 5>; // used to be `number`
```

So the size-aware combinators (`getUnion*`, `getPredicate*`, `getPatternMatch*`) can actually tell struct branches of different sizes apart now, which was the point in the issue.

How it works: it's just a type-level sum of each field's `fixedSize`. The catch is the addition builds a tuple of that length, and TS gives up with TS2589 once a tuple gets near ~1000 elements. So to make sure this never blows up in someone's code, I capped it (`MaxInferredStructSize`, 512 for now) — within the cap you get the literal sum, anything bigger or a non-literal field just stays `number` like before. The in-range check walks the cap tuple down instead of building a tuple of the field's size, so a huge single field doesn't trip TS2589 either.

Runtime is untouched — it already summed the sizes, this is purely the types.

Verified with `test:typecheck` (the acceptance criterion from the issue is in there as a typetest), plus lint/prettier and the unit tests on node + browser.

Couple of things I wasn't sure about:
- the cap value (512) — happy to change it. And do you want the size helpers in `struct.ts`, or moved into `codecs-core` so the union/predicate/pattern-match work (#1443, #1683) can reuse them?
- patch or minor changeset? I went patch since it's types-only and a literal size still satisfies the existing `FixedSizeEncoder<T>` tests.
