### PR TITLE
Update the example app to use transaction plan/send

### DIFF
--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -19,7 +19,7 @@
         "@radix-ui/themes": "3.3.0",
         "@solana-program/system": "^0.13.0",
         "@solana/kit": "workspace:*",
-        "@solana/kit-plugin-rpc": "0.13.0",
+        "@solana/kit-plugin-rpc": "0.15.0",
         "@solana/kit-plugin-wallet": "0.14.0",
         "@solana/react": "workspace:*",
         "@wallet-standard/core": "^1.1.2",

--- a/examples/react-app/src/components/SolanaPartialSignTransactionFeaturePanel.tsx
+++ b/examples/react-app/src/components/SolanaPartialSignTransactionFeaturePanel.tsx
@@ -1,11 +1,11 @@
 import { Blockquote, Box, Button, Dialog, Flex, Link, Select, Text, TextField } from '@radix-ui/themes';
 import {
     address,
-    appendTransactionMessageInstruction,
     assertIsSendableTransaction,
     assertIsTransactionWithBlockhashLifetime,
     createKeyPairFromBytes,
-    createTransactionMessage,
+    estimateAndSetResourceLimitsFactory,
+    estimateResourceLimitsFactory,
     getBase58Encoder,
     getSignatureFromTransaction,
     getTransactionDecoder,
@@ -55,6 +55,12 @@ export function SolanaPartialSignTransactionFeaturePanel({ signer }: Props) {
         () => sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions }),
         [rpc, rpcSubscriptions],
     );
+
+    const estimateResourceLimits = useMemo(() => estimateResourceLimitsFactory({ rpc: client.rpc }), [client.rpc]);
+    const estimateAndSetResourceLimits = useMemo(() => estimateAndSetResourceLimitsFactory(async (tx, config) => {
+        const resourceLimits = await estimateResourceLimits(tx, config);
+        return { ...resourceLimits, computeUnitLimit: resourceLimits.computeUnitLimit + 300 };
+    }), [estimateResourceLimits]);
     const wallets = useWallets(client);
     const [solQuantityString, setSolQuantityString] = useState<string>('');
     const [recipientAccountStorageKey, setRecipientAccountStorageKey] = useState<string | undefined>();
@@ -103,23 +109,30 @@ export function SolanaPartialSignTransactionFeaturePanel({ signer }: Props) {
         if (!recipientAccount) {
             throw new Error('The address of the recipient could not be found');
         }
+        // Use the client to plan the transaction, then set the payer to our mock server signer
+        const planned = await client.planTransaction(
+            getTransferSolInstruction({
+                amount,
+                destination: address(recipientAccount.address),
+                source: signer,
+            }),
+            { abortSignal: signal },
+        );
+        // `planTransaction` builds the message but does not set a lifetime or add CUs,
+        // these are part of the default transaction executor.
         const { value: latestBlockhash } = await rpc
             .getLatestBlockhash({ commitment: 'confirmed' })
             .send({ abortSignal: signal });
-        const message = pipe(
-            createTransactionMessage({ version: 0 }),
-            m => setTransactionMessageFeePayerSigner(feePayerSigner, m),
-            m => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
-            m =>
-                appendTransactionMessageInstruction(
-                    getTransferSolInstruction({
-                        amount,
-                        destination: address(recipientAccount.address),
-                        source: signer,
-                    }),
-                    m,
-                ),
+        const message = await pipe(
+            planned,
+            // Set the fee payer to our mock server signer
+            tx => setTransactionMessageFeePayerSigner(feePayerSigner, tx),
+            // Set the lifetime to the latest blockhash  
+            tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+            // Estimate and set the resource limits for the transaction
+            async tx => await estimateAndSetResourceLimits(tx, { abortSignal: signal }),
         );
+
         const transaction = await signTransactionMessageWithSigners(message);
         assertIsSendableTransaction(transaction);
         assertIsTransactionWithBlockhashLifetime(transaction);

--- a/examples/react-app/src/components/SolanaSignAndSendTransactionFeaturePanel.tsx
+++ b/examples/react-app/src/components/SolanaSignAndSendTransactionFeaturePanel.tsx
@@ -1,18 +1,7 @@
 import { Blockquote, Box, Button, Dialog, Flex, Link, Select, Text, TextField } from '@radix-ui/themes';
-import {
-    address,
-    appendTransactionMessageInstruction,
-    assertIsTransactionMessageWithSingleSendingSigner,
-    createTransactionMessage,
-    getBase58Decoder,
-    pipe,
-    setTransactionMessageFeePayerSigner,
-    setTransactionMessageLifetimeUsingBlockhash,
-    signAndSendTransactionMessageWithSigners,
-} from '@solana/kit';
-import type { WalletSigner } from '@solana/kit-plugin-wallet';
-import { useWallets } from '@solana/kit-plugin-wallet/react';
-import { useAction, useClient } from '@solana/react';
+import { address } from '@solana/kit';
+import { useConnectedWallet, useWallets } from '@solana/kit-plugin-wallet/react';
+import { useClient, useSendTransaction } from '@solana/react';
 import { getTransferSolInstruction } from '@solana-program/system';
 import { getUiWalletAccountStorageKey } from '@wallet-standard/ui';
 import type { SyntheticEvent } from 'react';
@@ -21,18 +10,14 @@ import { useId, useMemo, useState } from 'react';
 import { getExplorerClusterName } from '../chain';
 import type { AppClient } from '../context/ClientProvider';
 import { solStringToLamports } from '../lamports';
-import { assertCanSignAndSendTransactions } from '../walletCapability';
+import { assertCanSignTransactions } from '../walletCapability';
 import { ErrorDialog } from './ErrorDialog';
 import { WalletMenuItemContent } from './WalletMenuItemContent';
 
-type Props = Readonly<{
-    signer: WalletSigner | null;
-}>;
-
-export function SolanaSignAndSendTransactionFeaturePanel({ signer }: Props) {
+export function SolanaSignAndSendTransactionFeaturePanel() {
     const client = useClient<AppClient>();
-    const { rpc } = client;
     const wallets = useWallets(client);
+    const connectedWallet = useConnectedWallet(client);
     const [solQuantityString, setSolQuantityString] = useState<string>('');
     const [recipientAccountStorageKey, setRecipientAccountStorageKey] = useState<string | undefined>();
     const recipientAccount = useMemo(() => {
@@ -51,53 +36,35 @@ export function SolanaSignAndSendTransactionFeaturePanel({ signer }: Props) {
     const lamportsInputId = useId();
     const recipientSelectId = useId();
 
+    const signer = connectedWallet?.signer ?? null;
     // Render-time capability guard: throws so the surrounding `ErrorBoundary` renders
-    // `FeatureNotSupportedCallout` when the connected account can't sign and send transaction
-    // it also narrows `signer` for the `useAction` below
-    assertCanSignAndSendTransactions(signer);
+    // `FeatureNotSupportedCallout` when the connected account can't sign transactions.
+    // This also narrows `signer` to a `TransactionSigner` for use as
+    // the transfer `source` below.
+    assertCanSignTransactions(signer);
 
-    const {
-        data: lastSignature,
-        dispatchAsync,
-        error,
-        isRunning: isSendingTransaction,
-        reset,
-    } = useAction(async signal => {
-        const amount = solStringToLamports(solQuantityString);
-        if (!recipientAccount) {
-            throw new Error('The address of the recipient could not be found');
-        }
-        const { value: latestBlockhash } = await rpc
-            .getLatestBlockhash({ commitment: 'confirmed' })
-            .send({ abortSignal: signal });
-        const message = pipe(
-            createTransactionMessage({ version: 0 }),
-            m => setTransactionMessageFeePayerSigner(signer, m),
-            m => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
-            m =>
-                appendTransactionMessageInstruction(
-                    getTransferSolInstruction({
-                        amount,
-                        destination: address(recipientAccount.address),
-                        source: signer,
-                    }),
-                    m,
-                ),
-        );
-        assertIsTransactionMessageWithSingleSendingSigner(message);
-        return await signAndSendTransactionMessageWithSigners(message);
-    });
+    const { data: result, dispatchAsync, error, isRunning: isSendingTransaction, reset } = useSendTransaction(client);
+    const lastSignature = result?.context.signature;
 
     return (
         <Flex asChild gap="2" direction={{ initial: 'column', sm: 'row' }} style={{ width: '100%' }}>
             <form
                 onSubmit={async e => {
                     e.preventDefault();
+                    if (!recipientAccount) {
+                        return;
+                    }
                     try {
-                        await dispatchAsync();
+                        await dispatchAsync(
+                            getTransferSolInstruction({
+                                amount: solStringToLamports(solQuantityString),
+                                destination: address(recipientAccount.address),
+                                source: signer,
+                            }),
+                        );
                         setSolQuantityString('');
                     } catch {
-                        // Error is surfaced by `useAction`'s `error` field
+                        // Error is surfaced by `useSendTransaction`'s `error` field
                     }
                 }}
             >
@@ -178,12 +145,10 @@ export function SolanaSignAndSendTransactionFeaturePanel({ signer }: Props) {
                             <Dialog.Title>You transferred tokens!</Dialog.Title>
                             <Flex direction="column" gap="2">
                                 <Text>Signature:</Text>
-                                <Blockquote>{getBase58Decoder().decode(lastSignature)}</Blockquote>
+                                <Blockquote>{lastSignature}</Blockquote>
                                 <Text>
                                     <Link
-                                        href={`https://explorer.solana.com/tx/${getBase58Decoder().decode(
-                                            lastSignature,
-                                        )}?cluster=${solanaExplorerClusterName}`}
+                                        href={`https://explorer.solana.com/tx/${lastSignature}?cluster=${solanaExplorerClusterName}`}
                                         target="_blank"
                                     >
                                         View this transaction

--- a/examples/react-app/src/components/SolanaSignTransactionFeaturePanel.tsx
+++ b/examples/react-app/src/components/SolanaSignTransactionFeaturePanel.tsx
@@ -1,14 +1,13 @@
 import { Blockquote, Box, Button, Dialog, Flex, Link, Select, Text, TextField } from '@radix-ui/themes';
 import {
     address,
-    appendTransactionMessageInstruction,
     assertIsSendableTransaction,
     assertIsTransactionWithBlockhashLifetime,
-    createTransactionMessage,
+    estimateAndSetResourceLimitsFactory,
+    estimateResourceLimitsFactory,
     getSignatureFromTransaction,
     pipe,
     sendAndConfirmTransactionFactory,
-    setTransactionMessageFeePayerSigner,
     setTransactionMessageLifetimeUsingBlockhash,
     signTransactionMessageWithSigners,
 } from '@solana/kit';
@@ -38,6 +37,11 @@ export function SolanaSignTransactionFeaturePanel({ signer }: Props) {
         () => sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions }),
         [rpc, rpcSubscriptions],
     );
+    const estimateResourceLimits = useMemo(() => estimateResourceLimitsFactory({ rpc: client.rpc }), [client.rpc]);
+    const estimateAndSetResourceLimits = useMemo(() => estimateAndSetResourceLimitsFactory(async (tx, config) => {
+        const resourceLimits = await estimateResourceLimits(tx, config);
+        return { ...resourceLimits, computeUnitLimit: resourceLimits.computeUnitLimit + 300 };
+    }), [estimateResourceLimits]);
     const wallets = useWallets(client);
     const [solQuantityString, setSolQuantityString] = useState<string>('');
     const [recipientAccountStorageKey, setRecipientAccountStorageKey] = useState<string | undefined>();
@@ -68,22 +72,25 @@ export function SolanaSignTransactionFeaturePanel({ signer }: Props) {
         if (!recipientAccount) {
             throw new Error('The address of the recipient could not be found');
         }
+        const planned = await client.planTransaction(
+            getTransferSolInstruction({
+                amount,
+                destination: address(recipientAccount.address),
+                source: signer,
+            }),
+            { abortSignal: signal },
+        );
+        // `planTransaction` builds the message but does not set a lifetime or add CUs,
+        // these are part of the default transaction executor.
         const { value: latestBlockhash } = await rpc
             .getLatestBlockhash({ commitment: 'confirmed' })
             .send({ abortSignal: signal });
-        const message = pipe(
-            createTransactionMessage({ version: 0 }),
-            m => setTransactionMessageFeePayerSigner(signer, m),
-            m => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
-            m =>
-                appendTransactionMessageInstruction(
-                    getTransferSolInstruction({
-                        amount,
-                        destination: address(recipientAccount.address),
-                        source: signer,
-                    }),
-                    m,
-                ),
+        const message = await pipe(
+            planned,
+            // Set the lifetime to the latest blockhash  
+            tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+            // Estimate and set the resource limits for the transaction
+            async tx => await estimateAndSetResourceLimits(tx, { abortSignal: signal }),
         );
         const transaction = await signTransactionMessageWithSigners(message);
         assertIsSendableTransaction(transaction);

--- a/examples/react-app/src/routes/root.tsx
+++ b/examples/react-app/src/routes/root.tsx
@@ -65,7 +65,10 @@ function Root() {
                             <Heading as="h4" size="3">
                                 Balance
                             </Heading>
-                            <ErrorBoundary fallback={<Text>&ndash;</Text>} key={`${connected.account.address}:${chain}`}>
+                            <ErrorBoundary
+                                fallback={<Text>&ndash;</Text>}
+                                key={`${connected.account.address}:${chain}`}
+                            >
                                 <Suspense fallback={<Spinner loading my="1" />}>
                                     <Balance account={connected.account} />
                                 </Suspense>
@@ -88,7 +91,7 @@ function Root() {
                     </FeaturePanel>
                     <FeaturePanel label="Sign And Send Transaction">
                         <ErrorBoundary FallbackComponent={FeatureNotSupportedCallout}>
-                            <SolanaSignAndSendTransactionFeaturePanel signer={connected.signer} />
+                            <SolanaSignAndSendTransactionFeaturePanel />
                         </ErrorBoundary>
                     </FeaturePanel>
                     <FeaturePanel label="Sign Transaction">

--- a/examples/react-app/src/walletCapability.ts
+++ b/examples/react-app/src/walletCapability.ts
@@ -1,5 +1,5 @@
-import type { TransactionSendingSigner, TransactionSigner } from '@solana/kit';
-import { isTransactionModifyingSigner, isTransactionPartialSigner, isTransactionSendingSigner } from '@solana/kit';
+import type { TransactionSigner } from '@solana/kit';
+import { isTransactionModifyingSigner, isTransactionPartialSigner } from '@solana/kit';
 import type { WalletSigner } from '@solana/kit-plugin-wallet';
 import { SolanaSignMessage } from '@solana/wallet-standard-features';
 import type { UiWalletAccount } from '@wallet-standard/ui';
@@ -29,18 +29,6 @@ import { getWalletAccountFeature } from '@wallet-standard/ui';
 export function assertCanSignTransactions(signer: WalletSigner | null): asserts signer is TransactionSigner {
     if (!signer || !(isTransactionModifyingSigner(signer) || isTransactionPartialSigner(signer))) {
         throw new Error('This account does not support signing transactions');
-    }
-}
-
-/**
- * Asserts that the connected wallet's signer can sign *and send* transactions. Used by the "Sign
- * And Send Transaction" panel.
- */
-export function assertCanSignAndSendTransactions(
-    signer: WalletSigner | null,
-): asserts signer is TransactionSendingSigner {
-    if (!signer || !isTransactionSendingSigner(signer)) {
-        throw new Error('This account does not support signing and sending transactions');
     }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,8 +161,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/kit
       '@solana/kit-plugin-rpc':
-        specifier: 0.13.0
-        version: 0.13.0(@solana/kit@packages+kit)
+        specifier: 0.15.0
+        version: 0.15.0(@solana/kit@packages+kit)
       '@solana/kit-plugin-wallet':
         specifier: 0.14.0
         version: 0.14.0(@solana/kit@packages+kit)(@solana/react@packages+react)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.8)(typescript@5.9.3)
@@ -5149,8 +5149,8 @@ packages:
     peerDependencies:
       '@solana/kit': ^7.0.0
 
-  '@solana/kit-plugin-rpc@0.13.0':
-    resolution: {integrity: sha512-cYDbMjtp6vpU2FIuIQXN+EDSo2ljIA6m16B9BIi/ts/R0ETPt8rRvyXupi2dDS8wxUdRFUxXGXsPY78hRf4bfQ==}
+  '@solana/kit-plugin-rpc@0.15.0':
+    resolution: {integrity: sha512-Abymr7WLP9yQ6ixCCv+tKzjoWpAkxJ90JWzL+pfkTAFGTpVk9N0myhMcO2ohl6yztJRMOxsw1CXWjcVecxxUlg==}
     peerDependencies:
       '@solana/kit': ^7.0.0
 
@@ -14020,7 +14020,7 @@ snapshots:
     dependencies:
       '@solana/kit': link:packages/kit
 
-  '@solana/kit-plugin-rpc@0.13.0(@solana/kit@packages+kit)':
+  '@solana/kit-plugin-rpc@0.15.0(@solana/kit@packages+kit)':
     dependencies:
       '@solana/kit': link:packages/kit
       '@solana/kit-plugin-instruction-plan': 0.13.0(@solana/kit@packages+kit)


### PR DESCRIPTION
This PR updates the react example app to use our transaction plan/send functions, instead of hand-crafting transactions. Note that in a previous PR I added `solanaRpc` to the client, so it already has transaction plan/send functions available.

- The RPC plugin is updated to the latest version, with its improved CU calculation
- The sign + send panel is refactored to  use `useSendTransaction`
- The other panels are refactored to use `client.planTransaction` to construct their transaction 