### PR TITLE
Update `withCleanup` to use a minimal polyfill of `DisposableStack`

### DIFF
--- a/.changeset/sweet-rivers-taste.md
+++ b/.changeset/sweet-rivers-taste.md
@@ -1,0 +1,12 @@
+---
+'@solana/plugin-core': patch
+'@solana/kit': patch
+---
+
+Fix `withCleanup` throwing `DisposableStack is not defined` on Safari
+
+`withCleanup` constructed a `DisposableStack` unconditionally, but Safari has not shipped explicit resource management — as of Safari 27 it provides neither `DisposableStack` nor `Symbol.dispose` — so any plugin that registers a cleanup function threw `ReferenceError: Can't find variable: DisposableStack` while the client was being built.
+
+The runtime's own `DisposableStack` is still used whenever it exists. Only where it is missing does `withCleanup` fall back to an internal stack that reproduces the behaviour it depends on. The `withCleanup` test suite now runs twice, once against each stack, so the two cannot drift apart.
+
+Note that this fixes disposal on Safari but not `using` declarations in your own code, which additionally need a `Symbol.dispose` polyfill; disposing a client explicitly works either way.

--- a/packages/plugin-core/src/__tests__/client-test.ts
+++ b/packages/plugin-core/src/__tests__/client-test.ts
@@ -301,7 +301,27 @@ describe('extendClient', () => {
     });
 });
 
-describe('withCleanup', () => {
+const PLATFORM_DISPOSABLE_STACK = globalThis.DisposableStack;
+const PLATFORM_SUPPRESSED_ERROR = globalThis.SuppressedError;
+
+// `withCleanup` prefers the runtime's `DisposableStack` and falls back to an internal
+// implementation on runtimes that have not shipped explicit resource management (Safari, as of
+// Safari 27). The two paths must be indistinguishable, so this suite runs twice: once as the
+// runtime comes, and once with the platform class removed to force the fallback.
+describe.each([
+    { forceFallback: false, label: 'the platform `DisposableStack`' },
+    { forceFallback: true, label: 'the internal fallback stack' },
+])('withCleanup backed by $label', ({ forceFallback }) => {
+    beforeEach(() => {
+        if (forceFallback) {
+            // @ts-expect-error Removing the global forces `withCleanup` down its fallback path.
+            delete globalThis.DisposableStack;
+        }
+    });
+    afterEach(() => {
+        globalThis.DisposableStack = PLATFORM_DISPOSABLE_STACK;
+    });
+
     it('calls the cleanup function when disposed', () => {
         const cleanup = jest.fn();
         const result = withCleanup({}, cleanup);
@@ -385,5 +405,188 @@ describe('withCleanup', () => {
         const result = withCleanup(client, cleanup2);
         result[Symbol.dispose]();
         expect(callOrder).toStrictEqual(['cleanup2', 'cleanup1', 'parent']);
+    });
+
+    it('does not call the cleanup function again when disposed twice', () => {
+        const cleanup = jest.fn();
+        const result = withCleanup({}, cleanup);
+        result[Symbol.dispose]();
+        result[Symbol.dispose]();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls the remaining cleanups when an earlier one throws', () => {
+        const cleanup1 = jest.fn();
+        const cleanup2 = jest.fn(() => {
+            throw new Error('o no');
+        });
+        const client = withCleanup({}, cleanup1);
+        const result = withCleanup(client, cleanup2);
+        // Cleanups run LIFO, so `cleanup2` throws before `cleanup1` gets its turn.
+        expect(() => result[Symbol.dispose]()).toThrow('o no');
+        expect(cleanup1).toHaveBeenCalledTimes(1);
+    });
+
+    it('aggregates multiple cleanup errors into a `SuppressedError`', () => {
+        const firstError = new Error('first');
+        const secondError = new Error('second');
+        const client = withCleanup({}, () => {
+            throw firstError;
+        });
+        const result = withCleanup(client, () => {
+            throw secondError;
+        });
+        let thrown;
+        try {
+            result[Symbol.dispose]();
+        } catch (e) {
+            thrown = e;
+        }
+        // Cleanups run LIFO, so `secondError` is thrown first and then suppressed by `firstError`.
+        expect(thrown).toMatchObject({
+            error: firstError,
+            message: 'An error was suppressed during disposal',
+            name: 'SuppressedError',
+            suppressed: secondError,
+        });
+    });
+
+    it('does not expose enumerable properties on the aggregated error', () => {
+        const client = withCleanup({}, () => {
+            throw new Error('first');
+        });
+        const result = withCleanup(client, () => {
+            throw new Error('second');
+        });
+        let thrown;
+        try {
+            result[Symbol.dispose]();
+        } catch (e) {
+            thrown = e;
+        }
+        // Native `SuppressedError` keeps `error`/`suppressed` non-enumerable, so neither shows up
+        // when a consumer serializes or spreads the error.
+        expect(Object.keys(thrown as object)).toStrictEqual([]);
+    });
+
+    it('throws when the cleanup is not a function', () => {
+        expect(() => withCleanup({}, 42 as unknown as () => void)).toThrow(TypeError);
+    });
+
+    it('throws when a cleanup is added to an already-disposed client', () => {
+        const client = withCleanup({}, () => {});
+        client[Symbol.dispose]();
+        expect(() => withCleanup(client, () => {})).toThrow(ReferenceError);
+    });
+});
+
+describe('withCleanup on a runtime without explicit resource management', () => {
+    // Simulates Safari, which provides neither `DisposableStack` nor `SuppressedError`.
+    beforeEach(() => {
+        // @ts-expect-error Removing the global forces `withCleanup` down its fallback path.
+        delete globalThis.DisposableStack;
+        // @ts-expect-error Removing the global forces the fallback error aggregation.
+        delete globalThis.SuppressedError;
+    });
+    afterEach(() => {
+        globalThis.DisposableStack = PLATFORM_DISPOSABLE_STACK;
+        globalThis.SuppressedError = PLATFORM_SUPPRESSED_ERROR;
+    });
+
+    it('aggregates multiple cleanup errors without the `SuppressedError` constructor', () => {
+        const firstError = new Error('first');
+        const secondError = new Error('second');
+        const client = withCleanup({}, () => {
+            throw firstError;
+        });
+        const result = withCleanup(client, () => {
+            throw secondError;
+        });
+        let thrown;
+        try {
+            result[Symbol.dispose]();
+        } catch (e) {
+            thrown = e;
+        }
+        expect(thrown).toBeInstanceOf(Error);
+        expect(thrown).toMatchObject({
+            error: firstError,
+            message: 'An error was suppressed during disposal',
+            name: 'SuppressedError',
+            suppressed: secondError,
+        });
+        // The synthesized error must be shaped like the native one, whose properties are all
+        // non-enumerable, so that serializing or spreading it behaves the same either way.
+        expect(Object.keys(thrown as object)).toStrictEqual([]);
+    });
+});
+
+describe('withCleanup on a runtime without `Symbol.dispose`', () => {
+    // Safari lacks `Symbol.dispose` as well as `DisposableStack`, which makes the computed
+    // `[Symbol.dispose]` key degrade to the string `'undefined'`. Well-known symbols are
+    // non-configurable and so cannot be deleted, but swapping in a stand-in `Symbol` that never had
+    // `dispose` reproduces that runtime faithfully.
+    const PLATFORM_SYMBOL = globalThis.Symbol;
+    beforeEach(() => {
+        const symbolStandIn = ((description?: string) => PLATFORM_SYMBOL(description)) as unknown as SymbolConstructor;
+        for (const key of Reflect.ownKeys(PLATFORM_SYMBOL)) {
+            if (key === 'dispose' || key === 'asyncDispose') {
+                continue;
+            }
+            Object.defineProperty(symbolStandIn, key, {
+                ...Object.getOwnPropertyDescriptor(PLATFORM_SYMBOL, key),
+                configurable: true,
+            });
+        }
+        globalThis.Symbol = symbolStandIn;
+        // @ts-expect-error Removing the global forces `withCleanup` down its fallback path.
+        delete globalThis.DisposableStack;
+        // @ts-expect-error Removing the global forces the fallback error aggregation.
+        delete globalThis.SuppressedError;
+        if (Symbol.dispose !== undefined || globalThis.DisposableStack !== undefined) {
+            // Fail every test in this block rather than let one pass against a runtime that does
+            // have explicit resource management, which would prove nothing about Safari.
+            throw new Error('Failed to simulate a runtime without explicit resource management');
+        }
+    });
+    afterEach(() => {
+        globalThis.Symbol = PLATFORM_SYMBOL;
+        globalThis.DisposableStack = PLATFORM_DISPOSABLE_STACK;
+        globalThis.SuppressedError = PLATFORM_SUPPRESSED_ERROR;
+    });
+
+    it('disposes a client when the runtime has neither `DisposableStack` nor `Symbol.dispose`', () => {
+        const cleanup = jest.fn();
+        const client = withCleanup({}, cleanup);
+        // Registration and lookup coerce the missing symbol to the same string key, so explicit
+        // disposal works even though the `using` syntax could not.
+        client[Symbol.dispose]();
+        expect(cleanup).toHaveBeenCalledTimes(1);
+    });
+
+    it('chains an existing dispose method when the runtime has no `Symbol.dispose`', () => {
+        const callOrder: string[] = [];
+        const client = withCleanup({ [Symbol.dispose]: () => callOrder.push('parent') }, () =>
+            callOrder.push('cleanup'),
+        );
+        client[Symbol.dispose]();
+        expect(callOrder).toStrictEqual(['cleanup', 'parent']);
+    });
+});
+
+describe('withCleanup platform detection', () => {
+    afterEach(() => {
+        globalThis.DisposableStack = PLATFORM_DISPOSABLE_STACK;
+    });
+
+    it('defers cleanups to the platform `DisposableStack` when the runtime provides one', () => {
+        const defer = jest.fn();
+        const dispose = jest.fn();
+        globalThis.DisposableStack = jest.fn(() => ({ defer, dispose })) as unknown as typeof DisposableStack;
+        const cleanup = jest.fn();
+        const result = withCleanup({}, cleanup);
+        expect(defer).toHaveBeenCalledWith(cleanup);
+        result[Symbol.dispose]();
+        expect(dispose).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/plugin-core/src/client.ts
+++ b/packages/plugin-core/src/client.ts
@@ -292,6 +292,11 @@ function toConfigurableDescriptors<T extends PropertyDescriptorMap>(descriptors:
  * If the client already implements `Symbol.dispose`, the existing dispose
  * logic is chained so that it runs after the new `cleanup` function.
  *
+ * Cleanups run in reverse order of registration, disposal is idempotent, and if more than one
+ * cleanup throws then the errors are aggregated into a `SuppressedError` chain. Runtimes that have
+ * not shipped explicit resource management are supported too, though a `using` declaration needs a
+ * `Symbol.dispose` polyfill there.
+ *
  * The return type is an {@link ExtendedClient}, which flattens the merged shape into a
  * single object literal so chained calls do not accumulate nested intersections in editor
  * tooltips and error messages.
@@ -314,13 +319,28 @@ function toConfigurableDescriptors<T extends PropertyDescriptorMap>(descriptors:
  *     };
  * }
  *
- * // Later, when the client is no longer needed:
- * using client = createClient().use(myPlugin();
+ * // Build the client in the scope that should own it:
+ * using client = createClient().use(myPlugin());
  * // `socket.close()` is called automatically when `client` goes out of scope.
+ * ```
+ *
+ * @example Disposing without a using declaration
+ * `using` requires explicit resource management, which Safari has not shipped as of Safari 27.
+ * Either dispose the client yourself, as below, or polyfill `Symbol.dispose` — installing the
+ * polyfill before any client is created, since a client registers its dispose method under
+ * whatever `Symbol.dispose` was at the time.
+ * ```ts
+ * const client = createClient().use(myPlugin());
+ *
+ * // Later, when the client is no longer needed:
+ * client[Symbol.dispose]();
+ * // `socket.close()` has now been called.
  * ```
  *
  * @see {@link extendClient}
  * @see {@link ExtendedClient}
+ * @remarks See https://caniuse.com/mdn-javascript_builtins_disposablestack for platform
+ * availability of `DisposableStack`.
  */
 export function withCleanup<TClient extends object>(
     client: TClient,
@@ -328,7 +348,7 @@ export function withCleanup<TClient extends object>(
 ): ExtendedClient<TClient, Disposable> {
     if (DISPOSABLE_STACK_PROPERTY in client) {
         return addCleanupToClientWithExistingStack(
-            client as Record<typeof DISPOSABLE_STACK_PROPERTY, DisposableStack> & TClient,
+            client as Record<typeof DISPOSABLE_STACK_PROPERTY, CleanupStack> & TClient,
             cleanup,
         );
     } else {
@@ -338,7 +358,7 @@ export function withCleanup<TClient extends object>(
 
 const DISPOSABLE_STACK_PROPERTY = '__PRIVATE__DISPOSABLE_STACK' as const;
 
-function addCleanupToClientWithExistingStack<TClient extends Record<typeof DISPOSABLE_STACK_PROPERTY, DisposableStack>>(
+function addCleanupToClientWithExistingStack<TClient extends Record<typeof DISPOSABLE_STACK_PROPERTY, CleanupStack>>(
     client: TClient,
     cleanup: () => void,
 ): ExtendedClient<TClient, Disposable> {
@@ -352,7 +372,7 @@ function addCleanupToClientWithoutExistingStack<TClient extends object>(
     client: TClient,
     cleanup: () => void,
 ): ExtendedClient<TClient, Disposable> {
-    const stack = new DisposableStack();
+    const stack = createCleanupStack();
 
     // If the client has an existing dispose method but not our stack, we maintain this existing cleanup by deferring it to the new stack
     if (Symbol.dispose in client) {
@@ -367,9 +387,93 @@ function addCleanupToClientWithoutExistingStack<TClient extends object>(
     const additions = {
         [DISPOSABLE_STACK_PROPERTY]: stack,
         [Symbol.dispose]() {
-            stack[Symbol.dispose]();
+            stack.dispose();
         },
     };
 
     return extendClient(client, additions) as unknown as ExtendedClient<TClient, Disposable>;
+}
+
+/**
+ * The slice of `DisposableStack` that {@link withCleanup} relies on.
+ *
+ * Deliberately narrow — `defer()` and the plain `dispose()` method only — so that it can be
+ * satisfied both by the platform's `DisposableStack` and by {@link createFallbackCleanupStack} on
+ * runtimes that lack one. Note that `dispose()` is used in preference to `[Symbol.dispose]()`
+ * because runtimes missing `DisposableStack` are missing `Symbol.dispose` as well.
+ */
+type CleanupStack = {
+    defer(cleanup: () => void): void;
+    dispose(): void;
+};
+
+function createCleanupStack(): CleanupStack {
+    // Always prefer the runtime's own implementation. The fallback exists only for runtimes that
+    // have not shipped explicit resource management — most notably Safari, which as of Safari 27
+    // provides neither `DisposableStack` nor `Symbol.dispose`.
+    return typeof globalThis.DisposableStack === 'function'
+        ? new globalThis.DisposableStack()
+        : createFallbackCleanupStack();
+}
+
+function createFallbackCleanupStack(): CleanupStack {
+    const cleanups: (() => void)[] = [];
+    let disposed = false;
+    return {
+        defer(cleanup) {
+            if (disposed) {
+                // Mirrors the `ReferenceError` thrown by `DisposableStack.prototype.defer` so that
+                // both stacks refuse a late cleanup the same way, rather than silently accepting
+                // one that will never run.
+                throw new ReferenceError('Cannot add values to a disposed stack');
+            }
+            if (typeof cleanup !== 'function') {
+                // `DisposableStack.prototype.defer` rejects a non-callable up front. Deferring that
+                // failure to disposal would surface it far from its cause, and would tangle it up in
+                // the error aggregation of unrelated cleanups.
+                throw new TypeError(`${String(cleanup)} is not a function`);
+            }
+            cleanups.push(cleanup);
+        },
+        dispose() {
+            if (disposed) {
+                return;
+            }
+            disposed = true;
+            let error: unknown;
+            let hasError = false;
+            // Cleanups run in reverse order of registration, and one that throws must not stop the
+            // rest from running; their errors are aggregated into a `SuppressedError` chain instead.
+            for (let ii = cleanups.length - 1; ii >= 0; ii--) {
+                try {
+                    cleanups[ii]();
+                } catch (e) {
+                    error = hasError ? createSuppressedError(e, error) : e;
+                    hasError = true;
+                }
+            }
+            cleanups.length = 0;
+            if (hasError) {
+                throw error;
+            }
+        },
+    };
+}
+
+function createSuppressedError(error: unknown, suppressed: unknown): Error {
+    // The message `DisposableStack` disposal produces. Passing it explicitly matters: the two-argument
+    // form of `SuppressedError` leaves the message empty, which would make an aggregated error read
+    // differently depending on which stack produced it.
+    const message = 'An error was suppressed during disposal';
+    if (typeof globalThis.SuppressedError === 'function') {
+        return new globalThis.SuppressedError(error, suppressed, message);
+    }
+    // A runtime without `DisposableStack` has no `SuppressedError` constructor either, so reproduce
+    // its shape on a plain error — including the non-enumerability of every property, so that
+    // serializing or spreading the error does not depend on which runtime built it.
+    return Object.defineProperties(new Error(message), {
+        error: { configurable: true, value: error, writable: true },
+        name: { configurable: true, value: 'SuppressedError', writable: true },
+        suppressed: { configurable: true, value: suppressed, writable: true },
+    });
 }


### PR DESCRIPTION
#### Problem

Safari does not ship the explicit resource management APIs, such as `DisposableStack`: https://caniuse.com/mdn-javascript_builtins_disposablestack 

We rely on this for our `withCleanup` implementation, which enables a `[Symbol.Dispose]` function to be attached to a client, allowing plugins to clean up resources when the client is disposed. The wallet plugin is one user of this functionality.

Because of Safari not supporting it, it would crash on an app that used a client including a plugin that uses `withCleanup`, such as the wallet plugin

#### Summary of Changes

We now handle a missing `DisposableStack` in the runtime, by implementing a minimal version that implements only the `defer` and `dispose` functions that we use. If `DisposableStack` is available then we use it, following the same pattern as with our other polyfills (eg. in WebCrypto). If it is not available then we use our minimal polyfill instead.

We add extra tests to ensure the polyfill has all the behaviours we expect, and we now run the tests both with the global `DisposableStack` (it is available in our test environment) and with it removed to force use of the polyfill. 

With this change our example app works correctly on Safari
