### PR TITLE
Add `useRpc` and `useRpcSubscriptions` hooks to `@solana/react`

### DIFF
--- a/.changeset/chatty-pumas-strive.md
+++ b/.changeset/chatty-pumas-strive.md
@@ -1,0 +1,5 @@
+---
+'@solana/react': minor
+---
+
+Add `useRpc` and `useRpcSubscriptions` hooks for capability-checked access to a client's RPC and RPC subscriptions.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -92,6 +92,28 @@ function useRpc() {
 
 Pass an array of capability names when a hook needs more than one (e.g. `['rpc', 'rpcSubscriptions']`) — the same `providerHint` is surfaced for whichever is missing.
 
+### `useRpc()` / `useRpcSubscriptions()`
+
+First-class, capability-checked access to the client's `rpc` and `rpcSubscriptions` objects. Each is a thin `useClientCapability` wrapper: it asserts the capability at mount (throwing `SOLANA_ERROR__REACT__MISSING_CAPABILITY` when the plugin is absent) and returns the object directly. The generic is the method set, defaulting to `SolanaRpcApi` / `SolanaRpcSubscriptionsApi`; use it to match the client you built.
+
+```tsx
+import { useEffect, useState } from 'react';
+import { useRpc } from '@solana/react';
+
+function EpochBadge() {
+    const rpc = useRpc();
+    const [epoch, setEpoch] = useState<bigint>();
+    useEffect(() => {
+        rpc.getEpochInfo()
+            .send()
+            .then(info => setEpoch(info.epoch));
+    }, [rpc]);
+    return <span>{epoch !== undefined ? `Epoch ${epoch}` : '…'}</span>;
+}
+```
+
+Calling `.send()` (or `.subscribe()` on a subscription) yourself is the low-level path. In practice you'll usually hand the resulting `PendingRpcRequest` / `PendingRpcSubscriptionsRequest` to `useRequest`, `useSubscription`, or `useTrackedData` (below), which track the lifecycle as React state for you.
+
 ### `useAction(fn)`
 
 Bridges any async function into a tracked action with `dispatch` / `status` / `data` / `error` / `reset`. Each `dispatch(...)` runs `fn` with a fresh `AbortSignal` and tracks the lifecycle through React state; calling `dispatch` again while a prior call is in flight aborts the first.
@@ -138,12 +160,12 @@ Fires a one-shot request on mount and re-fires whenever `source` changes identit
 > Unlike `useAction`, `useRequest` needs the input to have stable identity across renders — it's how the hook knows when to re-fire. Memoize with `useMemo` (for a reactive store source) or `useCallback` (for a function), keyed on whatever inputs your call depends on.
 
 ```tsx
-import { useClient, useRequest } from '@solana/react';
-import type { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+import { useRequest, useRpc } from '@solana/react';
+import type { GetLatestBlockhashApi } from '@solana/kit';
 
 function LatestBlockhash() {
-    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
-    const source = useMemo(() => client.rpc.getLatestBlockhash(), [client]);
+    const rpc = useRpc<GetLatestBlockhashApi>();
+    const source = useMemo(() => rpc.getLatestBlockhash(), [rpc]);
     const { data, error, refresh } = useRequest(source);
     if (error) return <button onClick={refresh}>Retry</button>;
     return <p>{data ? `Blockhash: ${data.value.blockhash}` : 'Loading…'}</p>;
@@ -154,9 +176,9 @@ function LatestBlockhash() {
 
 ```tsx
 function Balance({ address }: { address: Address | null }) {
-    const client = useClient<ClientWithRpc<GetBalanceApi>>();
+    const rpc = useRpc<GetBalanceApi>();
     // Disabled until an address is selected.
-    const source = useMemo(() => (address ? client.rpc.getBalance(address) : null), [client, address]);
+    const source = useMemo(() => (address ? rpc.getBalance(address) : null), [rpc, address]);
     const { data, status } = useRequest(source);
     if (status === 'disabled') return <p>Select an account to see its balance.</p>;
     return <p>{data?.value !== undefined ? `${data.value} lamports` : 'Loading…'}</p>;
@@ -208,12 +230,12 @@ Subscribe to a stream-store source and surface the latest notification as reacti
 `data` is the notification as the source emits it. For RPC subscriptions that emit `SolanaRpcResponse<U>`, read the inner value at `data.value` and the slot at `data.context.slot`. For raw notifications, `data` is the raw shape.
 
 ```tsx
-import { useClient, useSubscription } from '@solana/react';
-import type { Address, AccountNotificationsApi, ClientWithRpcSubscriptions } from '@solana/kit';
+import { useRpcSubscriptions, useSubscription } from '@solana/react';
+import type { Address, AccountNotificationsApi } from '@solana/kit';
 
 function AccountBalance({ address }: { address: Address }) {
-    const client = useClient<ClientWithRpcSubscriptions<AccountNotificationsApi>>();
-    const source = useMemo(() => client.rpcSubscriptions.accountNotifications(address), [client, address]);
+    const rpcSubscriptions = useRpcSubscriptions<AccountNotificationsApi>();
+    const source = useMemo(() => rpcSubscriptions.accountNotifications(address), [rpcSubscriptions, address]);
     const { data, error, reconnect } = useSubscription(source);
     if (error) return <button onClick={reconnect}>Reconnect</button>;
     return <p>{data ? `${data.value.lamports} lamports at slot ${data.context.slot}` : 'Connecting…'}</p>;
@@ -251,25 +273,20 @@ Render reactive state for an RPC subscription seeded by a one-shot RPC fetch, sl
 `spec` is a `TrackedDataSpec<TRpcValue, TSubscriptionValue, TItem>` with four fields: a pending RPC request, a pending RPC subscription request, and two mappers that unify their value shapes into a common `TItem`. Both RPC responses and subscription notifications must have shape `SolanaRpcResponse` for slot de-dupe. Pass `null` to disable (the result reports `status: 'disabled'`). Memoize the spec with `useMemo` keyed on its inputs — stable identity is how the hook knows when to tear down and re-run.
 
 ```tsx
-import { useClient, useTrackedData } from '@solana/react';
-import type {
-    Address,
-    AccountNotificationsApi,
-    ClientWithRpc,
-    ClientWithRpcSubscriptions,
-    GetBalanceApi,
-} from '@solana/kit';
+import { useRpc, useRpcSubscriptions, useTrackedData } from '@solana/react';
+import type { Address, AccountNotificationsApi, GetBalanceApi } from '@solana/kit';
 
 function AccountBalance({ address }: { address: Address }) {
-    const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const rpc = useRpc<GetBalanceApi>();
+    const rpcSubscriptions = useRpcSubscriptions<AccountNotificationsApi>();
     const spec = useMemo(
         () => ({
-            rpcRequest: client.rpc.getBalance(address),
-            rpcSubscriptionRequest: client.rpcSubscriptions.accountNotifications(address),
+            rpcRequest: rpc.getBalance(address),
+            rpcSubscriptionRequest: rpcSubscriptions.accountNotifications(address),
             rpcValueMapper: (lamports: bigint) => lamports,
             rpcSubscriptionValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
         }),
-        [client, address],
+        [rpc, rpcSubscriptions, address],
     );
     const { data, error, refresh } = useTrackedData(spec);
     if (error) return <button onClick={refresh}>Retry</button>;
@@ -337,13 +354,13 @@ Opt-in subpath that bridges Kit's reactive primitives into SWR's cache. Import f
 SWR-backed counterpart to `useRequest`. Same `source` shape (a `ReactiveActionSource<T>` or `(signal: AbortSignal) => Promise<T>`). Returns SWR's native `SWRResponse<T>`. Pass `null` for either `key` or `source` to disable — useful when one of the source's inputs isn't yet known.
 
 ```tsx
-import { useClient } from '@solana/react';
+import { useRpc } from '@solana/react';
 import { useRequestSWR } from '@solana/react/swr';
-import type { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+import type { GetLatestBlockhashApi } from '@solana/kit';
 
 function LatestBlockhash() {
-    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
-    const { data, error, isLoading, mutate } = useRequestSWR(['latestBlockhash'], client.rpc.getLatestBlockhash());
+    const rpc = useRpc<GetLatestBlockhashApi>();
+    const { data, error, isLoading, mutate } = useRequestSWR(['latestBlockhash'], rpc.getLatestBlockhash());
     if (error) return <button onClick={() => mutate()}>Retry</button>;
     if (isLoading) return <p>Loading…</p>;
     return <p>Blockhash: {data!.value.blockhash}</p>;
@@ -387,10 +404,10 @@ SWR-backed counterpart to `useSubscription`. Routes a `ReactiveStreamSource<T>` 
 
 ```tsx
 function AccountBalance({ address }: { address: Address }) {
-    const client = useClient<ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const rpcSubscriptions = useRpcSubscriptions<AccountNotificationsApi>();
     const { data, error } = useSubscriptionSWR(
         address ? ['account', address] : null,
-        address ? client.rpcSubscriptions.accountNotifications(address) : null,
+        address ? rpcSubscriptions.accountNotifications(address) : null,
     );
     if (error) return <p>Failed to connect.</p>;
     if (!data) return <p>Connecting…</p>;
@@ -410,18 +427,19 @@ SWR-backed counterpart to `useTrackedData`. Takes the same `TrackedDataSpec` (RP
 
 ```tsx
 function AccountBalance({ address }: { address: Address }) {
-    const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const rpc = useRpc<GetBalanceApi>();
+    const rpcSubscriptions = useRpcSubscriptions<AccountNotificationsApi>();
     const spec = useMemo(
         () =>
             address
                 ? {
-                      initialValueSource: client.rpc.getBalance(address),
+                      initialValueSource: rpc.getBalance(address),
                       initialValueMapper: (lamports: bigint) => lamports,
-                      streamSource: client.rpcSubscriptions.accountNotifications(address),
+                      streamSource: rpcSubscriptions.accountNotifications(address),
                       streamValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
                   }
                 : null,
-        [client, address],
+        [rpc, rpcSubscriptions, address],
     );
     const { data } = useTrackedDataSWR(address ? ['balance', address] : null, spec);
     return <p>{data ? `${data.value} lamports at slot ${data.context.slot}` : 'Loading…'}</p>;
@@ -443,13 +461,13 @@ Opt-in subpath that bridges Kit's reactive primitives into [TanStack Query](http
 TanStack Query-backed counterpart to `useRequest`. Same `source` shape (a `ReactiveActionSource<T>` or `(signal: AbortSignal) => Promise<T>`). Returns TanStack's native `UseQueryResult<T>`. Pass `null` for `source` to disable — useful when one of the source's inputs isn't yet known. This maps to TanStack's `enabled: false`. Unlike SWR there is no nullable `key`, disable via a `null` source (or `enabled`) instead.
 
 ```tsx
-import { useClient } from '@solana/react';
+import { useRpc } from '@solana/react';
 import { useRequestQuery } from '@solana/react/query';
-import type { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+import type { GetLatestBlockhashApi } from '@solana/kit';
 
 function LatestBlockhash() {
-    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
-    const { data, error, isLoading, refetch } = useRequestQuery(['latestBlockhash'], client.rpc.getLatestBlockhash());
+    const rpc = useRpc<GetLatestBlockhashApi>();
+    const { data, error, isLoading, refetch } = useRequestQuery(['latestBlockhash'], rpc.getLatestBlockhash());
     if (error) return <button onClick={() => refetch()}>Retry</button>;
     if (isLoading) return <p>Loading…</p>;
     return <p>Blockhash: {data!.value.blockhash}</p>;
@@ -488,13 +506,13 @@ TanStack Query-backed counterpart to `useSubscription`, for streams that have no
 Returns TanStack's native `UseQueryResult<T>`. `data` is the raw notification, exactly as the source emits it, so for RPC subscriptions read `data.value` and `data.context.slot`. Pass `null` for `source` to disable (TanStack's `enabled: false`).
 
 ```tsx
-import { useClient } from '@solana/react';
+import { useRpcSubscriptions } from '@solana/react';
 import { useSubscriptionQuery } from '@solana/react/query';
-import type { ClientWithRpcSubscriptions, SlotNotificationsApi } from '@solana/kit';
+import type { SlotNotificationsApi } from '@solana/kit';
 
 function SlotHeight() {
-    const client = useClient<ClientWithRpcSubscriptions<SlotNotificationsApi>>();
-    const { data, error } = useSubscriptionQuery(['slot'], client.rpcSubscriptions.slotNotifications());
+    const rpcSubscriptions = useRpcSubscriptions<SlotNotificationsApi>();
+    const { data, error } = useSubscriptionQuery(['slot'], rpcSubscriptions.slotNotifications());
     if (error) return <p>Disconnected.</p>;
     if (!data) return <p>Connecting…</p>;
     return <p>Slot {String(data.slot)}</p>;
@@ -519,26 +537,21 @@ TanStack Query-backed counterpart to `useTrackedData`. Takes the same `TrackedDa
 Returns TanStack's native `UseQueryResult`. `data` is the `SolanaRpcResponse<TItem>` envelope emitted by the underlying Kit primitive, so callers can read `data.value` (the unified item produced by the mappers) and `data.context.slot` (the slot the store dedup'd on) directly. Pass `null` for `spec` to disable (TanStack's `enabled: false`).
 
 ```tsx
-import { useClient } from '@solana/react';
+import { useRpc, useRpcSubscriptions } from '@solana/react';
 import { useTrackedDataQuery } from '@solana/react/query';
-import type {
-    Address,
-    AccountNotificationsApi,
-    ClientWithRpc,
-    ClientWithRpcSubscriptions,
-    GetBalanceApi,
-} from '@solana/kit';
+import type { Address, AccountNotificationsApi, GetBalanceApi } from '@solana/kit';
 
 function AccountBalance({ address }: { address: Address }) {
-    const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const rpc = useRpc<GetBalanceApi>();
+    const rpcSubscriptions = useRpcSubscriptions<AccountNotificationsApi>();
     const spec = useMemo(
         () => ({
-            initialValueSource: client.rpc.getBalance(address),
+            initialValueSource: rpc.getBalance(address),
             initialValueMapper: (lamports: bigint) => lamports,
-            streamSource: client.rpcSubscriptions.accountNotifications(address),
+            streamSource: rpcSubscriptions.accountNotifications(address),
             streamValueMapper: ({ lamports }: { lamports: bigint }) => lamports,
         }),
-        [client, address],
+        [rpc, rpcSubscriptions, address],
     );
     const { data, error } = useTrackedDataQuery(['balance', address], spec);
     if (error) return <p>Failed to load.</p>;

--- a/packages/react/src/__test-utils__/client-wrapper.tsx
+++ b/packages/react/src/__test-utils__/client-wrapper.tsx
@@ -1,0 +1,21 @@
+import type { createClient } from '@solana/kit';
+import React from 'react';
+
+import { ClientProvider } from '../ClientProvider';
+
+/**
+ * Builds a `renderHook`/`render` wrapper that mounts its children inside a {@link ClientProvider}
+ * for the given client.
+ *
+ * Shared across the capability-hook tests (`useClientCapability`, `useRpc`, `useRpcSubscriptions`,
+ * …) so each file doesn't redeclare the same one-line provider wrapper.
+ *
+ * @example
+ * ```tsx
+ * const client = createClient<ClientWithRpc>({ rpc });
+ * const { result } = renderHook(() => useRpc(), { wrapper: createClientWrapper(client) });
+ * ```
+ */
+export function createClientWrapper<T extends object>(client: ReturnType<typeof createClient<T>>) {
+    return ({ children }: { children: React.ReactNode }) => <ClientProvider client={client}>{children}</ClientProvider>;
+}

--- a/packages/react/src/__tests__/useClientCapability-test.browser.tsx
+++ b/packages/react/src/__tests__/useClientCapability-test.browser.tsx
@@ -4,18 +4,13 @@ import {
     SOLANA_ERROR__REACT__MISSING_CAPABILITY,
     SOLANA_ERROR__REACT__MISSING_PROVIDER,
 } from '@solana/kit';
-import React from 'react';
 
+import { createClientWrapper } from '../__test-utils__/client-wrapper';
 import { renderHook } from '../__test-utils__/render';
-import { ClientProvider } from '../ClientProvider';
 import { useClient } from '../useClient';
 import { useClientCapability } from '../useClientCapability';
 
 type ClientWithFoo = { foo: { hello(): string } };
-
-function wrapperFor<T extends object>(client: ReturnType<typeof createClient<T>>) {
-    return ({ children }: { children: React.ReactNode }) => <ClientProvider client={client}>{children}</ClientProvider>;
-}
 
 describe('useClientCapability', () => {
     it('returns the client when the capability is present', () => {
@@ -27,7 +22,7 @@ describe('useClientCapability', () => {
                     hookName: 'useFoo',
                     providerHint: 'Install fooPlugin().',
                 }),
-            { wrapper: wrapperFor(client) },
+            { wrapper: createClientWrapper(client) },
         );
         expect(result.current).toBe(client);
     });
@@ -46,7 +41,7 @@ describe('useClientCapability', () => {
                     return err;
                 }
             },
-            { wrapper: wrapperFor(client) },
+            { wrapper: createClientWrapper(client) },
         );
         expect(isSolanaError(result.current, SOLANA_ERROR__REACT__MISSING_CAPABILITY)).toBe(true);
         const ctx = (
@@ -71,7 +66,7 @@ describe('useClientCapability', () => {
                     return err;
                 }
             },
-            { wrapper: wrapperFor(client) },
+            { wrapper: createClientWrapper(client) },
         );
         expect(isSolanaError(result.current, SOLANA_ERROR__REACT__MISSING_CAPABILITY)).toBe(true);
         expect((result.current as { context: { capabilities: readonly string[] } }).context.capabilities).toEqual([
@@ -93,7 +88,7 @@ describe('useClientCapability', () => {
                     return err;
                 }
             },
-            { wrapper: wrapperFor(client) },
+            { wrapper: createClientWrapper(client) },
         );
         expect(isSolanaError(result.current, SOLANA_ERROR__REACT__MISSING_CAPABILITY)).toBe(true);
         expect((result.current as { context: { capabilities: readonly string[] } }).context.capabilities).toEqual([

--- a/packages/react/src/__tests__/useRpc-test.browser.tsx
+++ b/packages/react/src/__tests__/useRpc-test.browser.tsx
@@ -1,0 +1,51 @@
+import {
+    type ClientWithRpc,
+    createClient,
+    isSolanaError,
+    type Rpc,
+    SOLANA_ERROR__REACT__MISSING_CAPABILITY,
+    SOLANA_ERROR__REACT__MISSING_PROVIDER,
+    type SolanaRpcApi,
+} from '@solana/kit';
+
+import { createClientWrapper } from '../__test-utils__/client-wrapper';
+import { renderHook } from '../__test-utils__/render';
+import { useRpc } from '../useRpc';
+
+describe('useRpc', () => {
+    it('returns the client rpc object when the capability is present', () => {
+        const rpc = { getBalance: () => {} } as unknown as Rpc<SolanaRpcApi>;
+        const client = createClient<ClientWithRpc<SolanaRpcApi>>({ rpc });
+        const { result } = renderHook(() => useRpc(), { wrapper: createClientWrapper(client) });
+        expect(result.current).toBe(rpc);
+    });
+
+    it('throws MISSING_CAPABILITY with hookName useRpc when rpc is absent', () => {
+        const client = createClient(); // no `rpc` capability
+        const { result } = renderHook(
+            () => {
+                try {
+                    return useRpc();
+                } catch (err) {
+                    return err;
+                }
+            },
+            { wrapper: createClientWrapper(client) },
+        );
+        expect(isSolanaError(result.current, SOLANA_ERROR__REACT__MISSING_CAPABILITY)).toBe(true);
+        const ctx = (result.current as { context: { capabilities: readonly string[]; hookName: string } }).context;
+        expect(ctx.capabilities).toEqual(['rpc']);
+        expect(ctx.hookName).toBe('useRpc');
+    });
+
+    it('throws MISSING_PROVIDER when rendered with no ClientProvider', () => {
+        const { result } = renderHook(() => {
+            try {
+                return useRpc();
+            } catch (err) {
+                return err;
+            }
+        });
+        expect(isSolanaError(result.current, SOLANA_ERROR__REACT__MISSING_PROVIDER)).toBe(true);
+    });
+});

--- a/packages/react/src/__tests__/useRpcSubscriptions-test.browser.tsx
+++ b/packages/react/src/__tests__/useRpcSubscriptions-test.browser.tsx
@@ -1,0 +1,53 @@
+import {
+    type ClientWithRpcSubscriptions,
+    createClient,
+    isSolanaError,
+    type RpcSubscriptions,
+    SOLANA_ERROR__REACT__MISSING_CAPABILITY,
+    SOLANA_ERROR__REACT__MISSING_PROVIDER,
+    type SolanaRpcSubscriptionsApi,
+} from '@solana/kit';
+
+import { createClientWrapper } from '../__test-utils__/client-wrapper';
+import { renderHook } from '../__test-utils__/render';
+import { useRpcSubscriptions } from '../useRpcSubscriptions';
+
+describe('useRpcSubscriptions', () => {
+    it('returns the client rpcSubscriptions object when the capability is present', () => {
+        const rpcSubscriptions = {
+            accountNotifications: () => {},
+        } as unknown as RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        const client = createClient<ClientWithRpcSubscriptions<SolanaRpcSubscriptionsApi>>({ rpcSubscriptions });
+        const { result } = renderHook(() => useRpcSubscriptions(), { wrapper: createClientWrapper(client) });
+        expect(result.current).toBe(rpcSubscriptions);
+    });
+
+    it('throws MISSING_CAPABILITY with hookName useRpcSubscriptions when rpcSubscriptions is absent', () => {
+        const client = createClient(); // no `rpcSubscriptions` capability
+        const { result } = renderHook(
+            () => {
+                try {
+                    return useRpcSubscriptions();
+                } catch (err) {
+                    return err;
+                }
+            },
+            { wrapper: createClientWrapper(client) },
+        );
+        expect(isSolanaError(result.current, SOLANA_ERROR__REACT__MISSING_CAPABILITY)).toBe(true);
+        const ctx = (result.current as { context: { capabilities: readonly string[]; hookName: string } }).context;
+        expect(ctx.capabilities).toEqual(['rpcSubscriptions']);
+        expect(ctx.hookName).toBe('useRpcSubscriptions');
+    });
+
+    it('throws MISSING_PROVIDER when rendered with no ClientProvider', () => {
+        const { result } = renderHook(() => {
+            try {
+                return useRpcSubscriptions();
+            } catch (err) {
+                return err;
+            }
+        });
+        expect(isSolanaError(result.current, SOLANA_ERROR__REACT__MISSING_PROVIDER)).toBe(true);
+    });
+});

--- a/packages/react/src/__typetests__/useRpc-typetest.ts
+++ b/packages/react/src/__typetests__/useRpc-typetest.ts
@@ -1,0 +1,28 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import type { Rpc, SolanaRpcApi, SolanaRpcApiMainnet } from '@solana/kit';
+
+import { useRpc } from '../useRpc';
+
+// [DESCRIBE] useRpc
+{
+    // It defaults to Rpc<SolanaRpcApi>
+    {
+        const rpc = useRpc();
+        rpc satisfies Rpc<SolanaRpcApi>;
+        void rpc.getBalance;
+    }
+
+    // It narrows to a custom method set
+    {
+        const rpc = useRpc<SolanaRpcApiMainnet>();
+        rpc satisfies Rpc<SolanaRpcApiMainnet>;
+    }
+
+    // A method absent from the narrowed API is rejected (requestAirdrop is not on Mainnet)
+    {
+        const rpc = useRpc<SolanaRpcApiMainnet>();
+        // @ts-expect-error - requestAirdrop is not part of SolanaRpcApiMainnet
+        void rpc.requestAirdrop;
+    }
+}

--- a/packages/react/src/__typetests__/useRpcSubscriptions-typetest.ts
+++ b/packages/react/src/__typetests__/useRpcSubscriptions-typetest.ts
@@ -1,0 +1,31 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+
+import type { RpcSubscriptions, SolanaRpcSubscriptionsApi } from '@solana/kit';
+
+import { useRpcSubscriptions } from '../useRpcSubscriptions';
+
+type SlotOnlySubscriptions = Pick<SolanaRpcSubscriptionsApi, 'slotNotifications'>;
+
+// [DESCRIBE] useRpcSubscriptions
+{
+    // It defaults to RpcSubscriptions<SolanaRpcSubscriptionsApi>
+    {
+        const rpcSubscriptions = useRpcSubscriptions();
+        rpcSubscriptions satisfies RpcSubscriptions<SolanaRpcSubscriptionsApi>;
+        void rpcSubscriptions.accountNotifications;
+    }
+
+    // It narrows to a custom subscription method set
+    {
+        const rpcSubscriptions = useRpcSubscriptions<SlotOnlySubscriptions>();
+        rpcSubscriptions satisfies RpcSubscriptions<SlotOnlySubscriptions>;
+        void rpcSubscriptions.slotNotifications;
+    }
+
+    // A method absent from the narrowed API is rejected
+    {
+        const rpcSubscriptions = useRpcSubscriptions<SlotOnlySubscriptions>();
+        // @ts-expect-error - accountNotifications is not part of SlotOnlySubscriptions
+        void rpcSubscriptions.accountNotifications;
+    }
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -10,6 +10,8 @@ export * from './useClientCapability';
 export * from './usePlanTransaction';
 export * from './usePlanTransactions';
 export * from './useRequest';
+export * from './useRpc';
+export * from './useRpcSubscriptions';
 export * from './useSendTransaction';
 export * from './useSendTransactions';
 export * from './useSignAndSendTransaction';

--- a/packages/react/src/useRpc.ts
+++ b/packages/react/src/useRpc.ts
@@ -1,0 +1,38 @@
+import type { ClientWithRpc, Rpc, SolanaRpcApi } from '@solana/kit';
+
+import { useClientCapability } from './useClientCapability';
+
+/**
+ * Reads the RPC client from the nearest {@link ClientProvider} and asserts at mount that the
+ * `rpc` capability is installed.
+ *
+ * Wraps {@link useClientCapability}, so a client missing the RPC plugin fails loudly at mount with
+ * a {@link SolanaError} of code {@link SOLANA_ERROR__REACT__MISSING_CAPABILITY} rather than
+ * surfacing later as an `undefined` access. Returns the client's `rpc` object directly — its
+ * identity is owned by the provided client, so it is stable for that client's lifetime and needs
+ * no memoization.
+ *
+ * @typeParam TRpcMethods - The RPC method set the returned client exposes. Defaults to the full
+ *   {@link SolanaRpcApi}; narrow it (e.g. to `SolanaRpcApiMainnet`) to match the client you built.
+ *
+ * @example
+ * ```tsx
+ * import { useRpc } from '@solana/react';
+ *
+ * function Balance({ address }) {
+ *     const rpc = useRpc();
+ *     // ...call rpc.getBalance(address).send() in an effect or with useRequest, etc.
+ * }
+ * ```
+ *
+ * @see {@link useRpcSubscriptions}
+ * @see {@link useClientCapability}
+ */
+export function useRpc<TRpcMethods = SolanaRpcApi>(): Rpc<TRpcMethods> {
+    const client = useClientCapability<ClientWithRpc<TRpcMethods>>({
+        capability: 'rpc',
+        hookName: 'useRpc',
+        providerHint: 'Install `solanaRpc()` on the client.',
+    });
+    return client.rpc;
+}

--- a/packages/react/src/useRpcSubscriptions.ts
+++ b/packages/react/src/useRpcSubscriptions.ts
@@ -1,0 +1,40 @@
+import type { ClientWithRpcSubscriptions, RpcSubscriptions, SolanaRpcSubscriptionsApi } from '@solana/kit';
+
+import { useClientCapability } from './useClientCapability';
+
+/**
+ * Reads the RPC subscriptions client from the nearest {@link ClientProvider} and asserts at mount
+ * that the `rpcSubscriptions` capability is installed.
+ *
+ * Wraps {@link useClientCapability}, so a client missing the RPC subscriptions plugin fails loudly
+ * at mount with a {@link SolanaError} of code {@link SOLANA_ERROR__REACT__MISSING_CAPABILITY}
+ * rather than surfacing later as an `undefined` access. Returns the client's `rpcSubscriptions`
+ * object directly — its identity is owned by the provided client, so it is stable for that
+ * client's lifetime and needs no memoization.
+ *
+ * @typeParam TRpcSubscriptionsMethods - The subscription method set the returned client exposes.
+ *   Defaults to the full {@link SolanaRpcSubscriptionsApi}; narrow it to match the client you built.
+ *
+ * @example
+ * ```tsx
+ * import { useRpcSubscriptions } from '@solana/react';
+ *
+ * function AccountWatcher({ address }) {
+ *     const rpcSubscriptions = useRpcSubscriptions();
+ *     // ...call rpcSubscriptions.accountNotifications(address).subscribe() in an effect or with useSubscription, etc.
+ * }
+ * ```
+ *
+ * @see {@link useRpc}
+ * @see {@link useClientCapability}
+ */
+export function useRpcSubscriptions<
+    TRpcSubscriptionsMethods = SolanaRpcSubscriptionsApi,
+>(): RpcSubscriptions<TRpcSubscriptionsMethods> {
+    const client = useClientCapability<ClientWithRpcSubscriptions<TRpcSubscriptionsMethods>>({
+        capability: 'rpcSubscriptions',
+        hookName: 'useRpcSubscriptions',
+        providerHint: 'Install `solanaRpcSubscriptions()` on the client.',
+    });
+    return client.rpcSubscriptions;
+}


### PR DESCRIPTION
This PR adds React hooks to read `rpc` and `rpcSubscriptions` from a Kit client

These are just wrappers around `useClientCapability` and require the rpc plugins, most likely using `solanaRpc`. Probably the simplest hooks we'll add, but I think justified by how much apps need to use the RPC.

They're added near the start of the readme, and the other hooks (useRequest etc) are updated to use them instead of using `useClient` directly.

If reading both `rpc` and `rpcSubscriptions` (as some examples in the readme do), this is now two hook calls instead of just one to `useClient[Capability]`. I think this tradeoff is worth it, and any app that needs the micro-optimisation can use `useClient[Capability]` instead. We could provide a hook that returns both in one call, but I don't think it's necessary.