### PR TITLE
Add typetest for getMinimumBalanceForRentExemption

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-minimum-balance-for-rent-exemption-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-minimum-balance-for-rent-exemption-typetest.ts
@@ -1,0 +1,14 @@
+import type { Rpc } from '@solana/rpc-spec';
+import type { Lamports, Slot } from '@solana/rpc-types';
+
+import type { GetMinimumBalanceForRentExemptionApi } from '../getMinimumBalanceForRentExemption';
+
+const rpc = null as unknown as Rpc<GetMinimumBalanceForRentExemptionApi>;
+const size = 0n;
+
+void (async () => {
+    {
+        const result = await rpc.getMinimumBalanceForRentExemption(size).send();
+        result satisfies Lamports;
+    }
+});


### PR DESCRIPTION
#### Summary

Adds a typetest for `getMinimumBalanceForRentExemption()`.

This continues the recent typetest coverage for RPC methods that take arguments by covering a method with a required `bigint` argument and a direct branded return type.