### PR TITLE
fix false confirmation success when subscription aborts

### DIFF
--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-nonce-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-nonce-test.ts
@@ -1,6 +1,11 @@
 import { Address } from '@solana/addresses';
 import { getBase58Encoder, getBase64Decoder } from '@solana/codecs-strings';
-import { SOLANA_ERROR__INVALID_NONCE, SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND, SolanaError } from '@solana/errors';
+import {
+    SOLANA_ERROR__INVALID_NONCE,
+    SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND,
+    SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED,
+    SolanaError,
+} from '@solana/errors';
 import { Nonce } from '@solana/transaction-messages';
 
 import { createNonceInvalidationPromiseFactory } from '../confirmation-strategy-nonce';
@@ -221,5 +226,46 @@ describe('createNonceInvalidationPromiseFactory', () => {
                 expectedNonceValue: '44444444444444444444444444444444444444444444',
             }),
         );
+    });
+    it('rejects when the account subscription ends without detecting nonce invalidation', async () => {
+        expect.assertions(1);
+        accountNotificationGenerator.mockImplementation(async function* () {
+            /* subscription ended without yielding a nonce change */
+        });
+        getAccountInfoMock.mockResolvedValue({
+            value: {
+                data: ['4'.repeat(44), 'base58'],
+            },
+        });
+        const invalidationPromise = getNonceInvalidationPromise({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            currentNonceValue: '4'.repeat(44) as Nonce,
+            nonceAccountAddress: '9'.repeat(44) as Address,
+        });
+        await expect(invalidationPromise).rejects.toThrow(
+            new SolanaError(SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED),
+        );
+    });
+    it('rejects when aborted before the nonce is invalidated', async () => {
+        expect.assertions(1);
+        getAccountInfoMock.mockReturnValue(FOREVER_PROMISE);
+        createSubscriptionIterable.mockImplementation(async ({ abortSignal }) => ({
+            [Symbol.asyncIterator]: async function* () {
+                await new Promise<void>(resolve => {
+                    abortSignal.addEventListener('abort', resolve, { once: true });
+                });
+            },
+        }));
+        const abortController = new AbortController();
+        const invalidationPromise = getNonceInvalidationPromise({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            currentNonceValue: '4'.repeat(44) as Nonce,
+            nonceAccountAddress: '9'.repeat(44) as Address,
+        });
+        await jest.runAllTimersAsync();
+        abortController.abort('canceled');
+        await expect(invalidationPromise).rejects.toThrow('canceled');
     });
 });

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-signature-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-signature-test.ts
@@ -1,4 +1,8 @@
-import { SOLANA_ERROR__TRANSACTION_ERROR__UNKNOWN, SolanaError } from '@solana/errors';
+import {
+    SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED,
+    SOLANA_ERROR__TRANSACTION_ERROR__UNKNOWN,
+    SolanaError,
+} from '@solana/errors';
 import { Signature } from '@solana/keys';
 
 import { createRecentSignatureConfirmationPromiseFactory } from '../confirmation-strategy-recent-signature';
@@ -197,5 +201,42 @@ describe('createSignatureConfirmationPromiseFactory', () => {
         expect(createSubscriptionIterable).toHaveBeenCalledWith({
             abortSignal: expect.objectContaining({ aborted: true }),
         });
+    });
+    it('rejects when the signature subscription ends without a confirming notification', async () => {
+        expect.assertions(1);
+        signatureNotificationGenerator.mockImplementation(async function* () {
+            /* subscription ended without yielding a confirmation */
+        });
+        getSignatureStatusesMock.mockResolvedValue({
+            value: [null],
+        });
+        const signatureConfirmationPromise = getSignatureConfirmationPromise({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            signature: 'abc' as Signature,
+        });
+        await expect(signatureConfirmationPromise).rejects.toThrow(
+            new SolanaError(SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED),
+        );
+    });
+    it('rejects when aborted before the signature is confirmed', async () => {
+        expect.assertions(1);
+        getSignatureStatusesMock.mockReturnValue(FOREVER_PROMISE);
+        createSubscriptionIterable.mockImplementation(async ({ abortSignal }) => ({
+            [Symbol.asyncIterator]: async function* () {
+                await new Promise<void>(resolve => {
+                    abortSignal.addEventListener('abort', resolve, { once: true });
+                });
+            },
+        }));
+        const abortController = new AbortController();
+        const signatureConfirmationPromise = getSignatureConfirmationPromise({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            signature: 'abc' as Signature,
+        });
+        await jest.runAllTimersAsync();
+        abortController.abort('canceled');
+        await expect(signatureConfirmationPromise).rejects.toThrow('canceled');
     });
 });

--- a/packages/transaction-confirmation/src/confirmation-strategy-nonce.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-nonce.ts
@@ -1,6 +1,11 @@
 import type { Address } from '@solana/addresses';
 import { getBase58Decoder, getBase64Encoder } from '@solana/codecs-strings';
-import { SOLANA_ERROR__INVALID_NONCE, SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND, SolanaError } from '@solana/errors';
+import {
+    SOLANA_ERROR__INVALID_NONCE,
+    SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND,
+    SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED,
+    SolanaError,
+} from '@solana/errors';
 import { AbortController } from '@solana/event-target-impl';
 import { safeRace } from '@solana/promises';
 import type { GetAccountInfoApi, Rpc } from '@solana/rpc';
@@ -119,6 +124,8 @@ export function createNonceInvalidationPromiseFactory<TCluster extends 'devnet' 
                     });
                 }
             }
+            abortController.signal.throwIfAborted();
+            throw new SolanaError(SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED);
         })();
         /**
          * STEP 2: Having subscribed for updates, make a one-shot request for the current nonce

--- a/packages/transaction-confirmation/src/confirmation-strategy-recent-signature.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-recent-signature.ts
@@ -1,4 +1,8 @@
-import { getSolanaErrorFromTransactionError } from '@solana/errors';
+import {
+    getSolanaErrorFromTransactionError,
+    SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED,
+    SolanaError,
+} from '@solana/errors';
 import { AbortController } from '@solana/event-target-impl';
 import type { Signature } from '@solana/keys';
 import { safeRace } from '@solana/promises';
@@ -99,6 +103,8 @@ export function createRecentSignatureConfirmationPromiseFactory<
                     return;
                 }
             }
+            abortController.signal.throwIfAborted();
+            throw new SolanaError(SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED);
         })();
         /**
          * STEP 2: Having subscribed for updates, make a one-shot request for the current status.


### PR DESCRIPTION
its moondev, checked the transaction confirmation code and found a bug in how aborts are handled

when you use sendAndConfirmTransaction or durable nonce confirmation, it races a websocket subscription against a one-shot rpc lookup. if the subscription gets aborted (timeout, user cancel, component unmount), the async iterator just returns silently instead of throwing. the for-await loop exits and the promise resolves as undefined, which safeRace treats as success. so you can get a confirmed result when nothing was actually confirmed

block height confirmation already had the right pattern with throwIfAborted() after the loop. this applies the same thing to recent signature confirmation and nonce invalidation. if the iterator ends without a result, we check abort first, otherwise throw CHANNEL_CONNECTION_CLOSED

added tests for subscription ending without notification and for abort before confirmation

cheers