### PR TITLE
Restrict compressTransactionMessageUsingAddressLookupTables to reject v1 messages

### DIFF
--- a/.changeset/sixty-ducks-count.md
+++ b/.changeset/sixty-ducks-count.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-messages': patch
+---
+
+Update type of compressTransactionMessageUsingAddressLookupTables to reject v1 transactions

--- a/packages/transaction-messages/src/__typetests__/compress-transaction-message-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/compress-transaction-message-typetest.ts
@@ -19,11 +19,18 @@ const addressesByLookupTableAddress = null as unknown as AddressesByLookupTableA
         result satisfies v0TransactionMessage;
     }
 
-    // It accepts only v0 transaction messages
+    // It rejects legacy transaction messages
     {
-        const invalidMessage = null as unknown as Exclude<TransactionMessage, { version: 0 }>;
-        // @ts-expect-error Only v0 messages are accepted.
-        compressTransactionMessageUsingAddressLookupTables(invalidMessage, addressesByLookupTableAddress);
+        const legacyMessage = null as unknown as Extract<TransactionMessage, { version: 'legacy' }>;
+        // @ts-expect-error Legacy messages are not accepted.
+        compressTransactionMessageUsingAddressLookupTables(legacyMessage, addressesByLookupTableAddress);
+    }
+
+    // It rejects v1 transaction messages
+    {
+        const v1Message = null as unknown as Extract<TransactionMessage, { version: 1 }>;
+        // @ts-expect-error Only v0 messages are accepted, not v1.
+        compressTransactionMessageUsingAddressLookupTables(v1Message, addressesByLookupTableAddress);
     }
 
     // It preserves the fee payer type

--- a/packages/transaction-messages/src/compress-transaction-message.ts
+++ b/packages/transaction-messages/src/compress-transaction-message.ts
@@ -28,7 +28,7 @@ function findAddressInLookupTables(
     }
 }
 
-type TransactionMessageNotLegacy = Exclude<TransactionMessage, { version: 'legacy' }>;
+type SupportedTransactionMessage = Extract<TransactionMessage, { version: 0 }>;
 
 // Each account can be AccountLookupMeta | AccountMeta
 type WidenInstructionAccounts<TInstruction extends Instruction> =
@@ -85,7 +85,7 @@ type WidenTransactionMessageInstructions<TTransactionMessage extends Transaction
  * ```
  */
 export function compressTransactionMessageUsingAddressLookupTables<
-    TTransactionMessage extends TransactionMessageNotLegacy = TransactionMessageNotLegacy,
+    TTransactionMessage extends SupportedTransactionMessage = SupportedTransactionMessage,
 >(
     transactionMessage: TTransactionMessage,
     addressesByLookupTableAddress: AddressesByLookupTableAddress,


### PR DESCRIPTION
#### Problem

Spotted while testing our examples with v1 transactions, the `compressTransactionMessageUsingAddressLookupTables` was typed to reject legacy transactions but not v1. v1 transactions do not support lookup tables.

#### Summary of Changes

Updated to only allow v0 transactions

I've also checked the rest of the transaction-messages function and higher-level APIs, and can't find anywhere else we missed. 