### PR TITLE
add typetest for getEpochSchedule

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-epoch-schedule-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-epoch-schedule-typetest.ts
@@ -1,0 +1,18 @@
+import type { Rpc } from '@solana/rpc-spec';
+
+import type { GetEpochScheduleApi } from '../getEpochSchedule';
+
+const rpc = null as unknown as Rpc<GetEpochScheduleApi>;
+
+void (async () => {
+    {
+        const result = await rpc.getEpochSchedule().send();
+        result satisfies Readonly<{
+            firstNormalEpoch: bigint;
+            firstNormalSlot: bigint;
+            leaderScheduleSlotOffset: bigint;
+            slotsPerEpoch: bigint;
+            warmup: boolean;
+        }>;
+    }
+});


### PR DESCRIPTION
#### Problem

`getEpochSchedule()` doesn't currently have a dedicated typetest.

#### Summary of Changes

This PR adds a typetest for `getEpochSchedule()`.

It verifies the inferred return type of:

```ts
const result = await rpc.getEpochSchedule().send();
```

and checks that it matches:

```ts
result satisfies Readonly<{
    firstNormalEpoch: bigint;
    firstNormalSlot: bigint;
    leaderScheduleSlotOffset: bigint;
    slotsPerEpoch: bigint;
    warmup: boolean;
}>;
```
#### Testing

```bash
pnpm compile
pnpm --filter @solana/rpc-api test:typecheck
```