### PR TITLE
Add react guides to docs

### DIFF
--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -9,6 +9,7 @@
         "sending-multiple-transactions",
         "fetching-accounts",
         "using-program-plugins",
-        "testing-and-local-development"
+        "testing-and-local-development",
+        "react"
     ]
 }

--- a/docs/content/docs/guides/react/core-hooks.mdx
+++ b/docs/content/docs/guides/react/core-hooks.mdx
@@ -1,0 +1,157 @@
+---
+title: Core hooks
+description: The core hooks in @solana/react
+---
+
+Every hook on this page must be rendered under a [`ClientProvider`](/docs/guides/react). They fall into four groups: accessing the client, reading once, reading live data, and triggering actions.
+
+## Accessing the client
+
+### `useClient`
+
+Reads the Kit client published by the nearest `ClientProvider`. It defaults to the base `Client` shape; when you know a plugin is installed, narrow the type through the generic. This is a pure type-cast with no runtime check - reach for `useClientCapability` instead when a missing plugin should fail. Throws `SOLANA_ERROR__REACT__MISSING_PROVIDER` if no provider is mounted above it.
+
+```tsx
+import { ClientWithRpc, GetEpochInfoApi } from '@solana/kit';
+import { useClient } from '@solana/react';
+
+function FetchEpochButton() {
+    const client = useClient<ClientWithRpc<GetEpochInfoApi>>();
+    return <button onClick={() => client.rpc.getEpochInfo().send()}>Fetch epoch</button>;
+}
+```
+
+### `useClientCapability`
+
+Reads the client and asserts at mount that a capability is installed, narrowing the return type via the generic. If the capability is absent it throws `SOLANA_ERROR__REACT__MISSING_CAPABILITY`, including the `hookName` and `providerHint` you supply so the mistake is easy to locate. This is the building block for plugin-specific hooks.
+
+```tsx
+import { ClientWithRpc, GetEpochInfoApi } from '@solana/kit';
+import { useClientCapability } from '@solana/react';
+
+function useRpc() {
+    return useClientCapability<ClientWithRpc<GetEpochInfoApi>>({
+        capability: 'rpc',
+        hookName: 'useRpc',
+        providerHint: 'Install a `solanaRpc()` plugin on the client.',
+    });
+}
+```
+
+Pass an array for `capability` when a hook needs more than one (e.g. `['rpc', 'rpcSubscriptions']`); the same `providerHint` is reported for whichever is missing.
+
+## Reading once
+
+### `useRequest`
+
+Fires a one-shot request on mount and re-fires whenever the source changes identity or you call `refresh()`. The result tracks the call's lifecycle and keeps stale `data`/`error` populated while a refresh is in flight (stale-while-revalidate). Status is `fetching`, `success`, `error`, or `disabled` (when the source is `null`).
+
+Pass either a Kit request source (most commonly a `PendingRpcRequest`) or an `async (signal) => Promise<T>` function to wrap any one-shot async call. Memoize the source (`useMemo`) or function (`useCallback`) on its inputs.
+
+```tsx
+import { useMemo } from 'react';
+import { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+import { useClient, useRequest } from '@solana/react';
+
+function LatestBlockhash() {
+    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+    const source = useMemo(() => client.rpc.getLatestBlockhash(), [client]);
+    const { data, error, status, refresh } = useRequest(source, {
+        getAbortSignal: () => AbortSignal.timeout(5_000),
+    });
+    if (error) return <button onClick={() => refresh()}>Retry</button>;
+    return <p>{data ? `Blockhash: ${data.value.blockhash}` : 'Loading…'}</p>;
+}
+```
+
+The `getAbortSignal` factory runs on every attempt (initial fire and every `refresh()`), so `() => AbortSignal.timeout(5_000)` gives each attempt its own five-second clock.
+
+## Reading live data
+
+### `useSubscription`
+
+Subscribes to a stream source and surfaces the latest notification - no initial fetch. The subscription opens on mount, re-opens when the source changes identity, and tears down on unmount. Use `reconnect()` to re-open manually. Status is `loading`, `loaded`, `error`, or `disabled`.
+
+```tsx
+import { useMemo } from 'react';
+import { Address, ClientWithRpcSubscriptions, AccountNotificationsApi } from '@solana/kit';
+import { useClient, useSubscription } from '@solana/react';
+
+function LiveAccount({ address }: { address: Address }) {
+    const client = useClient<ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const source = useMemo(
+        () => client.rpcSubscriptions.accountNotifications(address),
+        [client, address],
+    );
+    const { data, error, reconnect } = useSubscription(source);
+    if (error) return <button onClick={() => reconnect()}>Reconnect</button>;
+    return (
+        <p>
+            {data ? `${data.value.lamports} lamports at slot ${data.context.slot}` : 'Connecting…'}
+        </p>
+    );
+}
+```
+
+### `useTrackedData`
+
+Renders a value that loads quickly and then stays live: a one-shot fetch seeds the value, and a subscription keeps it updated. The underlying store slot-dedupes between the two sources, so out-of-order arrivals never regress the surfaced value. `data` is a `SolanaRpcResponse<T>` envelope (`{ context: { slot }, value }`), so you can read `data.value` and `data.context.slot` directly. Status is `loading`, `loaded`, `error`, or `disabled`.
+
+Pass a memoized spec with an `initialValueSource` + `initialValueMapper` (the initial fetch) and a `streamSource` + `streamValueMapper` (the subscription).
+
+```tsx
+import { useMemo } from 'react';
+import {
+    Address,
+    ClientWithRpc,
+    ClientWithRpcSubscriptions,
+    GetBalanceApi,
+    AccountNotificationsApi,
+} from '@solana/kit';
+import { useClient, useTrackedData } from '@solana/react';
+
+function AccountBalance({ address }: { address: Address }) {
+    const client = useClient<
+        ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>
+    >();
+    const spec = useMemo(
+        () => ({
+            initialValueSource: client.rpc.getBalance(address),
+            initialValueMapper: (lamports: bigint) => lamports,
+            streamSource: client.rpcSubscriptions.accountNotifications(address),
+            streamValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
+        }),
+        [client, address],
+    );
+    const { data, error, refresh } = useTrackedData(spec);
+    if (error) return <button onClick={() => refresh()}>Retry</button>;
+    return <p>{data ? `${data.value} lamports at slot ${data.context.slot}` : 'Loading…'}</p>;
+}
+```
+
+Reach for `useSubscription` when there is no meaningful "initial value" to fetch, reach for `useTrackedData` when you want a value before the first notification arrives.
+
+## Triggering actions
+
+### `useAction`
+
+Wraps an arbitrary async function and tracks each invocation through React state. Each `dispatch(...)` runs the function with a fresh `AbortSignal`, dispatching again while a call is in flight aborts the first. Status is `idle`, `running`, `success`, or `error`. Use `dispatch` from event handlers (fire-and-forget, never throws) and `dispatchAsync` when you need the resolved value or to propagate errors.
+
+```tsx
+import { useAction } from '@solana/react';
+
+function PostMessageButton({ url, body }: { url: string; body: string }) {
+    const { dispatch, isRunning, error } = useAction(async (signal, content: string) => {
+        const res = await fetch(url, { body: content, method: 'POST', signal });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return (await res.json()) as { id: string };
+    });
+    return (
+        <button disabled={isRunning} onClick={() => dispatch(body)}>
+            {isRunning ? 'Posting…' : error ? 'Retry' : 'Post'}
+        </button>
+    );
+}
+```
+
+`reset()` returns the action to `idle` and aborts any in-flight call. The `isIdle` / `isRunning` / `isSuccess` / `isError` booleans are derived from `status` - use whichever reads better at the call site.

--- a/docs/content/docs/guides/react/index.mdx
+++ b/docs/content/docs/guides/react/index.mdx
@@ -1,0 +1,113 @@
+---
+title: Overview
+description: Reactive hooks for building Solana apps with Kit
+---
+
+`@solana/react` is a set of React hooks built on top of Kit.
+
+```package-install
+@solana/kit @solana/react
+```
+
+## Set up the provider
+
+Every hook reads a Kit client from the nearest `ClientProvider`. You compose the client in plain Kit with `createClient().use(...)` and hand the finished client to the provider - the provider does no composition or lifecycle management, it just distributes the value you pass in.
+
+```ts twoslash
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+
+// Build once, at module scope, so the reference is stable across renders.
+const client = createClient().use(generatedSigner()).use(solanaDevnetRpc());
+```
+
+Wrap your app in the provider and pass the client in:
+
+```tsx
+import { ClientProvider } from '@solana/react';
+
+export function App() {
+    return (
+        <ClientProvider client={client}>
+            <Dashboard />
+        </ClientProvider>
+    );
+}
+```
+
+The client reference must be **stable** across renders. Build it at module scope (as above), or memoize it with `useMemo` when its configuration is reactive.
+
+### Rebuilding the client at runtime
+
+When a configuration value changes at runtime - a cluster toggle, an RPC URL switch - rebuild the client in `useMemo` keyed on that value and pass the new reference. The subtree re-subscribes against the new client identity.
+
+```tsx
+import { useMemo, useState } from 'react';
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc, solanaMainnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+import { ClientProvider } from '@solana/react';
+
+export function App() {
+    const [cluster, setCluster] = useState<'devnet' | 'mainnet'>('mainnet');
+    const client = useMemo(
+        () =>
+            createClient()
+                .use(generatedSigner())
+                .use(cluster === 'mainnet' ? solanaMainnetRpc() : solanaDevnetRpc()),
+        [cluster],
+    );
+    return (
+        <ClientProvider client={client}>
+            <ClusterToggle value={cluster} onChange={setCluster} />
+            <Dashboard />
+        </ClientProvider>
+    );
+}
+```
+
+### Async plugins (Suspense)
+
+If any plugin's `.use()` is async, `createClient().use(...)` returns a `Promise<Client>`. Pass the promise straight to `ClientProvider` and it suspends the subtree via the nearest `<Suspense>` boundary until the client resolves. The promise identity must be stable - pass a `useMemo`'d or module-scope value, never an inline `new Promise(...)`.
+
+```tsx
+import { Suspense, useMemo } from 'react';
+import { ClientProvider } from '@solana/react';
+
+function Root() {
+    const clientPromise = useMemo(() => createClientWithAsyncPlugins(), []);
+    return (
+        <ClientProvider client={clientPromise}>
+            <Dashboard />
+        </ClientProvider>
+    );
+}
+
+export function App() {
+    return (
+        <Suspense fallback={<Splash />}>
+            <Root />
+        </Suspense>
+    );
+}
+```
+
+## Choosing a hook
+
+Once a provider is mounted, pick a hook by what you are trying to do:
+
+| You want to…                                     | Hook                                                                       | What you get back                                                                    |
+| ------------------------------------------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Access the raw client imperatively               | [`useClient`](/docs/guides/react/core-hooks#useclient)                     | The Kit client from context (type-cast, no runtime check).                           |
+| Access the client and assert a plugin is present | [`useClientCapability`](/docs/guides/react/core-hooks#useclientcapability) | The narrowed client, throws if the capability is missing.                            |
+| Read a value once                                | [`useRequest`](/docs/guides/react/core-hooks#userequest)                   | `{ data, error, status, refresh }`. Request fires on mount, `refresh()` re-fires.    |
+| Subscribe to a stream of notifications           | [`useSubscription`](/docs/guides/react/core-hooks#usesubscription)         | `{ data, error, status, reconnect }`. Latest notification, no initial fetch.         |
+| Read a value that updates live                   | [`useTrackedData`](/docs/guides/react/core-hooks#usetrackeddata)           | `{ data, error, status, refresh }`. Initial fetch seeds, subscription keeps it live. |
+| Trigger an async action on user input            | [`useAction`](/docs/guides/react/core-hooks#useaction)                     | `{ dispatch, status, data, error, reset }`. Fires on demand.                         |
+
+The [SWR](/docs/guides/react/swr) and [TanStack Query](/docs/guides/react/query) adapters route the read hooks through those libraries' caches. These add features such as deduplication and devtools.
+
+## Server rendering
+
+Every hook is safe to render on the server. The fetch or subscription is committed in an effect, which never runs during SSR, so no request opens and no socket connects until the component hydrates on the client. On the server - and on the first client render, before hydration - each hook reports its pre-fetch status: `fetching` for `useRequest`, `loading` for `useSubscription` and `useTrackedData`, and `idle` for `useAction` (which only ever fires on demand). Server and client markup therefore match, and the live work begins after hydration.

--- a/docs/content/docs/guides/react/meta.json
+++ b/docs/content/docs/guides/react/meta.json
@@ -1,0 +1,9 @@
+{
+    "title": "React",
+    "pages": [
+        "index",
+        "core-hooks",
+        "query",
+        "swr"
+    ]
+}

--- a/docs/content/docs/guides/react/query.mdx
+++ b/docs/content/docs/guides/react/query.mdx
@@ -1,0 +1,110 @@
+---
+title: TanStack Query adapter
+description: Route @solana/react reads through TanStack Query's cache
+---
+
+The TanStack Query adapter routes the core read hooks through TanStack Query's cache: components reading the same key dedupe into one in-flight request, all TanStack Query features are available, and everything shows up in TanStack Query's devtools. Use it when your app already uses TanStack Query, or when you want its revalidation and cache-invalidation model.
+
+```package-install
+@solana/react @tanstack/react-query
+```
+
+Import from the `@solana/react/query` subpath. It declares `@tanstack/react-query` as a peer dependency, pulled in only when this subpath is imported. As with any TanStack Query usage, the tree must be wrapped in a `QueryClientProvider`.
+
+There's a Query variant for each core read hook. All three take a cache `key` up front and return TanStack's `UseQueryResult`:
+
+| Core hook                                                          | Query variant          |
+| ------------------------------------------------------------------ | ---------------------- |
+| [`useRequest`](/docs/guides/react/core-hooks#userequest)           | `useRequestQuery`      |
+| [`useSubscription`](/docs/guides/react/core-hooks#usesubscription) | `useSubscriptionQuery` |
+| [`useTrackedData`](/docs/guides/react/core-hooks#usetrackeddata)   | `useTrackedDataQuery`  |
+
+## `useRequestQuery`
+
+The TanStack Query-backed counterpart to `useRequest`. It takes a query `key`, the same source shape as `useRequest`, and any `useQuery` options. It returns TanStack's own `useQuery` result, so `data`, `error`, `isLoading`, and `refetch` behave as they do everywhere else.
+
+```tsx
+import { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+import { useClient } from '@solana/react';
+import { useRequestQuery } from '@solana/react/query';
+
+function LatestBlockhash() {
+    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+    const { data, error, isLoading, refetch } = useRequestQuery(
+        ['latestBlockhash'],
+        client.rpc.getLatestBlockhash(),
+        { getAbortSignal: () => AbortSignal.timeout(5_000) },
+    );
+    if (error) return <button onClick={() => refetch()}>Retry</button>;
+    if (isLoading) return <p>Loading…</p>;
+    return <p>Blockhash: {data!.value.blockhash}</p>;
+}
+```
+
+Unlike core `useRequest`, the source does **not** need to be memoized. The cache is keyed by `key`.
+
+TanStack Query hands the `queryFn` its own cancellation `AbortSignal`, and the hook threads that signal into the source. When you also pass a `getAbortSignal` factory, the two signals are combined with `AbortSignal.any`, so aborting either cancels the attempt.
+
+In addition to TanStack's `enabled: false`, you can pass `null` for `source` to disable the query. Call `refetch()` to refresh.
+
+## `useSubscriptionQuery`
+
+The counterpart to `useSubscription`, for a long-lived stream with no one-shot fetch. It takes a `key` and the same source shape as `useSubscription`, routes the stream through TanStack Query's cache (via `experimental_streamedQuery`), and returns a `UseQueryResult`. `data` is the raw notification exactly as the source emits it.
+
+```tsx
+import { ClientWithRpcSubscriptions, SlotNotificationsApi } from '@solana/kit';
+import { useClient } from '@solana/react';
+import { useSubscriptionQuery } from '@solana/react/query';
+
+function SlotHeight() {
+    const client = useClient<ClientWithRpcSubscriptions<SlotNotificationsApi>>();
+    const { data, error } = useSubscriptionQuery(
+        ['slot'],
+        client.rpcSubscriptions.slotNotifications(),
+    );
+    if (error) return <p>Disconnected.</p>;
+    if (!data) return <p>Connecting…</p>;
+    return <p>Slot {String(data.slot)}</p>;
+}
+```
+
+Because the stream never settles, the query stays in `fetchStatus: 'fetching'` for the subscription's whole life: `isFetching` is permanently `true`, while `isLoading` flips to `false` after the first notification. `refetch()` reconnects but the returned promise never resolves for a never-ending stream, so don't `await` it. The prior value stays visible across a reconnect.
+
+By default `retry`, `staleTime`, and `refetchOnWindowFocus` are tuned for a long-lived socket (`false`, `Infinity`, `false` respectively). All are overridable through the options. Again the source does not need to be memoized, and passing `null` disables the subscription.
+
+## `useTrackedDataQuery`
+
+The counterpart to `useTrackedData`: a one-shot fetch seeds the value and a subscription keeps it live, with the unified stream routed through TanStack Query's cache. It takes a `key` and the same `TrackedDataSpec` as `useTrackedData`. `data` is the `SolanaRpcResponse<TItem>` envelope, so read `data.value` and `data.context.slot` directly.
+
+```tsx
+import {
+    Address,
+    ClientWithRpc,
+    ClientWithRpcSubscriptions,
+    GetBalanceApi,
+    AccountNotificationsApi,
+} from '@solana/kit';
+import { useClient } from '@solana/react';
+import { useTrackedDataQuery } from '@solana/react/query';
+
+function AccountBalance({ address }: { address: Address }) {
+    const client = useClient<
+        ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>
+    >();
+    const { data, error } = useTrackedDataQuery(['balance', address], {
+        initialValueSource: client.rpc.getBalance(address),
+        initialValueMapper: (lamports: bigint) => lamports,
+        streamSource: client.rpcSubscriptions.accountNotifications(address),
+        streamValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
+    });
+    if (error) return <p>Failed to load.</p>;
+    return <p>{data ? `${data.value} lamports at slot ${data.context.slot}` : 'Loading…'}</p>;
+}
+```
+
+Like `useSubscriptionQuery`, the query never settles (`isFetching` stays `true`, don't `await refetch()`), and the same long-lived-socket defaults apply. The spec does not need to be memoized. Slot dedupe applies across a reconnect.
+
+<Callout type="info">
+    We do not have a `useAction` counterpart. Use `useAction` or TanStack Query's `useMutation`
+    directly, and call `queryClient.invalidateQueries()` if you need to invalidate cached reads.
+</Callout>

--- a/docs/content/docs/guides/react/swr.mdx
+++ b/docs/content/docs/guides/react/swr.mdx
@@ -1,0 +1,109 @@
+---
+title: SWR adapter
+description: Route @solana/react reads through SWR's cache
+---
+
+The SWR adapter routes the core read hooks through SWR's cache: components reading the same key dedupe into one in-flight request, all SWR features are available, and everything shows up in SWR's devtools. Use it when your app already uses SWR, or when you want its revalidation and cache-invalidation model.
+
+```package-install
+@solana/react swr
+```
+
+Import from the `@solana/react/swr` subpath. It declares `swr` as a peer dependency, pulled in only when this subpath is imported.
+
+There's an SWR variant for each core read hook, each taking a cache `key` up front. Their return shapes differ: `useRequestSWR` gives you SWR's full response object, while the two stream-backed variants are built on `useSWRSubscription` and return only `{ data, error }`.
+
+| Core hook                                                          | SWR variant          | Returns                   |
+| ------------------------------------------------------------------ | -------------------- | ------------------------- |
+| [`useRequest`](/docs/guides/react/core-hooks#userequest)           | `useRequestSWR`      | `SWRResponse`             |
+| [`useSubscription`](/docs/guides/react/core-hooks#usesubscription) | `useSubscriptionSWR` | `SWRSubscriptionResponse` |
+| [`useTrackedData`](/docs/guides/react/core-hooks#usetrackeddata)   | `useTrackedDataSWR`  | `SWRSubscriptionResponse` |
+
+## `useRequestSWR`
+
+The SWR-backed counterpart to `useRequest`. It takes an SWR `key`, the same source shape as `useRequest`, and any SWR configuration. It returns SWR's `SWRResponse`, so `data`, `error`, `isLoading`, and `mutate` behave exactly as they do everywhere else.
+
+```tsx
+import { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+import { useClient } from '@solana/react';
+import { useRequestSWR } from '@solana/react/swr';
+
+function LatestBlockhash() {
+    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+    const { data, error, isLoading, mutate } = useRequestSWR(
+        ['latestBlockhash'],
+        client.rpc.getLatestBlockhash(),
+        { getAbortSignal: () => AbortSignal.timeout(5_000) },
+    );
+    if (error) return <button onClick={() => mutate()}>Retry</button>;
+    if (isLoading) return <p>Loading…</p>;
+    return <p>Blockhash: {data!.value.blockhash}</p>;
+}
+```
+
+Unlike core `useRequest`, the source does **not** need to be memoized. The cache is keyed by `key`.
+
+Pass `null` for the `key` or the `source` to disable the request. Call `mutate()` to refresh.
+
+## `useSubscriptionSWR`
+
+The counterpart to `useSubscription`, for a long-lived stream with no one-shot fetch. It takes a `key` and the same source shape as `useSubscription`, and routes the stream through SWR's subscription cache (`useSWRSubscription`). It returns SWR's `SWRSubscriptionResponse`. `data` is the raw notification exactly as the source emits it.
+
+```tsx
+import { ClientWithRpcSubscriptions, SlotNotificationsApi } from '@solana/kit';
+import { useClient } from '@solana/react';
+import { useSubscriptionSWR } from '@solana/react/swr';
+
+function SlotHeight() {
+    const client = useClient<ClientWithRpcSubscriptions<SlotNotificationsApi>>();
+    const { data, error } = useSubscriptionSWR(
+        ['slot'],
+        client.rpcSubscriptions.slotNotifications(),
+    );
+    if (error) return <p>Disconnected.</p>;
+    if (!data) return <p>Connecting…</p>;
+    return <p>Slot {String(data.slot)}</p>;
+}
+```
+
+There's no `reconnect` and no `getAbortSignal`: to stop or restart the subscription, toggle its `key` to or from `null`. The source does not need to be memoized.
+
+When `key` flips to `null` the `data` is cleared, unlike core `useSubscription` where `reconnect()` keeps the last `data` visible. Pass SWR's `keepPreviousData` if you want the last value to persist across the toggle.
+
+## `useTrackedDataSWR`
+
+The counterpart to `useTrackedData`: a one-shot fetch seeds the value and a subscription keeps it live, with the unified stream routed through SWR's subscription cache. It takes a `key` and the same `TrackedDataSpec` as `useTrackedData`. Like `useSubscriptionSWR` it returns an `SWRSubscriptionResponse`, but `data` is the `SolanaRpcResponse<TItem>` envelope, so read `data.value` and `data.context.slot` directly.
+
+```tsx
+import {
+    Address,
+    ClientWithRpc,
+    ClientWithRpcSubscriptions,
+    GetBalanceApi,
+    AccountNotificationsApi,
+} from '@solana/kit';
+import { useClient } from '@solana/react';
+import { useTrackedDataSWR } from '@solana/react/swr';
+
+function AccountBalance({ address }: { address: Address }) {
+    const client = useClient<
+        ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>
+    >();
+    const { data, error } = useTrackedDataSWR(['balance', address], {
+        initialValueSource: client.rpc.getBalance(address),
+        initialValueMapper: (lamports: bigint) => lamports,
+        streamSource: client.rpcSubscriptions.accountNotifications(address),
+        streamValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
+    });
+    if (error) return <p>Failed to load.</p>;
+    return <p>{data ? `${data.value} lamports at slot ${data.context.slot}` : 'Loading…'}</p>;
+}
+```
+
+Like `useSubscriptionSWR`, it returns only `{ data, error }`, toggle the `key` to or from `null` to stop or restart. The spec does not need to be memoized. Slot dedupe spans the cache, not just one store, so a reconnect's fresh fetch can't regress the cached envelope to an older slot.
+
+Like `useSubscriptionSWR`, when `key` flips to `null` the `data` is cleared. Pass SWR's `keepPreviousData` if you want the last value to persist across the toggle.
+
+<Callout type="info">
+    We do not have a `useAction` counterpart. Use `useAction` or SWR's `mutate` directly.
+</Callout>


### PR DESCRIPTION
This PR adds the new react APIs to the docs, under a new section of Guides

<img width="1218" height="611" alt="Screenshot 2026-06-23 at 18 03 46" src="https://github.com/user-attachments/assets/45e6da77-6e74-4b79-9b7b-dd0c23a9548a" />

Covers setting up the provider, the `useClient[Capability]` hooks, the core `useRequest`, `useSubscription`, `useTrackedData`, `useAction` hooks, and the SWR/Tanstack Query variants.

Note: as we haven't published these hooks yet, we're not using ` ```twoslash ` to typecheck the new code snippets yet 