### PR TITLE
Add typetest for getSlotLeaders

### DIFF
--- a/packages/rpc-api/src/__typetests__/get-slot-leaders-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-slot-leaders-typetest.ts
@@ -1,0 +1,16 @@
+import type { Address } from '@solana/addresses';
+import type { Rpc } from '@solana/rpc-spec';
+import type { Slot } from '@solana/rpc-types';
+
+import type { GetSlotLeadersApi } from '../getSlotLeaders';
+
+const rpc = null as unknown as Rpc<GetSlotLeadersApi>;
+const startSlotInclusive = null as unknown as Slot;
+const limit = 1;
+
+void (async () => {
+    {
+        const result = await rpc.getSlotLeaders(startSlotInclusive, limit).send();
+        result satisfies Address[];
+    }
+});


### PR DESCRIPTION
#### Summary

Adds a typetest for `getSlotLeaders()`.

This continues the recent typetest coverage for RPC methods that take arguments by covering a method with multiple required positional arguments and a direct `Address[]` return.