### PR TITLE
Add typetest for getIdentity

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-identity-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-identity-typetest.ts
@@ -1,0 +1,15 @@
+import type { Address } from '@solana/addresses';
+import type { Rpc } from '@solana/rpc-spec';
+
+import type { GetIdentityApi } from '../getIdentity';
+
+const rpc = null as unknown as Rpc<GetIdentityApi>;
+
+void (async () => {
+    {
+        const result = await rpc.getIdentity().send();
+        result satisfies Readonly<{
+            identity: Address;
+        }>;
+    }
+});


### PR DESCRIPTION
#### Problem

`getIdentity()` doesn't currently have a dedicated typetest.

#### Summary of Changes

Adds a typetest for `getIdentity()` to verify the inferred return type returned by:

```ts
const result = await rpc.getIdentity().send();
```

#### Testing

```bash
pnpm compile
pnpm --filter @solana/rpc-api test:typecheck
```