### PR TITLE
Refactor the example app to use the system progam plugin

### DIFF
--- a/examples/react-app/src/components/SolanaPartialSignTransactionFeaturePanel.tsx
+++ b/examples/react-app/src/components/SolanaPartialSignTransactionFeaturePanel.tsx
@@ -23,7 +23,6 @@ import {
 import type { WalletSigner } from '@solana/kit-plugin-wallet';
 import { useWallets } from '@solana/kit-plugin-wallet/react';
 import { useAction, useClient } from '@solana/react';
-import { getTransferSolInstruction } from '@solana-program/system';
 import { getUiWalletAccountStorageKey } from '@wallet-standard/ui';
 import type { SyntheticEvent } from 'react';
 import { useId, useMemo, useState } from 'react';
@@ -57,10 +56,14 @@ export function SolanaPartialSignTransactionFeaturePanel({ signer }: Props) {
     );
 
     const estimateResourceLimits = useMemo(() => estimateResourceLimitsFactory({ rpc: client.rpc }), [client.rpc]);
-    const estimateAndSetResourceLimits = useMemo(() => estimateAndSetResourceLimitsFactory(async (tx, config) => {
-        const resourceLimits = await estimateResourceLimits(tx, config);
-        return { ...resourceLimits, computeUnitLimit: resourceLimits.computeUnitLimit + 300 };
-    }), [estimateResourceLimits]);
+    const estimateAndSetResourceLimits = useMemo(
+        () =>
+            estimateAndSetResourceLimitsFactory(async (tx, config) => {
+                const resourceLimits = await estimateResourceLimits(tx, config);
+                return { ...resourceLimits, computeUnitLimit: resourceLimits.computeUnitLimit + 300 };
+            }),
+        [estimateResourceLimits],
+    );
     const wallets = useWallets(client);
     const [solQuantityString, setSolQuantityString] = useState<string>('');
     const [recipientAccountStorageKey, setRecipientAccountStorageKey] = useState<string | undefined>();
@@ -111,7 +114,7 @@ export function SolanaPartialSignTransactionFeaturePanel({ signer }: Props) {
         }
         // Use the client to plan the transaction, then set the payer to our mock server signer
         const planned = await client.planTransaction(
-            getTransferSolInstruction({
+            client.system.instructions.transferSol({
                 amount,
                 destination: address(recipientAccount.address),
                 source: signer,
@@ -127,7 +130,7 @@ export function SolanaPartialSignTransactionFeaturePanel({ signer }: Props) {
             planned,
             // Set the fee payer to our mock server signer
             tx => setTransactionMessageFeePayerSigner(feePayerSigner, tx),
-            // Set the lifetime to the latest blockhash  
+            // Set the lifetime to the latest blockhash
             tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
             // Estimate and set the resource limits for the transaction
             async tx => await estimateAndSetResourceLimits(tx, { abortSignal: signal }),

--- a/examples/react-app/src/components/SolanaSignAndSendTransactionFeaturePanel.tsx
+++ b/examples/react-app/src/components/SolanaSignAndSendTransactionFeaturePanel.tsx
@@ -2,7 +2,6 @@ import { Blockquote, Box, Button, Dialog, Flex, Link, Select, Text, TextField } 
 import { address } from '@solana/kit';
 import { useConnectedWallet, useWallets } from '@solana/kit-plugin-wallet/react';
 import { useClient, useSendTransaction } from '@solana/react';
-import { getTransferSolInstruction } from '@solana-program/system';
 import { getUiWalletAccountStorageKey } from '@wallet-standard/ui';
 import type { SyntheticEvent } from 'react';
 import { useId, useMemo, useState } from 'react';
@@ -56,7 +55,7 @@ export function SolanaSignAndSendTransactionFeaturePanel() {
                     }
                     try {
                         await dispatchAsync(
-                            getTransferSolInstruction({
+                            client.system.instructions.transferSol({
                                 amount: solStringToLamports(solQuantityString),
                                 destination: address(recipientAccount.address),
                                 source: signer,

--- a/examples/react-app/src/components/SolanaSignTransactionFeaturePanel.tsx
+++ b/examples/react-app/src/components/SolanaSignTransactionFeaturePanel.tsx
@@ -14,7 +14,6 @@ import {
 import type { WalletSigner } from '@solana/kit-plugin-wallet';
 import { useWallets } from '@solana/kit-plugin-wallet/react';
 import { useAction, useClient } from '@solana/react';
-import { getTransferSolInstruction } from '@solana-program/system';
 import { getUiWalletAccountStorageKey } from '@wallet-standard/ui';
 import type { SyntheticEvent } from 'react';
 import { useId, useMemo, useState } from 'react';
@@ -38,10 +37,14 @@ export function SolanaSignTransactionFeaturePanel({ signer }: Props) {
         [rpc, rpcSubscriptions],
     );
     const estimateResourceLimits = useMemo(() => estimateResourceLimitsFactory({ rpc: client.rpc }), [client.rpc]);
-    const estimateAndSetResourceLimits = useMemo(() => estimateAndSetResourceLimitsFactory(async (tx, config) => {
-        const resourceLimits = await estimateResourceLimits(tx, config);
-        return { ...resourceLimits, computeUnitLimit: resourceLimits.computeUnitLimit + 300 };
-    }), [estimateResourceLimits]);
+    const estimateAndSetResourceLimits = useMemo(
+        () =>
+            estimateAndSetResourceLimitsFactory(async (tx, config) => {
+                const resourceLimits = await estimateResourceLimits(tx, config);
+                return { ...resourceLimits, computeUnitLimit: resourceLimits.computeUnitLimit + 300 };
+            }),
+        [estimateResourceLimits],
+    );
     const wallets = useWallets(client);
     const [solQuantityString, setSolQuantityString] = useState<string>('');
     const [recipientAccountStorageKey, setRecipientAccountStorageKey] = useState<string | undefined>();
@@ -73,7 +76,7 @@ export function SolanaSignTransactionFeaturePanel({ signer }: Props) {
             throw new Error('The address of the recipient could not be found');
         }
         const planned = await client.planTransaction(
-            getTransferSolInstruction({
+            client.system.instructions.transferSol({
                 amount,
                 destination: address(recipientAccount.address),
                 source: signer,
@@ -87,7 +90,7 @@ export function SolanaSignTransactionFeaturePanel({ signer }: Props) {
             .send({ abortSignal: signal });
         const message = await pipe(
             planned,
-            // Set the lifetime to the latest blockhash  
+            // Set the lifetime to the latest blockhash
             tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
             // Estimate and set the resource limits for the transaction
             async tx => await estimateAndSetResourceLimits(tx, { abortSignal: signal }),

--- a/examples/react-app/src/context/ClientProvider.tsx
+++ b/examples/react-app/src/context/ClientProvider.tsx
@@ -4,6 +4,7 @@ import { solanaRpc } from '@solana/kit-plugin-rpc';
 import { walletSigner } from '@solana/kit-plugin-wallet';
 import { ClientProvider as KitClientProvider } from '@solana/react';
 import type { SolanaChain } from '@solana/wallet-standard-chains';
+import { systemProgram } from '@solana-program/system';
 import { useLayoutEffect, useState } from 'react';
 
 import { getChainRpcUrl } from '../chain';
@@ -27,6 +28,7 @@ function buildClient(chain: SolanaChain, rpcUrl: ClusterUrl) {
             // importantly `Balance`'s SWR cache key — has to derive `chain` from the client, or it
             // would key the new network's fetch against the old network's rpc.
             .use(client => extendClient(client, { chain }))
+            .use(systemProgram())
     );
 }
 


### PR DESCRIPTION
Small refactor of the example app to use the `systemProgram()` plugin and its instruction builders, instead of importing instruction builder functions.

As the app is using the react hooks I'm just using the plugin to build the instructions, not its `.plan/sendTransaction` functionality - which would need to be wrapped in `useAction`. 