### PR TITLE
Update dismiss-stale-approvals to latest commit

### DIFF
--- a/.github/workflows/dismiss-stale-pr-reviews.yml
+++ b/.github/workflows/dismiss-stale-pr-reviews.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - name: Dismiss Stale PR Reviews
         if: ${{ !contains('OWNER,MEMBER,COLLABORATOR', github.event.pull_request.author_association) }}
-        uses: withgraphite/dismiss-stale-approvals@36620714c84092b9d1bd5123ab3b5e11c48b5119
+        uses: withgraphite/dismiss-stale-approvals@23da77dd04e4549404329f3078a3d978e4db13c2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action is using an older commit, and they haven't done a release with the newest version so dependabot didn't pick it up

Thanks to @derrekr for letting us know about this! 