### PR TITLE
Stop inflating every release to a major via the `@solana/react` peer dependency

### DIFF
--- a/.changeset/brown-deserts-shake.md
+++ b/.changeset/brown-deserts-shake.md
@@ -1,0 +1,5 @@
+---
+'@solana/react': patch
+---
+
+Widen the `@solana/kit` peer dependency of `@solana/react` from an exact version to a caret range. `@solana/react` previously declared `"@solana/kit": "workspace:*"`, which publishes as an exact pin (`"@solana/kit": "7.0.0"`), so a consumer who advanced `@solana/kit` without advancing `@solana/react` in the same step hit an unsatisfiable peer range even though the two are compatible. It now declares `workspace:^` and publishes as `^7.1.0`. The two packages continue to be released in lockstep at identical versions, so this does not loosen which combinations are actually shipped — it only stops describing a compatible pair as incompatible.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -18,5 +18,8 @@
     "version": false,
     "tag": false
   },
-  "updateInternalDependencies": "patch"
+  "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ RPC method response types live in `packages/rpc-api/src/<methodName>.ts`; types 
 - `patch` for fixes, `minor` for features, `major` for breaking changes (while pre-1.0, `minor` may be treated as breaking).
 - No changeset needed for docs-only changes, CI config, dev dependency updates, or test-only changes.
 - All publishable packages are version-locked via the `fixed` config in `.changeset/config.json`.
+- **Re-check the calculated version after any `@changesets/cli` bump.** Keeping releases off a spurious major depends on `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange` in `.changeset/config.json`, and that option is explicitly unstable — the name promises it may change in a patch. Since `@changesets/cli` is declared as `^2.31.1`, a routine Dependabot bump could alter or drop the behaviour. When reviewing a PR that upgrades `@changesets/cli`, run `npx changeset status` and confirm the calculated versions still match the highest bump among the pending changesets. Without the option, changesets bumps any package to `major` when a package it lists in `peerDependencies` gets a minor — `@solana/react` peer-depends on `@solana/kit`, so that alone would push all packages in the `fixed` group to a major. The peer range must also stay `workspace:^` rather than `workspace:*`, since changesets resolves `workspace:*` to an exact version that every bump leaves.
 
 ## CI
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -147,7 +147,7 @@
         "swr": "^2.4.2"
     },
     "peerDependencies": {
-        "@solana/kit": "workspace:*",
+        "@solana/kit": "workspace:^",
         "@tanstack/react-query": "^5.0.0",
         "react": ">=18",
         "swr": "^2.4.2"


### PR DESCRIPTION
TLDR: I noticed the open changesets PR #1830 has marked everything as 8.0 despite only minor/patch changesets. Fix and description below is all Claude 

#### Problem

The pending release PR (#1830) calculates the next version as **8.0.0**, even though every changeset on `main` is `minor` or `patch`. The expected version is 7.1.0.

The cause is a rule in `@changesets/assemble-release-plan` ([`shouldBumpMajor`](https://github.com/changesets/changesets/blob/main/packages/assemble-release-plan/src/determine-dependents.ts)): when a package receives a `minor` or `major` bump, any dependent that lists it in `peerDependencies` is bumped `major`, on the theory that tightening a peer range is breaking for consumers. `@solana/react` declares `@solana/kit` as a peer, `@solana/kit` has minor changesets, so `@solana/react` is forced to `major` — and because every publishable package shares one `fixed` group, that major propagates to all 48 packages.

`changeset status` on `main` today reports all 48 packages as `major`, most with an empty `changesets: []`.

#### Summary of Changes

Two changes, both required — either one alone still produces 8.0.0:

1. **`.changeset/config.json`** opts into `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange`, so a peer dependent is bumped `major` only when the new version actually leaves its declared range, rather than unconditionally.
2. **`packages/react/package.json`** changes the `@solana/kit` peer range from `workspace:*` to `workspace:^`. This is necessary because changesets resolves `workspace:*` to the *exact* current version, so any bump at all leaves the range even with the flag enabled.

Plus one piece of documentation:

3. **`CLAUDE.md`** documents that a `@changesets/cli` upgrade should be reviewed by re-running `changeset status`, since the flag is explicitly unstable — it lives under `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH`, and the dependency is declared as `^2.31.1`, so a routine Dependabot bump could change or drop the behaviour without any signal. Catching it at review time on the upgrade PR is better than discovering it on a release PR.

The caret range is also the more correct thing to publish, independent of the version-inflation issue. `workspace:*` publishes as an exact pin — `@solana/react@7.0.0` on npm today declares `"@solana/kit": "7.0.0"` — which is a semver-breaking declaration on every release by construction, since no one on a different `@solana/kit` version can satisfy it. In practice it means a consumer who advances `@solana/kit` without advancing `@solana/react` in the same step gets an unsatisfiable peer range even though the two are compatible. The lockstep release guarantee comes from the `fixed` group in the changesets config, not from the peer range, so nothing about which versions ship together changes. It also brings `@solana/kit` in line with the package's other peers (`^5.0.0`, `>=18`, `^2.4.2`), none of which are pinned exact.

Verified locally:

| Configuration | Calculated release |
| --- | --- |
| `main` as-is | 8.0.0 (48 × `major`) |
| flag only | 8.0.0 |
| `workspace:^` only | 8.0.0 |
| **both (this PR)** | **7.1.0 (48 × `minor`, 0 majors)** |

Also confirmed by packing a throwaway pnpm workspace that `workspace:^` publishes as `^7.1.0` while `workspace:*` publishes as the exact `7.1.0`, and that `pnpm install --lockfile-only` produces no lockfile change (`@solana/kit` is already a devDependency of `@solana/react`, so the peer specifier is not separately recorded).

Once this lands on `main`, the changesets action will regenerate #1830 as 7.1.0.
