### PR TITLE
Update parseJsonWithBigInts to protect against overly large numbers

### DIFF
--- a/.changeset/humble-words-shout.md
+++ b/.changeset/humble-words-shout.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-spec-types': patch
+---
+
+Validate `$n` BigInt value objects in `parseJsonWithBigInts` before materializing them. The parser now rejects non-integer and excessively large `$n` values with a `SolanaError` (`SOLANA_ERROR__MALFORMED_BIGINT_STRING`).

--- a/packages/rpc-spec-types/package.json
+++ b/packages/rpc-spec-types/package.json
@@ -73,6 +73,9 @@
         "supports bigint and not dead",
         "maintained node versions"
     ],
+    "dependencies": {
+        "@solana/errors": "workspace:*"
+    },
     "peerDependencies": {
         "typescript": ">=5.4.0"
     },

--- a/packages/rpc-spec-types/src/__tests__/parse-json-with-bigints-test.ts
+++ b/packages/rpc-spec-types/src/__tests__/parse-json-with-bigints-test.ts
@@ -1,3 +1,4 @@
+import { SOLANA_ERROR__MALFORMED_BIGINT_STRING, SolanaError } from '@solana/errors';
 import fs from 'fs';
 import path from 'path';
 
@@ -74,6 +75,40 @@ describe('parseJsonWithBigInts', () => {
         '{"data":["","base64"]}',
     ])('does not alter the value of %s', input => {
         expect(parseJsonWithBigInts(input)).toStrictEqual(JSON.parse(input));
+    });
+    it.each([
+        '{"$n":"not-a-number"}',
+        '{"$n":"abc"}',
+        '{"$n":""}',
+        '{"$n":"123a"}',
+        '{"$n":"1.5"}',
+        '{"$n":"0x10"}',
+        '{"$n":"1e-5"}',
+        '{"$n":"Infinity"}',
+    ])('throws a `SolanaError` when an injected `$n` value object is not a valid integer (%s)', input => {
+        const value = JSON.parse(input).$n;
+        expect(() => parseJsonWithBigInts(input)).toThrow(
+            new SolanaError(SOLANA_ERROR__MALFORMED_BIGINT_STRING, { value }),
+        );
+    });
+    it.each(['{"$n":"1e9999999"}', '{"$n":"1e99999999"}', '{"$n":"1e999999999"}', '{"$n":"1e999999999999999999"}'])(
+        'rejects an absurdly large `$n` value object instead of materializing it (%s)',
+        input => {
+            const value = JSON.parse(input).$n;
+            expect(() => parseJsonWithBigInts(input)).toThrow(
+                new SolanaError(SOLANA_ERROR__MALFORMED_BIGINT_STRING, { value }),
+            );
+        },
+    );
+    it('parses an integer whose digit count is exactly at the limit', () => {
+        // `1e999` materializes to a 1,000-digit integer (1 mantissa digit + 999 zeroes).
+        expect(parseJsonWithBigInts('{"$n":"1e999"}')).toBe(10n ** 999n);
+    });
+    it('rejects an integer whose digit count exceeds the limit by one', () => {
+        // `1e1000` would materialize to a 1,001-digit integer.
+        expect(() => parseJsonWithBigInts('{"$n":"1e1000"}')).toThrow(
+            new SolanaError(SOLANA_ERROR__MALFORMED_BIGINT_STRING, { value: '1e1000' }),
+        );
     });
     it('can parse complex JSON files', () => {
         const largeJsonPath = path.join(__dirname, 'large-json-file.json');

--- a/packages/rpc-spec-types/src/parse-json-with-bigints.ts
+++ b/packages/rpc-spec-types/src/parse-json-with-bigints.ts
@@ -1,3 +1,20 @@
+import { SOLANA_ERROR__MALFORMED_BIGINT_STRING, SolanaError } from '@solana/errors';
+
+/**
+ * Matches an optionally-signed integer with an optional non-negative exponent —
+ * matching the shape that {@link wrapBigIntValueObject} can emit. Capturing the
+ * sign, mantissa, and exponent separately lets us both validate the value and
+ * estimate how many digits it would materialize into.
+ */
+const BIGINT_VALUE_OBJECT_PATTERN = /^(-?)(\d+)(?:[eE]\+?(\d+))?$/;
+
+/**
+ * The largest integer (by decimal digit count) we are willing to materialize
+ * from a `$n` value object. This prevents a malformed `$n` value from causing
+ * us to allocate overly large numbers.
+ */
+const MAX_BIGINT_DIGITS = 1_000;
+
 /**
  * This function is a replacement for `JSON.parse` that can handle large
  * unsafe integers by parsing them as BigInts. It transforms every
@@ -69,11 +86,18 @@ function wrapBigIntValueObject(value: string): string {
 }
 
 function unwrapBigIntValueObject({ $n }: BigIntValueObject): bigint {
-    if ($n.match(/[eE]/)) {
-        const [units, exponent] = $n.split(/[eE]/);
-        return BigInt(units) * BigInt(10) ** BigInt(exponent);
+    const match = $n.match(BIGINT_VALUE_OBJECT_PATTERN);
+    if (match) {
+        const [, sign, mantissa, exponent] = match;
+        // The materialized integer has `mantissa.length + exponent` digits.
+        // `Number(exponent)` saturates to `Infinity` for absurd exponents, which
+        // safely exceeds the limit rather than overflowing.
+        const digitCount = mantissa.length + (exponent ? Number(exponent) : 0);
+        if (digitCount <= MAX_BIGINT_DIGITS) {
+            return exponent ? BigInt(`${sign}${mantissa}`) * 10n ** BigInt(exponent) : BigInt($n);
+        }
     }
-    return BigInt($n);
+    throw new SolanaError(SOLANA_ERROR__MALFORMED_BIGINT_STRING, { value: $n });
 }
 
 function isBigIntValueObject(value: unknown): value is BigIntValueObject {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1165,6 +1165,9 @@ importers:
 
   packages/rpc-spec-types:
     dependencies:
+      '@solana/errors':
+        specifier: workspace:*
+        version: link:../errors
       typescript:
         specifier: '>=5.4.0'
         version: 5.9.3


### PR DESCRIPTION
#### Problem

If an RPC returns a `$n` field then this gets parsed as a bigint. There was previously no bound on the number we'd attempt to convert to a bigint, nor validation that it was convertible to a bigint. This meant that a malformed RPC response could potentially freeze/crash JS.

#### Summary of Changes

Update our parsing, so it now validates the `$n` value is a number. It also validates that it materializes to a number with no more than 1000 digits, meaning it'll parse in a fraction of a millisecond. We don't currently have a usecase for RPC returning numbers any bigger than this.

Thanks to @nbelenkov and @EQSTLab for telling us about this issue!