### PR TITLE
Use the useAirdrop hook in the react-app example

### DIFF
--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -19,7 +19,7 @@
         "@radix-ui/themes": "3.3.0",
         "@solana-program/system": "^0.13.0",
         "@solana/kit": "workspace:*",
-        "@solana/kit-plugin-rpc": "0.15.0",
+        "@solana/kit-plugin-rpc": "0.16.0",
         "@solana/kit-plugin-wallet": "0.14.0",
         "@solana/react": "workspace:*",
         "@wallet-standard/core": "^1.1.2",

--- a/examples/react-app/src/chain.ts
+++ b/examples/react-app/src/chain.ts
@@ -1,5 +1,3 @@
-import type { ClusterUrl } from '@solana/kit';
-import { devnet, mainnet, testnet } from '@solana/kit';
 import type { SolanaChain } from '@solana/wallet-standard-chains';
 import { useCallback, useState } from 'react';
 
@@ -38,23 +36,6 @@ export function getExplorerClusterName(chain: SolanaChain): 'devnet' | 'mainnet-
         case 'solana:devnet':
         default:
             return 'devnet';
-    }
-}
-
-/**
- * The RPC HTTP endpoint for a chain, branded to that cluster. `solanaRpc` derives the WebSocket
- * (subscriptions) URL from this by swapping the protocol to `ws`/`wss`, so only the HTTP URL is
- * needed here. Mainnet uses `REACT_EXAMPLE_APP_MAINNET_URL` when set (see {@link SUPPORTED_CHAINS}).
- */
-export function getChainRpcUrl(chain: SolanaChain): ClusterUrl {
-    switch (chain) {
-        case 'solana:mainnet':
-            return mainnet(process.env.REACT_EXAMPLE_APP_MAINNET_URL ?? 'https://api.mainnet-beta.solana.com');
-        case 'solana:testnet':
-            return testnet('https://api.testnet.solana.com');
-        case 'solana:devnet':
-        default:
-            return devnet('https://api.devnet.solana.com');
     }
 }
 

--- a/examples/react-app/src/components/AirdropButton.tsx
+++ b/examples/react-app/src/components/AirdropButton.tsx
@@ -1,39 +1,35 @@
 import { Blockquote, Button, Dialog, Flex, Link, Text } from '@radix-ui/themes';
-import { Address, airdropFactory, lamports, Rpc, SolanaRpcApi } from '@solana/kit';
-import { useAction, useClient } from '@solana/react';
-import { useMemo } from 'react';
+import { Address, ClientWithAirdrop, lamports } from '@solana/kit';
+import { useAirdrop, useClient } from '@solana/react';
 
 import { getExplorerClusterName } from '../chain';
 import type { AppClient } from '../context/ClientProvider';
 import { ErrorDialog } from './ErrorDialog';
 
 export function AirdropButton({ address }: { address: Address }) {
-    const { chain, rpc, rpcSubscriptions } = useClient<AppClient>();
-    const solanaExplorerClusterName = getExplorerClusterName(chain);
+    const client = useClient<AppClient>();
+    // Airdrops aren't available on mainnet, whose client carries no `airdrop` capability. Narrow on
+    // its presence: absent (mainnet) → a permanently disabled button; present → the working control,
+    // which lives in its own component so `useAirdrop` is always called unconditionally.
+    if (!('airdrop' in client)) {
+        return (
+            <Button disabled type="button" variant="outline">
+                Airdrop to fee payer
+            </Button>
+        );
+    }
+    return <AirdropToFeePayerButton address={address} client={client} />;
+}
 
-    const isMainnet = chain === 'solana:mainnet';
-
-    // Cast RPC for airdrop, this is safe because we disable the airdrop button on mainnet
-    const airdrop = useMemo(
-        () => airdropFactory({ rpc: rpc as Rpc<SolanaRpcApi>, rpcSubscriptions }),
-        [rpc, rpcSubscriptions],
-    );
-
-    const {
-        data: lastSignature,
-        dispatch,
-        error,
-        isRunning,
-        reset,
-    } = useAction(async signal => {
-        if (isMainnet) throw new Error('Airdrops are not available on mainnet');
-        return await airdrop({
-            abortSignal: signal,
-            commitment: 'confirmed',
-            lamports: lamports(1_000_000_000n),
-            recipientAddress: address,
-        });
-    });
+function AirdropToFeePayerButton({
+    address,
+    client,
+}: {
+    address: Address;
+    client: Extract<AppClient, ClientWithAirdrop>;
+}) {
+    const solanaExplorerClusterName = getExplorerClusterName(client.chain);
+    const { data: lastSignature, dispatch, error, isRunning, reset } = useAirdrop(client);
 
     return (
         <>
@@ -49,10 +45,9 @@ export function AirdropButton({ address }: { address: Address }) {
                     <Button
                         variant="outline"
                         color={error ? 'red' : undefined}
-                        disabled={isMainnet}
                         loading={isRunning}
                         type="button"
-                        onClick={() => dispatch()}
+                        onClick={() => dispatch(address, lamports(1_000_000_000n))}
                     >
                         Airdrop to fee payer
                     </Button>

--- a/examples/react-app/src/context/ClientProvider.tsx
+++ b/examples/react-app/src/context/ClientProvider.tsx
@@ -1,35 +1,53 @@
-import type { ClusterUrl } from '@solana/kit';
 import { createClient, extendClient } from '@solana/kit';
-import { solanaRpc } from '@solana/kit-plugin-rpc';
+import { solanaDevnetRpc, solanaMainnetRpc, solanaTestnetRpc } from '@solana/kit-plugin-rpc';
 import { walletSigner } from '@solana/kit-plugin-wallet';
 import { ClientProvider as KitClientProvider } from '@solana/react';
 import type { SolanaChain } from '@solana/wallet-standard-chains';
 import { systemProgram } from '@solana-program/system';
 import { useLayoutEffect, useState } from 'react';
 
-import { getChainRpcUrl } from '../chain';
-
 type Props = Readonly<{
     chain: SolanaChain;
     children: React.ReactNode;
 }>;
 
-function buildClient(chain: SolanaChain, rpcUrl: ClusterUrl) {
-    return (
-        createClient()
-            .use(walletSigner({ chain }))
-            // Only `rpcUrl` is passed; `solanaRpc` derives the subscriptions URL from it by swapping
-            // the protocol to `ws`/`wss`.
-            .use(solanaRpc({ rpcUrl }))
-            // Stamp the target `chain` onto the client so consumers can read it back off `useClient()`
-            // *in lockstep with* `rpc`/`rpcSubscriptions`. This is load-bearing, not decorative: on a
-            // chain switch the selected chain (this component's `chain` prop) flips one render before
-            // the rebuilt client is published, so anything that must move with the client's rpc — most
-            // importantly `Balance`'s SWR cache key — has to derive `chain` from the client, or it
-            // would key the new network's fetch against the old network's rpc.
-            .use(client => extendClient(client, { chain }))
-            .use(systemProgram())
-    );
+function buildClient(chain: SolanaChain) {
+    const base = createClient().use(walletSigner({ chain }));
+    // Stamp the target `chain` onto the client so consumers can read it back off `useClient()` *in
+    // lockstep with* `rpc`/`rpcSubscriptions`, then install the system program. This is load-bearing,
+    // not decorative: on a chain switch the selected chain (this component's `chain` prop) flips one
+    // render before the rebuilt client is published, so anything that must move with the client's rpc —
+    // most importantly `Balance`'s SWR cache key — has to derive `chain` from the client, or it would
+    // key the new network's fetch against the old network's rpc.
+    //
+    // The RPC plugin is selected per chain, because each cluster's plugin brands its endpoint to that
+    // cluster and installs the capabilities that cluster actually has: `solanaDevnetRpc` and
+    // `solanaTestnetRpc` both bundle `airdrop` (and default to the public devnet/testnet endpoints),
+    // while `solanaMainnetRpc` does not, since mainnet has no faucet. Each branch returns its
+    // fully-built client, so `AppClient` stays a union whose mainnet member has no `airdrop` — which is
+    // what lets `AirdropButton` narrow with `'airdrop' in client`.
+    switch (chain) {
+        case 'solana:mainnet':
+            return base
+                .use(
+                    solanaMainnetRpc({
+                        rpcUrl: process.env.REACT_EXAMPLE_APP_MAINNET_URL ?? 'https://api.mainnet-beta.solana.com',
+                    }),
+                )
+                .use(client => extendClient(client, { chain }))
+                .use(systemProgram());
+        case 'solana:testnet':
+            return base
+                .use(solanaTestnetRpc())
+                .use(client => extendClient(client, { chain }))
+                .use(systemProgram());
+        case 'solana:devnet':
+        default:
+            return base
+                .use(solanaDevnetRpc())
+                .use(client => extendClient(client, { chain }))
+                .use(systemProgram());
+    }
 }
 
 /**
@@ -52,7 +70,7 @@ export type AppClient = ReturnType<typeof buildClient>;
 export function ClientProvider({ chain, children }: Props) {
     const [client, setClient] = useState<AppClient | null>(null);
     useLayoutEffect(() => {
-        const next = buildClient(chain, getChainRpcUrl(chain));
+        const next = buildClient(chain);
         // Publishing `next` synchronously here (rather than deriving it from state) is deliberate:
         // it lets the client be built/disposed alongside the external resource it wraps, with the
         // effect cleanup owning disposal.

--- a/examples/react-app/src/context/__tests__/ClientProvider-test.browser.tsx
+++ b/examples/react-app/src/context/__tests__/ClientProvider-test.browser.tsx
@@ -8,7 +8,8 @@ import { render } from '../../__test-utils__/render';
 const mockPublishedClients: unknown[] = [];
 
 // A chainable client stub: every `.use()` returns the same disposable object so the provider's
-// `createClient().use(walletSigner(…)).use(solanaRpc(…))` chain resolves to one disposable client.
+// `createClient().use(walletSigner(…)).use(solanaDevnetRpc())` chain resolves to one disposable
+// client.
 function makeDisposableClient() {
     const client: { [Symbol.dispose]: jest.Mock; use: () => typeof client } = {
         [Symbol.dispose]: jest.fn(),
@@ -19,17 +20,17 @@ function makeDisposableClient() {
 
 jest.mock('@solana/kit', () => ({
     createClient: () => ({ use: () => makeDisposableClient() }),
-    // `ClientProvider` derives RPC URLs via `chain.ts`, which brands them with these cluster helpers;
-    // since this mock replaces the whole module, all three must be provided.
-    devnet: (url: string) => url,
     // `buildClient` passes an `extendClient` plugin to `.use()`; the chainable stub above never
     // invokes plugins, so this only needs to exist for the import to resolve.
     extendClient: (client: unknown) => client,
-    mainnet: (url: string) => url,
-    testnet: (url: string) => url,
 }));
 jest.mock('@solana/kit-plugin-wallet', () => ({ walletSigner: () => ({}) }));
-jest.mock('@solana/kit-plugin-rpc', () => ({ solanaRpc: () => ({}) }));
+// `buildClient` picks one RPC plugin per chain, so every cluster plugin it can reach must be stubbed.
+jest.mock('@solana/kit-plugin-rpc', () => ({
+    solanaDevnetRpc: () => ({}),
+    solanaMainnetRpc: () => ({}),
+    solanaTestnetRpc: () => ({}),
+}));
 jest.mock('@solana/react', () => ({
     ClientProvider: ({ children, client }: { children: ReactNode; client: unknown }) => {
         mockPublishedClients.push(client);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,8 +161,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/kit
       '@solana/kit-plugin-rpc':
-        specifier: 0.15.0
-        version: 0.15.0(@solana/kit@packages+kit)
+        specifier: 0.16.0
+        version: 0.16.0(@solana/kit@packages+kit)
       '@solana/kit-plugin-wallet':
         specifier: 0.14.0
         version: 0.14.0(@solana/kit@packages+kit)(@solana/react@packages+react)(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.8)(typescript@5.9.3)
@@ -5149,8 +5149,8 @@ packages:
     peerDependencies:
       '@solana/kit': ^7.0.0
 
-  '@solana/kit-plugin-rpc@0.15.0':
-    resolution: {integrity: sha512-Abymr7WLP9yQ6ixCCv+tKzjoWpAkxJ90JWzL+pfkTAFGTpVk9N0myhMcO2ohl6yztJRMOxsw1CXWjcVecxxUlg==}
+  '@solana/kit-plugin-rpc@0.16.0':
+    resolution: {integrity: sha512-iMzlXEq7zU5YPN0G24aN+nl7XP7Kp+4cegsL5o8n4pBr6iazsSu0TU+5krK9LNR01vIKrXUw7MvnO+45XWVGUA==}
     peerDependencies:
       '@solana/kit': ^7.0.0
 
@@ -14020,7 +14020,7 @@ snapshots:
     dependencies:
       '@solana/kit': link:packages/kit
 
-  '@solana/kit-plugin-rpc@0.15.0(@solana/kit@packages+kit)':
+  '@solana/kit-plugin-rpc@0.16.0(@solana/kit@packages+kit)':
     dependencies:
       '@solana/kit': link:packages/kit
       '@solana/kit-plugin-instruction-plan': 0.13.0(@solana/kit@packages+kit)


### PR DESCRIPTION
#### This PR updates the react-app example to demonstrate the new `useAirdrop` hook

- `kit-plugin-rpc` is updated to 0.16.0, which added a `testnetRpc` plugin 
- The client building is updated to use `devnetRpc` or `testnetRpc` instead of `solanaRpc` based on the chain, meaning that we get the airdrop plugin on devnet/testnet
- `AirdropButton` is updated to use `useAirdrop` and to check if `airdrop` is available on the client. This typing all flows from `AppClient`. 