### PR TITLE
Rework the react docs to prioritise `useClient<AppClient>`

### DIFF
--- a/docs/content/docs/guides/react/core-hooks.mdx
+++ b/docs/content/docs/guides/react/core-hooks.mdx
@@ -9,36 +9,56 @@ Every hook on this page must be rendered under a [`ClientProvider`](/docs/guides
 
 ### `useClient`
 
-Reads the Kit client published by the nearest `ClientProvider`. It defaults to the base `Client` shape; when you know a plugin is installed, narrow the type through the generic. This is a pure type-cast with no runtime check - reach for `useClientCapability` instead when a missing plugin should fail. Throws `SOLANA_ERROR__REACT__MISSING_PROVIDER` if no provider is mounted above it.
+Reads the Kit client published by the nearest `ClientProvider`. Throws `SOLANA_ERROR__REACT__MISSING_PROVIDER` if no provider is mounted above it.
+
+Pass your client's type through the generic so every capability you installed is typed at the call site. The simplest way is to reuse the type of the [client you already built](/docs/guides/react) - export it once alongside the client - so the hook's type always matches your real plugin composition:
 
 ```tsx twoslash
-import { ClientWithRpc, GetEpochInfoApi } from '@solana/kit';
+// client.ts — where you build the client
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+
+export const client = createClient().use(generatedSigner()).use(solanaDevnetRpc());
+export type AppClient = Awaited<typeof client>;
+
+// any component
 import { useClient } from '@solana/react';
 
 function FetchEpochButton() {
-    const client = useClient<ClientWithRpc<GetEpochInfoApi>>();
+    const client = useClient<AppClient>(); // rpc, signers, … all typed
     return <button onClick={() => client.rpc.getEpochInfo().send()}>Fetch epoch</button>;
 }
 ```
 
+`AppClient` uses `Awaited<typeof client>` so it resolves the promise when a plugin is async, for a fully-synchronous client `Awaited<…>` is a no-op and `typeof client` alone would do.
+
+`useClient` is a pure type-cast with no runtime check.
+
 ### `useClientCapability`
 
-Reads the client and asserts at mount that a capability is installed, narrowing the return type via the generic. If the capability is absent it throws `SOLANA_ERROR__REACT__MISSING_CAPABILITY`, including the `hookName` and `providerHint` you supply so the mistake is easy to locate. This is the building block for plugin-specific hooks.
+A runtime escape hatch for the uncommon case where the client isn't precisely typed — a loosely-typed `Client` read from context, say — and you want a clear failure at mount instead of a downstream `undefined`. It reads the client, asserts a capability is installed, and narrows the return type via the generic; if the capability is absent it throws `SOLANA_ERROR__REACT__MISSING_CAPABILITY` with the `hookName` and `providerHint` you supply.
+
+When you type your client with `useClient<AppClient>()` the compiler already guarantees the capability is present, so you rarely need this.
 
 ```tsx twoslash
 import { ClientWithRpc, GetEpochInfoApi } from '@solana/kit';
 import { useClientCapability } from '@solana/react';
 
-function useRpc() {
-    return useClientCapability<ClientWithRpc<GetEpochInfoApi>>({
+// The provider holds a loosely-typed `Client` (built elsewhere, or by a
+// third party), so `useClient` can't prove `rpc` is installed. Assert it here
+// and get a clear mount-time error — with your hint — if it isn't.
+function EpochBadge() {
+    const client = useClientCapability<ClientWithRpc<GetEpochInfoApi>>({
         capability: 'rpc',
-        hookName: 'useRpc',
+        hookName: 'EpochBadge',
         providerHint: 'Install a `solanaRpc()` plugin on the client.',
     });
+    return <button onClick={() => client.rpc.getEpochInfo().send()}>Refresh epoch</button>;
 }
 ```
 
-Pass an array for `capability` when a hook needs more than one (e.g. `['rpc', 'rpcSubscriptions']`); the same `providerHint` is reported for whichever is missing.
+Pass an array for `capability` when you need more than one (e.g. `['rpc', 'rpcSubscriptions']`); the same `providerHint` is reported for whichever is missing.
 
 ## Reading once
 
@@ -49,12 +69,17 @@ Fires a one-shot request on mount and re-fires whenever the source changes ident
 Pass either a Kit request source (most commonly a `PendingRpcRequest`) or an `async (signal) => Promise<T>` function to wrap any one-shot async call. Memoize the source (`useMemo`) or function (`useCallback`) on its inputs.
 
 ```tsx twoslash
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = createClient().use(generatedSigner()).use(solanaDevnetRpc());
+type AppClient = Awaited<typeof client>;
+// ---cut-before---
 import { useMemo } from 'react';
-import { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
 import { useClient, useRequest } from '@solana/react';
 
 function LatestBlockhash() {
-    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+    const client = useClient<AppClient>();
     const source = useMemo(() => client.rpc.getLatestBlockhash(), [client]);
     const { data, error, status, refresh } = useRequest(source, {
         getAbortSignal: () => AbortSignal.timeout(5_000),
@@ -73,12 +98,18 @@ The `getAbortSignal` factory runs on every attempt (initial fire and every `refr
 Subscribes to a stream source and surfaces the latest notification - no initial fetch. The subscription opens on mount, re-opens when the source changes identity, and tears down on unmount. Use `reconnect()` to re-open manually. Status is `loading`, `loaded`, `error`, or `disabled`.
 
 ```tsx twoslash
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = createClient().use(generatedSigner()).use(solanaDevnetRpc());
+type AppClient = Awaited<typeof client>;
+// ---cut-before---
 import { useMemo } from 'react';
-import { Address, ClientWithRpcSubscriptions, AccountNotificationsApi } from '@solana/kit';
+import { Address } from '@solana/kit';
 import { useClient, useSubscription } from '@solana/react';
 
 function LiveAccount({ address }: { address: Address }) {
-    const client = useClient<ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const client = useClient<AppClient>();
     const source = useMemo(
         () => client.rpcSubscriptions.accountNotifications(address),
         [client, address],
@@ -100,20 +131,18 @@ Renders a value that loads quickly and then stays live: a one-shot fetch seeds t
 Pass a memoized spec with an `initialValueSource` + `initialValueMapper` (the initial fetch) and a `streamSource` + `streamValueMapper` (the subscription).
 
 ```tsx twoslash
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+const client = createClient().use(generatedSigner()).use(solanaDevnetRpc());
+type AppClient = Awaited<typeof client>;
+// ---cut-before---
 import { useMemo } from 'react';
-import {
-    Address,
-    ClientWithRpc,
-    ClientWithRpcSubscriptions,
-    GetBalanceApi,
-    AccountNotificationsApi,
-} from '@solana/kit';
+import { Address } from '@solana/kit';
 import { useClient, useTrackedData } from '@solana/react';
 
 function AccountBalance({ address }: { address: Address }) {
-    const client = useClient<
-        ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>
-    >();
+    const client = useClient<AppClient>();
     const spec = useMemo(
         () => ({
             initialValueSource: client.rpc.getBalance(address),

--- a/docs/content/docs/guides/react/index.mdx
+++ b/docs/content/docs/guides/react/index.mdx
@@ -19,8 +19,14 @@ import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
 import { generatedSigner } from '@solana/kit-plugin-signer';
 
 // Build once, at module scope, so the reference is stable across renders.
-const client = createClient().use(generatedSigner()).use(solanaDevnetRpc());
+export const client = createClient().use(generatedSigner()).use(solanaDevnetRpc());
+
+// Export the client's type too, so components can read a fully-typed client.
+// `Awaited<…>` resolves the promise when a plugin is async; it's a no-op otherwise.
+export type AppClient = Awaited<typeof client>;
 ```
+
+Exporting `AppClient` lets any component ask for the fully-typed client with [`useClient<AppClient>()`](/docs/guides/react/core-hooks#useclient) - every capability you installed above is typed, with no per-call narrowing or casting.
 
 Wrap your app in the provider and pass the client in:
 
@@ -132,14 +138,14 @@ export function App() {
 
 Once a provider is mounted, pick a hook by what you are trying to do:
 
-| You want to…                                     | Hook                                                                       | What you get back                                                                    |
-| ------------------------------------------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| Access the raw client imperatively               | [`useClient`](/docs/guides/react/core-hooks#useclient)                     | The Kit client from context (type-cast, no runtime check).                           |
-| Access the client and assert a plugin is present | [`useClientCapability`](/docs/guides/react/core-hooks#useclientcapability) | The narrowed client, throws if the capability is missing.                            |
-| Read a value once                                | [`useRequest`](/docs/guides/react/core-hooks#userequest)                   | `{ data, error, status, refresh }`. Request fires on mount, `refresh()` re-fires.    |
-| Subscribe to a stream of notifications           | [`useSubscription`](/docs/guides/react/core-hooks#usesubscription)         | `{ data, error, status, reconnect }`. Latest notification, no initial fetch.         |
-| Read a value that updates live                   | [`useTrackedData`](/docs/guides/react/core-hooks#usetrackeddata)           | `{ data, error, status, refresh }`. Initial fetch seeds, subscription keeps it live. |
-| Trigger an async action on user input            | [`useAction`](/docs/guides/react/core-hooks#useaction)                     | `{ dispatch, status, data, error, reset }`. Fires on demand.                         |
+| You want to…                                    | Hook                                                                       | What you get back                                                                    |
+| ----------------------------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| Access your typed client imperatively           | [`useClient`](/docs/guides/react/core-hooks#useclient)                     | Your `AppClient` from context (type-cast, no runtime check).                         |
+| Runtime-guard a capability on an untyped client | [`useClientCapability`](/docs/guides/react/core-hooks#useclientcapability) | The narrowed client; throws at mount if the capability is missing.                   |
+| Read a value once                               | [`useRequest`](/docs/guides/react/core-hooks#userequest)                   | `{ data, error, status, refresh }`. Request fires on mount, `refresh()` re-fires.    |
+| Subscribe to a stream of notifications          | [`useSubscription`](/docs/guides/react/core-hooks#usesubscription)         | `{ data, error, status, reconnect }`. Latest notification, no initial fetch.         |
+| Read a value that updates live                  | [`useTrackedData`](/docs/guides/react/core-hooks#usetrackeddata)           | `{ data, error, status, refresh }`. Initial fetch seeds, subscription keeps it live. |
+| Trigger an async action on user input           | [`useAction`](/docs/guides/react/core-hooks#useaction)                     | `{ dispatch, status, data, error, reset }`. Fires on demand.                         |
 
 The [SWR](/docs/guides/react/swr) and [TanStack Query](/docs/guides/react/query) adapters route the read hooks through those libraries' caches. These add features such as deduplication and devtools.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -19,7 +19,7 @@ The Kit client is a plugin-extensible value built outside the React tree (`creat
 
 ### `ClientProvider`
 
-Publishes a caller-owned Kit client to its subtree. Required for `useClient`, `useClientCapability`, and any plugin-specific hook that depends on a client capability. Generic primitives like `useAction` work against arbitrary async functions and don't need a provider.
+Publishes a caller-owned Kit client to its subtree. Required for `useClient` and any plugin-specific hook that reads a client capability. Generic primitives like `useAction` work against arbitrary async functions and don't need a provider.
 
 ```tsx
 import { createClient } from '@solana/kit';
@@ -59,38 +59,58 @@ function Root() {
 
 Reads the Kit client published by the nearest `ClientProvider`. Throws a `SolanaError` with code `SOLANA_ERROR__REACT__MISSING_PROVIDER` if no provider is mounted.
 
-Defaults to the base `Client` shape. Callers who know a specific plugin is installed may widen the type via the generic — this is a pure cast with no runtime check, so reach for `useClientCapability` when a missing plugin should fail loudly at mount instead of surfacing later as `undefined`.
+It defaults to the base `Client` shape, pass your client's type through the generic to get the capabilities you installed typed at the call site. The ergonomic way is to **reuse the type of the client you already built** — export it from wherever you compose the client and hand that to `useClient`, so the hook's type stays in sync with your real plugin composition automatically:
 
 ```tsx
-import { ClientWithRpc, GetEpochInfoApi } from '@solana/kit';
+// client.ts — where you build the client
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { generatedSigner } from '@solana/kit-plugin-signer';
+
+export const client = createClient().use(generatedSigner()).use(solanaDevnetRpc());
+
+// `Awaited<…>` resolves the promise when any plugin is async (e.g. `generatedSigner()`);
+// for a fully-synchronous client it is simply `typeof client`.
+export type AppClient = Awaited<typeof client>;
+```
+
+```tsx
+// any component
 import { useClient } from '@solana/react';
+import type { AppClient } from './client';
 
 function ManualSend() {
-    const client = useClient<ClientWithRpc<GetEpochInfoApi>>();
+    const client = useClient<AppClient>(); // rpc, signers, … all typed
     return <button onClick={() => client.rpc.getEpochInfo().send()}>Fetch</button>;
 }
 ```
 
+`useClient` is a pure type assertion with no runtime check.
+
 ### `useClientCapability<TClient>(config)`
 
-Reads the client and asserts at mount that the requested capability is installed, narrowing the return type via the generic. Throws a `SolanaError` with code `SOLANA_ERROR__REACT__MISSING_CAPABILITY` when the capability is absent — including `hookName` and `providerHint` so users can fix the mistake without cross-referencing docs.
+A runtime escape hatch for the uncommon case where the client isn't precisely typed — a loosely-typed `Client` read from context, say — and you want a clear failure at mount rather than a downstream `undefined`. It reads the client, asserts at mount that the requested capability is installed, and narrows the return type via the generic, throwing a `SolanaError` with code `SOLANA_ERROR__REACT__MISSING_CAPABILITY` (with your `hookName` and `providerHint`) when the capability is absent.
 
-Use this from the implementation of plugin-specific hooks. Apps that need ad-hoc access can reach for `useClient` directly and supply their own narrowing.
+When you type your client with `useClient<AppClient>()`, the compiler already guarantees the capability is present, so you rarely need this.
 
 ```tsx
 import { ClientWithRpc, GetEpochInfoApi } from '@solana/kit';
 import { useClientCapability } from '@solana/react';
 
-function useRpc() {
-    return useClientCapability<ClientWithRpc<GetEpochInfoApi>>({
+// The provider holds a loosely-typed `Client` (built elsewhere, or by a
+// third party), so `useClient` can't prove `rpc` is installed. Assert it here
+// and get a clear mount-time error — with your hint — if it isn't.
+function EpochBadge() {
+    const client = useClientCapability<ClientWithRpc<GetEpochInfoApi>>({
         capability: 'rpc',
-        hookName: 'useRpc',
+        hookName: 'EpochBadge',
         providerHint: 'Install `solanaRpc()` on the client.',
     });
+    return <button onClick={() => client.rpc.getEpochInfo().send()}>Refresh epoch</button>;
 }
 ```
 
-Pass an array of capability names when a hook needs more than one (e.g. `['rpc', 'rpcSubscriptions']`) — the same `providerHint` is surfaced for whichever is missing.
+Pass an array of capability names when you need more than one (e.g. `['rpc', 'rpcSubscriptions']`) — the same `providerHint` is surfaced for whichever is missing.
 
 ### `useAction(fn)`
 
@@ -139,10 +159,10 @@ Fires a one-shot request on mount and re-fires whenever `source` changes identit
 
 ```tsx
 import { useClient, useRequest } from '@solana/react';
-import type { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+import type { AppClient } from './client';
 
 function LatestBlockhash() {
-    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+    const client = useClient<AppClient>();
     const source = useMemo(() => client.rpc.getLatestBlockhash(), [client]);
     const { data, error, refresh } = useRequest(source);
     if (error) return <button onClick={refresh}>Retry</button>;
@@ -154,7 +174,7 @@ function LatestBlockhash() {
 
 ```tsx
 function Balance({ address }: { address: Address | null }) {
-    const client = useClient<ClientWithRpc<GetBalanceApi>>();
+    const client = useClient<AppClient>();
     // Disabled until an address is selected.
     const source = useMemo(() => (address ? client.rpc.getBalance(address) : null), [client, address]);
     const { data, status } = useRequest(source);
@@ -209,10 +229,11 @@ Subscribe to a stream-store source and surface the latest notification as reacti
 
 ```tsx
 import { useClient, useSubscription } from '@solana/react';
-import type { Address, AccountNotificationsApi, ClientWithRpcSubscriptions } from '@solana/kit';
+import type { Address } from '@solana/kit';
+import type { AppClient } from './client';
 
 function AccountBalance({ address }: { address: Address }) {
-    const client = useClient<ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const client = useClient<AppClient>();
     const source = useMemo(() => client.rpcSubscriptions.accountNotifications(address), [client, address]);
     const { data, error, reconnect } = useSubscription(source);
     if (error) return <button onClick={reconnect}>Reconnect</button>;
@@ -252,16 +273,11 @@ Render reactive state for an RPC subscription seeded by a one-shot RPC fetch, sl
 
 ```tsx
 import { useClient, useTrackedData } from '@solana/react';
-import type {
-    Address,
-    AccountNotificationsApi,
-    ClientWithRpc,
-    ClientWithRpcSubscriptions,
-    GetBalanceApi,
-} from '@solana/kit';
+import type { Address } from '@solana/kit';
+import type { AppClient } from './client';
 
 function AccountBalance({ address }: { address: Address }) {
-    const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const client = useClient<AppClient>();
     const spec = useMemo(
         () => ({
             rpcRequest: client.rpc.getBalance(address),
@@ -312,10 +328,10 @@ SWR-backed counterpart to `useRequest`. Same `source` shape (a `ReactiveActionSo
 ```tsx
 import { useClient } from '@solana/react';
 import { useRequestSWR } from '@solana/react/swr';
-import type { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+import type { AppClient } from './client';
 
 function LatestBlockhash() {
-    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+    const client = useClient<AppClient>();
     const { data, error, isLoading, mutate } = useRequestSWR(['latestBlockhash'], client.rpc.getLatestBlockhash());
     if (error) return <button onClick={() => mutate()}>Retry</button>;
     if (isLoading) return <p>Loading…</p>;
@@ -360,7 +376,7 @@ SWR-backed counterpart to `useSubscription`. Routes a `ReactiveStreamSource<T>` 
 
 ```tsx
 function AccountBalance({ address }: { address: Address }) {
-    const client = useClient<ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const client = useClient<AppClient>();
     const { data, error } = useSubscriptionSWR(
         address ? ['account', address] : null,
         address ? client.rpcSubscriptions.accountNotifications(address) : null,
@@ -383,7 +399,7 @@ SWR-backed counterpart to `useTrackedData`. Takes the same `TrackedDataSpec` (RP
 
 ```tsx
 function AccountBalance({ address }: { address: Address }) {
-    const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const client = useClient<AppClient>();
     const spec = useMemo(
         () =>
             address
@@ -418,10 +434,10 @@ TanStack Query-backed counterpart to `useRequest`. Same `source` shape (a `React
 ```tsx
 import { useClient } from '@solana/react';
 import { useRequestQuery } from '@solana/react/query';
-import type { ClientWithRpc, GetLatestBlockhashApi } from '@solana/kit';
+import type { AppClient } from './client';
 
 function LatestBlockhash() {
-    const client = useClient<ClientWithRpc<GetLatestBlockhashApi>>();
+    const client = useClient<AppClient>();
     const { data, error, isLoading, refetch } = useRequestQuery(['latestBlockhash'], client.rpc.getLatestBlockhash());
     if (error) return <button onClick={() => refetch()}>Retry</button>;
     if (isLoading) return <p>Loading…</p>;
@@ -463,10 +479,10 @@ Returns TanStack's native `UseQueryResult<T>`. `data` is the raw notification, e
 ```tsx
 import { useClient } from '@solana/react';
 import { useSubscriptionQuery } from '@solana/react/query';
-import type { ClientWithRpcSubscriptions, SlotNotificationsApi } from '@solana/kit';
+import type { AppClient } from './client';
 
 function SlotHeight() {
-    const client = useClient<ClientWithRpcSubscriptions<SlotNotificationsApi>>();
+    const client = useClient<AppClient>();
     const { data, error } = useSubscriptionQuery(['slot'], client.rpcSubscriptions.slotNotifications());
     if (error) return <p>Disconnected.</p>;
     if (!data) return <p>Connecting…</p>;
@@ -494,16 +510,11 @@ Returns TanStack's native `UseQueryResult`. `data` is the `SolanaRpcResponse<TIt
 ```tsx
 import { useClient } from '@solana/react';
 import { useTrackedDataQuery } from '@solana/react/query';
-import type {
-    Address,
-    AccountNotificationsApi,
-    ClientWithRpc,
-    ClientWithRpcSubscriptions,
-    GetBalanceApi,
-} from '@solana/kit';
+import type { Address } from '@solana/kit';
+import type { AppClient } from './client';
 
 function AccountBalance({ address }: { address: Address }) {
-    const client = useClient<ClientWithRpc<GetBalanceApi> & ClientWithRpcSubscriptions<AccountNotificationsApi>>();
+    const client = useClient<AppClient>();
     const spec = useMemo(
         () => ({
             initialValueSource: client.rpc.getBalance(address),


### PR DESCRIPTION
#### Problem

Initially I planned to write the react hooks around `useClientCapability`, which does a runtime check for the capability on the client under `ClientProvider`.

[As discussed here though](https://github.com/anza-xyz/kit/pull/1833#discussion_r3572581679), this reduces type safety which plugins otherwise maintain all the way through the stack.

We therefore plan to focus on a pattern where type safety is maintained for react apps using a typed client

We also plan to have hooks that do depend on a plugin, eg the wallet hooks, take the client with that plugin as a param: https://github.com/anza-xyz/kit-plugins/pull/326. This enables type safety across the whole app.

#### Summary of Changes

- We prioritise a pattern where apps export `AppClient`, the type of their built client. Each component uses this in a `useClient<AppClient>()` 
- `useClientCapability` is de-emphasised as a runtime escape hook, not the intended way to build client-dependent plugins
- All docs are updated to use this `<AppClient>` type, instead of manually typing a `useClient` call. 

This all fits the existing API, it's just a shift in documentation and in how we intend to build the hooks that depend on the client. 

Note that I decided not to add a `createClientContext` that creates a `ClientProvider` and a typed `useClient`, I don't think that additional API surface is warranted and I think it would be more confusing.

Also note that we plan to make the `useClient` type non-optional, this will be a follow up.  