### PR TITLE
Add typetest for getBlockTime

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-block-time-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-block-time-typetest.ts
@@ -1,0 +1,14 @@
+import type { Rpc } from '@solana/rpc-spec';
+import type { Slot, UnixTimestamp } from '@solana/rpc-types';
+
+import type { GetBlockTimeApi } from '../getBlockTime';
+
+const rpc = null as unknown as Rpc<GetBlockTimeApi>;
+const blockNumber = null as unknown as Slot;
+
+void (async () => {
+    {
+        const result = await rpc.getBlockTime(blockNumber).send();
+        result satisfies UnixTimestamp;
+    }
+});


### PR DESCRIPTION
#### Summary

Adds a typetest for `getBlockTime()`.

This continues the recent typetest coverage for RPC methods that take arguments.