### PR TITLE
Add typetest for getHighestSnapSlot

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-highest-snapshot-slot-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-highest-snapshot-slot-typetest.ts
@@ -1,0 +1,16 @@
+import type { Rpc } from '@solana/rpc-spec';
+import type { Slot } from '@solana/rpc-types';
+
+import type { GetHighestSnapshotSlotApi } from '../getHighestSnapshotSlot';
+
+const rpc = null as unknown as Rpc<GetHighestSnapshotSlotApi>;
+
+void (async () => {
+    {
+        const result = await rpc.getHighestSnapshotSlot().send();
+        result satisfies Readonly<{
+            full: Slot;
+            incremental: Slot | null;
+        }>;
+    }
+});


### PR DESCRIPTION
#### Problem

A previous PR added typetest coverage for `getEpochInfo()`, but `getHighestSnapshotSlot()` still doesn't have a dedicated typetest.

#### Summary of Changes

This PR adds a typetest for `getHighestSnapshotSlot()`.

It verifies the inferred return type of:

```ts
const result = await rpc.getHighestSnapshotSlot().send();
```

and checks that it matches:

```ts
result satisfies Readonly<{
    full: Slot;
    incremental: Slot | null;
}>;
```

This helps ensure the no-argument RPC method continues to infer the expected response type, including preserving the branded `Slot` type and the nullable `incremental` field.

#### Testing

```bash
pnpm compile
pnpm --filter @solana/rpc-api test:typecheck
```