### PR TITLE
feat(react): add createProgramHooks factory for Codama program plugins

### DIFF
--- a/.changeset/plenty-days-tickle.md
+++ b/.changeset/plenty-days-tickle.md
@@ -1,0 +1,19 @@
+---
+'@solana/react': minor
+---
+
+Added `createProgramHooks`, a factory that builds typed React hooks over a Codama-generated program plugin installed on the client published by `ClientProvider`.
+
+The generated plugin is already a fully typed runtime map — codecs with `fetch` helpers, instruction builders with `sendTransaction`, PDA finders — so a single factory covers every program with no per-program code generation:
+
+```tsx
+const { useTrackedAccount, useSendInstruction } = createProgramHooks<TokenClient>()('token');
+
+function MintSupply({ mint }: { mint: Address }) {
+    const { data } = useTrackedAccount('mint', mint);
+    const transfer = useSendInstruction('transfer');
+    return <span>{data?.value?.supply}</span>;
+}
+```
+
+Each hook maps one plugin function onto one existing primitive from this package, and is named for the primitive it uses. `useAccount`, `useMaybeAccount`, `useAllAccounts`, `useAllMaybeAccounts` and `usePda` issue a single request through `useRequest`; `useTrackedAccount` additionally opens a subscription through `useTrackedData`, decoding both the initial `getAccountInfo` response and later `accountNotifications` with the plugin's own codec; `useSendInstruction` builds, signs and sends through `useAction`. Passing a `null` address, address list or seed object disables a hook rather than requiring a conditional call.

--- a/packages/react/src/__tests__/createProgramHooks-test.browser.tsx
+++ b/packages/react/src/__tests__/createProgramHooks-test.browser.tsx
@@ -1,0 +1,300 @@
+import {
+    type Address,
+    createReactiveActionStore,
+    createReactiveStoreFromDataPublisherFactory,
+    getBase64Decoder,
+    type ReadonlyUint8Array,
+} from '@solana/kit';
+import { act, waitFor } from '@testing-library/react';
+import React, { type ReactNode } from 'react';
+
+import { render, renderHook } from '../__test-utils__/render';
+import { ClientProvider } from '../ClientProvider';
+import { createProgramHooks } from '../createProgramHooks';
+
+type CounterAccount = { count: number };
+
+type CounterPlugin = {
+    accounts: {
+        counter: {
+            decode: (bytes: ReadonlyUint8Array) => CounterAccount;
+            fetch: (address: Address) => Promise<{ address: Address; data: CounterAccount }>;
+            fetchAll: (addresses: Address[]) => Promise<{ address: Address; data: CounterAccount }[]>;
+            fetchAllMaybe: (
+                addresses: Address[],
+            ) => Promise<{ address: Address; data?: CounterAccount; exists: boolean }[]>;
+            fetchMaybe: (address: Address) => Promise<{ address: Address; data?: CounterAccount; exists: boolean }>;
+        };
+    };
+    instructions: {
+        increment: (input: { by: number }) => {
+            sendTransaction: (config?: { abortSignal?: AbortSignal; commitment?: string }) => Promise<string>;
+        };
+    };
+    pdas: {
+        counter: (seeds: { owner: Address }) => Promise<[Address, number]>;
+    };
+};
+
+const ADDRESS = '11111111111111111111111111111111' as Address;
+const OTHER_ADDRESS = 'SysvarC1ock11111111111111111111111111111111' as Address;
+
+const hooks = createProgramHooks<{ counter: CounterPlugin }>('counter');
+
+function encodeCount(count: number): string {
+    return getBase64Decoder().decode(new Uint8Array([count]));
+}
+
+function accountValue(count: number) {
+    return { data: [encodeCount(count), 'base64'] as const };
+}
+
+type Emit = (notification: { context: { slot: bigint }; value: ReturnType<typeof accountValue> }) => void;
+
+let emit: Emit;
+let fetchMock: jest.Mock;
+let fetchAllMock: jest.Mock;
+let fetchMaybeMock: jest.Mock;
+let fetchAllMaybeMock: jest.Mock;
+let sendTransactionMock: jest.Mock;
+let incrementMock: jest.Mock;
+let pdaMock: jest.Mock;
+let initialSlot: bigint;
+let initialValue: ReturnType<typeof accountValue> | null;
+
+function createClient() {
+    const namespace = {
+        accounts: {
+            counter: {
+                decode: (bytes: ReadonlyUint8Array): CounterAccount => ({ count: bytes[0] ?? 0 }),
+                fetch: fetchMock,
+                fetchAll: fetchAllMock,
+                fetchAllMaybe: fetchAllMaybeMock,
+                fetchMaybe: fetchMaybeMock,
+            },
+        },
+        instructions: { increment: incrementMock },
+        pdas: { counter: pdaMock },
+    };
+    return {
+        counter: namespace,
+        rpc: {
+            getAccountInfo: () => ({
+                reactiveStore: () =>
+                    createReactiveActionStore(() =>
+                        Promise.resolve({ context: { slot: initialSlot }, value: initialValue }),
+                    ),
+            }),
+        },
+        rpcSubscriptions: {
+            accountNotifications: () => ({
+                reactiveStore: () =>
+                    createReactiveStoreFromDataPublisherFactory({
+                        createDataPublisher: (signal: AbortSignal) =>
+                            Promise.resolve({
+                                on: (channelName: string, subscriber: (data: unknown) => void) => {
+                                    if (channelName === 'notification') {
+                                        emit = subscriber as Emit;
+                                    }
+                                    signal.addEventListener('abort', () => {
+                                        emit = () => {};
+                                    });
+                                    return () => {};
+                                },
+                            }),
+                        dataChannelName: 'notification',
+                        errorChannelName: 'error',
+                    }),
+            }),
+        },
+    };
+}
+
+let client: ReturnType<typeof createClient>;
+
+function wrapper({ children }: { children: ReactNode }) {
+    return <ClientProvider client={client as never}>{children}</ClientProvider>;
+}
+
+beforeEach(() => {
+    emit = () => {};
+    initialSlot = 1n;
+    initialValue = accountValue(1);
+    fetchMock = jest.fn((address: Address) => Promise.resolve({ address, data: { count: 7 } }));
+    fetchAllMock = jest.fn((addresses: Address[]) =>
+        Promise.resolve(addresses.map(address => ({ address, data: { count: 7 } }))),
+    );
+    fetchMaybeMock = jest.fn((address: Address) => Promise.resolve({ address, exists: false }));
+    fetchAllMaybeMock = jest.fn((addresses: Address[]) =>
+        Promise.resolve(addresses.map(address => ({ address, exists: false }))),
+    );
+    sendTransactionMock = jest.fn(() => Promise.resolve('signature'));
+    incrementMock = jest.fn(() => ({ sendTransaction: sendTransactionMock }));
+    pdaMock = jest.fn(() => Promise.resolve([OTHER_ADDRESS, 254] as [Address, number]));
+    client = createClient();
+});
+
+describe('useTrackedAccount', () => {
+    it('decodes the initial fetch with the plugin codec', async () => {
+        const { result } = renderHook(() => hooks.useTrackedAccount('counter', ADDRESS), { wrapper });
+
+        await waitFor(() => expect(result.current.status).toBe('loaded'));
+        expect(result.current.data?.value).toEqual({ count: 1 });
+    });
+
+    it('applies later notifications', async () => {
+        const { result } = renderHook(() => hooks.useTrackedAccount('counter', ADDRESS), { wrapper });
+        await waitFor(() => expect(result.current.status).toBe('loaded'));
+
+        act(() => emit({ context: { slot: 2n }, value: accountValue(42) }));
+
+        await waitFor(() => expect(result.current.data?.value).toEqual({ count: 42 }));
+    });
+
+    it('reports a missing account as null', async () => {
+        initialValue = null;
+        const { result } = renderHook(() => hooks.useTrackedAccount('counter', ADDRESS), { wrapper });
+
+        await waitFor(() => expect(result.current.status).toBe('loaded'));
+        expect(result.current.data?.value).toBeNull();
+    });
+
+    it('reports a closed account as null when a notification carries empty data', async () => {
+        const { result } = renderHook(() => hooks.useTrackedAccount('counter', ADDRESS), { wrapper });
+        await waitFor(() => expect(result.current.data?.value).toEqual({ count: 1 }));
+
+        act(() => emit({ context: { slot: 2n }, value: { data: ['', 'base64'] as const } }));
+
+        await waitFor(() => expect(result.current.data?.value).toBeNull());
+        expect(result.current.status).toBe('loaded');
+    });
+
+    it('is disabled without an address', () => {
+        const { result } = renderHook(() => hooks.useTrackedAccount('counter', null), { wrapper });
+
+        expect(result.current.status).toBe('disabled');
+        expect(result.current.data).toBeUndefined();
+    });
+});
+
+describe('useAccount', () => {
+    it('fetches through the plugin and passes the attempt abort signal', async () => {
+        const { result } = renderHook(() => hooks.useAccount('counter', ADDRESS), { wrapper });
+
+        await waitFor(() => expect(result.current.status).toBe('success'));
+        expect(result.current.data).toEqual({ address: ADDRESS, data: { count: 7 } });
+        expect(fetchMock).toHaveBeenCalledWith(ADDRESS, { abortSignal: expect.any(AbortSignal) });
+    });
+
+    it('opens no subscription', async () => {
+        const accountNotifications = jest.spyOn(client.rpcSubscriptions, 'accountNotifications');
+        const { result } = renderHook(() => hooks.useAccount('counter', ADDRESS), { wrapper });
+
+        await waitFor(() => expect(result.current.status).toBe('success'));
+        expect(accountNotifications).not.toHaveBeenCalled();
+    });
+
+    it('is disabled without an address', () => {
+        const { result } = renderHook(() => hooks.useAccount('counter', null), { wrapper });
+
+        expect(result.current.status).toBe('disabled');
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('useMaybeAccount', () => {
+    it('reports an absent account rather than rejecting', async () => {
+        const { result } = renderHook(() => hooks.useMaybeAccount('counter', ADDRESS), { wrapper });
+
+        await waitFor(() => expect(result.current.status).toBe('success'));
+        expect(result.current.data).toEqual({ address: ADDRESS, exists: false });
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('useAllAccounts', () => {
+    it('does not refetch when the address list is rebuilt with equal contents', async () => {
+        const { rerender, result } = renderHook(() => hooks.useAllAccounts('counter', [ADDRESS, OTHER_ADDRESS]), {
+            wrapper,
+        });
+
+        await waitFor(() => expect(result.current.status).toBe('success'));
+        rerender();
+        rerender();
+
+        expect(fetchAllMock).toHaveBeenCalledTimes(1);
+        expect(result.current.data).toHaveLength(2);
+    });
+});
+
+describe('useAllMaybeAccounts', () => {
+    it('fetches through the plugin', async () => {
+        const { result } = renderHook(() => hooks.useAllMaybeAccounts('counter', [ADDRESS]), { wrapper });
+
+        await waitFor(() => expect(result.current.status).toBe('success'));
+        expect(result.current.data).toEqual([{ address: ADDRESS, exists: false }]);
+        expect(fetchAllMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('useSendInstruction', () => {
+    it('sends the built instruction with the hook abort signal and caller config', async () => {
+        const { result } = renderHook(() => hooks.useSendInstruction('increment'), { wrapper });
+
+        await act(async () => {
+            await result.current.dispatchAsync({ by: 3 }, { commitment: 'finalized' });
+        });
+
+        expect(incrementMock).toHaveBeenCalledWith({ by: 3 });
+        const config = sendTransactionMock.mock.calls[0]?.[0] as { abortSignal: AbortSignal; commitment: string };
+        expect(config.commitment).toBe('finalized');
+        expect(config.abortSignal.aborted).toBe(false);
+        await waitFor(() => expect(result.current.data).toBe('signature'));
+    });
+
+    it('merges a caller-supplied abort signal with the hook signal', async () => {
+        const controller = new AbortController();
+        const { result } = renderHook(() => hooks.useSendInstruction('increment'), { wrapper });
+
+        await act(async () => {
+            await result.current.dispatchAsync({ by: 3 }, { abortSignal: controller.signal });
+        });
+
+        const config = sendTransactionMock.mock.calls[0]?.[0] as { abortSignal: AbortSignal };
+        expect(config.abortSignal).not.toBe(controller.signal);
+        expect(config.abortSignal.aborted).toBe(false);
+        controller.abort();
+        expect(config.abortSignal.aborted).toBe(true);
+    });
+});
+
+describe('usePda', () => {
+    it('derives through the plugin', async () => {
+        const { result } = renderHook(() => hooks.usePda('counter', { owner: ADDRESS }), { wrapper });
+
+        await waitFor(() => expect(result.current.status).toBe('success'));
+        expect(result.current.data).toEqual([OTHER_ADDRESS, 254]);
+    });
+
+    it('is disabled without seeds', () => {
+        const { result } = renderHook(() => hooks.usePda('counter', null), { wrapper });
+
+        expect(result.current.status).toBe('disabled');
+    });
+});
+
+it('fails with an actionable error when the client lacks the program plugin', () => {
+    const clientWithoutPlugin = { rpc: {}, rpcSubscriptions: {} };
+    function Probe() {
+        hooks.useAccount('counter', ADDRESS);
+        return null;
+    }
+
+    expect(() =>
+        render(
+            <ClientProvider client={clientWithoutPlugin as never}>
+                <Probe />
+            </ClientProvider>,
+        ),
+    ).toThrow(/counter/);
+});

--- a/packages/react/src/__typetests__/createProgramHooks-typetest.ts
+++ b/packages/react/src/__typetests__/createProgramHooks-typetest.ts
@@ -1,0 +1,131 @@
+import type { Account, Address, MaybeAccount, ReadonlyUint8Array } from '@solana/kit';
+
+import { createProgramHooks } from '../createProgramHooks';
+import type {
+    DecodedProgramAccount,
+    FetchedProgramAccount,
+    FetchedProgramAccounts,
+    ProgramAccountKey,
+    ProgramInstructionInput,
+    ProgramInstructionKey,
+} from '../programPlugin';
+
+type Mint = { supply: bigint };
+type TransferInput = { amount: bigint; destination: Address; source: Address };
+
+/** Stands in for a Codama-generated plugin, matching the shape `renderers-js` emits. */
+type TokenPlugin = {
+    accounts: {
+        mint: {
+            decode: (bytes: ReadonlyUint8Array, offset?: number) => Mint;
+            fetch: <TAddress extends string>(address: Address<TAddress>) => Promise<Account<Mint, TAddress>>;
+            fetchAll: (addresses: Address[]) => Promise<Account<Mint>[]>;
+            fetchAllMaybe: (addresses: Address[]) => Promise<MaybeAccount<Mint>[]>;
+            fetchMaybe: <TAddress extends string>(address: Address<TAddress>) => Promise<MaybeAccount<Mint, TAddress>>;
+        };
+    };
+    instructions: {
+        transfer: (input: TransferInput) => {
+            sendTransaction: (config?: { commitment?: string }) => Promise<string>;
+        };
+    };
+    pdas: {
+        mintAuthority: (seeds: { mint: Address }) => Promise<[Address, number]>;
+    };
+};
+
+type AssociatedTokenPlugin = {
+    pdas: {
+        associatedToken: (seeds: { mint: Address; owner: Address }) => Promise<[Address, number]>;
+    };
+};
+
+/** A client type carrying two program plugins, as `typeof client` would. */
+type TwoPluginClient = { associatedToken: AssociatedTokenPlugin; token: TokenPlugin };
+
+// [DESCRIBE] programPlugin type projections
+{
+    // Keys are projected off the plugin's own maps
+    {
+        null as unknown as ProgramAccountKey<TokenPlugin> satisfies 'mint';
+        null as unknown as ProgramInstructionKey<TokenPlugin> satisfies 'transfer';
+    }
+
+    // Account types are recovered from the codec and its fetch helpers
+    {
+        null as unknown as DecodedProgramAccount<TokenPlugin, 'mint'> satisfies Mint;
+        null as unknown as FetchedProgramAccount<TokenPlugin, 'mint'> satisfies Account<Mint, string>;
+        null as unknown as FetchedProgramAccounts<TokenPlugin, 'mint'> satisfies Account<Mint>[];
+    }
+
+    // Instruction input is recovered from the builder
+    {
+        null as unknown as ProgramInstructionInput<TokenPlugin, 'transfer'> satisfies TransferInput;
+    }
+}
+
+// [DESCRIBE] createProgramHooks
+{
+    // The curried form infers the capability from a multi-plugin client type
+    {
+        const hooks = createProgramHooks<TwoPluginClient>();
+        hooks('token').useSendInstruction('transfer');
+        hooks('associatedToken').usePda('associatedToken', null);
+        // @ts-expect-error - 'transfer' belongs to the token plugin, not associatedToken
+        hooks('associatedToken').useSendInstruction('transfer');
+        // @ts-expect-error - 'tokne' is not a capability of the client type
+        hooks('tokne');
+    }
+
+    // An explicit capability type argument works on a multi-plugin client type
+    {
+        const hooks = createProgramHooks<TwoPluginClient, 'token'>('token');
+        hooks.useSendInstruction('transfer');
+    }
+
+    // The direct call is rejected on a multi-plugin client type, since the capability cannot be
+    // inferred alongside an explicit namespace type argument and the hooks would otherwise type
+    // against the union of every installed plugin
+    {
+        // @ts-expect-error - requires the curried form or a second type argument
+        createProgramHooks<TwoPluginClient>('token');
+    }
+
+    // Keys the plugin does not declare are rejected
+    {
+        const hooks = createProgramHooks<{ token: TokenPlugin }>('token');
+        // @ts-expect-error - 'nope' is not an account of the token program
+        hooks.useAccount('nope', null);
+        // @ts-expect-error - 'nope' is not an instruction of the token program
+        hooks.useSendInstruction('nope');
+    }
+
+    // A capability the namespace type does not declare is rejected
+    {
+        // @ts-expect-error - 'tokne' is not a key of the namespace type
+        createProgramHooks<{ token: TokenPlugin }>('tokne');
+    }
+
+    // Hook results carry the decoded account types through
+    {
+        const hooks = createProgramHooks<{ token: TokenPlugin }>('token');
+
+        hooks.useAccount('mint', null).data satisfies Account<Mint, string> | undefined;
+        hooks.useMaybeAccount('mint', null).data satisfies MaybeAccount<Mint, string> | undefined;
+        hooks.useAllAccounts('mint', null).data satisfies Account<Mint>[] | undefined;
+        hooks.useAllMaybeAccounts('mint', null).data satisfies MaybeAccount<Mint>[] | undefined;
+        hooks.useTrackedAccount('mint', null).data?.value satisfies Mint | null | undefined;
+        hooks.usePda('mintAuthority', null).data satisfies [Address, number] | undefined;
+        hooks.useSendInstruction('transfer').data satisfies string | undefined;
+    }
+
+    // The instruction dispatcher takes the builder's own input
+    {
+        const hooks = createProgramHooks<{ token: TokenPlugin }>('token');
+        const { dispatch } = hooks.useSendInstruction('transfer');
+
+        dispatch({ amount: 1n, destination: '2' as Address, source: '1' as Address });
+        // @ts-expect-error - `amount` must be a bigint
+        dispatch({ amount: 1, destination: '2' as Address, source: '1' as Address });
+    }
+}

--- a/packages/react/src/createProgramHooks.ts
+++ b/packages/react/src/createProgramHooks.ts
@@ -1,0 +1,328 @@
+import type { Address } from '@solana/kit';
+import { useMemo } from 'react';
+
+import {
+    type Base64AccountValue,
+    decodeAccountValue,
+    getAccountEntry,
+    getInstructionEntry,
+    getPdaEntry,
+    type ProgramHooksClient,
+} from './programNamespace';
+import type {
+    DecodedProgramAccount,
+    FetchedMaybeProgramAccount,
+    FetchedMaybeProgramAccounts,
+    FetchedProgramAccount,
+    FetchedProgramAccounts,
+    ProgramAccountKey,
+    ProgramInstructionInput,
+    ProgramInstructionKey,
+    ProgramPdaKey,
+    ProgramPdaResult,
+    ProgramPdaSeeds,
+    ProgramSendConfig,
+    ProgramSendResult,
+} from './programPlugin';
+import { type ActionResult, useAction } from './useAction';
+import { useClientCapability } from './useClientCapability';
+import { type RequestResult, useRequest, type UseRequestOptions } from './useRequest';
+import { useStableValue } from './useStableValue';
+import { type TrackedDataResult, useTrackedData, type UseTrackedDataOptions } from './useTrackedData';
+
+/**
+ * The hooks produced by {@link createProgramHooks} for one program plugin.
+ *
+ * Each hook is a direct mapping from one function on the plugin to one of this package's
+ * primitives, and its name states which: the `use*Account*` hooks that read through the plugin's
+ * `fetch*` family issue a single request via {@link useRequest}, while {@link
+ * ProgramHooks.useTrackedAccount | useTrackedAccount} additionally opens a subscription via
+ * {@link useTrackedData}.
+ *
+ * @typeParam TPlugin - The Codama-generated program plugin the hooks read from.
+ */
+export type ProgramHooks<TPlugin> = {
+    /**
+     * Fetches one account through the plugin's `fetch`, resolving to the decoded `Account`
+     * envelope. Rejects if the account does not exist — use {@link
+     * ProgramHooks.useMaybeAccount | useMaybeAccount} when absence is expected.
+     *
+     * Issues one request when the address changes; it opens no subscription and so does not
+     * observe later on-chain writes. Reach for {@link ProgramHooks.useTrackedAccount |
+     * useTrackedAccount} when the UI must stay live.
+     *
+     * Passing a `null` address disables the hook (`status: 'disabled'`).
+     */
+    useAccount<TKey extends ProgramAccountKey<TPlugin>>(
+        key: TKey,
+        address: Address | null,
+        options?: UseRequestOptions,
+    ): RequestResult<FetchedProgramAccount<TPlugin, TKey>>;
+
+    /**
+     * Fetches several accounts of the same type in one request through the plugin's `fetchAll`.
+     * Rejects if any of the accounts does not exist — use {@link
+     * ProgramHooks.useAllMaybeAccounts | useAllMaybeAccounts} when absence is expected.
+     *
+     * Issues one request when the address list changes by value; it opens no subscription and so
+     * does not observe later on-chain writes.
+     *
+     * Passing a `null` address list disables the hook (`status: 'disabled'`).
+     */
+    useAllAccounts<TKey extends ProgramAccountKey<TPlugin>>(
+        key: TKey,
+        addresses: readonly Address[] | null,
+        options?: UseRequestOptions,
+    ): RequestResult<FetchedProgramAccounts<TPlugin, TKey>>;
+
+    /**
+     * Fetches several accounts of the same type in one request through the plugin's
+     * `fetchAllMaybe`, resolving to a `MaybeAccount` for each so that absent accounts are reported
+     * rather than thrown.
+     *
+     * Issues one request when the address list changes by value; it opens no subscription and so
+     * does not observe later on-chain writes.
+     *
+     * Passing a `null` address list disables the hook (`status: 'disabled'`).
+     */
+    useAllMaybeAccounts<TKey extends ProgramAccountKey<TPlugin>>(
+        key: TKey,
+        addresses: readonly Address[] | null,
+        options?: UseRequestOptions,
+    ): RequestResult<FetchedMaybeProgramAccounts<TPlugin, TKey>>;
+
+    /**
+     * Fetches one account through the plugin's `fetchMaybe`, resolving to a `MaybeAccount` so that
+     * an absent account is reported as `exists: false` rather than thrown.
+     *
+     * Issues one request when the address changes; it opens no subscription and so does not
+     * observe later on-chain writes.
+     *
+     * Passing a `null` address disables the hook (`status: 'disabled'`).
+     */
+    useMaybeAccount<TKey extends ProgramAccountKey<TPlugin>>(
+        key: TKey,
+        address: Address | null,
+        options?: UseRequestOptions,
+    ): RequestResult<FetchedMaybeProgramAccount<TPlugin, TKey>>;
+
+    /**
+     * Derives a program derived address from the plugin's `find*Pda` function.
+     *
+     * Passing `null` seeds disables the hook (`status: 'disabled'`).
+     */
+    usePda<TKey extends ProgramPdaKey<TPlugin>>(
+        key: TKey,
+        seeds: ProgramPdaSeeds<TPlugin, TKey> | null,
+        options?: UseRequestOptions,
+    ): RequestResult<ProgramPdaResult<TPlugin, TKey>>;
+
+    /**
+     * Builds, signs and sends an instruction through the plugin's builder and its
+     * `sendTransaction`, as a {@link useAction} mutation.
+     *
+     * `dispatch` takes the instruction builder's own input plus an optional `sendTransaction`
+     * config; the hook's abort signal is merged into that config, so a caller-supplied
+     * `abortSignal` still cancels the send.
+     */
+    useSendInstruction<TKey extends ProgramInstructionKey<TPlugin>>(
+        key: TKey,
+    ): ActionResult<
+        [input: ProgramInstructionInput<TPlugin, TKey>, config?: ProgramSendConfig<TPlugin, TKey>],
+        ProgramSendResult<TPlugin, TKey>
+    >;
+
+    /**
+     * Keeps one account live: an initial `getAccountInfo` fetch followed by `accountNotifications`
+     * updates, slot-deduplicated by {@link useTrackedData} and decoded with the program plugin's
+     * own codec.
+     *
+     * This holds a subscription open for as long as the component is mounted, which costs an
+     * RPC-subscription slot per address. Prefer {@link ProgramHooks.useAccount | useAccount} when
+     * a value read once at mount is enough.
+     *
+     * `data` is the `SolanaRpcResponse` envelope — read `data?.value`, which is `null` while the
+     * account does not exist and after it is closed.
+     *
+     * Requires `rpcSubscriptions` on the client in addition to the program plugin.
+     *
+     * Passing a `null` address disables the hook (`status: 'disabled'`).
+     */
+    useTrackedAccount<TKey extends ProgramAccountKey<TPlugin>>(
+        key: TKey,
+        address: Address | null,
+        options?: UseTrackedDataOptions,
+    ): TrackedDataResult<DecodedProgramAccount<TPlugin, TKey> | null>;
+};
+
+type UnionToIntersection<TUnion> = (TUnion extends unknown ? (member: TUnion) => void : never) extends (
+    member: infer TIntersection,
+) => void
+    ? TIntersection
+    : never;
+
+type IsUnion<TType> = [TType] extends [UnionToIntersection<TType>] ? false : true;
+
+/**
+ * The `capability` argument of the direct call form. TypeScript never infers a type parameter that
+ * also has a default, so when only `TNamespace` is given explicitly, `TCapability` resolves to its
+ * default — the union of every key. A single-key namespace makes that union one literal and the
+ * call is fully typed; a multi-key namespace would silently type the hooks against the union of
+ * every installed plugin, so the parameter degrades to an instructive error literal instead of
+ * accepting any key.
+ */
+type CapabilityArgument<TCapability extends string> =
+    IsUnion<TCapability> extends true
+        ? 'Error: the capability cannot be inferred from a client type with several plugins. Use the curried form createProgramHooks<Client>()(capability), or pass the capability as a second type argument.'
+        : TCapability;
+
+/**
+ * Builds typed React hooks over a Codama-generated program plugin installed on the client
+ * published by {@link ClientProvider}.
+ *
+ * The plugin is already a fully typed runtime map — codecs with `fetch` helpers, instruction
+ * builders with `sendTransaction`, PDA finders — so one factory covers every program with no
+ * per-program code generation. Each returned hook is a thin mapping onto one of this package's
+ * primitives, named for the primitive it uses.
+ *
+ * Point `TNamespace` at the client type itself and an uninstalled plugin is a compile-time error
+ * rather than a first-render runtime error. Because the client type carries every installed
+ * capability, the capability literal must be recovered through the curried call —
+ * `createProgramHooks<Client>()` — so the returned function can infer it from the argument. The
+ * direct call `createProgramHooks<{ token: TokenPlugin }>('token')` remains available for a
+ * hand-written single-plugin slice.
+ *
+ * @typeParam TNamespace - The client type (or the slice of it the plugin occupies, e.g. `{ token:
+ *   TokenPlugin }`). The `capability` argument is constrained to its keys, so a mismatched string
+ *   is a compile-time error.
+ * @param capability - The key the plugin is installed under, e.g. `'token'`.
+ *
+ * @example
+ * ```tsx
+ * import { createTokenClient } from './client';
+ *
+ * type TokenClient = Awaited<ReturnType<typeof createTokenClient>>;
+ *
+ * const { useTrackedAccount, useSendInstruction } = createProgramHooks<TokenClient>()('token');
+ *
+ * function MintSupply({ mint }: { mint: Address }) {
+ *     const { data } = useTrackedAccount('mint', mint);
+ *     const transfer = useSendInstruction('transfer');
+ *     return <span>{data?.value?.supply}</span>;
+ * }
+ * ```
+ *
+ * @see {@link ProgramHooks}
+ */
+export function createProgramHooks<TNamespace extends object>(): <TCapability extends string & keyof TNamespace>(
+    capability: TCapability,
+) => ProgramHooks<TNamespace[TCapability]>;
+export function createProgramHooks<
+    TNamespace extends object,
+    TCapability extends string & keyof TNamespace = string & keyof TNamespace,
+>(capability: CapabilityArgument<TCapability>): ProgramHooks<TNamespace[TCapability]>;
+export function createProgramHooks(capability?: string): unknown {
+    if (capability === undefined) {
+        return (inferredCapability: string) => buildProgramHooks(inferredCapability);
+    }
+    return buildProgramHooks(capability);
+}
+
+function buildProgramHooks<TPlugin>(capability: string): ProgramHooks<TPlugin> {
+    const providerHint = `Install the "${capability}" program plugin on the client you pass to <ClientProvider>.`;
+
+    function useProgramClient(hookName: string, ...extraCapabilities: string[]): ProgramHooksClient {
+        return useClientCapability<ProgramHooksClient>({
+            capability: [capability, ...extraCapabilities],
+            hookName,
+            providerHint,
+        });
+    }
+
+    return {
+        useAccount(key, address, options) {
+            const client = useProgramClient('useAccount', 'rpc');
+            const source = useMemo(() => {
+                if (address == null) return null;
+                return (abortSignal: AbortSignal) =>
+                    getAccountEntry(client, capability, key).fetch(address, { abortSignal });
+            }, [client, key, address]);
+            return useRequest(source, options) as RequestResult<never>;
+        },
+
+        useAllAccounts(key, addresses, options) {
+            const client = useProgramClient('useAllAccounts', 'rpc');
+            const stableAddresses = useStableValue(addresses);
+            const source = useMemo(() => {
+                if (stableAddresses == null) return null;
+                return (abortSignal: AbortSignal) =>
+                    getAccountEntry(client, capability, key).fetchAll([...stableAddresses], { abortSignal });
+            }, [client, key, stableAddresses]);
+            return useRequest(source, options) as RequestResult<never>;
+        },
+
+        useAllMaybeAccounts(key, addresses, options) {
+            const client = useProgramClient('useAllMaybeAccounts', 'rpc');
+            const stableAddresses = useStableValue(addresses);
+            const source = useMemo(() => {
+                if (stableAddresses == null) return null;
+                return (abortSignal: AbortSignal) =>
+                    getAccountEntry(client, capability, key).fetchAllMaybe([...stableAddresses], { abortSignal });
+            }, [client, key, stableAddresses]);
+            return useRequest(source, options) as RequestResult<never>;
+        },
+
+        useMaybeAccount(key, address, options) {
+            const client = useProgramClient('useMaybeAccount', 'rpc');
+            const source = useMemo(() => {
+                if (address == null) return null;
+                return (abortSignal: AbortSignal) =>
+                    getAccountEntry(client, capability, key).fetchMaybe(address, { abortSignal });
+            }, [client, key, address]);
+            return useRequest(source, options) as RequestResult<never>;
+        },
+
+        usePda(key, seeds, options) {
+            const client = useProgramClient('usePda');
+            const stableSeeds = useStableValue(seeds);
+            const source = useMemo(() => {
+                if (stableSeeds == null) return null;
+                return async () => await getPdaEntry(client, capability, key)(stableSeeds as never);
+            }, [client, key, stableSeeds]);
+            return useRequest(source, options) as RequestResult<never>;
+        },
+
+        useSendInstruction<TKey extends ProgramInstructionKey<TPlugin>>(key: TKey) {
+            const client = useProgramClient('useSendInstruction');
+            return useAction<
+                [input: ProgramInstructionInput<TPlugin, TKey>, config?: ProgramSendConfig<TPlugin, TKey>],
+                ProgramSendResult<TPlugin, TKey>
+            >((abortSignal, input, config) => {
+                const instruction = getInstructionEntry(client, capability, key)(input as never);
+                const sendConfig = config as { abortSignal?: AbortSignal } | undefined;
+                return instruction.sendTransaction({
+                    ...sendConfig,
+                    abortSignal: sendConfig?.abortSignal
+                        ? AbortSignal.any([abortSignal, sendConfig.abortSignal])
+                        : abortSignal,
+                }) as Promise<ProgramSendResult<TPlugin, TKey>>;
+            });
+        },
+
+        useTrackedAccount(key, address, options) {
+            const client = useProgramClient('useTrackedAccount', 'rpc', 'rpcSubscriptions');
+            const spec = useMemo(() => {
+                if (address == null) return null;
+                const entry = getAccountEntry(client, capability, key);
+                const decode = (value: Base64AccountValue) => decodeAccountValue(entry, value);
+                return {
+                    initialValueMapper: decode,
+                    initialValueSource: client.rpc.getAccountInfo(address, { encoding: 'base64' }),
+                    streamSource: client.rpcSubscriptions.accountNotifications(address, { encoding: 'base64' }),
+                    streamValueMapper: decode,
+                };
+            }, [client, key, address]);
+            return useTrackedData(spec, options) as TrackedDataResult<never>;
+        },
+    };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -4,6 +4,8 @@
  * @packageDocumentation
  */
 export * from './ClientProvider';
+export * from './createProgramHooks';
+export * from './programPlugin';
 export * from './useAction';
 export * from './useAirdrop';
 export * from './useClient';

--- a/packages/react/src/programNamespace.ts
+++ b/packages/react/src/programNamespace.ts
@@ -1,0 +1,82 @@
+import {
+    type AccountNotificationsApi,
+    type Address,
+    type ClientWithRpc,
+    type ClientWithRpcSubscriptions,
+    type GetAccountInfoApi,
+    getBase64Encoder,
+    type GetMultipleAccountsApi,
+    type ReadonlyUint8Array,
+} from '@solana/kit';
+
+/** Config shared by every account fetch the program hooks perform. */
+type FetchConfig = { abortSignal?: AbortSignal };
+
+/** Runtime view of one entry in a program plugin's `accounts` map. */
+export type ProgramAccountEntry = {
+    decode: (bytes: ReadonlyUint8Array, offset?: number) => unknown;
+    fetch: (address: Address, config?: FetchConfig) => Promise<unknown>;
+    fetchAll: (addresses: Address[], config?: FetchConfig) => Promise<unknown>;
+    fetchAllMaybe: (addresses: Address[], config?: FetchConfig) => Promise<unknown>;
+    fetchMaybe: (address: Address, config?: FetchConfig) => Promise<unknown>;
+};
+
+/** Runtime view of one entry in a program plugin's `instructions` map. */
+export type ProgramInstructionEntry = (input: never) => {
+    sendTransaction: (config?: unknown) => Promise<unknown>;
+};
+
+/** Runtime view of a program plugin as installed on the client. */
+export type ProgramNamespace = {
+    accounts?: Record<string, ProgramAccountEntry>;
+    instructions?: Record<string, ProgramInstructionEntry>;
+    pdas?: Record<string, (seeds: never) => unknown>;
+};
+
+/** The client capabilities the program hooks read from. */
+export type ProgramHooksClient = ClientWithRpc<GetAccountInfoApi & GetMultipleAccountsApi> &
+    ClientWithRpcSubscriptions<AccountNotificationsApi>;
+
+/** A base64 account payload as returned by `getAccountInfo` / `accountNotifications`. */
+export type Base64AccountValue = Readonly<{ data: readonly [string, 'base64'] }> | null;
+
+export function getNamespace(client: object, capability: string): ProgramNamespace {
+    return (client as Record<string, ProgramNamespace>)[capability];
+}
+
+export function getAccountEntry(client: object, capability: string, key: string): ProgramAccountEntry {
+    const entry = getNamespace(client, capability).accounts?.[key];
+    if (!entry) {
+        throw new Error(`Program plugin "${capability}" does not declare an account named "${key}".`);
+    }
+    return entry;
+}
+
+export function getInstructionEntry(client: object, capability: string, key: string): ProgramInstructionEntry {
+    const entry = getNamespace(client, capability).instructions?.[key];
+    if (!entry) {
+        throw new Error(`Program plugin "${capability}" does not declare an instruction named "${key}".`);
+    }
+    return entry;
+}
+
+export function getPdaEntry(client: object, capability: string, key: string): (seeds: never) => unknown {
+    const entry = getNamespace(client, capability).pdas?.[key];
+    if (!entry) {
+        throw new Error(`Program plugin "${capability}" does not declare a PDA named "${key}".`);
+    }
+    return entry;
+}
+
+/**
+ * Decodes a base64 account payload with the program plugin's own codec, mapping a missing or
+ * closed account to `null`. A missing account arrives as a `null` value from `getAccountInfo`; a
+ * closed account arrives from `accountNotifications` with zero-length data, which no program codec
+ * can decode.
+ */
+export function decodeAccountValue(entry: ProgramAccountEntry, value: Base64AccountValue): unknown {
+    if (value == null) return null;
+    const bytes = getBase64Encoder().encode(value.data[0]);
+    if (bytes.length === 0) return null;
+    return entry.decode(bytes);
+}

--- a/packages/react/src/programPlugin.ts
+++ b/packages/react/src/programPlugin.ts
@@ -1,0 +1,112 @@
+/**
+ * Type-level projections over a Codama-generated program plugin.
+ *
+ * A generated plugin is a runtime map of the shape `{ accounts?, instructions?, pdas? }` where
+ * each account entry is a codec augmented with `SelfFetchFunctions`, each instruction entry is a
+ * builder returning an instruction augmented with `SelfPlanAndSendFunctions`, and each PDA entry
+ * is a `find*Pda` function. Every hook signature produced by {@link createProgramHooks} is derived
+ * from that map, so no Codama naming convention is re-implemented here.
+ */
+
+/**
+ * The `accounts` map of a program plugin, or an empty map when it declares none — so that
+ * {@link ProgramAccountKey} is `never` and every account hook rejects every key.
+ */
+export type ProgramAccounts<TPlugin> = TPlugin extends { accounts: infer TAccounts } ? TAccounts : Record<never, never>;
+
+/**
+ * The `instructions` map of a program plugin, or an empty map when it declares none — so that
+ * {@link ProgramInstructionKey} is `never` and every instruction hook rejects every key.
+ */
+export type ProgramInstructions<TPlugin> = TPlugin extends { instructions: infer TInstructions }
+    ? TInstructions
+    : Record<never, never>;
+
+/**
+ * The `pdas` map of a program plugin, or an empty map when it declares none — so that
+ * {@link ProgramPdaKey} is `never` and the PDA hook rejects every key.
+ */
+export type ProgramPdas<TPlugin> = TPlugin extends { pdas: infer TPdas } ? TPdas : Record<never, never>;
+
+/** Names of the accounts a program plugin can decode and fetch. */
+export type ProgramAccountKey<TPlugin> = string & keyof ProgramAccounts<TPlugin>;
+
+/** Names of the instructions a program plugin can build. */
+export type ProgramInstructionKey<TPlugin> = string & keyof ProgramInstructions<TPlugin>;
+
+/** Names of the program derived addresses a program plugin can find. */
+export type ProgramPdaKey<TPlugin> = string & keyof ProgramPdas<TPlugin>;
+
+/** The account type produced by an account codec's `decode`. */
+export type DecodedProgramAccount<
+    TPlugin,
+    TKey extends ProgramAccountKey<TPlugin>,
+> = ProgramAccounts<TPlugin>[TKey] extends { decode: (...args: never[]) => infer TDecoded } ? TDecoded : never;
+
+/** The `Account` envelope produced by an account entry's `fetch`. */
+export type FetchedProgramAccount<
+    TPlugin,
+    TKey extends ProgramAccountKey<TPlugin>,
+> = ProgramAccounts<TPlugin>[TKey] extends { fetch: (...args: never[]) => PromiseLike<infer TAccount> }
+    ? TAccount
+    : never;
+
+/** The `Account` envelopes produced by an account entry's `fetchAll`. */
+export type FetchedProgramAccounts<
+    TPlugin,
+    TKey extends ProgramAccountKey<TPlugin>,
+> = ProgramAccounts<TPlugin>[TKey] extends { fetchAll: (...args: never[]) => PromiseLike<infer TAccounts> }
+    ? TAccounts
+    : never;
+
+/** The `MaybeAccount` envelope produced by an account entry's `fetchMaybe`. */
+export type FetchedMaybeProgramAccount<
+    TPlugin,
+    TKey extends ProgramAccountKey<TPlugin>,
+> = ProgramAccounts<TPlugin>[TKey] extends { fetchMaybe: (...args: never[]) => PromiseLike<infer TAccount> }
+    ? TAccount
+    : never;
+
+/** The `MaybeAccount` envelopes produced by an account entry's `fetchAllMaybe`. */
+export type FetchedMaybeProgramAccounts<
+    TPlugin,
+    TKey extends ProgramAccountKey<TPlugin>,
+> = ProgramAccounts<TPlugin>[TKey] extends { fetchAllMaybe: (...args: never[]) => PromiseLike<infer TAccounts> }
+    ? TAccounts
+    : never;
+
+/** The input accepted by an instruction builder. */
+export type ProgramInstructionInput<
+    TPlugin,
+    TKey extends ProgramInstructionKey<TPlugin>,
+> = ProgramInstructions<TPlugin>[TKey] extends (input: infer TInput) => unknown ? TInput : never;
+
+type BuiltInstruction<
+    TPlugin,
+    TKey extends ProgramInstructionKey<TPlugin>,
+> = ProgramInstructions<TPlugin>[TKey] extends (...args: never[]) => infer TInstruction ? TInstruction : never;
+
+/** The config accepted by a built instruction's `sendTransaction`. */
+export type ProgramSendConfig<TPlugin, TKey extends ProgramInstructionKey<TPlugin>> =
+    BuiltInstruction<TPlugin, TKey> extends { sendTransaction: (config?: infer TConfig) => unknown } ? TConfig : never;
+
+/** The result of a built instruction's `sendTransaction`. */
+export type ProgramSendResult<TPlugin, TKey extends ProgramInstructionKey<TPlugin>> =
+    BuiltInstruction<TPlugin, TKey> extends { sendTransaction: (...args: never[]) => PromiseLike<infer TResult> }
+        ? TResult
+        : never;
+
+/** The seeds accepted by a PDA finder. */
+export type ProgramPdaSeeds<TPlugin, TKey extends ProgramPdaKey<TPlugin>> = ProgramPdas<TPlugin>[TKey] extends (
+    seeds: infer TSeeds,
+    ...rest: never[]
+) => unknown
+    ? TSeeds
+    : never;
+
+/** The address produced by a PDA finder. */
+export type ProgramPdaResult<TPlugin, TKey extends ProgramPdaKey<TPlugin>> = ProgramPdas<TPlugin>[TKey] extends (
+    ...args: never[]
+) => infer TResult
+    ? Awaited<TResult>
+    : never;

--- a/packages/react/src/useStableValue.ts
+++ b/packages/react/src/useStableValue.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+function isEqual(a: unknown, b: unknown): boolean {
+    if (Object.is(a, b)) return true;
+    if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) return false;
+    if (ArrayBuffer.isView(a) || ArrayBuffer.isView(b)) {
+        if (!(a instanceof Uint8Array) || !(b instanceof Uint8Array) || a.length !== b.length) return false;
+        return a.every((byte, index) => byte === b[index]);
+    }
+    if (Array.isArray(a) || Array.isArray(b)) {
+        if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) return false;
+        return a.every((item, index) => isEqual(item, b[index]));
+    }
+    const aRecord = a as Record<string, unknown>;
+    const bRecord = b as Record<string, unknown>;
+    const aKeys = Object.keys(aRecord);
+    if (aKeys.length !== Object.keys(bRecord).length) return false;
+    return aKeys.every(key => Object.hasOwn(bRecord, key) && isEqual(aRecord[key], bRecord[key]));
+}
+
+/**
+ * Returns the previously seen value whenever the incoming value is structurally equal to it, so a
+ * fresh object or array literal keeps a stable identity across renders.
+ *
+ * The reactive hooks key their stores off argument identity, so an inline `{ mint, owner }` seed
+ * object or `[addressA, addressB]` array would otherwise rebuild the store on every render — and
+ * each rebuild refires the request, whose resulting state update renders again, so the caller
+ * never converges.
+ *
+ * Implemented with the state-adjustment-during-render pattern rather than a ref, so the hook stays
+ * render-pure: the render that first sees a structurally new value returns it directly and
+ * schedules the re-render that makes it the stored value.
+ *
+ * @typeParam T - The value to hold stable. Compared structurally across plain objects, arrays and
+ *   `Uint8Array`s; every other type is compared with `Object.is`.
+ */
+export function useStableValue<T>(value: T): T {
+    const [stored, setStored] = useState(value);
+    if (!isEqual(stored, value)) {
+        setStored(value);
+        return value;
+    }
+    return stored;
+}


### PR DESCRIPTION
A Codama-generated program plugin is already a fully typed runtime map — codecs with `fetch` helpers, instruction builders with `sendTransaction`, PDA finders. `createProgramHooks` projects that map into React hooks, so one factory covers every program with no per-program codegen.

```tsx
const programHooks = createProgramHooks<MyClient>();
const { useAccount, useSendInstruction } = programHooks('token');
const { usePda } = programHooks('associatedToken');

const ata = usePda('associatedToken', { mint, owner });
const balance = useAccount('token', ata.data?.[0] ?? null);
const mintTo = useSendInstruction('mintTo');
```

Point the type argument at the client type and an uninstalled plugin is a compile-time error. A `null` address, address list or seed object disables a hook rather than requiring a conditional call.

## Hooks

Each one maps a single plugin function onto an existing primitive in this package, and is named for the primitive it uses.

| Hook | Plugin fn | Primitive |
| --- | --- | --- |
| `useAccount` | `.fetch` | `useRequest` |
| `useMaybeAccount` | `.fetchMaybe` | `useRequest` |
| `useAllAccounts` | `.fetchAll` | `useRequest` |
| `useAllMaybeAccounts` | `.fetchAllMaybe` | `useRequest` |
| `usePda` | `find*Pda` | `useRequest` |
| `useTrackedAccount` | `.decode` | `useTrackedData` |
| `useSendInstruction` | builder + `.sendTransaction` | `useAction` |

`useTrackedAccount` is the only one that opens a subscription: initial `getAccountInfo` plus `accountNotifications`, slot-deduped, both decoded with the plugin's own codec. It's opt-in rather than the default for `useAccount`, since holding a subscription per address isn't the right cost for every app.

## Notes

- Type projections (`ProgramAccountKey`, `ProgramInstructionInput`, …) derive everything from the plugin type — no Codama naming convention is reimplemented.
- `useStableValue` holds inline array/object arguments stable by value, so `usePda('associatedToken', { mint, owner })` doesn't rebuild its store every render.
- The curried call recovers the capability literal from a multi-plugin client type. The direct form `createProgramHooks<{ token: TokenPlugin }>('token')` still works for a single-plugin slice; on a multi-plugin type it degrades to an instructive error literal rather than silently typing against the union. Happy to simplify to curried-only if you'd prefer one call shape.

## Test plan

- 16 unit tests (`createProgramHooks-test.browser.tsx`) and a type test with a self-contained plugin fixture.
- `packages/react`: prettier, lint, typecheck, browser unit (313), node unit (77), treeshakability — all green.
