### PR TITLE
Wrap long inline code inside callouts

### DIFF
--- a/docs/src/app/styles/fumadocs-overrides.css
+++ b/docs/src/app/styles/fumadocs-overrides.css
@@ -142,6 +142,14 @@
     @apply text-sm md:text-base lg:text-base;
 }
 
+/* --------- */
+/* Callouts. */
+/* --------- */
+
+.fd-callout code {
+    overflow-wrap: anywhere;
+}
+
 /* ------ */
 /* Steps. */
 /* ------ */


### PR DESCRIPTION
Long error codes in callouts overflow past the border on narrower screens. Allow inline code inside callouts to wrap anywhere so it stays inside the box.

before
<img width="1256" height="216" alt="before-660" src="https://github.com/user-attachments/assets/819247bb-c6c6-48e6-9536-acab79917316" />
after
<img width="1256" height="256" alt="after-660" src="https://github.com/user-attachments/assets/53f3f50b-4093-412d-b7a3-b2c4005807f8" />

Fixes #1802