### PR TITLE
Add getSignatureFromTransactionIfPresent

### DIFF
--- a/.changeset/common-cats-roll.md
+++ b/.changeset/common-cats-roll.md
@@ -1,0 +1,5 @@
+---
+'@solana/transactions': minor
+---
+
+Added `getSignatureFromTransactionIfPresent`, which returns the `Signature` that uniquely identifies a transaction, or `undefined` when its fee payer has not signed it yet. Use it in preference to `getSignatureFromTransaction` when a transaction is legitimately allowed to be unsigned by its fee payer — for instance one that has been partially signed by an authority and is destined for a relayer that will pay for it. `getSignatureFromTransaction` is now implemented in terms of it and continues to throw `SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING` in that case.

--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -65,6 +65,19 @@ const signature = getSignatureFromTransaction(tx);
 console.debug(`Inspect this transaction at https://explorer.solana.com/tx/${signature}`);
 ```
 
+#### `getSignatureFromTransactionIfPresent()`
+
+The same as `getSignatureFromTransaction()`, but returns `undefined` instead of throwing when the transaction's fee payer has not signed it. Use this when a transaction is legitimately allowed to be unsigned by its fee payer — for instance one that has been partially signed by an authority and is destined for a relayer that will pay for it.
+
+```ts
+import { getSignatureFromTransactionIfPresent } from '@solana/transactions';
+
+const signature = getSignatureFromTransactionIfPresent(tx);
+if (signature !== undefined) {
+    console.debug(`Inspect this transaction at https://explorer.solana.com/tx/${signature}`);
+}
+```
+
 ### `signTransaction()`
 
 Given an array of `CryptoKey` objects which are private keys pertaining to addresses that are required to sign a transaction, this method will return a new signed transaction of type `FullySignedTransaction`. This function will throw unless the resulting transaction is fully signed.

--- a/packages/transactions/src/__tests__/signatures-test.ts
+++ b/packages/transactions/src/__tests__/signatures-test.ts
@@ -15,6 +15,7 @@ import { TransactionWithLifetime } from '../lifetime';
 import {
     assertIsFullySignedTransaction,
     getSignatureFromTransaction,
+    getSignatureFromTransactionIfPresent,
     isFullySignedTransaction,
     partiallySignTransaction,
     signTransaction,
@@ -51,6 +52,63 @@ describe('getSignatureFromTransaction', () => {
         expect(() => {
             getSignatureFromTransaction(transactionWithoutFeePayerSignature);
         }).toThrow(new SolanaError(SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING));
+    });
+    it('does not throw when the fee payer slot is filled with zero-length bytes', () => {
+        // A filled slot counts as signed even when decoding it produces an empty string. Only a
+        // `null` or absent slot means that the fee payer has not signed.
+        const signatures: SignaturesMap = {};
+        signatures['123' as Address] = new Uint8Array() as SignatureBytes;
+        const transactionWithEmptyFeePayerSignature: Transaction & TransactionWithLifetime = {
+            lifetimeConstraint: MOCK_BLOCKHASH_LIFETIME,
+            messageBytes: new Uint8Array() as ReadonlyUint8Array as TransactionMessageBytes,
+            signatures,
+        };
+        expect(getSignatureFromTransaction(transactionWithEmptyFeePayerSignature)).toBe('');
+    });
+});
+
+describe('getSignatureFromTransactionIfPresent', () => {
+    it("returns the signature associated with a transaction's fee payer", () => {
+        const signatures: SignaturesMap = {};
+        signatures['123' as Address] = new Uint8Array(new Array(64).fill(9)) as SignatureBytes;
+        const transactionWithFeePayerSignature: Transaction & TransactionWithLifetime = {
+            lifetimeConstraint: MOCK_BLOCKHASH_LIFETIME,
+            messageBytes: new Uint8Array() as ReadonlyUint8Array as TransactionMessageBytes,
+            signatures,
+        };
+        expect(getSignatureFromTransactionIfPresent(transactionWithFeePayerSignature)).toBe(
+            'BUguQsv2ZuHus54HAFzjdJHzZBkygAjKhEeYwSG19tUfUyvvz3worsdQCdAXDNjakJHioSiyxhFiDJrm8XpSXRA',
+        );
+    });
+    it('returns undefined when supplied a transaction with no signatures at all', () => {
+        const transactionWithoutSignatures: Transaction & TransactionWithLifetime = {
+            lifetimeConstraint: MOCK_BLOCKHASH_LIFETIME,
+            messageBytes: new Uint8Array() as ReadonlyUint8Array as TransactionMessageBytes,
+            signatures: {},
+        };
+        expect(getSignatureFromTransactionIfPresent(transactionWithoutSignatures)).toBeUndefined();
+    });
+    it('returns undefined when the fee payer has not signed but another signer has', () => {
+        const signatures: SignaturesMap = {};
+        // The fee payer's slot comes first and is still empty.
+        signatures['123' as Address] = null;
+        signatures['456' as Address] = new Uint8Array(new Array(64).fill(9)) as SignatureBytes;
+        const partiallySignedTransaction: Transaction & TransactionWithLifetime = {
+            lifetimeConstraint: MOCK_BLOCKHASH_LIFETIME,
+            messageBytes: new Uint8Array() as ReadonlyUint8Array as TransactionMessageBytes,
+            signatures,
+        };
+        expect(getSignatureFromTransactionIfPresent(partiallySignedTransaction)).toBeUndefined();
+    });
+    it('returns an empty signature when the fee payer slot is filled with zero-length bytes', () => {
+        const signatures: SignaturesMap = {};
+        signatures['123' as Address] = new Uint8Array() as SignatureBytes;
+        const transactionWithEmptyFeePayerSignature: Transaction & TransactionWithLifetime = {
+            lifetimeConstraint: MOCK_BLOCKHASH_LIFETIME,
+            messageBytes: new Uint8Array() as ReadonlyUint8Array as TransactionMessageBytes,
+            signatures,
+        };
+        expect(getSignatureFromTransactionIfPresent(transactionWithEmptyFeePayerSignature)).toBe('');
     });
 });
 

--- a/packages/transactions/src/signatures.ts
+++ b/packages/transactions/src/signatures.ts
@@ -21,6 +21,42 @@ export type FullySignedTransaction = NominalType<'transactionSignedness', 'fully
 let base58Decoder: Decoder<string> | undefined;
 
 /**
+ * Given a transaction, this method will return the {@link Signature} that uniquely identifies it,
+ * or `undefined` when its fee payer has not signed it yet.
+ *
+ * Use this in preference to {@link getSignatureFromTransaction} when a transaction is legitimately
+ * allowed to be unsigned by its fee payer — for instance one that has been partially signed by an
+ * authority and is destined for a relayer that will pay for it.
+ *
+ * @example
+ * ```ts
+ * import { getSignatureFromTransactionIfPresent } from '@solana/transactions';
+ *
+ * const signature = getSignatureFromTransactionIfPresent(tx);
+ * if (signature !== undefined) {
+ *     console.debug(`Inspect this transaction at https://explorer.solana.com/tx/${signature}`);
+ * }
+ * ```
+ *
+ * @returns The transaction's signature, or `undefined` if its fee payer has not signed it.
+ *
+ * @see {@link getSignatureFromTransaction} if you expect the transaction to have been signed by its
+ * fee payer and want to throw otherwise.
+ */
+export function getSignatureFromTransactionIfPresent(transaction: Transaction): Signature | undefined {
+    if (!base58Decoder) base58Decoder = getBase58Decoder();
+
+    // We have ordered signatures from the compiled message accounts
+    // first signature is the fee payer
+    const signatureBytes = Object.values(transaction.signatures)[0];
+    if (!signatureBytes) {
+        return undefined;
+    }
+    const transactionSignature = base58Decoder.decode(signatureBytes);
+    return transactionSignature as Signature;
+}
+
+/**
  * Given a transaction signed by its fee payer, this method will return the {@link Signature} that
  * uniquely identifies it. This string can be used to look up transactions at a later date, for
  * example on a Solana block explorer.
@@ -32,18 +68,19 @@ let base58Decoder: Decoder<string> | undefined;
  * const signature = getSignatureFromTransaction(tx);
  * console.debug(`Inspect this transaction at https://explorer.solana.com/tx/${signature}`);
  * ```
+ *
+ * @throws {SolanaError} with code {@link SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING} if
+ * the transaction's fee payer has not signed it.
+ *
+ * @see {@link getSignatureFromTransactionIfPresent} if the transaction might legitimately not have
+ * been signed by its fee payer.
  */
 export function getSignatureFromTransaction(transaction: Transaction): Signature {
-    if (!base58Decoder) base58Decoder = getBase58Decoder();
-
-    // We have ordered signatures from the compiled message accounts
-    // first signature is the fee payer
-    const signatureBytes = Object.values(transaction.signatures)[0];
-    if (!signatureBytes) {
+    const transactionSignature = getSignatureFromTransactionIfPresent(transaction);
+    if (transactionSignature === undefined) {
         throw new SolanaError(SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING);
     }
-    const transactionSignature = base58Decoder.decode(signatureBytes);
-    return transactionSignature as Signature;
+    return transactionSignature;
 }
 
 /**


### PR DESCRIPTION
#### Summary of Changes

This PR adds a new function `getSignatureFromTransactionIfPresent`, a non-throwing variant of `getSignatureFromTransaction`

If the transaction has a fee-payer signature then it is returned, otherwise `undefined`

This allows apps to avoid dealing with the details of a transaction signature, while handling the case where the transaction may not be signed yet.

This is primarily added for use in #1893 , but exported from `@solana/transactions` because it's useful functionality for apps.