### PR TITLE
fix: narrow transaction message signer types

### DIFF
--- a/.changeset/red-ties-notice.md
+++ b/.changeset/red-ties-notice.md
@@ -1,0 +1,5 @@
+---
+'@solana/signers': patch
+---
+
+Fix `TransactionMessageWithSigners` so its signer type parameter rejects fee payer and instruction signers of other transaction signer kinds.

--- a/packages/signers/src/__typetests__/transaction-message-with-signers-typetest.ts
+++ b/packages/signers/src/__typetests__/transaction-message-with-signers-typetest.ts
@@ -1,0 +1,85 @@
+import { Address } from '@solana/addresses';
+import { AccountRole } from '@solana/instructions';
+import { createTransactionMessage } from '@solana/transaction-messages';
+
+import { TransactionMessageWithSigners } from '../account-signer-meta';
+import { setTransactionMessageFeePayerSigner } from '../fee-payer-signer';
+import { TransactionModifyingSigner } from '../transaction-modifying-signer';
+import { TransactionPartialSigner } from '../transaction-partial-signer';
+
+// [DESCRIBE] TransactionMessageWithSigners
+{
+    // It rejects a fee payer whose signer type is outside the requested signer type
+    {
+        const signer = null as unknown as TransactionModifyingSigner;
+        const transactionMessage = setTransactionMessageFeePayerSigner(
+            signer,
+            createTransactionMessage({ version: 0 }),
+        );
+
+        // @ts-expect-error The fee payer is not a TransactionPartialSigner.
+        transactionMessage satisfies TransactionMessageWithSigners<Address, TransactionPartialSigner>;
+    }
+
+    // It accepts plain fee payers and account metas without signers
+    {
+        const accountAddress = null as unknown as Address;
+        ({
+            feePayer: { address: accountAddress },
+            instructions: [
+                {
+                    accounts: [
+                        {
+                            address: accountAddress,
+                            role: AccountRole.READONLY,
+                        },
+                    ],
+                    programAddress: accountAddress,
+                },
+            ],
+        }) satisfies TransactionMessageWithSigners<Address, TransactionPartialSigner>;
+    }
+
+    // It accepts fee payer and instruction signers matching the requested signer type
+    {
+        const signer = null as unknown as TransactionPartialSigner;
+        const transactionMessage = {
+            feePayer: signer,
+            instructions: [
+                {
+                    accounts: [
+                        {
+                            address: signer.address,
+                            role: AccountRole.READONLY_SIGNER,
+                            signer,
+                        },
+                    ],
+                    programAddress: signer.address,
+                },
+            ],
+        } as const;
+        transactionMessage satisfies TransactionMessageWithSigners<Address, TransactionPartialSigner>;
+    }
+
+    // It rejects an instruction signer outside the requested signer type
+    {
+        const signer = null as unknown as TransactionModifyingSigner;
+        const transactionMessage = {
+            instructions: [
+                {
+                    accounts: [
+                        {
+                            address: signer.address,
+                            role: AccountRole.READONLY_SIGNER,
+                            signer,
+                        },
+                    ],
+                    programAddress: signer.address,
+                },
+            ],
+        } as const;
+
+        // @ts-expect-error The instruction signer is not a TransactionPartialSigner.
+        transactionMessage satisfies TransactionMessageWithSigners<Address, TransactionPartialSigner>;
+    }
+}

--- a/packages/signers/src/__typetests__/transaction-message-with-signers-typetest.ts
+++ b/packages/signers/src/__typetests__/transaction-message-with-signers-typetest.ts
@@ -2,10 +2,11 @@ import { Address } from '@solana/addresses';
 import { AccountRole } from '@solana/instructions';
 import { createTransactionMessage } from '@solana/transaction-messages';
 
-import { TransactionMessageWithSigners } from '../account-signer-meta';
+import { InstructionWithSigners, TransactionMessageWithSigners } from '../account-signer-meta';
 import { setTransactionMessageFeePayerSigner } from '../fee-payer-signer';
 import { TransactionModifyingSigner } from '../transaction-modifying-signer';
 import { TransactionPartialSigner } from '../transaction-partial-signer';
+import { TransactionSendingSigner } from '../transaction-sending-signer';
 
 // [DESCRIBE] TransactionMessageWithSigners
 {
@@ -81,5 +82,25 @@ import { TransactionPartialSigner } from '../transaction-partial-signer';
 
         // @ts-expect-error The instruction signer is not a TransactionPartialSigner.
         transactionMessage satisfies TransactionMessageWithSigners<Address, TransactionPartialSigner>;
+    }
+
+    // It accepts mixed signer kinds when using the default signer type parameter
+    {
+        const feePayer = null as unknown as TransactionModifyingSigner;
+        const instructionSigner = null as unknown as TransactionSendingSigner;
+        const instruction = {
+            accounts: [
+                {
+                    address: instructionSigner.address,
+                    role: AccountRole.READONLY_SIGNER,
+                    signer: instructionSigner,
+                },
+            ],
+            programAddress: instructionSigner.address,
+        } as const satisfies InstructionWithSigners & { programAddress: Address };
+        ({
+            feePayer,
+            instructions: [instruction],
+        }) satisfies TransactionMessageWithSigners;
     }
 }

--- a/packages/signers/src/account-signer-meta.ts
+++ b/packages/signers/src/account-signer-meta.ts
@@ -38,12 +38,22 @@ export interface AccountSignerMeta<
     readonly signer: TSigner;
 }
 
+type AccountMetaWithoutSigner = Readonly<{ signer?: never }> & (AccountLookupMeta | AccountMeta);
+
+type TransactionMessageWithNonSignerFeePayer<TAddress extends string = string> = Readonly<{
+    feePayer: Readonly<{
+        modifyAndSignTransactions?: never;
+        signAndSendTransactions?: never;
+        signTransactions?: never;
+    }> &
+        TransactionMessageWithFeePayer<TAddress>['feePayer'];
+}>;
+
 /**
  * A union type that supports base account metas as well as {@link AccountSignerMeta | signer account metas}.
  */
 type AccountMetaWithSigner<TSigner extends TransactionSigner = TransactionSigner> =
-    | AccountLookupMeta
-    | AccountMeta
+    | AccountMetaWithoutSigner
     | AccountSignerMeta<string, TSigner>;
 
 /**
@@ -115,7 +125,10 @@ export type TransactionMessageWithSigners<
     TSigner extends TransactionSigner<TAddress> = TransactionSigner<TAddress>,
     TAccounts extends readonly AccountMetaWithSigner<TSigner>[] = readonly AccountMetaWithSigner<TSigner>[],
 > = Partial<
-    Pick<TransactionMessageWithFeePayer<TAddress> | TransactionMessageWithFeePayerSigner<TAddress, TSigner>, 'feePayer'>
+    Pick<
+        TransactionMessageWithFeePayerSigner<TAddress, TSigner> | TransactionMessageWithNonSignerFeePayer<TAddress>,
+        'feePayer'
+    >
 > &
     Readonly<{ instructions: readonly (Instruction & InstructionWithSigners<TSigner, TAccounts>)[] }>;
 
@@ -148,8 +161,8 @@ export type TransactionMessageWithSigners<
 export function getSignersFromInstruction<TSigner extends TransactionSigner = TransactionSigner>(
     instruction: InstructionWithSigners<TSigner>,
 ): readonly TSigner[] {
-    return deduplicateSigners(
-        (instruction.accounts ?? []).flatMap(account => ('signer' in account ? account.signer : [])),
+    return deduplicateSigners<TSigner>(
+        (instruction.accounts ?? []).flatMap(account => (account.signer ? [account.signer] : [])),
     );
 }
 
@@ -198,8 +211,8 @@ export function getSignersFromTransactionMessage<
         TSigner
     >,
 >(transaction: TTransactionMessage): readonly TSigner[] {
-    return deduplicateSigners([
+    return deduplicateSigners<TSigner>([
         ...(transaction.feePayer && isTransactionSigner(transaction.feePayer) ? [transaction.feePayer as TSigner] : []),
-        ...transaction.instructions.flatMap(getSignersFromInstruction),
+        ...transaction.instructions.flatMap(instruction => getSignersFromInstruction<TSigner>(instruction)),
     ]);
 }

--- a/packages/signers/src/account-signer-meta.ts
+++ b/packages/signers/src/account-signer-meta.ts
@@ -40,10 +40,13 @@ export interface AccountSignerMeta<
 
 type AccountMetaWithoutSigner = Readonly<{ signer?: never }> & (AccountLookupMeta | AccountMeta);
 
-// Derived from `TransactionSigner`'s member types rather than hardcoded, so that a future signer
-// variant with a new method automatically excludes that method from a non-signer fee payer too.
+// Derived from `TransactionSigner`'s member types, excluding whatever keys are shared with a plain
+// fee payer shape, so future shared fields remain representable for non-signer fee payers.
 type UnionKeys<T> = T extends unknown ? keyof T : never;
-type TransactionSignerMethodKeys = Exclude<UnionKeys<TransactionSigner>, 'address'>;
+type TransactionSignerMethodKeys = Exclude<
+    UnionKeys<TransactionSigner>,
+    keyof TransactionMessageWithFeePayer['feePayer']
+>;
 type WithoutSignerMethods = Readonly<{ [K in TransactionSignerMethodKeys]?: never }>;
 
 type TransactionMessageWithNonSignerFeePayer<TAddress extends string = string> = Readonly<{

--- a/packages/signers/src/account-signer-meta.ts
+++ b/packages/signers/src/account-signer-meta.ts
@@ -40,13 +40,14 @@ export interface AccountSignerMeta<
 
 type AccountMetaWithoutSigner = Readonly<{ signer?: never }> & (AccountLookupMeta | AccountMeta);
 
+// Derived from `TransactionSigner`'s member types rather than hardcoded, so that a future signer
+// variant with a new method automatically excludes that method from a non-signer fee payer too.
+type UnionKeys<T> = T extends unknown ? keyof T : never;
+type TransactionSignerMethodKeys = Exclude<UnionKeys<TransactionSigner>, 'address'>;
+type WithoutSignerMethods = Readonly<{ [K in TransactionSignerMethodKeys]?: never }>;
+
 type TransactionMessageWithNonSignerFeePayer<TAddress extends string = string> = Readonly<{
-    feePayer: Readonly<{
-        modifyAndSignTransactions?: never;
-        signAndSendTransactions?: never;
-        signTransactions?: never;
-    }> &
-        TransactionMessageWithFeePayer<TAddress>['feePayer'];
+    feePayer: TransactionMessageWithFeePayer<TAddress>['feePayer'] & WithoutSignerMethods;
 }>;
 
 /**


### PR DESCRIPTION
## Summary

Make `TransactionMessageWithSigners<TAddress, TSigner>` enforce its signer type parameter for both fee payers and instruction account metas.

## Problem

Signer objects structurally satisfy the plain fee-payer and account-meta branches because their extra methods and `signer` property do not make them incompatible. As a result, a transaction containing a `TransactionModifyingSigner` can satisfy `TransactionMessageWithSigners<Address, TransactionPartialSigner>`.

## Changes

- Distinguish plain account metas from account metas containing signers.
- Distinguish plain fee payers from all transaction signer interfaces.
- Preserve signer extraction with the narrowed union types.
- Add regression typetests for matching, mismatched, and non-signer cases.
- Add a patch changeset for `@solana/signers`.

## Testing

- Signer typecheck
- Focused JS and declaration build
- Node signer unit suite: 138 tests
- Browser signer unit suite: 135 tests
- Full signer ESLint suite
- Direct Prettier validation

## Before

The narrowed signer parameter can be bypassed through the plain structural union branches.

## After

Mismatched fee-payer and instruction signers are rejected, while matching signers and plain non-signer account shapes remain accepted.

## Related issue

Fixes #1036
