### PR TITLE
Add useTrackedDataQuery to react/query subpath

### DIFF
--- a/.changeset/new-turtles-invent.md
+++ b/.changeset/new-turtles-invent.md
@@ -1,0 +1,5 @@
+---
+'@solana/react': minor
+---
+
+Add `useTrackedDataQuery` to the `@solana/react/query` subpath. This is the TanStack Query-backed counterpart to `useTrackedData`: it pairs a one-shot RPC fetch with an ongoing subscription (slot-deduped) and routes the unified stream through TanStack Query's cache via `experimental_streamedQuery`, surfacing the `SolanaRpcResponse<TItem>` envelope as `data`. Slot dedupe spans the cache, so a `refetch()`'s fresh store cannot regress the cached envelope to an older slot from a lagging RPC node.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -485,6 +485,48 @@ function Ticker() {
 }
 ```
 
+### `useTrackedDataQuery(key, spec, options?)`
+
+TanStack Query-backed counterpart to `useTrackedData`. Takes the same `TrackedDataSpec` (a one-shot RPC fetch paired with a subscription, plus two mappers that unify their value shapes into a common `TItem`) and routes the unified, slot-deduped stream through TanStack Query's cache via `experimental_streamedQuery`. Like `useSubscriptionQuery` it stays `fetching` for the subscription's whole life, but the initial fetch surfaces a value as soon as it resolves — typically before the first notification — so the loading paint is shorter. Components reading the same `key` share one underlying connection and the stream shows up in TanStack Query's devtools.
+
+Returns TanStack's native `UseQueryResult`. `data` is the `SolanaRpcResponse<TItem>` envelope emitted by the underlying Kit primitive, so callers can read `data.value` (the unified item produced by the mappers) and `data.context.slot` (the slot the store dedup'd on) directly. Pass `null` for `spec` to disable (TanStack's `enabled: false`).
+
+```tsx
+import { useClient } from '@solana/react';
+import { useTrackedDataQuery } from '@solana/react/query';
+import type {
+    Address,
+    AccountNotificationsApi,
+    ClientWithRpc,
+    ClientWithRpcSubscriptions,
+    GetBalanceApi,
+} from '@solana/kit';
+
+function AccountBalance({ address }: { address: Address }) {
+    const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const spec = useMemo(
+        () => ({
+            initialValueSource: client.rpc.getBalance(address),
+            initialValueMapper: (lamports: bigint) => lamports,
+            streamSource: client.rpcSubscriptions.accountNotifications(address),
+            streamValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
+        }),
+        [client, address],
+    );
+    const { data, error } = useTrackedDataQuery(['balance', address], spec);
+    if (error) return <p>Failed to load.</p>;
+    return <p>{data ? `${data.value} lamports at slot ${data.context.slot}` : 'Loading…'}</p>;
+}
+```
+
+The hook reads the latest `spec` from a ref, so an inline spec recreated each render is fine — no `useMemo` needed for correctness. TanStack keys the cache off `key`, not the spec identity, so bump the `key` to swap specs.
+
+Because the subscription never settles, the query sits in `fetchStatus: 'fetching'` for its whole life — `isFetching` is permanently `true`, and `isLoading` flips false after the first value. Read `data` / `error` / `status` and ignore `isFetching`. Note that `isLoading` only reports the _initial_ connect — it stays false across reconnects. `result.refetch()` is the reconnect verb: it aborts the current connection (resetting its store) and re-runs both the initial RPC fetch and the subscription. Fire and forget — for a never-ending stream the returned promise never resolves, so don't `await refetch()` or it will hang forever. Sensible defaults are applied and all overridable: `retry: false` (the underlying reactive store owns retry/backoff), and `staleTime: Infinity` + `refetchOnWindowFocus: false` so a focus revalidation doesn't tear down and re-open the socket.
+
+Slot dedupe spans the whole TanStack cache, not just one store. The underlying primitive tracks a slot high-water mark per store, but that mark dies when the store is disposed (on reconnect or remount) while the cache entry survives. This hook bridges that gap: a fresh store's reconnect cannot regress the cached envelope to an older slot — e.g. a lagging RPC node resolving the new initial fetch behind the cached value is refused, and the warmer cached value stands until something newer arrives.
+
+Like the other query hooks, you can pass a `getAbortSignal: () => AbortSignal` factory to add a per-attempt signal (typically a timeout); it is combined with TanStack's own cancellation signal via `AbortSignal.any`, so aborting either one tears the connection down.
+
 ### Why no `useActionQuery`?
 
 It would just be a wrapper around Tanstack's built-in [`useMutation`](https://tanstack.com/query/latest/docs/framework/react/guides/mutations) with no additional functionality. Either use `useMutation` or, if you don't need the Tanstack integration, use `useAction`.

--- a/packages/react/src/__test-utils__/render.tsx
+++ b/packages/react/src/__test-utils__/render.tsx
@@ -1,10 +1,10 @@
-import React, { ComponentType, ReactElement, ReactNode, StrictMode } from 'react';
 import {
     render as baseRender,
     renderHook as baseRenderHook,
     RenderHookOptions,
     RenderOptions,
 } from '@testing-library/react';
+import React, { ComponentType, ReactElement, ReactNode, StrictMode } from 'react';
 
 /**
  * Shared test renderers that wrap every React tree in `<StrictMode>`.

--- a/packages/react/src/__tests__/useSubscription-test.browser.tsx
+++ b/packages/react/src/__tests__/useSubscription-test.browser.tsx
@@ -11,7 +11,7 @@ import { renderToString } from 'react-dom/server';
 import { renderHook } from '../__test-utils__/render';
 import { useSubscription } from '../useSubscription';
 
-type Notification<T> = T | SolanaRpcResponse<T>;
+type Notification<T> = SolanaRpcResponse<T> | T;
 
 function makeFakeSubscription<T>(): {
     publish: (notification: Notification<T>) => Promise<void>;
@@ -88,7 +88,7 @@ describe('useSubscription', () => {
         expect(result.current.status).toBe('loading');
         expect(result.current.data).toBeUndefined();
 
-        await act(async () => sub.publish({ value: 42 }));
+        await act(async () => await sub.publish({ value: 42 }));
         expect(result.current.status).toBe('loaded');
         expect(result.current.data).toStrictEqual({ value: 42 });
     });
@@ -97,26 +97,26 @@ describe('useSubscription', () => {
         const sub = makeFakeSubscription<SolanaRpcResponse<{ lamports: bigint }>>();
         const { result } = renderHook(() => useSubscription(sub.source));
 
-        await act(async () => sub.publish({ context: { slot: 99n }, value: { lamports: 5n } }));
+        await act(async () => await sub.publish({ context: { slot: 99n }, value: { lamports: 5n } }));
         expect(result.current.data).toStrictEqual({ context: { slot: 99n }, value: { lamports: 5n } });
     });
 
     it('passes raw notifications through unchanged', async () => {
-        const sub = makeFakeSubscription<{ slot: bigint; parent: bigint; root: bigint }>();
+        const sub = makeFakeSubscription<{ parent: bigint, root: bigint, slot: bigint }>();
         const { result } = renderHook(() => useSubscription(sub.source));
 
-        await act(async () => sub.publish({ parent: 9n, root: 8n, slot: 10n }));
+        await act(async () => await sub.publish({ parent: 9n, root: 8n, slot: 10n }));
         expect(result.current.data).toStrictEqual({ parent: 9n, root: 8n, slot: 10n });
     });
 
     it('transitions to error on error-channel publish, preserving stale data', async () => {
         const sub = makeFakeSubscription<{ value: number }>();
         const { result } = renderHook(() => useSubscription(sub.source));
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         expect(result.current.data).toStrictEqual({ value: 1 });
 
         const boom = new Error('boom');
-        await act(async () => sub.publishError(boom));
+        await act(async () => await sub.publishError(boom));
         expect(result.current.status).toBe('error');
         expect(result.current.error).toBe(boom);
         expect(result.current.data).toStrictEqual({ value: 1 }); // stale preserved
@@ -125,9 +125,9 @@ describe('useSubscription', () => {
     it('reconnect() re-opens the connection and transitions loading → loaded (SWR for data + error)', async () => {
         const sub = makeFakeSubscription<{ value: number }>();
         const { result } = renderHook(() => useSubscription(sub.source));
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         const boom = new Error('fail');
-        await act(async () => sub.publishError(boom));
+        await act(async () => await sub.publishError(boom));
         expect(result.current.status).toBe('error');
 
         act(() => result.current.reconnect());
@@ -135,7 +135,7 @@ describe('useSubscription', () => {
         expect(result.current.data).toStrictEqual({ value: 1 }); // stale data preserved
         expect(result.current.error).toBe(boom); // stale error preserved (SWR)
 
-        await act(async () => sub.publish({ value: 2 }));
+        await act(async () => await sub.publish({ value: 2 }));
         expect(result.current.status).toBe('loaded');
         expect(result.current.data).toStrictEqual({ value: 2 });
         expect(result.current.error).toBeUndefined(); // cleared on successful reconnect
@@ -157,7 +157,7 @@ describe('useSubscription', () => {
 
         rerender({ source: sub.source });
         expect(result.current.status).toBe('loading');
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         expect(result.current.status).toBe('loaded');
         expect(sub.publishersCreated()).toBe(1);
     });
@@ -166,7 +166,7 @@ describe('useSubscription', () => {
         const sub = makeFakeSubscription<{ value: number }>();
         const initialProps: { source: ReactiveStreamSource<{ value: number }> | null } = { source: sub.source };
         const { result, rerender } = renderHook(({ source }) => useSubscription(source), { initialProps });
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         expect(result.current.status).toBe('loaded');
 
         rerender({ source: null });
@@ -181,11 +181,11 @@ describe('useSubscription', () => {
             ({ which }: { which: 'a' | 'b' }) => useSubscription(which === 'a' ? subA.source : subB.source),
             { initialProps: { which: 'a' } },
         );
-        await act(async () => subA.publish({ value: 1 }));
+        await act(async () => await subA.publish({ value: 1 }));
         expect(result.current.data).toStrictEqual({ value: 1 });
 
         rerender({ which: 'b' });
-        await act(async () => subB.publish({ value: 2 }));
+        await act(async () => await subB.publish({ value: 2 }));
         expect(result.current.data).toStrictEqual({ value: 2 });
     });
 
@@ -196,14 +196,14 @@ describe('useSubscription', () => {
             ({ which }: { which: 'a' | 'b' }) => useSubscription(which === 'a' ? subA.source : subB.source),
             { initialProps: { which: 'a' } },
         );
-        await act(async () => subA.publish({ value: 1 }));
+        await act(async () => await subA.publish({ value: 1 }));
 
         rerender({ which: 'b' });
         // Late publishes from the now-torn-down prior connection must not reach the hook.
-        await act(async () => subA.publish({ value: 99 }));
+        await act(async () => await subA.publish({ value: 99 }));
         expect(result.current.data).not.toStrictEqual({ value: 99 });
 
-        await act(async () => subB.publish({ value: 2 }));
+        await act(async () => await subB.publish({ value: 2 }));
         expect(result.current.data).toStrictEqual({ value: 2 });
     });
 
@@ -224,12 +224,12 @@ describe('useSubscription', () => {
             return ctrl.signal;
         });
         const { result } = renderHook(() => useSubscription(sub.source, { getAbortSignal }));
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         expect(getAbortSignal).toHaveBeenCalledTimes(1);
 
-        await act(async () => sub.publishError(new Error('fail')));
+        await act(async () => await sub.publishError(new Error('fail')));
         act(() => result.current.reconnect());
-        await act(async () => sub.publish({ value: 2 }));
+        await act(async () => await sub.publish({ value: 2 }));
         expect(getAbortSignal).toHaveBeenCalledTimes(2);
         expect(signals[1]).not.toBe(signals[0]);
     });
@@ -238,7 +238,7 @@ describe('useSubscription', () => {
         const sub = makeFakeSubscription<{ value: number }>();
         const getAbortSignal = jest.fn(() => new AbortController().signal);
         const { result } = renderHook(() => useSubscription(sub.source, { getAbortSignal }));
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         expect(getAbortSignal).toHaveBeenCalledTimes(1);
 
         const overrideCtrl = new AbortController();
@@ -254,7 +254,7 @@ describe('useSubscription', () => {
         const sub = makeFakeSubscription<{ value: number }>();
         const getAbortSignal = jest.fn(() => new AbortController().signal);
         const { result } = renderHook(() => useSubscription(sub.source, { getAbortSignal }));
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         expect(getAbortSignal).toHaveBeenCalledTimes(1);
 
         act(() => result.current.reconnect({ abortSignal: undefined }));
@@ -266,7 +266,7 @@ describe('useSubscription', () => {
         const sub = makeFakeSubscription<{ value: number }>();
         const getAbortSignal = jest.fn(() => new AbortController().signal);
         const { result } = renderHook(() => useSubscription(sub.source, { getAbortSignal }));
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         expect(getAbortSignal).toHaveBeenCalledTimes(1);
 
         act(() => result.current.reconnect());
@@ -290,7 +290,7 @@ describe('useSubscription', () => {
         act(() => result.current.reconnect());
         expect(currentCtrl!.signal.aborted).toBe(false); // brand-new controller for the new connection
 
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         expect(result.current.status).toBe('loaded');
         expect(result.current.data).toStrictEqual({ value: 1 });
     });
@@ -298,7 +298,7 @@ describe('useSubscription', () => {
     it('aborts the in-flight subscription when the component unmounts', async () => {
         const sub = makeFakeSubscription<{ value: number }>();
         const { unmount } = renderHook(() => useSubscription(sub.source));
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         expect(sub.publishersCreated()).toBe(1);
         unmount();
         // After unmount, late publishes don't drive listeners — they've been removed via reset().

--- a/packages/react/src/query.ts
+++ b/packages/react/src/query.ts
@@ -12,3 +12,4 @@
  */
 export * from './query/useRequestQuery';
 export * from './query/useSubscriptionQuery';
+export * from './query/useTrackedDataQuery';

--- a/packages/react/src/query/__tests__/useTrackedDataQuery-test.browser.tsx
+++ b/packages/react/src/query/__tests__/useTrackedDataQuery-test.browser.tsx
@@ -1,0 +1,388 @@
+import {
+    createReactiveActionStore,
+    createReactiveStoreFromDataPublisherFactory,
+    isSolanaError,
+    ReactiveActionSource,
+    ReactiveStreamSource,
+    SOLANA_ERROR__REACT__SUBSCRIPTION_CLOSED_WITHOUT_ERROR,
+    SolanaRpcResponse,
+} from '@solana/kit';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, waitFor } from '@testing-library/react';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+import { renderHook } from '../../__test-utils__/render';
+import { TrackedDataSpec } from '../../useTrackedData';
+import { useTrackedDataQuery } from '../useTrackedDataQuery';
+
+// A fresh `QueryClient` per wrapper so cache state never leaks between tests, with the focus /
+// reconnect refetch triggers off so the test environment never re-fires queries mid-assertion.
+function makeWrapper() {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { gcTime: 0, refetchOnReconnect: false, refetchOnWindowFocus: false, retry: false },
+        },
+    });
+    return function wrapper({ children }: { children: React.ReactNode }) {
+        return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+    };
+}
+
+type TestValue = { count: number };
+
+function rpcResponse(slot: number, value: TestValue): SolanaRpcResponse<TestValue> {
+    return { context: { slot: BigInt(slot) }, value };
+}
+
+// Backs `initialValueSource` with a real `ReactiveActionStore`. `resolve`/`reject` latch their
+// outcome and apply it to every dispatch — past and future — so value delivery is independent of
+// StrictMode's mount → cleanup → mount cycle (which re-dispatches against a fresh store).
+function createMockInitialValueSource(): {
+    fn: jest.Mock;
+    reject(error: unknown): void;
+    resolve(response: SolanaRpcResponse<TestValue>): void;
+    source: ReactiveActionSource<SolanaRpcResponse<TestValue>>;
+} {
+    type Settled = { error: unknown; type: 'reject' } | { response: SolanaRpcResponse<TestValue>; type: 'resolve' };
+    let settled: Settled | undefined;
+    const pending: { reject(error: unknown): void; resolve(response: SolanaRpcResponse<TestValue>): void }[] = [];
+    const fn = jest.fn().mockImplementation(() => {
+        const { promise, resolve, reject } = Promise.withResolvers<SolanaRpcResponse<TestValue>>();
+        if (settled?.type === 'resolve') resolve(settled.response);
+        else if (settled?.type === 'reject') reject(settled.error);
+        else pending.push({ reject, resolve });
+        return promise;
+    });
+    return {
+        fn,
+        reject(error) {
+            settled = { error, type: 'reject' };
+            pending.splice(0).forEach(p => p.reject(error));
+        },
+        resolve(response) {
+            settled = { response, type: 'resolve' };
+            pending.splice(0).forEach(p => p.resolve(response));
+        },
+        source: { reactiveStore: () => createReactiveActionStore(fn) },
+    };
+}
+
+// Backs `streamSource` with a real `ReactiveStreamStore` built from a mock `DataPublisher` factory.
+// Delivered notifications are logged and replayed to any publisher that subscribes later, so values
+// reach whichever connection survives StrictMode's remount. Tracks the net number of active
+// (non-aborted) connections.
+function createMockStreamSource(): {
+    activeConnections: () => number;
+    createDataPublisher: jest.Mock;
+    error(err: unknown): void;
+    pushNotification(notification: SolanaRpcResponse<TestValue>): void;
+    source: ReactiveStreamSource<SolanaRpcResponse<TestValue>>;
+} {
+    let activeCount = 0;
+    const listeners: { channel: string; listener: (payload: unknown) => void; options?: { signal?: AbortSignal } }[] =
+        [];
+    const log: { channel: string; payload: unknown }[] = [];
+    const createDataPublisher = jest.fn().mockImplementation(() => {
+        activeCount++;
+        let cleanedUp = false;
+        const cleanup = () => {
+            if (!cleanedUp) {
+                cleanedUp = true;
+                activeCount--;
+            }
+        };
+        return Promise.resolve({
+            on(channel: string, listener: (payload: unknown) => void, options?: { signal?: AbortSignal }) {
+                const entry = { channel, listener, options };
+                listeners.push(entry);
+                options?.signal?.addEventListener('abort', cleanup, { once: true });
+                log.filter(e => e.channel === channel).forEach(e => {
+                    if (!options?.signal?.aborted) listener(e.payload);
+                });
+                return () => {
+                    const idx = listeners.indexOf(entry);
+                    if (idx !== -1) listeners.splice(idx, 1);
+                };
+            },
+        });
+    });
+    const deliver = (channel: string, payload: unknown) => {
+        log.push({ channel, payload });
+        listeners.filter(l => l.channel === channel && !l.options?.signal?.aborted).forEach(l => l.listener(payload));
+    };
+    return {
+        activeConnections: () => activeCount,
+        createDataPublisher,
+        error: err => deliver('error', err),
+        pushNotification: notification => deliver('data', notification),
+        source: {
+            reactiveStore: () =>
+                createReactiveStoreFromDataPublisherFactory<SolanaRpcResponse<TestValue>>({
+                    createDataPublisher,
+                    dataChannelName: 'data',
+                    errorChannelName: 'error',
+                }),
+        },
+    };
+}
+
+type Spec = TrackedDataSpec<TestValue, TestValue, number>;
+function makeSpec(): {
+    activeConnections: () => number;
+    error: (err: unknown) => void;
+    pushNotification: (notification: SolanaRpcResponse<TestValue>) => void;
+    rejectRpc: (error: unknown) => void;
+    resolveRpc: (response: SolanaRpcResponse<TestValue>) => void;
+    rpcSendCalls: () => number;
+    spec: Spec;
+    subscribeCalls: () => number;
+} {
+    const initialValue = createMockInitialValueSource();
+    const stream = createMockStreamSource();
+    return {
+        activeConnections: stream.activeConnections,
+        error: stream.error,
+        pushNotification: stream.pushNotification,
+        rejectRpc: initialValue.reject,
+        resolveRpc: initialValue.resolve,
+        rpcSendCalls: () => initialValue.fn.mock.calls.length,
+        spec: {
+            initialValueMapper: v => v.count,
+            initialValueSource: initialValue.source,
+            streamSource: stream.source,
+            streamValueMapper: v => v.count,
+        },
+        subscribeCalls: () => stream.createDataPublisher.mock.calls.length,
+    };
+}
+
+describe('useTrackedDataQuery', () => {
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('surfaces the initial RPC value as the `SolanaRpcResponse` envelope', async () => {
+        const fake = makeSpec();
+        const { result } = renderHook(() => useTrackedDataQuery(['balance'], fake.spec), { wrapper: makeWrapper() });
+        expect(result.current.data).toBeUndefined();
+
+        await act(async () => fake.resolveRpc(rpcResponse(100, { count: 42 })));
+        await waitFor(() => expect(result.current.data).toStrictEqual({ context: { slot: 100n }, value: 42 }));
+    });
+
+    it('promotes a newer subscription notification over the initial RPC', async () => {
+        const fake = makeSpec();
+        const { result } = renderHook(() => useTrackedDataQuery(['promote'], fake.spec), { wrapper: makeWrapper() });
+
+        await act(async () => fake.resolveRpc(rpcResponse(100, { count: 1 })));
+        await waitFor(() => expect(result.current.data).toStrictEqual({ context: { slot: 100n }, value: 1 }));
+
+        await act(async () => fake.pushNotification(rpcResponse(200, { count: 2 })));
+        await waitFor(() => expect(result.current.data).toStrictEqual({ context: { slot: 200n }, value: 2 }));
+        expect(result.current.error).toBeNull();
+    });
+
+    it('surfaces a rejected initial RPC as result.error', async () => {
+        const fake = makeSpec();
+        const { result } = renderHook(() => useTrackedDataQuery(['rpc-error'], fake.spec), { wrapper: makeWrapper() });
+
+        const boom = new Error('rpc failed');
+        await act(async () => fake.rejectRpc(boom));
+        await waitFor(() => expect(result.current.error).toBe(boom));
+    });
+
+    it('surfaces a subscription error as result.error', async () => {
+        const fake = makeSpec();
+        const { result } = renderHook(() => useTrackedDataQuery(['sub-error'], fake.spec), { wrapper: makeWrapper() });
+
+        const boom = new Error('subscription failed');
+        await act(async () => fake.error(boom));
+        await waitFor(() => expect(result.current.error).toBe(boom));
+    });
+
+    it('surfaces a nullish subscription error as a sentinel error', async () => {
+        // A store can reach `status: 'error'` with a nullish error (e.g. `controller.abort(null)` or
+        // a publisher emitting `undefined` on its error channel). The bridge substitutes a sentinel
+        // so the failure surfaces as `error` rather than being read as a value-less success.
+        const fake = makeSpec();
+        const { result } = renderHook(() => useTrackedDataQuery(['nullish-error'], fake.spec), {
+            wrapper: makeWrapper(),
+        });
+
+        await act(async () => fake.error(undefined));
+        await waitFor(() =>
+            expect(isSolanaError(result.current.error, SOLANA_ERROR__REACT__SUBSCRIPTION_CLOSED_WITHOUT_ERROR)).toBe(
+                true,
+            ),
+        );
+    });
+
+    it('drops a stale subscription notification with a slot older than the current value', async () => {
+        // Fake timers so the negative ("the stale value did not displace the current one") can be
+        // asserted after `runAllTimersAsync()` has drained every scheduled microtask and timer — if
+        // the stale value were going to land, it would have by then.
+        jest.useFakeTimers();
+        const fake = makeSpec();
+        const { result } = renderHook(() => useTrackedDataQuery(['stale-slot'], fake.spec), {
+            wrapper: makeWrapper(),
+        });
+
+        await act(async () => {
+            fake.resolveRpc(rpcResponse(200, { count: 99 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 200n }, value: 99 });
+
+        // Older slot — the store drops it in its slot-floor gate (no value is yielded), so even after
+        // the delivery fully settles the UI must still hold the newer value.
+        await act(async () => {
+            fake.pushNotification(rpcResponse(150, { count: 7 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 200n }, value: 99 });
+    });
+
+    it('does not fire when the spec is null', async () => {
+        // A null spec maps to `enabled: false`, so the query stays idle and never fires the RPC.
+        // Fake timers let the negative assertion flush async scheduling exhaustively before checking
+        // that nothing was scheduled.
+        jest.useFakeTimers();
+        const fake = makeSpec();
+        const { result } = renderHook(() => useTrackedDataQuery<TestValue, TestValue, number>(['no-spec'], null), {
+            wrapper: makeWrapper(),
+        });
+        await act(async () => {
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.fetchStatus).toBe('idle');
+        expect(result.current.data).toBeUndefined();
+        expect(fake.rpcSendCalls()).toBe(0);
+    });
+
+    it('starts when the spec transitions from null to a real spec', async () => {
+        // Fake timers so the head assertion ("disabled while null, the RPC never fires") can flush
+        // exhaustively; the same exhaustive flush then drives the post-transition value to the cache.
+        jest.useFakeTimers();
+        const fake = makeSpec();
+        const initialProps: { spec: Spec | null } = { spec: null };
+        const { result, rerender } = renderHook(({ spec }) => useTrackedDataQuery(['spec-set'], spec), {
+            initialProps,
+            wrapper: makeWrapper(),
+        });
+        // Disabled while the spec is null, so the RPC never fires.
+        await act(async () => {
+            await jest.runAllTimersAsync();
+        });
+        expect(fake.rpcSendCalls()).toBe(0);
+
+        rerender({ spec: fake.spec });
+        await act(async () => {
+            fake.resolveRpc(rpcResponse(100, { count: 1 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 100n }, value: 1 });
+    });
+
+    it('shares one active underlying store across components with the same key', async () => {
+        const fake = makeSpec();
+        renderHook(
+            () => [useTrackedDataQuery(['shared'], fake.spec), useTrackedDataQuery(['shared'], fake.spec)] as const,
+            { wrapper: makeWrapper() },
+        );
+        await waitFor(() => expect(fake.activeConnections()).toBe(1));
+    });
+
+    it('resets the store and aborts the connection on unmount', async () => {
+        const fake = makeSpec();
+        const { unmount } = renderHook(() => useTrackedDataQuery(['teardown'], fake.spec), { wrapper: makeWrapper() });
+        await waitFor(() => expect(fake.activeConnections()).toBe(1));
+
+        unmount();
+        await waitFor(() => expect(fake.activeConnections()).toBe(0));
+    });
+
+    it('combines a `getAbortSignal`-supplied signal so aborting it tears down the connection', async () => {
+        const fake = makeSpec();
+        const ctrl = new AbortController();
+        const getAbortSignal = jest.fn(() => ctrl.signal);
+        renderHook(() => useTrackedDataQuery(['user-signal'], fake.spec, { getAbortSignal }), {
+            wrapper: makeWrapper(),
+        });
+        await waitFor(() => expect(fake.activeConnections()).toBe(1));
+        expect(getAbortSignal).toHaveBeenCalled();
+
+        await act(async () => ctrl.abort());
+        await waitFor(() => expect(fake.activeConnections()).toBe(0));
+    });
+
+    it('does not let an older-slot fetch on reconnect regress the warmer cached value', async () => {
+        // The TanStack cache outlives the per-attempt store, but the store's slot high-water mark
+        // does not — a fresh store (minted on every `refetch()`) starts its window at -1. With
+        // `refetchMode: 'append'` the prior envelope stays cached across the reconnect, so a lagging
+        // RPC node resolving the new store's initial fetch at an older slot must be refused by the
+        // bridge's slot-floor gate (which reads the cached envelope) rather than regressing the value.
+        //
+        // Fake timers throughout: each step drains to completion via `runAllTimersAsync()`, so the
+        // mid-test negative ("the older-slot fetch did not regress the value") is asserted only after
+        // everything it could have scheduled has run.
+        jest.useFakeTimers();
+        const first = makeSpec();
+        // A second spec whose RPC node lags behind; the reconnect rebinds the streamFn to it.
+        const lagging = makeSpec();
+        const initialProps: { spec: Spec } = { spec: first.spec };
+        const { result, rerender } = renderHook(({ spec }) => useTrackedDataQuery(['reconnect'], spec), {
+            initialProps,
+            wrapper: makeWrapper(),
+        });
+        await act(async () => {
+            first.resolveRpc(rpcResponse(200, { count: 1 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 200n }, value: 1 });
+
+        // Swapping the spec under a stable key does not itself reconnect (the streamFn reads the spec
+        // from a ref); the next `refetch()` picks up the lagging spec.
+        rerender({ spec: lagging.spec });
+        // Don't await `refetch()`: a streamedQuery never settles, so its promise never resolves.
+        await act(async () => {
+            void result.current.refetch();
+            await jest.runAllTimersAsync();
+        });
+        expect(lagging.rpcSendCalls()).toBeGreaterThan(0);
+
+        // The older-slot fetch is suppressed; even after it settles the newer cached value stands.
+        await act(async () => {
+            lagging.resolveRpc(rpcResponse(150, { count: 2 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 200n }, value: 1 });
+
+        // A genuinely newer notification on the reconnected stream still flows through.
+        await act(async () => {
+            lagging.pushNotification(rpcResponse(300, { count: 3 }));
+            await jest.runAllTimersAsync();
+        });
+        expect(result.current.data).toStrictEqual({ context: { slot: 300n }, value: 3 });
+    });
+
+    describe('SSR', () => {
+        it('renders without firing the RPC or subscription', () => {
+            const fake = makeSpec();
+            function Component() {
+                const { data } = useTrackedDataQuery(['ssr'], fake.spec);
+                return <p>{data ? 'has-data' : 'no-data'}</p>;
+            }
+            const html = renderToString(
+                <QueryClientProvider client={new QueryClient()}>
+                    <Component />
+                </QueryClientProvider>,
+            );
+            expect(html).toBe('<p>no-data</p>');
+            // On the server, no observer subscribes during renderToString, so TanStack never
+            // schedules the queryFn.
+            expect(fake.rpcSendCalls()).toBe(0);
+            expect(fake.subscribeCalls()).toBe(0);
+        });
+    });
+});

--- a/packages/react/src/query/__typetests__/useTrackedDataQuery-typetest.ts
+++ b/packages/react/src/query/__typetests__/useTrackedDataQuery-typetest.ts
@@ -1,0 +1,107 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import type { SolanaRpcResponse } from '@solana/kit';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+import type { TrackedDataSpec } from '../../useTrackedData';
+import { useTrackedDataQuery } from '../useTrackedDataQuery';
+
+const spec = null as unknown as TrackedDataSpec<{ a: number }, { b: number }, number>;
+
+// [DESCRIBE] useTrackedDataQuery
+{
+    // `data` is the underlying primitive's guaranteed `SolanaRpcResponse<TItem>` envelope. Callers
+    // read data.value and data.context.slot directly, and it is `undefined` until the first value.
+    {
+        const result = useTrackedDataQuery(['balance'], spec);
+        result satisfies UseQueryResult<SolanaRpcResponse<number>, unknown>;
+        result.data satisfies SolanaRpcResponse<number> | undefined;
+        result.data?.value satisfies number | undefined;
+        result.data?.context.slot satisfies bigint | undefined;
+    }
+
+    // Null spec is accepted (disables the query, mapping to TanStack's `enabled: false`). Explicit
+    // generics are required — there's no spec value for inference to pick them up from.
+    {
+        useTrackedDataQuery<{ a: number }, { b: number }, number>(['balance'], null) satisfies UseQueryResult<
+            SolanaRpcResponse<number>,
+            unknown
+        >;
+    }
+
+    // Default error type is unknown; TanStack surfaces `TError | null`.
+    {
+        const { error } = useTrackedDataQuery(['balance'], spec);
+        error satisfies unknown;
+        // @ts-expect-error - errors default to unknown, not Error.
+        error satisfies Error | null;
+    }
+
+    // `TError` is overridable via the generic.
+    {
+        useTrackedDataQuery<{ a: number }, { b: number }, number, string>(['balance'], spec).error satisfies
+            | string
+            | null;
+    }
+
+    // `select` transforms `data`, and `TData` is inferred from its return type.
+    {
+        const { data } = useTrackedDataQuery(['balance'], spec, {
+            select: envelope => envelope.value,
+        });
+        data satisfies number | undefined;
+        // @ts-expect-error - after `select`, `data` is the projected type, not the envelope.
+        data satisfies SolanaRpcResponse<number> | undefined;
+    }
+
+    // `select`'s input is the `SolanaRpcResponse<TItem>` envelope.
+    {
+        useTrackedDataQuery(['balance'], spec, {
+            select: data => {
+                data satisfies SolanaRpcResponse<number>;
+                return data.value;
+            },
+        });
+    }
+
+    // `TData` is overridable via the fifth generic (e.g. for a null spec where there's nothing to
+    // infer `select`'s input from).
+    {
+        useTrackedDataQuery<{ a: number }, { b: number }, number, unknown, bigint>(['balance'], null, {
+            select: ({ context }) => context.slot,
+        }).data satisfies bigint | undefined;
+    }
+
+    // Options are forwarded to TanStack's configuration.
+    {
+        useTrackedDataQuery(['balance'], spec, {
+            enabled: false,
+            // @ts-expect-error - TanStack doesn't accept arbitrary keys.
+            notARealOption: true,
+        });
+    }
+
+    // `queryKey` and `queryFn` are owned by the hook and cannot be overridden via options.
+    {
+        useTrackedDataQuery(['balance'], spec, {
+            // @ts-expect-error - the hook owns queryFn.
+            queryFn: () => Promise.resolve({} as SolanaRpcResponse<number>),
+        });
+    }
+
+    // Kit-specific `getAbortSignal` merges into the TanStack options bag.
+    {
+        useTrackedDataQuery(['balance'], spec, {
+            enabled: true,
+            getAbortSignal: () => AbortSignal.timeout(30_000),
+        });
+    }
+
+    // `getAbortSignal` must return an AbortSignal (or undefined when omitted).
+    {
+        useTrackedDataQuery(['balance'], spec, {
+            // @ts-expect-error - factory must return AbortSignal.
+            getAbortSignal: () => 'not a signal',
+        });
+    }
+}

--- a/packages/react/src/query/bridgeStoreToAsyncIterable.ts
+++ b/packages/react/src/query/bridgeStoreToAsyncIterable.ts
@@ -11,9 +11,9 @@ import {
  * iterable, since `streamedQuery` drives the stream by `for await`-ing it.
  *
  * Subscribes to the store, `connect()`s it bound to `signal`, and yields its unified lifecycle:
- * - `loaded` → yields the value. Latest-wins: if several notifications land between pulls, only the
- *   most recent unconsumed value is yielded (a subscription consumer wants the freshest state, not a
- *   backlog).
+ * - `loaded` → yields the value, unless an optional `shouldYield` predicate rejects it. Latest-wins:
+ *   if several notifications land between pulls, only the most recent unconsumed value is yielded (a
+ *   subscription consumer wants the freshest state, not a backlog).
  * - `error` → throws, so the `streamedQuery` queryFn rejects and the query surfaces `error`.
  *   Substitutes a {@link SOLANA_ERROR__REACT__SUBSCRIPTION_CLOSED_WITHOUT_ERROR} sentinel when the
  *   store reports an error with a nullish payload (mirrors `bridgeStoreToSwr`). An error takes
@@ -32,13 +32,19 @@ import {
  * @param store - An idle stream store to drive.
  * @param signal - The abort signal to bind the connection to (TanStack's query-cancellation signal,
  *   optionally combined with a caller-supplied one). Aborting it tears the stream down.
+ * @param shouldYield - Optional gate run against each `loaded` value before it is yielded. Return
+ *   `false` to drop the value. When omitted, every loaded value is yielded.
  *
  * @returns An `AsyncIterable<T>` that yields each store value until the store errors or `signal`
  *   aborts.
  *
  * @internal
  */
-export function bridgeStoreToAsyncIterable<T>(store: ReactiveStreamStore<T>, signal: AbortSignal): AsyncIterable<T> {
+export function bridgeStoreToAsyncIterable<T>(
+    store: ReactiveStreamStore<T>,
+    signal: AbortSignal,
+    shouldYield?: (value: T) => boolean,
+): AsyncIterable<T> {
     return {
         async *[Symbol.asyncIterator](): AsyncIterator<T> {
             // Latest-wins single-slot buffer plus a one-shot "something changed" deferred the loop
@@ -55,6 +61,8 @@ export function bridgeStoreToAsyncIterable<T>(store: ReactiveStreamStore<T>, sig
             const onChange = () => {
                 const state = store.getUnifiedState();
                 if (state.status === 'loaded') {
+                    // Drop a value the gate rejects. The stream parks again rather than yielding it.
+                    if (shouldYield && !shouldYield(state.data)) return;
                     latest = { value: state.data };
                     wake();
                 } else if (state.status === 'error') {

--- a/packages/react/src/query/useTrackedDataQuery.ts
+++ b/packages/react/src/query/useTrackedDataQuery.ts
@@ -1,0 +1,180 @@
+import { createReactiveStoreWithInitialValueAndSlotTracking, type SolanaRpcResponse } from '@solana/kit';
+import {
+    experimental_streamedQuery,
+    type QueryFunction,
+    type QueryFunctionContext,
+    type QueryKey,
+    useQuery,
+    useQueryClient,
+    type UseQueryOptions,
+    type UseQueryResult,
+} from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useLatest } from '../useLatest';
+import type { UseRequestOptions } from '../useRequest';
+import type { TrackedDataSpec } from '../useTrackedData';
+import { bridgeStoreToAsyncIterable } from './bridgeStoreToAsyncIterable';
+
+/**
+ * Options accepted by {@link useTrackedDataQuery}: every option `@tanstack/react-query`'s `useQuery`
+ * takes (minus `queryKey` and `queryFn`, which this hook owns) plus the Kit-specific
+ * {@link UseRequestOptions}.
+ *
+ * @typeParam TItem - The unified item type produced by the spec's two mappers, surfaced as
+ * `data.value`.
+ * @typeParam TError - The error type TanStack Query will surface on failure.
+ * @typeParam TData - The shape of `data` after any `select` transform. Defaults to the
+ * `SolanaRpcResponse<TItem>` envelope when no `select` is supplied.
+ */
+export type UseTrackedDataQueryOptions<TItem, TError = unknown, TData = SolanaRpcResponse<TItem>> = Omit<
+    UseQueryOptions<SolanaRpcResponse<TItem>, TError, TData, QueryKey>,
+    'queryFn' | 'queryKey'
+> &
+    UseRequestOptions;
+
+/**
+ * TanStack Query-backed counterpart to core's `useTrackedData`. Pairs a one-shot RPC fetch with an
+ * ongoing subscription (slot-deduped by the underlying Kit primitive) and routes the unified stream
+ * through TanStack Query's cache via `experimental_streamedQuery`, so components reading the same
+ * `key` share one underlying connection and the stream participates in TanStack Query's cache and
+ * devtools.
+ *
+ * `data` is the `SolanaRpcResponse<TItem>` envelope emitted by the underlying kit primitive — the
+ * primitive's type guarantees the envelope shape, so callers can read `data.value` (the unified item
+ * produced by the spec's mappers) and `data.context.slot` (the slot the store dedup'd on) directly.
+ *
+ * Pass a {@link TrackedDataSpec} keyed on whatever inputs it depends on; the hook reads the latest
+ * one from a ref, so an inline spec recreated each render is fine (TanStack keys the cache off `key`,
+ * not the spec identity — bump the `key` to swap specs). Pass `null` for `spec` to disable — maps to
+ * TanStack's `enabled: false` and combines with any `enabled` you pass (the query runs only when the
+ * spec is non-null *and* your `enabled` is not `false`).
+ *
+ * Because the subscription never settles, the query stays in `fetchStatus: 'fetching'` for its whole
+ * life — `isFetching` is permanently `true` and `isLoading` flips false after the first value. Read
+ * `data` / `error` / `status` and ignore `isFetching`. `result.refetch()` reconnects: TanStack aborts
+ * the old signal (ending the prior iterable, which resets its store) and re-runs both the initial RPC
+ * fetch and the subscription. Fire and forget — for a never-ending stream the returned promise never
+ * resolves, so don't `await refetch()`.
+ *
+ * Defaults, all overridable: `retry: false` (the underlying reactive store owns retry/backoff),
+ * `staleTime: Infinity` and `refetchOnWindowFocus: false` (a focus revalidation must not tear down
+ * and re-open the socket — the subscription is what keeps data fresh). The internal `refetchMode` is
+ * `'append'` paired with a replace-latest reducer: every value is written to the cache live, and the
+ * prior value stays visible across a reconnect (stale-while-revalidate).
+ *
+ * Slot dedupe spans the TanStack cache, not just one store. The underlying primitive tracks a slot
+ * high-water mark per store, but that mark dies when the store is disposed while the cache entry
+ * survives. `refetch()` mints a fresh store (high-water reset to -1) while `refetchMode: 'append'`
+ * keeps the prior envelope cached, so this hook bridges that gap: the reconnect's fresh store cannot
+ * regress the cached envelope to an older slot — e.g. a lagging RPC node resolving the new initial
+ * fetch behind the cached value is refused, and the warmer cached value stands until something newer
+ * arrives.
+ *
+ * @typeParam TInitialValue - The value inside the initial RPC `SolanaRpcResponse` envelope.
+ * @typeParam TStreamValue - The value inside subscription `SolanaRpcResponse` notifications.
+ * @typeParam TItem - The unified item type produced by the two mappers, surfaced as `data.value`.
+ * @typeParam TError - The error type TanStack Query will surface on failure.
+ * @typeParam TData - The shape of `data` after any `select` transform. Defaults to the
+ * `SolanaRpcResponse<TItem>` envelope when no `select` is supplied; pass a
+ * `select: (data: SolanaRpcResponse<TItem>) => TData` option to project each value into a different
+ * shape and `result.data` narrows accordingly.
+ *
+ * @example
+ * ```tsx
+ * function AccountBalance({ address }: { address: Address }) {
+ *     const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+ *     const spec = useMemo(() => ({
+ *         initialValueSource: client.rpc.getBalance(address),
+ *         initialValueMapper: (lamports: bigint) => lamports,
+ *         streamSource: client.rpcSubscriptions.accountNotifications(address),
+ *         streamValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
+ *     }), [client, address]);
+ *     const { data, error } = useTrackedDataQuery(['balance', address], spec);
+ *     if (error) return <p>Failed to load.</p>;
+ *     return <p>{data ? `${data.value} lamports at slot ${data.context.slot}` : 'Loading…'}</p>;
+ * }
+ * ```
+ *
+ * @see {@link UseTrackedDataQueryOptions}
+ * @see {@link useSubscriptionQuery}
+ */
+export function useTrackedDataQuery<
+    TInitialValue,
+    TStreamValue,
+    TItem,
+    TError = unknown,
+    TData = SolanaRpcResponse<TItem>,
+>(
+    key: QueryKey,
+    spec: TrackedDataSpec<TInitialValue, TStreamValue, TItem> | null,
+    options?: UseTrackedDataQueryOptions<TItem, TError, TData>,
+): UseQueryResult<TData, TError> {
+    // Split our option off the TanStack config so we can hand the rest to `useQuery` cleanly.
+    const { getAbortSignal, ...queryOptions } = options ?? {};
+
+    // Ref-sync the spec and the abort-signal factory so an inline value passed each render doesn't
+    // change the streamFn's identity. The streamFn reads the latest values from the refs when it
+    // fires; TanStack uses the key (not the queryFn identity) for cache lookup.
+    const specRef = useLatest(spec);
+    const getAbortSignalRef = useLatest(getAbortSignal);
+
+    // The cache outlives the per-attempt store, but the store's slot high-water mark does not — a
+    // fresh store (remount, refetch) starts its window at -1. The streamFn reads the currently
+    // cached envelope through this client to refuse any value older than what the cache already
+    // holds. `useQueryClient` returns a stable reference, so listing it in the deps below is churn-free.
+    const queryClient = useQueryClient();
+
+    const queryFn = useCallback<QueryFunction<SolanaRpcResponse<TItem>, QueryKey>>(
+        context =>
+            // `streamedQuery`'s generics default to array accumulation (`TData = Array<TQueryFnData>`).
+            // The explicit `<Envelope, Envelope>` plus a replace-latest reducer types the cache value
+            // as the latest scalar envelope rather than an array. `initialValue` only seeds the
+            // (ignored) reducer accumulator before the first chunk, so its value is irrelevant — only
+            // its type matters.
+            experimental_streamedQuery<SolanaRpcResponse<TItem>, SolanaRpcResponse<TItem>>({
+                initialValue: undefined as unknown as SolanaRpcResponse<TItem>,
+                reducer: (_previous, chunk) => chunk,
+                // `'append'` is the only mode that writes every chunk to the cache live while leaving
+                // the prior value in place across a refetch. `'reset'` would flash to pending on each
+                // reconnect; `'replace'` only flushes once at stream end — which for a never-ending
+                // subscription never happens (an abort skips the final write), freezing the value.
+                refetchMode: 'append',
+                streamFn: ({ queryKey, signal }: QueryFunctionContext) => {
+                    const current = specRef.current;
+                    if (current == null) {
+                        // Defensive: a null spec forces `enabled: false` below, so TanStack won't
+                        // schedule this queryFn. This branch should be unreachable.
+                        throw new Error('useTrackedDataQuery: the streamFn ran with a null spec');
+                    }
+                    const userSignal = getAbortSignalRef.current?.();
+                    // `signal` is TanStack's query-cancellation signal. Combine it with the caller's
+                    // signal (when present) so aborting either tears the stream down.
+                    const combinedSignal = userSignal ? AbortSignal.any([signal, userSignal]) : signal;
+                    const store = createReactiveStoreWithInitialValueAndSlotTracking(current);
+                    // Refuse any envelope older than the slot the cache already holds. A fresh store
+                    // (e.g. after a remount) tracks slots from scratch, so without this it could
+                    // overwrite the cached value with an older one from a lagging RPC node.
+                    return bridgeStoreToAsyncIterable(store, combinedSignal, value => {
+                        const cachedSlot =
+                            queryClient.getQueryData<SolanaRpcResponse<TItem>>(queryKey)?.context.slot ?? -1n;
+                        return value.context.slot > cachedSlot;
+                    });
+                },
+            })(context),
+        [getAbortSignalRef, queryClient, specRef],
+    );
+
+    return useQuery<SolanaRpcResponse<TItem>, TError, TData, QueryKey>({
+        // Sensible defaults for a long-lived stream; all overridable by `queryOptions` below.
+        refetchOnWindowFocus: false,
+        retry: false,
+        staleTime: Infinity,
+        ...queryOptions,
+        // A null spec disables the query (TanStack's `enabled: false`). Combine with the caller's own
+        // `enabled` so the query runs only when the spec is present *and* not disabled.
+        enabled: spec != null && (queryOptions.enabled ?? true),
+        queryFn,
+        queryKey: key,
+    });
+}

--- a/packages/react/src/swr/__tests__/useSubscriptionSWR-test.browser.tsx
+++ b/packages/react/src/swr/__tests__/useSubscriptionSWR-test.browser.tsx
@@ -122,7 +122,7 @@ describe('useSubscriptionSWR', () => {
         await waitForActiveSubscription(sub);
         expect(result.current.data).toBeUndefined();
 
-        await act(async () => sub.publish({ context: { slot: 99n }, value: { lamports: 5n } }));
+        await act(async () => await sub.publish({ context: { slot: 99n }, value: { lamports: 5n } }));
         await waitFor(() =>
             expect(result.current.data).toStrictEqual({ context: { slot: 99n }, value: { lamports: 5n } }),
         );
@@ -134,7 +134,7 @@ describe('useSubscriptionSWR', () => {
         await waitForActiveSubscription(sub);
         expect(result.current.data).toBeUndefined();
 
-        await act(async () => sub.publish({ slot: 10n }));
+        await act(async () => await sub.publish({ slot: 10n }));
         await waitFor(() => expect(result.current.data).toStrictEqual({ slot: 10n }));
     });
 
@@ -145,7 +145,7 @@ describe('useSubscriptionSWR', () => {
         expect(result.current.error).toBeUndefined();
 
         const boom = new Error('boom');
-        await act(async () => sub.publishError(boom));
+        await act(async () => await sub.publishError(boom));
         await waitFor(() => expect(result.current.error).toBe(boom));
     });
 
@@ -163,11 +163,11 @@ describe('useSubscriptionSWR', () => {
         expect(result.current.data).toBeUndefined();
         expect(result.current.error).toBeUndefined();
 
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         await waitFor(() => expect(result.current.data).toStrictEqual({ value: 1 }));
 
         const boom = new Error('boom after load');
-        await act(async () => sub.publishError(boom));
+        await act(async () => await sub.publishError(boom));
         await waitFor(() => expect(result.current.error).toBe(boom));
         // The prior notification is retained alongside the surfaced error.
         expect(result.current.data).toStrictEqual({ value: 1 });
@@ -185,10 +185,10 @@ describe('useSubscriptionSWR', () => {
         expect(result.current.data).toBeUndefined();
         expect(result.current.error).toBeUndefined();
 
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         await waitFor(() => expect(result.current.data).toStrictEqual({ value: 1 }));
 
-        await act(async () => sub.publishError(undefined));
+        await act(async () => await sub.publishError(undefined));
         await waitFor(() =>
             expect(isSolanaError(result.current.error, SOLANA_ERROR__REACT__SUBSCRIPTION_CLOSED_WITHOUT_ERROR)).toBe(
                 true,
@@ -225,7 +225,7 @@ describe('useSubscriptionSWR', () => {
 
         rerender({ source: sub.source });
         await waitForActiveSubscription(sub);
-        await act(async () => sub.publish({ value: 1 }));
+        await act(async () => await sub.publish({ value: 1 }));
         await waitFor(() => expect(result.current.data).toStrictEqual({ value: 1 }));
         expect(sub.activeConnections()).toBe(1);
     });
@@ -257,7 +257,7 @@ describe('useSubscriptionSWR', () => {
         source = null;
         rerender();
         await waitFor(() => expect(sub.activeConnections()).toBe(0));
-        await act(async () => sub.publish({ value: 2 }));
+        await act(async () => await sub.publish({ value: 2 }));
     });
 
     it('tears down the old subscription and opens a new one when the key changes', async () => {

--- a/packages/react/src/useReactiveStoreLifecycle.ts
+++ b/packages/react/src/useReactiveStoreLifecycle.ts
@@ -84,7 +84,7 @@ export function useReactiveStoreLifecycle<TStore extends { reset(): void }>(
             }
             if (++churn.count > CHURN_WARNING_THRESHOLD && !churn.warned) {
                 churn.warned = true;
-                // eslint-disable-next-line no-console
+
                 console.error(
                     'A reactive-store hook (e.g. `useRequest`) recreated its store %d times within ' +
                         '1s. This almost always means the `source`/`spec` passed to it is a fresh ' +


### PR DESCRIPTION
#### Summary of Changes

This PR adds `useTrackedDataQuery`, the Tanstack Query shaped version of `useTrackedData`.

```tsx
function AccountBalance({ address }: { address: Address }) {
    const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
    const spec = useMemo(
        () => ({
            initialValueSource: client.rpc.getBalance(address),
            initialValueMapper: (lamports: bigint) => lamports,
            streamSource: client.rpcSubscriptions.accountNotifications(address),
            streamValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
        }),
        [client, address],
    );
    const { data, error } = useTrackedDataQuery(['balance', address], spec);
    if (error) return <p>Failed to load.</p>;
    return <p>{data ? `${data.value} lamports at slot ${data.context.slot}` : 'Loading…'}</p>;
}
```

Similarly to `useRequestQuery` the third param is an `UseQueryOptions`, with our usual `getAbortSignal` factory to add a custom signal. It also disables when either key or source are null.

Note that like `useSubscriptionQuery`, under the hood this uses [`experimental_streamedQuery`](https://tanstack.com/query/latest/docs/reference/streamedQuery), which allows `useQuery` to work with a `queryFn` that streams an `AsyncIterable`. Unlike SWR this does not use a different subscription type, so we expose the same API as any other `useQuery`. Most notably this means that we have `refetch` which is missing from `useSubscriptionSWR`. The cache is maintained across calls to `refetch`, meaning the slot will not regress. 

We use the same bridge function as `useSubscriptionQuery` to bridge from our `ReactiveStreamStore` into an `AsyncIterable`, in the same way that we bridged to SWR's custom subscription interface.