### PR TITLE
Add a ClientWithFetchAccounts interface

### DIFF
--- a/.changeset/ten-sloths-call.md
+++ b/.changeset/ten-sloths-call.md
@@ -1,0 +1,7 @@
+---
+'@solana/plugin-interfaces': minor
+---
+
+Add a `ClientWithFetchAccounts` interface
+
+This new plugin interface represents a client that can fetch the encoded content of accounts from their addresses via a `fetchAccounts(addresses, config?)` method. Like the other `@solana/plugin-interfaces` capabilities, it lets plugins provide or require account-fetching without coupling to a concrete RPC. The returned array matches the provided addresses in length and order, using `MaybeEncodedAccount` to represent accounts that may not exist.

--- a/packages/plugin-interfaces/README.md
+++ b/packages/plugin-interfaces/README.md
@@ -138,6 +138,25 @@ function accountCreationPlugin() {
 }
 ```
 
+### `ClientWithFetchAccounts`
+
+Represents a client that can fetch the encoded content of accounts from their addresses. Different implementations may fetch accounts differently — for example, by calling the `getAccountInfo` and/or `getMultipleAccounts` RPC methods, or by using a locally cached value. The returned array matches the provided addresses in both length and order, using `MaybeEncodedAccount` to represent accounts that may not exist.
+
+```ts
+import { extendClient } from '@solana/plugin-core';
+import { ClientWithFetchAccounts } from '@solana/plugin-interfaces';
+
+function accountLoaderPlugin() {
+    return <T extends ClientWithFetchAccounts>(client: T) =>
+        extendClient(client, {
+            loadExistingAccounts: async (addresses: Address[]) => {
+                const accounts = await client.fetchAccounts(addresses);
+                return accounts.filter(account => account.exists);
+            },
+        });
+}
+```
+
 ### `ClientWithRpc<TRpcMethods>`
 
 Represents a client with access to a Solana RPC endpoint.

--- a/packages/plugin-interfaces/package.json
+++ b/packages/plugin-interfaces/package.json
@@ -40,6 +40,7 @@
         "maintained node versions"
     ],
     "dependencies": {
+        "@solana/accounts": "workspace:*",
         "@solana/addresses": "workspace:*",
         "@solana/instruction-plans": "workspace:*",
         "@solana/keys": "workspace:*",

--- a/packages/plugin-interfaces/src/__typetests__/fetch-accounts-typetest.ts
+++ b/packages/plugin-interfaces/src/__typetests__/fetch-accounts-typetest.ts
@@ -1,0 +1,29 @@
+import type { MaybeEncodedAccount } from '@solana/accounts';
+import type { Address } from '@solana/addresses';
+
+import type { ClientWithFetchAccounts } from '../fetch-accounts';
+
+// [DESCRIBE] ClientWithFetchAccounts.
+{
+    // It provides a fetchAccounts method with the correct signature.
+    {
+        const client = null as unknown as ClientWithFetchAccounts;
+        void (client.fetchAccounts([] as Address[]) satisfies Promise<MaybeEncodedAccount[]>);
+    }
+
+    // It accepts an optional config parameter.
+    {
+        const client = null as unknown as ClientWithFetchAccounts;
+        void (client.fetchAccounts([] as Address[], { commitment: 'confirmed' }) satisfies Promise<
+            MaybeEncodedAccount[]
+        >);
+    }
+
+    // It can be combined with other interfaces via intersection.
+    {
+        type CustomClient = ClientWithFetchAccounts & { otherMethod(): string };
+        const client = null as unknown as CustomClient;
+        client.fetchAccounts satisfies ClientWithFetchAccounts['fetchAccounts'];
+        client.otherMethod satisfies () => string;
+    }
+}

--- a/packages/plugin-interfaces/src/fetch-accounts.ts
+++ b/packages/plugin-interfaces/src/fetch-accounts.ts
@@ -1,0 +1,40 @@
+import { FetchAccountsConfig, MaybeEncodedAccount } from '@solana/accounts';
+import { Address } from '@solana/addresses';
+
+/**
+ * Represents a client that can fetch the content of accounts from their addresses.
+ *
+ * Different implementations may fetch accounts differently — for example, by calling the
+ * `getAccountInfo` and/or `getMultipleAccounts` RPC methods, by reading from a local validator,
+ * or by using a locally cached value.
+ *
+ * Note that this interface only fetches encoded accounts. Callers that need decoded accounts should
+ * decode the returned {@link MaybeEncodedAccount | MaybeEncodedAccounts} themselves using the codec
+ * of their choice.
+ *
+ * If you have a raw `Rpc` object instead of a client, you can construct a client implementing this
+ * interface using the {@link createClientWithFetchAccountsFromRpc} helper from `@solana/kit`.
+ *
+ * @example
+ * ```ts
+ * async function fetchProgramAddresses(client: ClientWithFetchAccounts, addresses: Address[]) {
+ *     const accounts = await client.fetchAccounts(addresses);
+ *     return accounts.filter(account => account.exists).map(account => account.programAddress);
+ * }
+ * ```
+ */
+export type ClientWithFetchAccounts = {
+    /**
+     * Fetches the encoded content of the accounts at the provided addresses.
+     *
+     * The returned array matches the provided addresses in both length and order. Each item is a
+     * {@link MaybeEncodedAccount} so that missing accounts can be represented whilst keeping track
+     * of their address.
+     *
+     * @param addresses - The addresses of the accounts to fetch.
+     * @param config - Optional configuration for the fetch.
+     * @returns A promise resolving to an array of {@link MaybeEncodedAccount | MaybeEncodedAccounts}
+     *          in the same order as the provided addresses.
+     */
+    fetchAccounts: (addresses: Address[], config?: FetchAccountsConfig) => Promise<MaybeEncodedAccount[]>;
+};

--- a/packages/plugin-interfaces/src/index.ts
+++ b/packages/plugin-interfaces/src/index.ts
@@ -6,6 +6,7 @@
  * @packageDocumentation
  */
 export * from './airdrop';
+export * from './fetch-accounts';
 export * from './instruction-plans';
 export * from './get-minimum-balance';
 export * from './identity';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -876,6 +876,9 @@ importers:
 
   packages/plugin-interfaces:
     dependencies:
+      '@solana/accounts':
+        specifier: workspace:*
+        version: link:../accounts
       '@solana/addresses':
         specifier: workspace:*
         version: link:../addresses


### PR DESCRIPTION
This adds a new `ClientWithFetchAccounts` plugin interface to `@solana/plugin-interfaces`, representing a client that can fetch the encoded content of accounts from their addresses via a `fetchAccounts(addresses, config?)` method. Like the other capability interfaces, it lets plugins provide or require account fetching without coupling to a concrete RPC. The returned array matches the provided addresses in length and order, using `MaybeEncodedAccount` to represent accounts that may not exist. The interface intentionally takes an array and returns an array (no single/array overload) to keep it easy to implement for custom fetch strategies.