### PR TITLE
Re-export `@solana/promises` from `@solana/kit`

### DIFF
--- a/.changeset/short-mails-read.md
+++ b/.changeset/short-mails-read.md
@@ -1,0 +1,7 @@
+---
+'@solana/kit': minor
+---
+
+Re-export `@solana/promises` from `@solana/kit`
+
+`@solana/kit` now re-exports the `@solana/promises` package, so its helpers — `isAbortError`, `getAbortablePromise`, and `safeRace` — are available directly from `@solana/kit` without a separate dependency. This is particularly useful alongside `@solana/react`'s `useAction`, whose superseded or aborted dispatches reject with an `AbortError` that callers filter using `isAbortError`.

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -114,6 +114,7 @@
         "@solana/plugin-interfaces": "workspace:*",
         "@solana/program-client-core": "workspace:*",
         "@solana/programs": "workspace:*",
+        "@solana/promises": "workspace:*",
         "@solana/rpc": "workspace:*",
         "@solana/rpc-api": "workspace:*",
         "@solana/rpc-parsed-types": "workspace:*",

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -18,6 +18,7 @@ export * from '@solana/offchain-messages';
 export * from '@solana/plugin-core';
 export type * from '@solana/plugin-interfaces';
 export * from '@solana/programs';
+export * from '@solana/promises';
 export * from '@solana/rpc';
 export * from '@solana/rpc-parsed-types';
 export * from '@solana/rpc-subscriptions';

--- a/packages/promises/README.md
+++ b/packages/promises/README.md
@@ -11,7 +11,7 @@
 
 # @solana/promises
 
-This package contains helpers for using JavaScript promises.
+This package contains helpers for using JavaScript promises. It can be used standalone, but it is also exported as part of Kit [`@solana/kit`](https://github.com/anza-xyz/kit/tree/main/packages/kit).
 
 ## Functions
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -756,6 +756,9 @@ importers:
       '@solana/programs':
         specifier: workspace:*
         version: link:../programs
+      '@solana/promises':
+        specifier: workspace:*
+        version: link:../promises
       '@solana/rpc':
         specifier: workspace:*
         version: link:../rpc


### PR DESCRIPTION
This PR includes `@solana/promises` in the `@solana/kit` package. `promises` has a very small API with 3 small useful helpers.

The primary reason for this is that `isAbortError` is the documented way to identify an error caused by a reactive store being superseded. I don't think it makes sense to require consumers of these stores (or the react hooks that use them) to import a separate `@solana/promises` dependency to use `isAbortError`.  