### PR TITLE
Add typetest for getBalance

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-balance-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-balance-typetest.ts
@@ -1,0 +1,20 @@
+import type { Address } from '@solana/addresses';
+import type { Rpc } from '@solana/rpc-spec';
+import type { Lamports, Slot } from '@solana/rpc-types';
+
+import type { GetBalanceApi } from '../getBalance';
+
+const rpc = null as unknown as Rpc<GetBalanceApi>;
+const address = null as unknown as Address;
+
+void (async () => {
+    {
+        const result = await rpc.getBalance(address).send();
+        result satisfies Readonly<{
+            context: Readonly<{
+                slot: Slot;
+            }>;
+            value: Lamports;
+        }>;
+    }
+});


### PR DESCRIPTION
#### Summary

Adds a typetest for `getBalance()`.

This builds on the earlier no-argument typetests by covering a method that takes an `Address` and returns a `SolanaRpcResponse<Lamports>`.