### PR TITLE
Fix array decoder empty check

### DIFF
--- a/.changeset/quick-arrays-decode.md
+++ b/.changeset/quick-arrays-decode.md
@@ -1,0 +1,7 @@
+---
+'@solana/codecs-data-structures': patch
+---
+
+Avoid copying the remaining buffer in `getArrayDecoder`'s emptiness check
+
+`getArrayDecoder`'s `read()` tested for an empty byte array with `bytes.slice(offset).length === 0`, which allocates and copies every byte from `offset` to the end just to read `.length` off the result. On large accounts containing many prefixed arrays, maps, or sets this made decoding quadratic in account size. The check is now the equivalent O(1) comparison `offset >= bytes.length`. `getMapDecoder` and `getSetDecoder` delegate to `getArrayDecoder` and benefit as well.

--- a/packages/codecs-data-structures/src/array.ts
+++ b/packages/codecs-data-structures/src/array.ts
@@ -178,7 +178,7 @@ export function getArrayDecoder<TTo>(item: Decoder<TTo>, config: ArrayCodecConfi
         ...(fixedSize !== null ? { fixedSize } : { maxSize }),
         read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
             const array: TTo[] = [];
-            if (typeof size === 'object' && bytes.slice(offset).length === 0) {
+            if (typeof size === 'object' && offset >= bytes.length) {
                 return [array, offset];
             }
 


### PR DESCRIPTION
#### Problem

"getArrayDecoder" emptiness check copies the whole remaining buffer, making large-account decoding quadratic

#### Summary of Changes

For the non-negative offsets the codec framework guarantees (decode() starts at 0, composite reads only ever advance the offset, and offsetCodec normalises and asserts its offsets into range before the inner codec sees them), bytes.slice(offset).length === 0 is true precisely when offset >= bytes.length. 

Fixes #1877