### PR TITLE
Make the type param in useClient non-optional

### DIFF
--- a/.changeset/clear-tigers-go.md
+++ b/.changeset/clear-tigers-go.md
@@ -1,0 +1,10 @@
+---
+'@solana/react': minor
+---
+
+Make the `TClient` type parameter of `useClient` required by removing its `object` default, matching `useClientCapability`. Callers should always pass their client's shape (typically an exported `AppClient` type) so installed capabilities are typed at the call site.
+
+```diff
+- const client = useClient();
++ const client = useClient<AppClient>();
+```

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -59,7 +59,7 @@ function Root() {
 
 Reads the Kit client published by the nearest `ClientProvider`. Throws a `SolanaError` with code `SOLANA_ERROR__REACT__MISSING_PROVIDER` if no provider is mounted.
 
-It defaults to the base `Client` shape, pass your client's type through the generic to get the capabilities you installed typed at the call site. The ergonomic way is to **reuse the type of the client you already built** — export it from wherever you compose the client and hand that to `useClient`, so the hook's type stays in sync with your real plugin composition automatically:
+Pass your client's type through the generic to get the capabilities you installed typed at the call site. The ergonomic way is to **reuse the type of the client you already built** — export it from wherever you compose the client and hand that to `useClient`, so the hook's type stays in sync with your real plugin composition automatically:
 
 ```tsx
 // client.ts — where you build the client

--- a/packages/react/src/__typetests__/useClient-typetest.ts
+++ b/packages/react/src/__typetests__/useClient-typetest.ts
@@ -8,14 +8,6 @@ type ClientWithFoo = { foo: { hello(): string } };
 
 // [DESCRIBE] useClient
 {
-    // It defaults to `Client<object>`
-    {
-        const client = useClient();
-        client satisfies Client<object>;
-        // @ts-expect-error - the base shape carries no plugin capabilities
-        void client.foo;
-    }
-
     // It narrows to the requested shape via the generic
     {
         const client = useClient<ClientWithFoo>();

--- a/packages/react/src/useClient.ts
+++ b/packages/react/src/useClient.ts
@@ -8,12 +8,13 @@ import { ClientContext } from './ClientProvider';
  * {@link SolanaError} with code {@link SOLANA_ERROR__REACT__MISSING_PROVIDER} if no provider is
  * mounted in the ancestor tree.
  *
- * Defaults to the base {@link Client} shape. Callers who know a specific plugin is installed may
- * widen the type via the generic — this is a pure cast with no runtime capability check, so reach
- * for {@link useClientCapability} when a missing plugin should fail loudly at mount instead of
- * surfacing later as `undefined`.
+ * Pass the shape of your client through the generic (typically the `AppClient` type you export
+ * alongside the client) so every installed capability is typed at the call site. This is a pure
+ * cast with no runtime capability check, so reach for {@link useClientCapability} when a missing
+ * plugin should fail loudly at mount instead of surfacing later as `undefined`.
  *
- * @typeParam TClient - The shape the client is expected to satisfy. Pure type assertion.
+ * @typeParam TClient - The shape the client is expected to satisfy. Pure type assertion, so this
+ *   must always be supplied — the hook can't infer it from its (absent) arguments.
  *
  * @example
  * ```tsx
@@ -29,7 +30,7 @@ import { ClientContext } from './ClientProvider';
  * @see {@link ClientProvider}
  * @see {@link useClientCapability}
  */
-export function useClient<TClient extends object = object>(): Client<TClient> {
+export function useClient<TClient extends object>(): Client<TClient> {
     const client = React.useContext(ClientContext);
     if (client == null) {
         throw new SolanaError(SOLANA_ERROR__REACT__MISSING_PROVIDER, { hookName: 'useClient' });


### PR DESCRIPTION
#### Problem

- `useClient()` gives you `Client<object>` which is basically useless
- We're now documenting a pattern of using `useClient<AppClient>()` for type safety

#### Summary of Changes

Make the `TClient` type param in `useClient()` required, so that the type error is there instead of when you try to access `client.rpc` etc

This is a breaking change, but we are using a minor changeset because `useClient()` is not useful as-is and this is worth fixing. It's unlikely that any code is using `useClient()` as-is.

Note that `useClientCapability`, the runtime checked variant, already required its type param.