### PR TITLE
add typetest for getversion

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-version-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-version-typetest.ts
@@ -1,0 +1,15 @@
+import type { Rpc } from '@solana/rpc-spec';
+
+import type { GetVersionApi } from '../getVersion';
+
+const rpc = null as unknown as Rpc<GetVersionApi>;
+
+void (async () => {
+    {
+        const result = await rpc.getVersion().send();
+        result satisfies Readonly<{
+            'feature-set': number;
+            'solana-core': string;
+        }>;
+    }
+});


### PR DESCRIPTION
#### Problem

`getVersion()` doesn't currently have a dedicated typetest.

#### Summary of Changes

This PR adds a typetest for `getVersion()`.

It verifies the inferred return type of:

```ts
const result = await rpc.getVersion().send();
```

and checks that it matches:

```ts
result satisfies Readonly<{
    'feature-set': number;
    'solana-core': string;
}>;
```
#### Testing

```bash
pnpm compile
pnpm --filter @solana/rpc-api test:typecheck
```