### PR TITLE
Remove deprecated functions from ReactiveStreamStore

### DIFF
--- a/.changeset/twenty-poets-fix.md
+++ b/.changeset/twenty-poets-fix.md
@@ -1,0 +1,38 @@
+---
+'@solana/subscribable': major
+'@solana/kit': major
+'@solana/react': major
+---
+
+Streamline the `ReactiveStreamStore` contract by removing deprecated members and unifying its state accessor with `ReactiveActionStore`. The `getUnifiedState()` method has been renamed to `getState()`, and the deprecated value-only `getState()`, `getError()`, and `retry()` members along with the `ReactiveStore` type alias have been removed.
+
+**BREAKING CHANGES**
+
+**`getUnifiedState()` renamed to `getState()`.** The unified `{ data, error, status }` snapshot accessor is now simply `getState()`, matching `ReactiveActionStore.getState()`.
+
+```diff
+- const state = useSyncExternalStore(store.subscribe, store.getUnifiedState);
++ const state = useSyncExternalStore(store.subscribe, store.getState);
+```
+
+**Removed the deprecated value-only `getState()` and `getError()`.** Read the value and error off the unified snapshot instead.
+
+```diff
+- const data = store.getState();
+- const error = store.getError();
++ const { data, error } = store.getState();
+```
+
+**Removed `retry()`.** Use `connect()`, which always (re)connects regardless of status. Wrap it with a status guard if you need the error-only behavior.
+
+```diff
+- store.retry();
++ if (store.getState().status === 'error') store.connect();
+```
+
+**Removed the `ReactiveStore` type alias.** Use `ReactiveStreamStore` directly.
+
+```diff
+- import type { ReactiveStore } from '@solana/subscribable';
++ import type { ReactiveStreamStore } from '@solana/subscribable';
+```

--- a/examples/react-app/src/components/__tests__/SlotIndicator-test.browser.tsx
+++ b/examples/react-app/src/components/__tests__/SlotIndicator-test.browser.tsx
@@ -40,7 +40,7 @@ function makeReactiveStreamStore() {
         resetCalls: () => reset.mock.calls.length,
         store: {
             connect,
-            getUnifiedState: () => snapshot,
+            getState: () => snapshot,
             reset,
             subscribe: (cb: () => void) => {
                 subscribers.add(cb);

--- a/packages/kit/README.md
+++ b/packages/kit/README.md
@@ -64,7 +64,7 @@ const balanceStore = createReactiveStoreWithInitialValueAndSlotTracking({
 });
 
 const unsubscribe = balanceStore.subscribe(() => {
-    const state = balanceStore.getUnifiedState();
+    const state = balanceStore.getState();
     if (state.status === 'error') console.error('Error:', state.error);
     else if (state.status === 'loaded') console.log('Balance:', state.data.value);
 });

--- a/packages/kit/src/__tests__/create-reactive-store-with-initial-value-and-slot-tracking-test.ts
+++ b/packages/kit/src/__tests__/create-reactive-store-with-initial-value-and-slot-tracking-test.ts
@@ -104,134 +104,6 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
         abortController.abort();
     });
 
-    describe('getState()', () => {
-        it('returns `undefined` before any data arrives', () => {
-            const { source: initialValueSource } = createMockInitialValueSource();
-            const { source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            expect(store.getState()).toBeUndefined();
-        });
-        it('updates with the initial-value source response', async () => {
-            expect.assertions(1);
-            const { instances, source: initialValueSource } = createMockInitialValueSource();
-            const { source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            instances[0].resolve(rpcResponse(100, { count: 42 }));
-            await jest.runAllTimersAsync();
-            expect(store.getState()).toEqual({ context: { slot: 100n }, value: 42 });
-        });
-        it('updates with a stream notification value', async () => {
-            expect.assertions(1);
-            const { source: initialValueSource } = createMockInitialValueSource();
-            const { publishers, source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            await jest.runAllTimersAsync();
-            publishers[0].publish('data', rpcResponse(100, { count: 99 }));
-            await jest.runAllTimersAsync();
-            expect(store.getState()).toEqual({ context: { slot: 100n }, value: 99 });
-        });
-        it('ignores the initial value when a newer stream notification has already arrived', async () => {
-            expect.assertions(1);
-            const { instances, source: initialValueSource } = createMockInitialValueSource();
-            const { publishers, source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            await jest.runAllTimersAsync();
-            publishers[0].publish('data', rpcResponse(200, { count: 99 }));
-            await jest.runAllTimersAsync();
-            // Initial value arrives later at an older slot
-            instances[0].resolve(rpcResponse(100, { count: 42 }));
-            await jest.runAllTimersAsync();
-            expect(store.getState()).toEqual({ context: { slot: 200n }, value: 99 });
-        });
-        it('ignores a stream notification when the initial value was at a newer slot', async () => {
-            expect.assertions(1);
-            const { instances, source: initialValueSource } = createMockInitialValueSource();
-            const { publishers, source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            instances[0].resolve(rpcResponse(200, { count: 42 }));
-            await jest.runAllTimersAsync();
-            publishers[0].publish('data', rpcResponse(100, { count: 99 }));
-            await jest.runAllTimersAsync();
-            expect(store.getState()).toEqual({ context: { slot: 200n }, value: 42 });
-        });
-        it('preserves the last known value after an error', async () => {
-            expect.assertions(1);
-            const { instances, source: initialValueSource } = createMockInitialValueSource();
-            const { publishers, source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            instances[0].resolve(rpcResponse(100, { count: 42 }));
-            await jest.runAllTimersAsync();
-            publishers[0].publish('error', new Error('stream failed'));
-            await jest.runAllTimersAsync();
-            expect(store.getState()).toEqual({ context: { slot: 100n }, value: 42 });
-        });
-    });
-
-    describe('getError()', () => {
-        it('returns `undefined` before any error', () => {
-            const { source: initialValueSource } = createMockInitialValueSource();
-            const { source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            expect(store.getError()).toBeUndefined();
-        });
-        it('captures an error from the initial-value source', async () => {
-            expect.assertions(1);
-            const { instances, source: initialValueSource } = createMockInitialValueSource();
-            const { source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            const error = new Error('initial value failed');
-            instances[0].reject(error);
-            await jest.runAllTimersAsync();
-            expect(store.getError()).toBe(error);
-        });
-        it('captures an error from the stream', async () => {
-            expect.assertions(1);
-            const { source: initialValueSource } = createMockInitialValueSource();
-            const { publishers, source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            await jest.runAllTimersAsync();
-            const streamError = new Error('stream failed');
-            publishers[0].publish('error', streamError);
-            await jest.runAllTimersAsync();
-            expect(store.getError()).toBe(streamError);
-        });
-        it('only captures the first error when the initial value fails then the stream fails', async () => {
-            expect.assertions(1);
-            const { instances, source: initialValueSource } = createMockInitialValueSource();
-            const { publishers, source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            await jest.runAllTimersAsync();
-            instances[0].reject(new Error('initial value error'));
-            await jest.runAllTimersAsync();
-            publishers[0].publish('error', new Error('stream error'));
-            await jest.runAllTimersAsync();
-            expect(store.getError()).toEqual(new Error('initial value error'));
-        });
-        it('only captures the first error when the stream fails then the initial value fails', async () => {
-            expect.assertions(1);
-            const { instances, source: initialValueSource } = createMockInitialValueSource();
-            const { publishers, source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            await jest.runAllTimersAsync();
-            publishers[0].publish('error', new Error('stream error'));
-            await jest.runAllTimersAsync();
-            instances[0].reject(new Error('initial value error'));
-            await jest.runAllTimersAsync();
-            expect(store.getError()).toEqual(new Error('stream error'));
-        });
-    });
-
     describe('subscribe()', () => {
         it('calls the subscriber when the initial value arrives', async () => {
             expect.assertions(1);
@@ -355,7 +227,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             store.withSignal(abortController.signal).connect();
             const reason = new Error('timed out');
             abortController.abort(reason);
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: reason,
                 status: 'error',
@@ -371,7 +243,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             abortController.abort(reason);
             instances[0].reject(new Error('late'));
             await jest.runAllTimersAsync();
-            expect(store.getError()).toBe(reason);
+            expect(store.getState().error).toBe(reason);
         });
         it('does not update state when the initial value arrives after abort', async () => {
             expect.assertions(1);
@@ -382,7 +254,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             abortController.abort();
             instances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
-            expect(store.getState()).toBeUndefined();
+            expect(store.getState().data).toBeUndefined();
         });
         it('does not update state when a stream notification arrives after abort', async () => {
             expect.assertions(1);
@@ -394,17 +266,17 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             abortController.abort();
             publishers[0].publish('data', rpcResponse(100, { count: 99 }));
             await jest.runAllTimersAsync();
-            expect(store.getState()).toBeUndefined();
+            expect(store.getState().data).toBeUndefined();
         });
     });
 
-    describe('getUnifiedState()', () => {
+    describe('getState()', () => {
         it('starts in `loading` status', () => {
             const { source: initialValueSource } = createMockInitialValueSource();
             const { source: streamSource } = createMockStreamSource();
             const store = createStore(initialValueSource, streamSource);
             store.connect();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: undefined,
                 status: 'loading',
@@ -418,7 +290,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             store.connect();
             instances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { context: { slot: 100n }, value: 42 },
                 error: undefined,
                 status: 'loaded',
@@ -433,7 +305,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const failure = new Error('initial value failed');
             instances[0].reject(failure);
             await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: failure,
                 status: 'error',
@@ -450,7 +322,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             const failure = new Error('stream failed');
             publishers[0].publish('error', failure);
             await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { context: { slot: 100n }, value: 42 },
                 error: failure,
                 status: 'error',
@@ -465,7 +337,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             await jest.runAllTimersAsync();
             publishers[0].publish('data', rpcResponse(100, { count: 99 }));
             await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { context: { slot: 100n }, value: 99 },
                 error: undefined,
                 status: 'loaded',
@@ -483,7 +355,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             // Initial value arrives later at an older slot and should be ignored
             instances[0].resolve(rpcResponse(100, { count: 42 }));
             await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { context: { slot: 200n }, value: 99 },
                 error: undefined,
                 status: 'loaded',
@@ -500,7 +372,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             // Stream notification arrives at an older slot and should be ignored
             publishers[0].publish('data', rpcResponse(100, { count: 99 }));
             await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { context: { slot: 200n }, value: 42 },
                 error: undefined,
                 status: 'loaded',
@@ -518,7 +390,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             await jest.runAllTimersAsync();
             publishers[0].publish('error', new Error('stream error'));
             await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: firstError,
                 status: 'error',
@@ -536,105 +408,11 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             await jest.runAllTimersAsync();
             instances[0].reject(new Error('initial value error'));
             await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: firstError,
                 status: 'error',
             });
-        });
-    });
-
-    describe('retry()', () => {
-        it('is a no-op when the store is not in error state', async () => {
-            expect.assertions(1);
-            const { fn, source: initialValueSource } = createMockInitialValueSource();
-            const { source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            await jest.runAllTimersAsync();
-            store.retry();
-            expect(fn).toHaveBeenCalledTimes(1);
-        });
-        it('transitions back to `loading` with preserved data AND error (SWR)', async () => {
-            expect.assertions(1);
-            const { instances, source: initialValueSource } = createMockInitialValueSource();
-            const { publishers, source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            instances[0].resolve(rpcResponse(100, { count: 42 }));
-            await jest.runAllTimersAsync();
-            const fail = new Error('stream died');
-            publishers[0].publish('error', fail);
-            await jest.runAllTimersAsync();
-            store.retry();
-            expect(store.getUnifiedState()).toStrictEqual({
-                data: { context: { slot: 100n }, value: 42 },
-                error: fail,
-                status: 'loading',
-            });
-        });
-        it('re-builds both inner stores on retry', async () => {
-            expect.assertions(2);
-            const { fn, instances, source: initialValueSource } = createMockInitialValueSource();
-            const { createDataPublisher, source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            instances[0].reject(new Error('boom'));
-            await jest.runAllTimersAsync();
-            store.retry();
-            await jest.runAllTimersAsync();
-            expect(fn).toHaveBeenCalledTimes(2);
-            expect(createDataPublisher).toHaveBeenCalledTimes(2);
-        });
-        it('recovers to `loaded` when the retried initial value succeeds', async () => {
-            expect.assertions(1);
-            const { instances, source: initialValueSource } = createMockInitialValueSource();
-            const { source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            instances[0].reject(new Error('first failure'));
-            await jest.runAllTimersAsync();
-            store.retry();
-            await jest.runAllTimersAsync();
-            instances[1].resolve(rpcResponse(200, { count: 99 }));
-            await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
-                data: { context: { slot: 200n }, value: 99 },
-                error: undefined,
-                status: 'loaded',
-            });
-        });
-        it('transitions to `error` again when the retried initial value also fails', async () => {
-            expect.assertions(1);
-            const { instances, source: initialValueSource } = createMockInitialValueSource();
-            const { source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            instances[0].reject(new Error('first'));
-            await jest.runAllTimersAsync();
-            store.retry();
-            await jest.runAllTimersAsync();
-            const secondFailure = new Error('second');
-            instances[1].reject(secondFailure);
-            await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
-                data: undefined,
-                error: secondFailure,
-                status: 'error',
-            });
-        });
-        it('notifies subscribers on the error → loading transition after retry', async () => {
-            expect.assertions(1);
-            const { instances, source: initialValueSource } = createMockInitialValueSource();
-            const { source: streamSource } = createMockStreamSource();
-            const store = createStore(initialValueSource, streamSource);
-            store.connect();
-            instances[0].reject(new Error('fail'));
-            await jest.runAllTimersAsync();
-            const subscriber = jest.fn();
-            store.subscribe(subscriber);
-            store.retry();
-            expect(subscriber).toHaveBeenCalledTimes(1);
         });
     });
 
@@ -660,7 +438,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             await jest.runAllTimersAsync();
             // The store must leave `loading`, retaining the newer slot-100 data rather than
             // regressing to the stale slot-99 value.
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { context: { slot: 100n }, value: 42 },
                 error: undefined,
                 status: 'loaded',
@@ -681,7 +459,7 @@ describe('createReactiveStoreWithInitialValueAndSlotTracking', () => {
             await jest.runAllTimersAsync();
             publishers[1].publish('data', rpcResponse(99, { count: 7 }));
             await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { context: { slot: 100n }, value: 42 },
                 error: undefined,
                 status: 'loaded',

--- a/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
+++ b/packages/kit/src/create-reactive-store-with-initial-value-and-slot-tracking.ts
@@ -103,7 +103,7 @@ const IDLE_STATE: ReactiveState<never> = Object.freeze({
  * });
  *
  * const unsubscribe = balanceStore.subscribe(() => {
- *     const state = balanceStore.getUnifiedState();
+ *     const state = balanceStore.getState();
  *     if (state.status === 'error') {
  *         console.error('Error:', state.error);
  *         balanceStore.connect();
@@ -213,7 +213,7 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TInitialValue
             }
         });
         const unsubscribeStream = streamStore.subscribe(() => {
-            const state = streamStore.getUnifiedState();
+            const state = streamStore.getState();
             if (state.status === 'loaded') {
                 const { context, value } = state.data;
                 handleSlottedValue({ context, value: streamValueMapper(value) });
@@ -250,20 +250,10 @@ export function createReactiveStoreWithInitialValueAndSlotTracking<TInitialValue
         connect(): void {
             performConnect(undefined);
         },
-        getError(): unknown {
-            return currentState.error;
-        },
-        getState(): SolanaRpcResponse<TItem> | undefined {
-            return currentState.data;
-        },
-        getUnifiedState(): ReactiveState<SolanaRpcResponse<TItem>> {
+        getState(): ReactiveState<SolanaRpcResponse<TItem>> {
             return currentState;
         },
         reset: performReset,
-        retry(): void {
-            if (currentState.status !== 'error') return;
-            performConnect(undefined);
-        },
         subscribe(callback: () => void): () => void {
             subscribers.add(callback);
             return () => {

--- a/packages/react/src/__tests__/staticStores-test.ts
+++ b/packages/react/src/__tests__/staticStores-test.ts
@@ -49,6 +49,7 @@ describe('disabledActionStore', () => {
     });
 
     it('`dispatchAsync()` rejects with an AbortError so accidental awaits surface, not silently hang', async () => {
+        expect.assertions(1);
         const store = disabledActionStore<string>();
         await expect(store.dispatchAsync()).rejects.toMatchObject({ name: 'AbortError' });
     });
@@ -57,45 +58,38 @@ describe('disabledActionStore', () => {
 describe('disabledStreamStore', () => {
     it('reports a frozen `idle` state with no data or error', () => {
         const store = disabledStreamStore<string>();
-        const state = store.getUnifiedState();
+        const state = store.getState();
         expect(state).toEqual({ data: undefined, error: undefined, status: 'idle' });
         expect(Object.isFrozen(state)).toBe(true);
     });
 
-    it('returns the same getUnifiedState() reference across calls', () => {
+    it('returns the same getState() reference across calls', () => {
         const store = disabledStreamStore<string>();
-        expect(store.getUnifiedState()).toBe(store.getUnifiedState());
+        expect(store.getState()).toBe(store.getState());
     });
 
     it('`connect()` is a no-op — state does not change', () => {
         const store = disabledStreamStore<string>();
-        const before = store.getUnifiedState();
+        const before = store.getState();
         store.connect();
         store.connect();
-        expect(store.getUnifiedState()).toBe(before);
+        expect(store.getState()).toBe(before);
     });
 
     it('`reset()` is a no-op — state does not change', () => {
         const store = disabledStreamStore<string>();
-        const before = store.getUnifiedState();
+        const before = store.getState();
         store.reset();
-        expect(store.getUnifiedState()).toBe(before);
-    });
-
-    it('`retry()` is a no-op — state does not change', () => {
-        const store = disabledStreamStore<string>();
-        const before = store.getUnifiedState();
-        store.retry();
-        expect(store.getUnifiedState()).toBe(before);
+        expect(store.getState()).toBe(before);
     });
 
     it('`withSignal(signal).connect()` is a no-op — state does not change, signal is not observed', () => {
         const store = disabledStreamStore<string>();
         const ctrl = new AbortController();
-        const before = store.getUnifiedState();
+        const before = store.getState();
         store.withSignal(ctrl.signal).connect();
         ctrl.abort(new Error('would-be-cancellation'));
-        expect(store.getUnifiedState()).toBe(before);
+        expect(store.getState()).toBe(before);
     });
 
     it('`subscribe()` never notifies (connect + reset produce no state change to observe)', () => {
@@ -104,7 +98,6 @@ describe('disabledStreamStore', () => {
         const unsubscribe = store.subscribe(listener);
         store.connect();
         store.reset();
-        store.retry();
         store.withSignal(new AbortController().signal).connect();
         expect(listener).not.toHaveBeenCalled();
         unsubscribe();

--- a/packages/react/src/query/__tests__/bridgeStoreToAsyncIterable-test.ts
+++ b/packages/react/src/query/__tests__/bridgeStoreToAsyncIterable-test.ts
@@ -26,19 +26,10 @@ function createFakeStore<T>(): {
         connect: jest.fn().mockImplementation(() => {
             throw new Error('not implemented');
         }),
-        getError: jest.fn().mockImplementation(() => {
-            throw new Error('not implemented');
-        }),
-        getState: jest.fn().mockImplementation(() => {
-            throw new Error('not implemented');
-        }),
-        getUnifiedState: () => state,
+        getState: () => state,
         reset: () => {
             resets++;
         },
-        retry: jest.fn().mockImplementation(() => {
-            throw new Error('not implemented');
-        }),
         subscribe: (callback: () => void) => {
             listeners.add(callback);
             return () => {

--- a/packages/react/src/query/__tests__/useSubscriptionQuery-test.browser.tsx
+++ b/packages/react/src/query/__tests__/useSubscriptionQuery-test.browser.tsx
@@ -99,19 +99,10 @@ function createFakeStore<T>(): {
         connect: jest.fn().mockImplementation(() => {
             throw new Error('not implemented');
         }),
-        getError: jest.fn().mockImplementation(() => {
-            throw new Error('not implemented');
-        }),
-        getState: jest.fn().mockImplementation(() => {
-            throw new Error('not implemented');
-        }),
-        getUnifiedState: () => state,
+        getState: () => state,
         reset: () => {
             resets++;
         },
-        retry: jest.fn().mockImplementation(() => {
-            throw new Error('not implemented');
-        }),
         subscribe: (callback: () => void) => {
             listeners.add(callback);
             return () => {

--- a/packages/react/src/query/bridgeStoreToAsyncIterable.ts
+++ b/packages/react/src/query/bridgeStoreToAsyncIterable.ts
@@ -59,7 +59,7 @@ export function bridgeStoreToAsyncIterable<T>(
             };
 
             const onChange = () => {
-                const state = store.getUnifiedState();
+                const state = store.getState();
                 if (state.status === 'loaded') {
                     // Drop a value the gate rejects. The stream parks again rather than yielding it.
                     if (shouldYield && !shouldYield(state.data)) return;

--- a/packages/react/src/staticStores.ts
+++ b/packages/react/src/staticStores.ts
@@ -41,7 +41,7 @@ export function disabledActionStore<T>(): ReactiveActionStore<[], T> {
 
 /**
  * A {@link ReactiveStreamStore} that never transitions out of `idle` and ignores every
- * `connect` / `retry` / `reset` / `subscribe` call. Returned by `useSubscription` when its
+ * `connect` / `reset` / `subscribe` call. Returned by `useSubscription` when its
  * source is `null`, signalling that the subscription should be gated off — for example because
  * a required input (an address) is not yet known.
  *
@@ -51,11 +51,8 @@ export function disabledActionStore<T>(): ReactiveActionStore<[], T> {
 export function disabledStreamStore<T>(): ReactiveStreamStore<T> {
     return {
         connect: noopUnsubscribe,
-        getError: () => undefined,
-        getState: () => undefined,
-        getUnifiedState: () => IDLE_STREAM_STATE,
+        getState: () => IDLE_STREAM_STATE,
         reset: noopUnsubscribe,
-        retry: noopUnsubscribe,
         subscribe: noopSubscribe,
         withSignal: () => ({ connect: noopUnsubscribe }),
     };

--- a/packages/react/src/swr/__tests__/bridgeStoreToSWR-test.ts
+++ b/packages/react/src/swr/__tests__/bridgeStoreToSWR-test.ts
@@ -23,26 +23,17 @@ function createFakeStore<T>(): {
         connect: () => {
             connects++;
         },
-        // Deprecated getters / APIs the bridge never touches — fail loudly if they're called.
-        getError: jest.fn().mockImplementation(() => {
-            throw new Error('not implemented');
-        }),
-        getState: jest.fn().mockImplementation(() => {
-            throw new Error('not implemented');
-        }),
-        getUnifiedState: () => state,
+        getState: () => state,
         reset: () => {
             resets++;
         },
-        retry: jest.fn().mockImplementation(() => {
-            throw new Error('not implemented');
-        }),
         subscribe: (callback: () => void) => {
             listeners.add(callback);
             return () => {
                 listeners.delete(callback);
             };
         },
+        // The bridge never touches `withSignal` — fail loudly if it's called.
         withSignal: jest.fn().mockImplementation(() => {
             throw new Error('not implemented');
         }),

--- a/packages/react/src/swr/bridgeStoreToSWR.ts
+++ b/packages/react/src/swr/bridgeStoreToSWR.ts
@@ -40,7 +40,7 @@ export function bridgeStoreToSWR<T, TError>(
     shouldForward?: (data: T) => boolean,
 ): () => void {
     const unsubscribe = store.subscribe(() => {
-        const state = store.getUnifiedState();
+        const state = store.getState();
         if (state.status === 'loaded') {
             if (shouldForward && !shouldForward(state.data)) return;
             next(null, state.data);

--- a/packages/react/src/useSubscriptionResult.ts
+++ b/packages/react/src/useSubscriptionResult.ts
@@ -28,7 +28,7 @@ export function useSubscriptionResult<T>(
     reconnect: (options?: { abortSignal?: AbortSignal | undefined }) => void,
     disabled: boolean,
 ): SubscriptionResult<T> {
-    const state = useSyncExternalStore(store.subscribe, store.getUnifiedState, store.getUnifiedState);
+    const state = useSyncExternalStore(store.subscribe, store.getState, store.getState);
     return useMemo(() => {
         const status: SubscriptionResult<T>['status'] =
             state.status === 'idle' ? (disabled ? 'disabled' : 'loading') : state.status;

--- a/packages/react/src/useTrackedDataResult.ts
+++ b/packages/react/src/useTrackedDataResult.ts
@@ -31,7 +31,7 @@ export function useTrackedDataResult<TItem>(
     refresh: (options?: { abortSignal?: AbortSignal | undefined }) => void,
     disabled: boolean,
 ): TrackedDataResult<TItem> {
-    const state = useSyncExternalStore(store.subscribe, store.getUnifiedState, store.getUnifiedState);
+    const state = useSyncExternalStore(store.subscribe, store.getState, store.getState);
     return useMemo(() => {
         const status: TrackedDataResult<TItem>['status'] =
             state.status === 'idle' ? (disabled ? 'disabled' : 'loading') : state.status;

--- a/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-test.ts
+++ b/packages/rpc-subscriptions-spec/src/__tests__/rpc-subscriptions-test.ts
@@ -67,7 +67,7 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
 
     it('returns a store that starts in `idle` status and does not call the transport before connect()', () => {
         const store = rpcSubscriptions.thingNotifications().reactiveStore();
-        expect(store.getUnifiedState()).toStrictEqual({
+        expect(store.getState()).toStrictEqual({
             data: undefined,
             error: undefined,
             status: 'idle',
@@ -87,7 +87,7 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
     it('transitions to `loading` after connect() before the transport resolves', () => {
         const store = rpcSubscriptions.thingNotifications().reactiveStore();
         store.connect();
-        expect(store.getUnifiedState()).toStrictEqual({
+        expect(store.getState()).toStrictEqual({
             data: undefined,
             error: undefined,
             status: 'loading',
@@ -99,7 +99,7 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
         store.connect();
         await flushMicrotasks();
         publish('notification', { value: 42 });
-        expect(store.getUnifiedState()).toStrictEqual({
+        expect(store.getState()).toStrictEqual({
             data: { value: 42 },
             error: undefined,
             status: 'loaded',
@@ -115,14 +115,14 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
         publish('notification', { value: 42 });
         expect(subscriber).toHaveBeenCalledTimes(1);
     });
-    it('surfaces errors via getUnifiedState()', async () => {
+    it('surfaces errors via getState()', async () => {
         expect.assertions(1);
         const store = rpcSubscriptions.thingNotifications().reactiveStore();
         store.connect();
         await flushMicrotasks();
         const error = new Error('o no');
         publish('error', error);
-        expect(store.getUnifiedState()).toStrictEqual({
+        expect(store.getState()).toStrictEqual({
             data: undefined,
             error,
             status: 'error',
@@ -150,13 +150,13 @@ describe('PendingRpcSubscriptionsRequest.reactiveStore()', () => {
         abortController.abort();
         expect(listenerSignal.aborted).toBe(true);
     });
-    it('returns the same getUnifiedState() snapshot across consecutive calls when state has not changed', async () => {
+    it('returns the same getState() snapshot across consecutive calls when state has not changed', async () => {
         expect.assertions(2);
         const store = rpcSubscriptions.thingNotifications().reactiveStore();
         store.connect();
         await flushMicrotasks();
-        expect(store.getUnifiedState()).toBe(store.getUnifiedState());
+        expect(store.getState()).toBe(store.getState());
         publish('notification', { value: 42 });
-        expect(store.getUnifiedState()).toBe(store.getUnifiedState());
+        expect(store.getState()).toBe(store.getState());
     });
 });

--- a/packages/rpc-subscriptions-spec/src/rpc-subscriptions-request.ts
+++ b/packages/rpc-subscriptions-spec/src/rpc-subscriptions-request.ts
@@ -20,7 +20,7 @@ export type PendingRpcSubscriptionsRequest<TNotification> = {
     /**
      * Synchronously returns a {@link ReactiveStreamStore} that holds the latest notification.
      * Compatible with `useSyncExternalStore` and other reactive primitives that expect a
-     * `{ subscribe, getUnifiedState }` contract. The returned store is in `status: 'idle'` — call
+     * `{ subscribe, getState }` contract. The returned store is in `status: 'idle'` — call
      * {@link ReactiveStreamStore.connect | `connect()`} to open the subscription; a follow-up
      * `connect()` after an error reopens it. Attach a caller-provided cancellation source via
      * {@link ReactiveStreamStore.withSignal | `withSignal()`}.
@@ -31,7 +31,7 @@ export type PendingRpcSubscriptionsRequest<TNotification> = {
      * // Per-connection timeout — fresh clock per attempt:
      * store.withSignal(AbortSignal.timeout(30_000)).connect();
      * // React — the unified snapshot has stable identity per update.
-     * const state = useSyncExternalStore(store.subscribe, store.getUnifiedState);
+     * const state = useSyncExternalStore(store.subscribe, store.getState);
      * if (state.status === 'error') return <ErrorMessage error={state.error} onRetry={store.connect} />;
      * if (state.status === 'loading' || state.status === 'idle') return <Spinner />;
      * return <View data={state.data} />;

--- a/packages/subscribable/README.md
+++ b/packages/subscribable/README.md
@@ -29,9 +29,9 @@ dataPublisher.on('error', e => {
 
 ### `ReactiveStreamStore<T>`
 
-This type represents a reactive store that holds the latest value published to a data channel. It exposes a `{ getUnifiedState, retry, subscribe }` contract compatible with `useSyncExternalStore`, Svelte stores, and other reactive primitives.
+This type represents a reactive store that holds the latest value published to a data channel. It exposes a `{ getState, retry, subscribe }` contract compatible with `useSyncExternalStore`, Svelte stores, and other reactive primitives.
 
-`getUnifiedState()` returns a discriminated snapshot of the store's lifecycle:
+`getState()` returns a discriminated snapshot of the store's lifecycle:
 
 ```ts
 type ReactiveState<T> =
@@ -49,7 +49,7 @@ The store starts in `status: 'idle'`. Call `connect()` to open the underlying st
 const store: ReactiveStreamStore<AccountInfo> = /* ... */;
 
 // React — snapshot identity is stable between updates, so it can be passed directly.
-const state = useSyncExternalStore(store.subscribe, store.getUnifiedState);
+const state = useSyncExternalStore(store.subscribe, store.getState);
 useEffect(() => {
     store.connect();
     return () => store.reset();
@@ -64,16 +64,12 @@ return (
 );
 
 // Vue
-const snapshot = shallowRef(store.getUnifiedState());
+const snapshot = shallowRef(store.getState());
 store.subscribe(() => {
-    snapshot.value = store.getUnifiedState();
+    snapshot.value = store.getState();
 });
 store.connect();
 ```
-
-`retry()` is a deprecated alias for the error-recovery case — prefer calling `connect()` directly. `connect()` always reopens the stream, regardless of current status; wrap with a status guard at the call site if you need the error-only behaviour.
-
-The individual `getState()` and `getError()` getters on `ReactiveStreamStore<T>` are `@deprecated` &mdash; prefer `getUnifiedState()`, which exposes the same information with a stable snapshot identity and `status` discriminator.
 
 ### `ReactiveActionStore<TArgs, TResult>`
 
@@ -210,7 +206,7 @@ const store = createReactiveStoreFromDataPublisherFactory({
     errorChannelName: 'error',
 });
 const unsubscribe = store.subscribe(() => {
-    const snapshot = store.getUnifiedState();
+    const snapshot = store.getState();
     if (snapshot.status === 'error') console.error('Connection failed:', snapshot.error);
     else if (snapshot.status === 'loaded') console.log('Latest:', snapshot.data);
 });

--- a/packages/subscribable/src/__tests__/reactive-stream-store-test.ts
+++ b/packages/subscribable/src/__tests__/reactive-stream-store-test.ts
@@ -44,7 +44,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 dataChannelName: 'data',
                 errorChannelName: 'error',
             });
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: undefined,
                 status: 'idle',
@@ -62,7 +62,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
                 errorChannelName: 'error',
             });
             store.connect();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: undefined,
                 status: 'loading',
@@ -80,7 +80,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             store.connect();
             await jest.runAllTimersAsync();
             publishers[0].publish('data', { value: 42 });
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { value: 42 },
                 error: undefined,
                 status: 'loaded',
@@ -97,7 +97,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             });
             store.connect();
             await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: failure,
                 status: 'error',
@@ -116,7 +116,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             publishers[0].publish('data', { value: 42 });
             const failure = new Error('stream died');
             publishers[0].publish('error', failure);
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { value: 42 },
                 error: failure,
                 status: 'error',
@@ -136,7 +136,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             const fail = new Error('fail');
             publishers[0].publish('error', fail);
             store.connect();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { value: 42 },
                 error: fail,
                 status: 'loading',
@@ -154,7 +154,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             await jest.runAllTimersAsync();
             publishers[0].publish('data', { value: 42 });
             store.connect();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { value: 42 },
                 error: undefined,
                 status: 'loading',
@@ -188,7 +188,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             store.connect();
             await jest.runAllTimersAsync();
             publishers[1].publish('data', { value: 'recovered' });
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { value: 'recovered' },
                 error: undefined,
                 status: 'loaded',
@@ -224,11 +224,11 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             });
             store.connect();
             await jest.runAllTimersAsync();
-            expect(store.getUnifiedState().status).toBe('error');
+            expect(store.getState().status).toBe('error');
             store.connect();
             await jest.runAllTimersAsync();
             publisher.publish('data', { value: 99 });
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { value: 99 },
                 error: undefined,
                 status: 'loaded',
@@ -248,7 +248,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             await jest.runAllTimersAsync();
             store.connect();
             await jest.runAllTimersAsync();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: secondFailure,
                 status: 'error',
@@ -263,7 +263,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             });
             store.connect();
             store.connect();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: undefined,
                 status: 'loading',
@@ -314,7 +314,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             await jest.runAllTimersAsync();
             publishers[0].publish('data', { value: 42 });
             store.reset();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: undefined,
                 status: 'idle',
@@ -379,48 +379,10 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             await jest.runAllTimersAsync();
             publishers[1].publish('data', { value: 'fresh' });
             expect(mockRequest).toHaveBeenCalledTimes(2);
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { value: 'fresh' },
                 error: undefined,
                 status: 'loaded',
-            });
-        });
-    });
-
-    describe('retry() (deprecated)', () => {
-        it('is a no-op when the store is not in `error` state', async () => {
-            expect.assertions(2);
-            const { mockRequest } = createFactory();
-            const store = createReactiveStoreFromDataPublisherFactory({
-                createDataPublisher: mockRequest,
-                dataChannelName: 'data',
-                errorChannelName: 'error',
-            });
-            store.connect();
-            await jest.runAllTimersAsync();
-            const callsBefore = mockRequest.mock.calls.length;
-            store.retry();
-            expect(mockRequest).toHaveBeenCalledTimes(callsBefore);
-            expect(store.getUnifiedState().status).toBe('loading');
-        });
-        it('transitions back to `loading` from `error`, preserving stale data and error (SWR)', async () => {
-            expect.assertions(1);
-            const { mockRequest, publishers } = createFactory();
-            const store = createReactiveStoreFromDataPublisherFactory({
-                createDataPublisher: mockRequest,
-                dataChannelName: 'data',
-                errorChannelName: 'error',
-            });
-            store.connect();
-            await jest.runAllTimersAsync();
-            publishers[0].publish('data', { value: 42 });
-            const fail = new Error('fail');
-            publishers[0].publish('error', fail);
-            store.retry();
-            expect(store.getUnifiedState()).toStrictEqual({
-                data: { value: 42 },
-                error: fail,
-                status: 'loading',
             });
         });
     });
@@ -501,7 +463,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             store.withSignal(abortController.signal).connect();
             const reason = new Error('timed out');
             abortController.abort(reason);
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: reason,
                 status: 'error',
@@ -521,7 +483,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             publishers[0].publish('data', { value: 42 });
             const reason = new Error('timed out');
             abortController.abort(reason);
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: { value: 42 },
                 error: reason,
                 status: 'error',
@@ -539,7 +501,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             });
             store.withSignal(abortController.signal).connect();
             expect(mockRequest).not.toHaveBeenCalled();
-            expect(store.getUnifiedState()).toStrictEqual({
+            expect(store.getState()).toStrictEqual({
                 data: undefined,
                 error: reason,
                 status: 'error',
@@ -567,7 +529,7 @@ describe('createReactiveStoreFromDataPublisherFactory', () => {
             killController.abort(reason);
             killable.connect();
             expect(mockRequest).toHaveBeenCalledTimes(2);
-            expect(store.getUnifiedState().status).toBe('error');
+            expect(store.getState().status).toBe('error');
         });
         it('does not abort the listener signal on supersede via a fresh connect()', async () => {
             expect.assertions(1);

--- a/packages/subscribable/src/reactive-action-store.ts
+++ b/packages/subscribable/src/reactive-action-store.ts
@@ -41,7 +41,13 @@ export type ReactiveActionStore<TArgs extends readonly unknown[], TResult> = {
      * `@solana/promises`.
      */
     readonly dispatchAsync: (...args: TArgs) => Promise<TResult>;
-    /** Returns the current state. */
+    /**
+     * Returns the current lifecycle snapshot: `{ data, error, status }`. The returned object has
+     * stable identity between state changes, making it safe to pass directly as the
+     * `getSnapshot` argument to React's `useSyncExternalStore`.
+     *
+     * @see {@link ReactiveActionState}
+     */
     readonly getState: () => ReactiveActionState<TResult>;
     /** Aborts any in-flight dispatch and resets the state to `{ status: 'idle' }`. */
     readonly reset: () => void;

--- a/packages/subscribable/src/reactive-stream-store.ts
+++ b/packages/subscribable/src/reactive-stream-store.ts
@@ -59,7 +59,7 @@ const IDLE_STATE: ReactiveState<never> = Object.freeze({
 /**
  * A reactive store that holds the latest value published to a data channel and allows external
  * systems to subscribe to changes. Compatible with `useSyncExternalStore`, Svelte stores, Solid's
- * `from()`, and other reactive primitives that expect a `{ subscribe, getUnifiedState }` contract.
+ * `from()`, and other reactive primitives that expect a `{ subscribe, getState }` contract.
  *
  * The store starts in `status: 'idle'`. Call {@link ReactiveStreamStore.connect | `connect()`}
  * to open the underlying stream; the store transitions through `loading` → `loaded` (or `error`).
@@ -70,7 +70,7 @@ const IDLE_STATE: ReactiveState<never> = Object.freeze({
  * ```ts
  * // React — the unified state snapshot has stable identity per update, making it suitable as
  * // the second argument to `useSyncExternalStore`.
- * const state = useSyncExternalStore(store.subscribe, store.getUnifiedState);
+ * const state = useSyncExternalStore(store.subscribe, store.getState);
  * useEffect(() => {
  *     store.connect();
  *     return () => store.reset();
@@ -91,29 +91,13 @@ export type ReactiveStreamStore<T> = {
      */
     connect(): void;
     /**
-     * Returns the error published to the error channel, or `undefined` if no error has occurred.
-     *
-     * @deprecated Use {@link ReactiveStreamStore.getUnifiedState | `getUnifiedState()`} instead. This
-     * getter returns only the error field and cannot narrow the relationship between the current
-     * value, error, and status.
-     */
-    getError(): unknown;
-    /**
-     * Returns the most recent value published to the data channel, or `undefined` if no
-     * notification has arrived yet. On error, continues to return the last known value.
-     *
-     * @deprecated Use {@link ReactiveStreamStore.getUnifiedState | `getUnifiedState()`} instead. This
-     * getter returns only the value field and does not surface lifecycle status (e.g. `loading`).
-     */
-    getState(): T | undefined;
-    /**
      * Returns the current lifecycle snapshot: `{ data, error, status }`. The returned object has
      * stable identity between state changes, making it safe to pass directly as the
      * `getSnapshot` argument to React's `useSyncExternalStore`.
      *
      * @see {@link ReactiveState}
      */
-    getUnifiedState(): ReactiveState<T>;
+    getState(): ReactiveState<T>;
     /**
      * Aborts any currently active connection and resets the store to `{ status: 'idle' }`. Both
      * `data` and `error` are cleared. Use this to tear down the connection without permanently
@@ -121,14 +105,6 @@ export type ReactiveStreamStore<T> = {
      * a fresh stream.
      */
     reset(): void;
-    /**
-     * Re-opens the stream after an error. No-op when the store is not in `status: 'error'`.
-     *
-     * @deprecated Use {@link ReactiveStreamStore.connect | `connect()`} instead. `connect()`
-     * always (re)connects, regardless of current status — wrap with a status guard at the call
-     * site if you need the error-only behaviour.
-     */
-    retry(): void;
     /**
      * Registers a callback to be called whenever the state changes or an error is received.
      * Returns an unsubscribe function. Safe to call multiple times.
@@ -150,17 +126,11 @@ export type ReactiveStreamStore<T> = {
      *   everywhere; aborting the controller cancels the active connection and short-circuits
      *   future calls through the bound wrapper.
      *
-     * The wrapper exposes only `connect()` — `getUnifiedState` / `subscribe` / `reset` remain
+     * The wrapper exposes only `connect()` — `getState` / `subscribe` / `reset` remain
      * store-level concerns on the parent.
      */
     withSignal(signal: AbortSignal): { readonly connect: () => void };
 };
-
-/**
- * @deprecated Use {@link ReactiveStreamStore} instead. This alias will be removed in a future
- * major release.
- */
-export type ReactiveStore<T> = ReactiveStreamStore<T>;
 
 /**
  * Duck-type for objects that build a {@link ReactiveStreamStore} on demand via a `reactiveStore()`
@@ -224,7 +194,7 @@ export type ReactiveStreamSource<T> = {
  *     errorChannelName: 'error',
  * });
  * const unsubscribe = store.subscribe(() => {
- *     const snapshot = store.getUnifiedState();
+ *     const snapshot = store.getState();
  *     if (snapshot.status === 'error') console.error('Connection failed:', snapshot.error);
  *     else if (snapshot.status === 'loaded') console.log('Latest:', snapshot.data);
  * });
@@ -324,20 +294,10 @@ export function createReactiveStoreFromDataPublisherFactory<TData>({
         connect(): void {
             performConnect(undefined);
         },
-        getError(): unknown {
-            return currentState.error;
-        },
-        getState(): TData | undefined {
-            return currentState.data;
-        },
-        getUnifiedState(): ReactiveState<TData> {
+        getState(): ReactiveState<TData> {
             return currentState;
         },
         reset: performReset,
-        retry(): void {
-            if (currentState.status !== 'error') return;
-            performConnect(undefined);
-        },
         subscribe(callback: () => void): () => void {
             subscribers.add(callback);
             return () => {


### PR DESCRIPTION
We previously deprecated some functionality in `ReactiveStreamStore`, to align it better with `ReactiveActionStore` as both APIs were properly fleshed out and built on. This stack is a major version and makes use of this code, so this PR removes the deprecated functionality to fully align the APIs.

- `getState()` which previously returned just the data is removed
- `getError()` is removed
- `getUnifiedState()` which returns the data/error/status is renamed `getState().` This means `useSyncExternalStore(store.subscribe, store.getState)` is the react binding.
- `retry()` is removed. This was the same as `connect()` but was a no-op unless there was an error. Now we just have `connect()` and callers can add whatever gating logic makes sense, if any.
- The type `ReactiveStore` is removed, it was an alias for `ReactiveStreamStore`. Now we have `ReactiveActionStore` and `ReactiveStreamStore`.

These changes make them a cohesive family of reactive stores, which will make their docs read much better! 