### PR TITLE
Expose codecs subpath from kit

### DIFF
--- a/.changeset/khaki-codecs-exist.md
+++ b/.changeset/khaki-codecs-exist.md
@@ -1,0 +1,5 @@
+---
+'@solana/kit': minor
+---
+
+Expose `@solana/kit/codecs` as a dedicated subpath export that re-exports `@solana/codecs`.

--- a/packages/build-scripts/getBaseConfig.ts
+++ b/packages/build-scripts/getBaseConfig.ts
@@ -19,7 +19,7 @@ export function getBaseConfig(platform: Platform, formats: Format[], _options: O
     // via the package.json `exports` map.
     const moduleEntry =
         env.npm_package_name === '@solana/kit'
-            ? ['./src/index.ts', './src/program-client-core.ts']
+            ? ['./src/index.ts', './src/codecs.ts', './src/program-client-core.ts']
             : env.npm_package_name === '@solana/react'
               ? ['./src/index.ts', './src/swr.ts', './src/query.ts']
               : ['./src/index.ts'];

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -24,6 +24,26 @@
             "react-native": "./dist/index.native.mjs",
             "types": "./dist/types/index.d.ts"
         },
+        "./codecs": {
+            "edge-light": {
+                "import": "./dist/codecs.node.mjs",
+                "require": "./dist/codecs.node.cjs"
+            },
+            "workerd": {
+                "import": "./dist/codecs.node.mjs",
+                "require": "./dist/codecs.node.cjs"
+            },
+            "browser": {
+                "import": "./dist/codecs.browser.mjs",
+                "require": "./dist/codecs.browser.cjs"
+            },
+            "node": {
+                "import": "./dist/codecs.node.mjs",
+                "require": "./dist/codecs.node.cjs"
+            },
+            "react-native": "./dist/codecs.native.mjs",
+            "types": "./dist/types/codecs.d.ts"
+        },
         "./program-client-core": {
             "edge-light": {
                 "import": "./dist/program-client-core.node.mjs",
@@ -46,6 +66,8 @@
         }
     },
     "browser": {
+        "./dist/codecs.node.cjs": "./dist/codecs.browser.cjs",
+        "./dist/codecs.node.mjs": "./dist/codecs.browser.mjs",
         "./dist/index.node.cjs": "./dist/index.browser.cjs",
         "./dist/index.node.mjs": "./dist/index.browser.mjs",
         "./dist/program-client-core.node.cjs": "./dist/program-client-core.browser.cjs",

--- a/packages/kit/src/__tests__/program-client-core-subpath-export-test.node.ts
+++ b/packages/kit/src/__tests__/program-client-core-subpath-export-test.node.ts
@@ -5,6 +5,11 @@ const kitPackageFolder = path.resolve(__dirname, '../../');
 const requireFromKit = createRequire(path.join(kitPackageFolder, 'package.json'));
 
 describe('@solana/kit program-client-core subpath export', () => {
+    it('resolves `@solana/kit/codecs` to its dedicated dist entrypoint', () => {
+        const resolvedSubpathExport = requireFromKit.resolve('@solana/kit/codecs');
+        expect(resolvedSubpathExport).toBe(path.join(kitPackageFolder, 'dist', 'codecs.node.cjs'));
+    });
+
     it('resolves `@solana/kit/program-client-core` to its dedicated dist entrypoint', () => {
         const resolvedSubpathExport = requireFromKit.resolve('@solana/kit/program-client-core');
         expect(resolvedSubpathExport).toBe(path.join(kitPackageFolder, 'dist', 'program-client-core.node.cjs'));
@@ -12,9 +17,11 @@ describe('@solana/kit program-client-core subpath export', () => {
 
     it('keeps root and subpath exports distinct', () => {
         const resolvedRootExport = requireFromKit.resolve('@solana/kit');
+        const resolvedCodecsSubpathExport = requireFromKit.resolve('@solana/kit/codecs');
         const resolvedSubpathExport = requireFromKit.resolve('@solana/kit/program-client-core');
 
         expect(resolvedRootExport).toBe(path.join(kitPackageFolder, 'dist', 'index.node.cjs'));
+        expect(resolvedRootExport).not.toBe(resolvedCodecsSubpathExport);
         expect(resolvedRootExport).not.toBe(resolvedSubpathExport);
     });
 });

--- a/packages/kit/src/codecs.ts
+++ b/packages/kit/src/codecs.ts
@@ -1,0 +1,1 @@
+export * from '@solana/codecs';

--- a/packages/kit/tsconfig.declarations.json
+++ b/packages/kit/tsconfig.declarations.json
@@ -6,5 +6,10 @@
         "outDir": "./dist/types"
     },
     "extends": "./tsconfig.json",
-    "include": ["../build-scripts/build-time-constants.d.ts", "src/index.ts", "src/program-client-core.ts"]
+    "include": [
+        "../build-scripts/build-time-constants.d.ts",
+        "src/index.ts",
+        "src/codecs.ts",
+        "src/program-client-core.ts"
+    ]
 }


### PR DESCRIPTION
#### Problem

`@solana/web3.js` v3 wants to consume codecs through `@solana/kit/codecs`, but `@solana/kit` currently only exposes codecs from the root package export. That means downstream packages need to add or maintain a direct `@solana/codecs` dependency instead of importing through Kit.

#### Summary of Changes

Adds a dedicated `@solana/kit/codecs` subpath export that re-exports `@solana/codecs`.

This PR also:
- Adds the `src/codecs.ts` entrypoint.
- Adds the `./codecs` package export for Node, browser, React Native, workerd, and edge-light.
- Includes the codecs entrypoint in JS and declaration builds.
- Extends the existing subpath export test.
- Adds a changeset for `@solana/kit`.

Fixes #1834