### PR TITLE
Add typetest for getInflationReward

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-inflation-reward-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-inflation-reward-typetest.ts
@@ -1,0 +1,21 @@
+import type { Address } from '@solana/addresses';
+import type { Rpc } from '@solana/rpc-spec';
+import type { Lamports, Slot } from '@solana/rpc-types';
+
+import type { GetInflationRewardApi } from '../getInflationReward';
+
+const rpc = null as unknown as Rpc<GetInflationRewardApi>;
+const addresses = null as unknown as readonly Address[];
+
+void (async () => {
+    {
+        const result = await rpc.getInflationReward(addresses).send();
+        result satisfies readonly (Readonly<{
+            amount: Lamports;
+            commission: number;
+            effectiveSlot: Slot;
+            epoch: bigint;
+            postBalance: Lamports;
+        }> | null)[];
+    }
+});


### PR DESCRIPTION
#### Summary

Adds a typetest for `getInflationReward()`.

This continues the recent typetest coverage for RPC methods that take arguments by covering a method with a required array argument and nullable elements in the response.