### PR TITLE
Add typetest for getBlockCommitment

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-block-commitment-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-block-commitment-typetest.ts
@@ -1,0 +1,17 @@
+import type { Rpc } from '@solana/rpc-spec';
+import type { Lamports, Slot } from '@solana/rpc-types';
+
+import type { GetBlockCommitmentApi } from '../getBlockCommitment';
+
+const rpc = null as unknown as Rpc<GetBlockCommitmentApi>;
+const slot = null as unknown as Slot;
+
+void (async () => {
+    {
+        const result = await rpc.getBlockCommitment(slot).send();
+        result satisfies Readonly<{
+            commitment: readonly Lamports[] | null;
+            totalStake: Lamports;
+        }>;
+    }
+});


### PR DESCRIPTION
#### Summary

Adds a typetest for `getBlockCommitment()`.

This continues the recent typetest coverage for RPC methods that take arguments by covering a method that returns a direct object with nullable arrays of branded types.