### PR TITLE
Recover failed transaction signatures on a best-effort basis

### DIFF
--- a/.changeset/seven-experts-walk.md
+++ b/.changeset/seven-experts-walk.md
@@ -1,0 +1,9 @@
+---
+'@solana/instruction-plans': patch
+---
+
+Fix `createTransactionPlanExecutor` throwing away the original error when a failed transaction was not signed by its fee payer
+
+When the `executeTransactionMessage` callback stored a transaction on the context and then threw, the executor tried to recover that transaction's signature while handling the failure. If the fee payer had not signed it — as is the case for a transaction that is only partially signed at the point of failure — that recovery threw `SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING` from inside the error handler, destroying the original error and the partial `TransactionPlanResult` along with it.
+
+The signature is now recovered on a best-effort basis. Whenever it cannot be determined — because the fee payer has not signed, or because the stored transaction is malformed in any other way — the `signature` property is simply left absent from the failed result's context, and the original error propagates as intended.

--- a/packages/instruction-plans/src/__tests__/__setup__.ts
+++ b/packages/instruction-plans/src/__tests__/__setup__.ts
@@ -66,6 +66,18 @@ export function createTransaction<TId extends string>(id: TId): Transaction & { 
     return Object.freeze({ id, signatures }) as unknown as Transaction & { id: TId };
 }
 
+/**
+ * Creates a transaction signed by someone other than its fee payer. Since the fee payer's signature
+ * slot — the first one in the signatures map — is empty, no signature can be derived from it.
+ */
+export function createPartiallySignedTransaction<TId extends string>(id: TId): Transaction & { id: TId } {
+    const signatures: SignaturesMap = {
+        ['' as Address]: null /* The fee payer has not signed this transaction yet. */,
+        ['someOtherSigner' as Address]: signatureEncoder.encode(id) as SignatureBytes,
+    };
+    return Object.freeze({ id, signatures }) as unknown as Transaction & { id: TId };
+}
+
 const signatureEncoder = getBase58Encoder();
 
 export function instructionFactory(baseSeed?: string) {

--- a/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
@@ -1,5 +1,6 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
+import { Address } from '@solana/addresses';
 import {
     SOLANA_ERROR__INSTRUCTION_ERROR__INVALID_ARGUMENT,
     SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
@@ -9,6 +10,7 @@ import {
 } from '@solana/errors';
 import { Signature } from '@solana/keys';
 import { TransactionMessage, TransactionMessageWithFeePayer } from '@solana/transaction-messages';
+import { Transaction } from '@solana/transactions';
 
 import {
     canceledSingleTransactionPlanResult,
@@ -25,7 +27,7 @@ import {
     successfulSingleTransactionPlanResultFromTransaction,
     TransactionPlanResult,
 } from '../index';
-import { createMessage, createTransaction, FOREVER_PROMISE } from './__setup__';
+import { createMessage, createPartiallySignedTransaction, createTransaction, FOREVER_PROMISE } from './__setup__';
 
 jest.useFakeTimers();
 
@@ -296,6 +298,56 @@ describe('createTransactionPlanExecutor', () => {
                         transaction: transactionA,
                     }),
                 }),
+            );
+        });
+
+        it('does not add a signature to a failed context when the fee payer has not signed the transaction', async () => {
+            expect.assertions(1);
+            const messageA = createMessage('A');
+            const transactionA = createPartiallySignedTransaction('A');
+            const cause = new SolanaError(SOLANA_ERROR__INSTRUCTION_ERROR__INVALID_ARGUMENT, { index: 0 });
+            const throwCause = (): void => {
+                throw cause;
+            };
+            const executor = createTransactionPlanExecutor({
+                executeTransactionMessage: async context => {
+                    context.transaction = transactionA;
+                    throwCause();
+                    return await Promise.resolve(transactionA);
+                },
+            });
+
+            const promise = passthroughFailedTransactionPlanExecution(executor(singleTransactionPlan(messageA)));
+            await expect(promise).resolves.toStrictEqual(
+                failedSingleTransactionPlanResult(messageA, cause, { transaction: transactionA }),
+            );
+        });
+
+        it('does not add a signature to a failed context when the stored transaction is malformed', async () => {
+            expect.assertions(1);
+            const messageA = createMessage('A');
+            // A transaction whose fee payer signature slot holds something that is not signature bytes.
+            const transactionA = Object.freeze({
+                id: 'A',
+                // note: the test assumes that base58 decoding this throws
+                // (because it expects a Uint8Array)
+                signatures: { ['' as Address]: 'not signature bytes' },
+            }) as unknown as Transaction;
+            const cause = new SolanaError(SOLANA_ERROR__INSTRUCTION_ERROR__INVALID_ARGUMENT, { index: 0 });
+            const throwCause = (): void => {
+                throw cause;
+            };
+            const executor = createTransactionPlanExecutor({
+                executeTransactionMessage: async context => {
+                    context.transaction = transactionA;
+                    throwCause();
+                    return await Promise.resolve(transactionA);
+                },
+            });
+
+            const promise = passthroughFailedTransactionPlanExecution(executor(singleTransactionPlan(messageA)));
+            await expect(promise).resolves.toStrictEqual(
+                failedSingleTransactionPlanResult(messageA, cause, { transaction: transactionA }),
             );
         });
 

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -218,11 +218,25 @@ async function traverseSingle<TContext extends TransactionPlanResultContext>(
             : successfulSingleTransactionPlanResultFromTransaction(transactionPlan.message, result, context);
     } catch (error) {
         traverseConfig.canceled = true;
-        const contextWithSignature =
-            'transaction' in context && typeof context.transaction === 'object' && context.signature == null
-                ? { ...context, signature: getSignatureFromTransaction(context.transaction) }
-                : context;
-        return failedSingleTransactionPlanResult(transactionPlan.message, error as Error, contextWithSignature);
+        // The callback may have stored a transaction on the context before throwing.
+        // If that transaction was signed by its fee payer, we can recover its signature.
+        // We may not be able to though, if it doesn't have a fee payer signature or
+        // is malformed in some way. In these cases we catch and ignore that error,
+        // maintaining the original error instead. We leave the `signature` property
+        // absent.
+        let signature: Signature | undefined;
+        if ('transaction' in context && typeof context.transaction === 'object' && context.signature == null) {
+            try {
+                signature = getSignatureFromTransaction(context.transaction);
+            } catch {
+                /* Swallowed on purpose. The error we are handling takes precedence. */
+            }
+        }
+        return failedSingleTransactionPlanResult(
+            transactionPlan.message,
+            error as Error,
+            signature !== undefined ? { ...context, signature } : context,
+        );
     }
 }
 


### PR DESCRIPTION
#### Problem

When a `TransactionPlanExecutor` throws, we catch that error and return it as `failedSingleTransactionPlanResult`. This allows a `TransactionPlanResult` to include all errors from all transactions that were attempted.

In this block though, we use `getSignatureFromTransaction` on whatever transaction made it to the context at the point the error was thrown. There is no guarantee that this transaction has a signature, or is valid. Therefore `getSignatureFromTransaction` may throw. In this case, currently we will throw eg a fee payer missing error from the catch block of `traverseSingle`, and  lose both the original caught error and the coalescing of errors across the plan.

#### Summary of Changes

This PR makes reading the signature best effort, by wrapping it with a try-catch and swallowing any error thrown. We assume that the error originally thrown by the executor and caught is the most useful error to return.

This intentionally covers all errors, not just a missing fee payer. In this branch something has gone wrong with the executor and we make no assumptions about the validity of the transaction it has written to context.

Notes:

- The `transaction` is still available on context regardless, if it was written there
- This does not use the `getSignatureFromTransactionIfPresent` helper in a draft PR, because we intentionally swallow all errors, not just the fee payer signature missing one.
- This is related to the planned work to enable executors to return partially signed transactions in general, but this PR specifically is just fixing an existing bug on main. 
