### PR TITLE
CI: skip preview docs on non-docs PRs, add retry

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -53,8 +53,30 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          vercel pull --token="$VERCEL_TOKEN" --yes --environment=production
-          vercel build --token="$VERCEL_TOKEN" --prod
+          # `vercel build` fails intermittently — it can be killed when `next build` exhausts the
+          # runner's memory
+          retry() {
+            # Label attempts with the command and subcommand (eg. `vercel build`) but not the
+            # remaining arguments, which include the Vercel token
+            local label="$1 $2"
+            local attempt
+            for attempt in 1 2 3; do
+              if "$@"; then
+                return 0
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "::warning::'$label' failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+                sleep "$((attempt * 15))"
+              fi
+            done
+            echo "::error::'$label' failed after 3 attempts"
+            return 1
+          }
+          retry vercel pull --token="$VERCEL_TOKEN" --yes --environment=production
+          retry vercel build --token="$VERCEL_TOKEN" --prod
+          # Deliberately not retried: this uploads the prebuilt output, so it's not subject to the
+          # memory issue above, and a failure *after* the deployment was created would result in a
+          # second deployment on retry
           vercel deploy --token="$VERCEL_TOKEN" --archive=tgz --prebuilt --prod
 
       - name: Synchronize InKeep Search Index

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -2,7 +2,9 @@ name: Preview Documentation
 
 on:
   pull_request:
-  merge_group:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/preview-docs.yml'
 
 permissions:
   contents: read
@@ -52,17 +54,37 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          vercel pull --token="$VERCEL_TOKEN" --yes --environment=preview
-          vercel build --token="$VERCEL_TOKEN" --target=preview
-          DEPLOY_OUTPUT=$(vercel deploy --token="$VERCEL_TOKEN" --archive=tgz --env GITHUB_PR_NUMBER="$PR_NUMBER" --env GITHUB_PR_BRANCH="$BRANCH_NAME" --prebuilt --target=preview 2>&1)
-          DEPLOY_EXIT_CODE=$?
-          if [ $DEPLOY_EXIT_CODE -ne 0 ]; then
+          # `vercel build` fails intermittently — it can be killed when `next build` exhausts the
+          # runner's memory
+          retry() {
+            # Label attempts with the command and subcommand (eg. `vercel build`) but not the
+            # remaining arguments, which include the Vercel token
+            local label="$1 $2"
+            local attempt
+            for attempt in 1 2 3; do
+              if "$@"; then
+                return 0
+              fi
+              if [ "$attempt" -lt 3 ]; then
+                echo "::warning::'$label' failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
+                sleep "$((attempt * 15))"
+              fi
+            done
+            echo "::error::'$label' failed after 3 attempts"
+            return 1
+          }
+          retry vercel pull --token="$VERCEL_TOKEN" --yes --environment=preview
+          retry vercel build --token="$VERCEL_TOKEN" --target=preview
+          # Deliberately not retried: this uploads the prebuilt output, so it's not subject to the
+          # memory issue above, and a failure *after* the deployment was created would result in a
+          # second deployment on retry
+          if ! DEPLOY_OUTPUT=$(vercel deploy --token="$VERCEL_TOKEN" --archive=tgz --env GITHUB_PR_NUMBER="$PR_NUMBER" --env GITHUB_PR_BRANCH="$BRANCH_NAME" --prebuilt --target=preview 2>&1); then
             echo "Vercel deploy failed:"
             echo "$DEPLOY_OUTPUT"
-            exit $DEPLOY_EXIT_CODE
+            exit 1
           fi
           DEPLOY_URL=$(echo "$DEPLOY_OUTPUT" | grep -o 'https://[a-zA-Z0-9.-]*\.vercel\.app' | tail -1)
-          echo "preview_url=$DEPLOY_URL" >> $GITHUB_OUTPUT
+          echo "preview_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR with Preview URL
         if: steps.vercel_deploy.outcome == 'success'


### PR DESCRIPTION
#### Problem

We have fairly regular failures on the deploy docs CI job, where the build is exhausting the runner's memory. For now this is intermittent and resolved by retrying.

#### Summary of Changes

- Only run the deploy job if a PR actually changes docs/*. This means that we can no longer preview the auto-generated pages for new/changed APIs. But should eliminate the most common CI issue on most PRs. Note that I've removed this job from the ruleset, ie PRs no longer require it to pass. Note that it also runs if we change the CI job (to verify that change), and therefore does run on this PR. 

- Adds automatic `retry` in the docs jobs, so that if they fail we try again twice before failing the job. They'll obviously take longer if they fail and then pass, but quicker and less annoying than re-running them ourselves. In most cases I think trying again will succeed, but it'll depend how well memory is cleaned up after the error. If we see this not helping we can drop it and manually retry, but worth trying I think.
