### PR TITLE
feat: expose codecs subpath from kit

### DIFF
--- a/.changeset/swift-humans-grin.md
+++ b/.changeset/swift-humans-grin.md
@@ -1,0 +1,5 @@
+---
+"@solana/kit": minor
+---
+
+Expose `@solana/codecs` from the `@solana/kit/codecs` subpath.

--- a/packages/build-scripts/getBaseConfig.ts
+++ b/packages/build-scripts/getBaseConfig.ts
@@ -19,7 +19,7 @@ export function getBaseConfig(platform: Platform, formats: Format[], _options: O
     // via the package.json `exports` map.
     const moduleEntry =
         env.npm_package_name === '@solana/kit'
-            ? ['./src/index.ts', './src/program-client-core.ts']
+            ? ['./src/index.ts', './src/program-client-core.ts', './src/codecs.ts']
             : env.npm_package_name === '@solana/react'
               ? ['./src/index.ts', './src/swr.ts', './src/query.ts']
               : ['./src/index.ts'];

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -43,6 +43,26 @@
             },
             "react-native": "./dist/program-client-core.native.mjs",
             "types": "./dist/types/program-client-core.d.ts"
+        },
+        "./codecs": {
+            "edge-light": {
+                "import": "./dist/codecs.node.mjs",
+                "require": "./dist/codecs.node.cjs"
+            },
+            "workerd": {
+                "import": "./dist/codecs.node.mjs",
+                "require": "./dist/codecs.node.cjs"
+            },
+            "browser": {
+                "import": "./dist/codecs.browser.mjs",
+                "require": "./dist/codecs.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/codecs.node.mjs",
+                "require": "./dist/codecs.node.cjs"
+            },
+            "react-native": "./dist/codecs.native.mjs",
+            "types": "./dist/types/codecs.d.ts"
         }
     },
     "browser": {

--- a/packages/kit/src/codecs.ts
+++ b/packages/kit/src/codecs.ts
@@ -1,0 +1,1 @@
+export * from '@solana/codecs';

--- a/packages/kit/tsconfig.declarations.json
+++ b/packages/kit/tsconfig.declarations.json
@@ -6,5 +6,5 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts", "src/program-client-core.ts"]
+    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts", "src/program-client-core.ts", "src/codecs.ts"]
 }


### PR DESCRIPTION
#### Problem

Expose a ./codecs subpath to allow downstream consumers (like @solana/web3.js) to import codecs via @solana/kit/codecs.

#### Summary of Changes

- Created src/codecs.ts to re-export everything from @solana/codecs.
- Exposed ./codecs subpath in the kit's package.json exports.
- Configured build scripts and tsconfig to build the new entrypoint and generate type declarations.
- Added a changeset.

Fixes #1834