### PR TITLE
Add typetest for isBLockhashValid

### DIFF
--- a/packages/rpc-api/src/__typetests__/is-blockhash-valid-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/is-blockhash-valid-typetest.ts
@@ -1,0 +1,19 @@
+import type { Rpc } from '@solana/rpc-spec';
+import type { Blockhash, Slot } from '@solana/rpc-types';
+
+import type { IsBlockhashValidApi } from '../isBlockhashValid';
+
+const rpc = null as unknown as Rpc<IsBlockhashValidApi>;
+const blockhash = null as unknown as Blockhash;
+
+void (async () => {
+    {
+        const result = await rpc.isBlockhashValid(blockhash).send();
+        result satisfies Readonly<{
+            context: Readonly<{
+                slot: Slot;
+            }>;
+            value: boolean;
+        }>;
+    }
+});


### PR DESCRIPTION
#### Summary

Adds a typetest for `isBlockhashValid()`.

Following the earlier `getBalance()` typetest, this covers another RPC method that takes arguments and returns a `SolanaRpcResponse<T>`.