### PR TITLE
Add typetest for getInflatioRate

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-inflation-rate-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-inflation-rate-typetest.ts
@@ -1,0 +1,18 @@
+import type { Rpc } from '@solana/rpc-spec';
+import type { F64UnsafeSeeDocumentation } from '@solana/rpc-types';
+
+import type { GetInflationRateApi } from '../getInflationRate';
+
+const rpc = null as unknown as Rpc<GetInflationRateApi>;
+
+void (async () => {
+    {
+        const result = await rpc.getInflationRate().send();
+        result satisfies Readonly<{
+            epoch: bigint;
+            foundation: F64UnsafeSeeDocumentation;
+            total: F64UnsafeSeeDocumentation;
+            validator: F64UnsafeSeeDocumentation;
+        }>;
+    }
+});


### PR DESCRIPTION
#### Problem

`getInflationRate()` doesn't currently have a dedicated typetest.

#### Summary of Changes

Adds a typetest for `getInflationRate()` to verify the inferred return type of:

```ts
const result = await rpc.getInflationRate().send();
```

#### Testing

```bash
pnpm compile
pnpm --filter @solana/rpc-api test:typecheck
```