### PR TITLE
test(rpc-api): add getEpochInfo typetest

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-epoch-info-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-epoch-info-typetest.ts
@@ -1,0 +1,20 @@
+import type { Rpc } from '@solana/rpc-spec';
+import type { Slot } from '@solana/rpc-types';
+
+import type { GetEpochInfoApi } from '../getEpochInfo';
+
+const rpc = null as unknown as Rpc<GetEpochInfoApi>;
+
+void (async () => {
+    {
+        const result = await rpc.getEpochInfo().send();
+        result satisfies Readonly<{
+            absoluteSlot: Slot;
+            blockHeight: bigint;
+            epoch: bigint;
+            slotIndex: bigint;
+            slotsInEpoch: bigint;
+            transactionCount: bigint | null;
+        }>;
+    }
+});


### PR DESCRIPTION
#### Problem

Issue #249 tracks adding typetest coverage for RPC methods that can be called without arguments.

As discussed in #1454, the intended approach is to validate the inferred response types of these methods rather than only verifying that they can be called without arguments. `getEpochInfo()` currently does not have dedicated typetest coverage.

#### Summary of Changes

Adds a dedicated typetest for `getEpochInfo()`.

The test validates the inferred return type of:

```ts
const result = await rpc.getEpochInfo().send();
```

and verifies that:

```ts
result satisfies Readonly<{
    absoluteSlot: Slot;
    blockHeight: bigint;
    epoch: bigint;
    slotIndex: bigint;
    slotsInEpoch: bigint;
    transactionCount: bigint | null;
}>;
```

This ensures the no-argument overload continues to infer the expected response shape, including preserving the branded `Slot` type and the nullable `transactionCount` field.

#### Testing

```bash
pnpm compile
pnpm --filter @solana/rpc-api test:typecheck
```

Fixes #249