### PR TITLE
Let `TContext` decide what a result context contains

### DIFF
--- a/.changeset/salty-clubs-show.md
+++ b/.changeset/salty-clubs-show.md
@@ -1,0 +1,41 @@
+---
+'@solana/instruction-plans': major
+---
+
+Let `TContext` decide what a transaction plan result context contains
+
+The context attached to a transaction plan result was never entirely controlled by the executor. `SuccessfulSingleTransactionPlanResult` hardcoded it as `SuccessfulBaseTransactionPlanResultContext & TContext`, and `createTransactionPlanExecutor` mixed further properties into both the callback's context and the executor's result type. Because intersections only ever narrow, no choice of `TContext` could relax the required `signature` — which made it impossible to type an executor that partially signs transactions for a relayer to submit later.
+
+`TContext` is now the only thing that says what a context contains. The signature guarantee moved out of the *structure* of the result types and into the *default* value of `TContext`, so every zero-type-argument spelling behaves exactly as it did before.
+
+**A new context type.** `TransactionPlanResultContextWithSignature` guarantees a `signature` and is the new default everywhere. `SuccessfulBaseTransactionPlanResultContext` is deprecated in favour of it.
+
+**Explicit context types must be migrated.** Intersect the new default to keep the signature guarantee:
+
+```diff
+- SingleTransactionPlanResult<{ startedAt: number }>
++ SingleTransactionPlanResult<TransactionPlanResultContextWithSignature & { startedAt: number }>
+```
+
+**The executor callback now receives `Partial<TContext>`.** A fresh, empty context is created for every transaction message and filling it in is the callback's job, but its properties used to be typed as required — so a callback could read one before writing it, be told a value was there, and get `undefined` at runtime. Everything is optional on entry now. Writing still narrows, so a read after `context.custom = 'value'` gives the non-optional type.
+
+One consequence is that a callback can no longer annotate its own parameter with required properties, which was a common way to infer a custom context. Use a type argument instead:
+
+```diff
+- createTransactionPlanExecutor({
+-     executeTransactionMessage: async (context: { startedAt: number }) => { /* ... */ },
+- })
++ createTransactionPlanExecutor<TransactionPlanResultContextWithSignature & { startedAt: number }>({
++     executeTransactionMessage: async context => { /* ... */ },
++ })
+```
+
+**A returned context no longer has to carry a `signature`.** The `executeTransactionMessage` callback may return the context that a successful result should carry, and that context used to need a signature because the result type hardcoded one. `TContext` decides now: the default still requires it, and a custom `TContext` that omits it is accepted — which is what makes the relayer case above expressible end to end, rather than merely possible at runtime. Consequently the executor no longer tells a returned context apart from a returned `Transaction` by looking for a `signature` on it, since a context may not have one; it looks for the `signatures` map that only a `Transaction` has.
+
+**Failed and canceled results type their context as `Readonly<Partial<TContext>>`.** Those branches never guaranteed custom properties at runtime — the context is built incrementally and the callback may throw at any point — so the types now say so.
+
+**Inference from object literals is narrower**, since the result constructors no longer add properties you did not pass. `successfulSingleTransactionPlanResult(message, { signature })` infers `Readonly<{ signature: Signature }>` rather than a context that also carried optional `message` and `transaction` fields plus an index signature, so reading `result.context.message` off it is now an error. On the failed and canceled constructors the `Partial` goes further: even a field you did pass comes back optional, so `failedSingleTransactionPlanResult(message, error, { transaction }).context.transaction` is `Transaction | undefined`. Pass an explicit type argument wherever you need a field to type as required. Relatedly, `successfulSingleTransactionPlanResultFromTransaction`'s optional `context` parameter changes from `Omit<BaseTransactionPlanResultContext, 'signature' | 'transaction'> & TContext` to `TContext`; `signature` and `transaction` are still derived from the `transaction` argument and intersected into the result's context type.
+
+**Helpers that consume results now accept any context.** `passthroughFailedTransactionPlanExecution`, `createFailedToSendTransactionError`, `createFailedToSendTransactionsError` and `createFailedToExecuteTransactionPlanError` were non-generic, so they implicitly demanded the default signature-guaranteeing context and rejected results parameterised with anything else. They are now generic over `TContext` and preserve it. Where they read a signature to build an error message they narrow it at runtime, so a result without one simply omits it from the message.
+
+**Execution behaviour is unchanged.** The executor still populates `context.signature` from the signature or transaction your callback returns, and still recovers one for failed results from a `transaction` left on the context. Those writes just no longer show up in the result type unless your `TContext` asked for them. The behavioural changes are the two described above: an error message built from a context whose `signature` is absent, or is not a string, now omits it rather than interpolating whatever was there, and a returned context is recognised by the absence of a `signatures` map rather than the presence of a `signature`.

--- a/packages/instruction-plans/src/__tests__/transaction-plan-errors-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-errors-test.ts
@@ -155,6 +155,15 @@ describe('createFailedToSendTransactionError', () => {
         });
     });
 
+    describe('given a failed result with a non-string signature in the context', () => {
+        it('omits the signature from the causeMessage', () => {
+            const plainError = new Error('Transaction failed');
+            const result = failedSingleTransactionPlanResult(createMessage('A'), plainError, { signature: 42 });
+            const error = createFailedToSendTransactionError(result);
+            expect(error.message).toBe('Failed to send transaction: Transaction failed');
+        });
+    });
+
     describe('given a failed result with a compute-limit simulation error', () => {
         it('unwraps the simulation error', () => {
             const innerError = new SolanaError(SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE);
@@ -423,6 +432,18 @@ describe('createFailedToSendTransactionsError', () => {
             ]);
             const error = createFailedToSendTransactionsError(result);
             expect(error.message).toBe(`Failed to send transactions.\n[Tx #1 (${signature})] Transaction failed\n`);
+        });
+    });
+
+    describe('given failures with non-string signatures in the context', () => {
+        it('omits the signature from causeMessages', () => {
+            const messageA = createMessage('A');
+            const plainError = new Error('Transaction failed');
+            const result = sequentialTransactionPlanResult([
+                failedSingleTransactionPlanResult(messageA, plainError, { signature: 42 }),
+            ]);
+            const error = createFailedToSendTransactionsError(result);
+            expect(error.message).toBe('Failed to send transactions.\n[Tx #1] Transaction failed\n');
         });
     });
 

--- a/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
@@ -24,6 +24,7 @@ import {
     successfulSingleTransactionPlanResult,
     successfulSingleTransactionPlanResultFromTransaction,
     TransactionPlanResult,
+    TransactionPlanResultContextWithSignature,
 } from '../index';
 import { createMessage, createPartiallySignedTransaction, createTransaction, FOREVER_PROMISE } from './__setup__';
 
@@ -299,7 +300,9 @@ describe('createTransactionPlanExecutor', () => {
             expect.assertions(1);
             const messageA = createMessage('A');
             const messageB = createMessage('B');
-            const executor = createTransactionPlanExecutor<{ custom: string }>({
+            const executor = createTransactionPlanExecutor<
+                TransactionPlanResultContextWithSignature & { custom: string }
+            >({
                 executeTransactionMessage: context => {
                     context.custom = 'custom value';
                     context.message = messageB;
@@ -344,7 +347,9 @@ describe('createTransactionPlanExecutor', () => {
             const throwCause = (): void => {
                 throw cause;
             };
-            const executor = createTransactionPlanExecutor<{ afterFailure: string; beforeFailure: string }>({
+            const executor = createTransactionPlanExecutor<
+                TransactionPlanResultContextWithSignature & { afterFailure: string; beforeFailure: string }
+            >({
                 executeTransactionMessage: async context => {
                     context.beforeFailure = 'before failure';
                     context.message = messageB;

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-errors-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-errors-typetest.ts
@@ -1,0 +1,35 @@
+import {
+    createFailedToExecuteTransactionPlanError,
+    createFailedToSendTransactionError,
+    createFailedToSendTransactionsError,
+    FailedSingleTransactionPlanResult,
+    type TransactionPlanResult,
+} from '../index';
+
+// [DESCRIBE] createFailedToSendTransactionError
+{
+    // It accepts a result carrying an entirely custom context, which makes no promise about the
+    // signature it reads to build its message.
+    {
+        const result = null as unknown as FailedSingleTransactionPlanResult<{ custom: string }>;
+        createFailedToSendTransactionError(result);
+    }
+}
+
+// [DESCRIBE] createFailedToSendTransactionsError
+{
+    // It accepts a result tree carrying an entirely custom context.
+    {
+        const result = null as unknown as TransactionPlanResult<{ custom: string }>;
+        createFailedToSendTransactionsError(result);
+    }
+}
+
+// [DESCRIBE] createFailedToExecuteTransactionPlanError
+{
+    // It accepts a result tree carrying an entirely custom context.
+    {
+        const result = null as unknown as TransactionPlanResult<{ custom: string }>;
+        createFailedToExecuteTransactionPlanError(result);
+    }
+}

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
@@ -13,12 +13,15 @@ import {
     CanceledSingleTransactionPlanResult,
     createTransactionPlanExecutor,
     FailedSingleTransactionPlanResult,
+    flattenTransactionPlanResult,
     passthroughFailedTransactionPlanExecution,
     SingleTransactionPlanResult,
     SuccessfulSingleTransactionPlanResult,
+    summarizeTransactionPlanResult,
     type TransactionPlan,
     type TransactionPlanExecutor,
     type TransactionPlanResult,
+    type TransactionPlanResultContextWithSignature,
 } from '../index';
 
 // [DESCRIBE] TransactionPlanExecutor
@@ -64,11 +67,20 @@ import {
         });
     }
 
-    // It requires a returned context to carry the signature a successful result guarantees.
+    // A returned context needs no signature of its own; since `TContext` alone decides what a
+    // context carries, one inferred from the return value drops the signature guarantee.
     {
-        createTransactionPlanExecutor({
-            // @ts-expect-error A context without a signature is neither a valid context nor a `Transaction`.
-            executeTransactionMessage: () => Promise.resolve({ sent: true, transaction: {} as Transaction }),
+        const executor = createTransactionPlanExecutor({
+            executeTransactionMessage: () => Promise.resolve({ sent: true }),
+        });
+        executor satisfies TransactionPlanExecutor<{ sent: boolean }>;
+    }
+
+    // It requires a returned context to carry the signature when `TContext` guarantees one.
+    {
+        createTransactionPlanExecutor<TransactionPlanResultContextWithSignature>({
+            // @ts-expect-error The returned context is missing the guaranteed `signature` property.
+            executeTransactionMessage: () => Promise.resolve({ sent: true }),
         });
     }
 
@@ -89,6 +101,8 @@ import {
                 context.message satisfies (TransactionMessage & TransactionMessageWithFeePayer) | undefined;
                 context.transaction satisfies Transaction | undefined;
                 context.signature satisfies Signature | undefined;
+                // @ts-expect-error Populating the signature is the callback's job; it is absent on entry.
+                context.signature satisfies Signature;
                 return Promise.resolve({} as Signature);
             },
         });
@@ -109,28 +123,59 @@ import {
         });
     }
 
-    // It can use a custom context which is then assigned to the created TransactionPlanExecutor.
+    // It can infer a custom context from the callback, which is then assigned to the created TransactionPlanExecutor.
     {
         const executor = createTransactionPlanExecutor({
+            executeTransactionMessage: (_: { custom?: string }) => {
+                return Promise.resolve({} as Signature);
+            },
+        });
+        executor satisfies TransactionPlanExecutor<{ custom?: string }>;
+    }
+
+    // A callback cannot demand that a custom property is already populated. A fresh context is
+    // created for every single transaction plan, so anything the callback declares is its own job
+    // to fill in. Supply the context as an explicit type argument to guarantee it on the result.
+    {
+        createTransactionPlanExecutor({
+            // @ts-expect-error The context starts empty, so `custom` cannot be present on entry.
             executeTransactionMessage: (_: { custom: string }) => {
                 return Promise.resolve({} as Signature);
             },
         });
-        executor satisfies TransactionPlanExecutor<{ custom: string }>;
     }
 
-    // It can use a custom context with the base context.
+    // It can use a custom context with the base context, by intersecting one of the base context
+    // types into the type argument. Nothing is added to `TContext` on the caller's behalf.
     {
-        const executor = createTransactionPlanExecutor<{ custom: string }>({
+        const executor = createTransactionPlanExecutor<TransactionPlanResultContextWithSignature & { custom: string }>({
             executeTransactionMessage: context => {
+                context.custom satisfies string | undefined;
+                // @ts-expect-error Populating the custom property is the callback's job; it is absent on entry.
+                context.custom satisfies string;
+                context.custom = 'value';
                 context.custom satisfies string;
                 context.message satisfies (TransactionMessage & TransactionMessageWithFeePayer) | undefined;
                 context.transaction satisfies Transaction | undefined;
                 context.signature satisfies Signature | undefined;
+                // @ts-expect-error Populating the signature is the callback's job; it is absent on entry.
+                context.signature satisfies Signature;
                 return Promise.resolve({} as Signature);
             },
         });
-        executor satisfies TransactionPlanExecutor<{ custom: string }>;
+        executor satisfies TransactionPlanExecutor<TransactionPlanResultContextWithSignature & { custom: string }>;
+    }
+
+    // A bare custom context gets exactly what it declared — no base properties are injected.
+    {
+        createTransactionPlanExecutor<{ custom: string }>({
+            executeTransactionMessage: context => {
+                context.custom satisfies string | undefined;
+                // @ts-expect-error This context declares no `message`, so the executor does not add one.
+                void context.message;
+                return Promise.resolve({} as Signature);
+            },
+        });
     }
 
     // It can return a custom context.
@@ -207,5 +252,101 @@ import {
         const promise = null as unknown as Promise<TransactionPlanResult>;
         const result = passthroughFailedTransactionPlanExecution(promise);
         void (result satisfies Promise<TransactionPlanResult>);
+    }
+
+    // It accepts a result carrying an entirely custom context, and preserves it.
+    {
+        const promise = null as unknown as Promise<SingleTransactionPlanResult<{ custom: string }>>;
+        const result = passthroughFailedTransactionPlanExecution(promise);
+        void (result satisfies Promise<SingleTransactionPlanResult<{ custom: string }>>);
+    }
+}
+
+// [DESCRIBE] createTransactionPlanExecutor result contexts
+{
+    // Its results guarantee a signature by default, as they did before the context types were loosened.
+    {
+        const executor = createTransactionPlanExecutor({
+            executeTransactionMessage: () => Promise.resolve({} as Signature),
+        });
+        void executor(null as unknown as TransactionPlan).then(result => {
+            if (result.kind === 'single' && result.status === 'successful') {
+                result.context.signature satisfies Signature;
+            }
+        });
+    }
+
+    // Its failed results guarantee nothing.
+    {
+        const executor = createTransactionPlanExecutor({
+            executeTransactionMessage: () => Promise.resolve({} as Signature),
+        });
+        void executor(null as unknown as TransactionPlan).then(result => {
+            if (result.kind === 'single' && result.status === 'failed') {
+                result.context.signature satisfies Signature | undefined;
+                // @ts-expect-error A failed result guarantees no signature.
+                result.context.signature satisfies Signature;
+            }
+        });
+    }
+
+    // A custom context reports exactly what it declared. The signature guarantee comes from
+    // intersecting it in, not from the executor adding it behind the caller's back.
+    {
+        const executor = createTransactionPlanExecutor<TransactionPlanResultContextWithSignature & { custom: string }>({
+            executeTransactionMessage: context => {
+                context.custom = 'value';
+                return Promise.resolve({} as Signature);
+            },
+        });
+        void executor(null as unknown as TransactionPlan).then(result => {
+            if (result.kind === 'single' && result.status === 'successful') {
+                result.context.signature satisfies Signature;
+                result.context.custom satisfies string;
+            }
+        });
+    }
+
+    // A custom context that omits the signature does not get one back. The executor still
+    // populates `context.signature` at runtime, but it makes no type-level promise the caller
+    // did not ask for, which is what lets an executor be typed with no signature at all.
+    {
+        const executor = createTransactionPlanExecutor<{ custom: string }>({
+            executeTransactionMessage: context => {
+                context.custom = 'value';
+                return Promise.resolve({} as Signature);
+            },
+        });
+        void executor(null as unknown as TransactionPlan).then(result => {
+            if (result.kind === 'single' && result.status === 'successful') {
+                result.context.custom satisfies string;
+                // @ts-expect-error This context declared no signature, so none is reported.
+                void result.context.signature;
+            }
+        });
+    }
+}
+
+// [DESCRIBE] TransactionPlanExecutor with an optional signature
+{
+    // An executor can be typed to produce results that have a transaction but no signature.
+    {
+        const result = null as unknown as Awaited<ReturnType<TransactionPlanExecutor<{ transaction: Transaction }>>>;
+        if (result.kind === 'single' && result.status === 'successful') {
+            result.context.transaction satisfies Transaction;
+            // @ts-expect-error This executor makes no promise about the signature.
+            void result.context.signature;
+        }
+    }
+
+    // Such a result is still a TransactionPlanResult and works with the traversal helpers.
+    {
+        const result = null as unknown as TransactionPlanResult<{ transaction: Transaction }>;
+        const flattened = flattenTransactionPlanResult(result);
+        flattened satisfies SingleTransactionPlanResult<{ transaction: Transaction }>[];
+        const summary = summarizeTransactionPlanResult(result);
+        summary.successfulTransactions satisfies SuccessfulSingleTransactionPlanResult<{
+            transaction: Transaction;
+        }>[];
     }
 }

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-result-typetest.ts
@@ -37,6 +37,7 @@ import {
     SuccessfulTransactionPlanResult,
     TransactionPlanResult,
     TransactionPlanResultContext,
+    TransactionPlanResultContextWithSignature,
 } from '../index';
 
 const messageA = null as unknown as TransactionMessage & TransactionMessageWithFeePayer & { id: 'A' };
@@ -172,6 +173,37 @@ type CustomContext = { customData: string };
         });
         result satisfies SuccessfulSingleTransactionPlanResult<CustomContext, typeof messageA>;
         result satisfies TransactionPlanResult;
+    }
+
+    // The result's context claims exactly what was passed — custom properties stay required —
+    // plus the signature and transaction derived from the transaction argument, both required.
+    {
+        const result = successfulSingleTransactionPlanResultFromTransaction(messageA, transactionA, {
+            customData: 'test',
+        });
+        result.context.customData satisfies string;
+        result.context.signature satisfies Signature;
+        result.context.transaction satisfies Transaction;
+    }
+
+    // It does not add the optional `message` property of the default context.
+    {
+        const result = successfulSingleTransactionPlanResultFromTransaction<CustomContext>(messageA, transactionA, {
+            customData: 'test',
+        });
+        // @ts-expect-error The context claims nothing but `customData`, `signature` and `transaction`.
+        void result.context.message;
+    }
+
+    // With an explicit type argument, a passed context must supply the declared properties;
+    // nothing but the derived `signature` and `transaction` is asserted on the caller's behalf.
+    {
+        successfulSingleTransactionPlanResultFromTransaction<CustomContext>(
+            messageA,
+            transactionA,
+            // @ts-expect-error The declared `customData` property is missing.
+            {},
+        );
     }
 }
 
@@ -533,6 +565,139 @@ type CustomContext = { customData: string };
         const plan = null as unknown;
         if (isTransactionPlanResult(plan)) {
             plan satisfies TransactionPlanResult;
+        }
+    }
+}
+
+// [DESCRIBE] TransactionPlanResultContextWithSignature
+{
+    // It requires a signature and leaves the other base fields optional.
+    {
+        const context = null as unknown as TransactionPlanResultContextWithSignature;
+        context.signature satisfies Signature;
+        context.message satisfies (TransactionMessage & TransactionMessageWithFeePayer) | undefined;
+        context.transaction satisfies Transaction | undefined;
+    }
+
+    // It satisfies the loose context constraint, so it is usable as a default.
+    {
+        const context = null as unknown as TransactionPlanResultContextWithSignature;
+        context satisfies TransactionPlanResultContext;
+    }
+
+    // It carries an index signature, so unknown custom properties can still be read.
+    {
+        const context = null as unknown as TransactionPlanResultContextWithSignature;
+        context.anythingElse satisfies unknown;
+    }
+}
+
+// Mutual-assignability equality. `Eq<A, B>` is `true` only when A and B accept each other.
+type Eq<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+// [DESCRIBE] Zero-argument result shapes
+//
+// These spell out, structurally, the exact context you get when you name no context type at all.
+// Written this way rather than in terms of the context aliases, they would fail if a future change
+// to those aliases altered what the unparameterised result types deliver.
+{
+    // A successful context requires a signature and leaves the other base fields optional.
+    {
+        type Expected = Readonly<{
+            [key: number | string | symbol]: unknown;
+            message?: TransactionMessage & TransactionMessageWithFeePayer;
+            signature: Signature;
+            transaction?: Transaction;
+        }>;
+        type Actual = SuccessfulSingleTransactionPlanResult['context'];
+        true satisfies Eq<Expected, Actual>;
+    }
+
+    // A failed context guarantees nothing; every base field is optional.
+    {
+        type Expected = Readonly<{
+            [key: number | string | symbol]: unknown;
+            message?: TransactionMessage & TransactionMessageWithFeePayer;
+            signature?: Signature;
+            transaction?: Transaction;
+        }>;
+        type Actual = FailedSingleTransactionPlanResult['context'];
+        true satisfies Eq<Expected, Actual>;
+    }
+
+    // A canceled context guarantees nothing either.
+    {
+        type Expected = Readonly<{
+            [key: number | string | symbol]: unknown;
+            message?: TransactionMessage & TransactionMessageWithFeePayer;
+            signature?: Signature;
+            transaction?: Transaction;
+        }>;
+        type Actual = CanceledSingleTransactionPlanResult['context'];
+        true satisfies Eq<Expected, Actual>;
+    }
+
+    // A successful result guarantees a signature.
+    {
+        const result = null as unknown as SuccessfulSingleTransactionPlanResult;
+        result.context.signature satisfies Signature;
+    }
+
+    // A failed result does not.
+    {
+        const result = null as unknown as FailedSingleTransactionPlanResult;
+        result.context.signature satisfies Signature | undefined;
+        // @ts-expect-error A failed result guarantees no signature.
+        result.context.signature satisfies Signature;
+    }
+
+    // The index signature means custom properties can be read off an unparameterised result.
+    {
+        const result = null as unknown as SingleTransactionPlanResult;
+        result.context.startedAt satisfies unknown;
+    }
+}
+
+// [DESCRIBE] Explicitly parameterised result contexts
+{
+    // A bare custom context is exactly itself on the successful branch — no base fields are forced on it.
+    {
+        const result = null as unknown as SuccessfulSingleTransactionPlanResult<{ startedAt: number }>;
+        result.context.startedAt satisfies number;
+        // @ts-expect-error This context makes no promise about the signature.
+        result.context.signature satisfies Signature;
+    }
+
+    // Intersecting the default context back in restores the signature guarantee alongside it.
+    {
+        const result = null as unknown as SuccessfulSingleTransactionPlanResult<
+            TransactionPlanResultContextWithSignature & { startedAt: number }
+        >;
+        result.context.startedAt satisfies number;
+        result.context.signature satisfies Signature;
+    }
+
+    // Custom properties survive `Partial` on the failed branch as optionals, not as `unknown`.
+    {
+        const result = null as unknown as FailedSingleTransactionPlanResult<{ startedAt: number }>;
+        result.context.startedAt satisfies number | undefined;
+        // @ts-expect-error A failed result guarantees nothing about the context.
+        result.context.startedAt satisfies number;
+    }
+
+    // A context that guarantees a transaction rather than a signature narrows both branches as
+    // expected, which is what lets a result describe a transaction that was never submitted.
+    {
+        const result = null as unknown as SingleTransactionPlanResult<{ transaction: Transaction }>;
+        if (isSuccessfulSingleTransactionPlanResult(result)) {
+            result.context.transaction satisfies Transaction;
+            // @ts-expect-error This context declares no signature, so none is reported.
+            void result.context.signature;
+        }
+        if (isFailedSingleTransactionPlanResult(result)) {
+            result.context.transaction satisfies Transaction | undefined;
+            // @ts-expect-error A failed result's context makes every field optional, including transaction.
+            result.context.transaction satisfies Transaction;
         }
     }
 }

--- a/packages/instruction-plans/src/transaction-plan-errors.ts
+++ b/packages/instruction-plans/src/transaction-plan-errors.ts
@@ -15,6 +15,8 @@ import {
     type FailedSingleTransactionPlanResult,
     flattenTransactionPlanResult,
     type TransactionPlanResult,
+    type TransactionPlanResultContext,
+    type TransactionPlanResultContextWithSignature,
 } from './transaction-plan-result';
 
 type PreflightData = Omit<RpcSimulateTransactionResult, 'err'>;
@@ -32,6 +34,8 @@ type PreflightData = Omit<RpcSimulateTransactionResult, 'err'>;
  * preflight error or includes the on-chain transaction signature for easy
  * copy-pasting into block explorers.
  *
+ * @typeParam TContext - The type of the context object attached to the result. Any context is
+ * accepted; the signature is read from it only if one happens to be there.
  * @param result - A failed or canceled single transaction plan result.
  * @param abortReason - An optional abort reason if the transaction was canceled.
  * @return A {@link SolanaError} with the appropriate error code, context, and cause.
@@ -52,8 +56,10 @@ type PreflightData = Omit<RpcSimulateTransactionResult, 'err'>;
  *
  * @see {@link createFailedToSendTransactionsError}
  */
-export function createFailedToSendTransactionError(
-    result: CanceledSingleTransactionPlanResult | FailedSingleTransactionPlanResult,
+export function createFailedToSendTransactionError<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
+>(
+    result: CanceledSingleTransactionPlanResult<TContext> | FailedSingleTransactionPlanResult<TContext>,
     abortReason?: unknown,
 ): SolanaError<typeof SOLANA_ERROR__FAILED_TO_SEND_TRANSACTION> {
     let causeMessage: string;
@@ -66,7 +72,7 @@ export function createFailedToSendTransactionError(
         logs = unwrapped.logs;
         preflightData = unwrapped.preflightData;
         cause = unwrapped.unwrappedError;
-        const indicator = getFailedIndicator(!!preflightData, result.context.signature);
+        const indicator = getFailedIndicator(!!preflightData, getSignatureFromContext(result.context));
         causeMessage = `${indicator}: ${(cause as Error).message}${formatLogSnippet(logs)}`;
     } else {
         cause = abortReason;
@@ -101,6 +107,8 @@ export function createFailedToSendTransactionError(
  * indicator showing whether it was a preflight error or includes the transaction
  * signature. When all transactions were canceled, the message is a single line.
  *
+ * @typeParam TContext - The type of the context object attached to the results. Any context is
+ * accepted; each signature is read from it only if one happens to be there.
  * @param result - The full transaction plan result tree.
  * @param abortReason - An optional abort reason if the plan was aborted.
  * @return A {@link SolanaError} with the appropriate error code, context, and cause.
@@ -121,8 +129,10 @@ export function createFailedToSendTransactionError(
  *
  * @see {@link createFailedToSendTransactionError}
  */
-export function createFailedToSendTransactionsError(
-    result: TransactionPlanResult,
+export function createFailedToSendTransactionsError<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
+>(
+    result: TransactionPlanResult<TContext>,
     abortReason?: unknown,
 ): SolanaError<typeof SOLANA_ERROR__FAILED_TO_SEND_TRANSACTIONS> {
     const flattenedResults = flattenTransactionPlanResult(result);
@@ -146,7 +156,10 @@ export function createFailedToSendTransactionsError(
     if (failedTransactions.length > 0) {
         cause = failedTransactions.length === 1 ? failedTransactions[0].error : undefined;
         const failureLines = failedTransactions.map(({ error, index, preflightData }) => {
-            const indicator = getFailedIndicator(!!preflightData, flattenedResults[index].context.signature);
+            const indicator = getFailedIndicator(
+                !!preflightData,
+                getSignatureFromContext(flattenedResults[index].context),
+            );
             return `\n[Tx #${index + 1}${indicator}] ${error.message}`;
         });
         const logSnippet = failedTransactions.length === 1 ? formatLogSnippet(failedTransactions[0].logs) : '';
@@ -180,6 +193,8 @@ export function createFailedToSendTransactionsError(
  * property so that callers can inspect execution details without the result
  * being serialized with the error.
  *
+ * @typeParam TContext - The type of the context object attached to the results. Any context is
+ * accepted, since this helper never reads from it.
  * @param result - The full transaction plan result tree.
  * @param abortReason - An optional abort reason if the plan was aborted.
  * @return A {@link SolanaError} with the appropriate error code and context.
@@ -195,8 +210,10 @@ export function createFailedToSendTransactionsError(
  * @see {@link createFailedToSendTransactionError}
  * @see {@link createFailedToSendTransactionsError}
  */
-export function createFailedToExecuteTransactionPlanError(
-    result: TransactionPlanResult,
+export function createFailedToExecuteTransactionPlanError<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
+>(
+    result: TransactionPlanResult<TContext>,
     abortReason?: unknown,
 ): SolanaError<typeof SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN> {
     const context: Record<string, unknown> = {
@@ -234,7 +251,9 @@ function unwrapErrorWithPreflightData(error: Error): {
     return { logs: undefined, preflightData: undefined, unwrappedError: error };
 }
 
-function findErrorFromTransactionPlanResult(result: TransactionPlanResult): Error | undefined {
+function findErrorFromTransactionPlanResult<TContext extends TransactionPlanResultContext>(
+    result: TransactionPlanResult<TContext>,
+): Error | undefined {
     if (result.kind === 'single') {
         return result.status === 'failed' ? result.error : undefined;
     }
@@ -252,6 +271,16 @@ function formatLogSnippet(logs: readonly string[] | undefined): string {
     const lastLines = logs.slice(-maxLines);
     const header = logs.length > maxLines ? `\n\nLogs (last ${maxLines} of ${logs.length}):` : '\n\nLogs:';
     return `${header}\n${lastLines.map(line => `  > ${line}\n`).join('')}`;
+}
+
+/**
+ * Reads a signature out of an arbitrary result context.
+ *
+ * Nothing guarantees that a context has a signature — an executor may produce results for
+ * transactions it never submitted — so this narrows at runtime rather than trusting the type.
+ */
+function getSignatureFromContext(context: TransactionPlanResultContext): string | undefined {
+    return typeof context.signature === 'string' ? context.signature : undefined;
 }
 
 function getFailedIndicator(isPreflight: boolean, signature: string | undefined): string {

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -24,11 +24,11 @@ import {
     parallelTransactionPlanResult,
     sequentialTransactionPlanResult,
     SingleTransactionPlanResult,
-    type SuccessfulBaseTransactionPlanResultContext,
     successfulSingleTransactionPlanResult,
     successfulSingleTransactionPlanResultFromTransaction,
     type TransactionPlanResult,
     type TransactionPlanResultContext,
+    type TransactionPlanResultContextWithSignature,
 } from './transaction-plan-result';
 
 /**
@@ -36,6 +36,10 @@ import {
  *
  * This function traverses the transaction plan tree, executing each transaction
  * message and collecting results that mirror the structure of the original plan.
+ *
+ * The zero-argument spelling defaults `TContext` to {@link TransactionPlanResultContextWithSignature},
+ * so its results guarantee a `context.signature` on every successful single result — but a different
+ * `TContext` may drop that guarantee entirely.
  *
  * @typeParam TContext - The type of the context object that may be passed along with results.
  * @param transactionPlan - The transaction plan to execute.
@@ -46,19 +50,18 @@ import {
  * @see {@link TransactionPlanResult}
  * @see {@link createTransactionPlanExecutor}
  */
-export type TransactionPlanExecutor<TContext extends TransactionPlanResultContext = TransactionPlanResultContext> = (
+export type TransactionPlanExecutor<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
+> = (
     transactionPlan: TransactionPlan,
     config?: { abortSignal?: AbortSignal },
 ) => Promise<TransactionPlanResult<TContext>>;
 
-type SuccessfulTransactionPlanResultContext<TContext extends TransactionPlanResultContext> =
-    SuccessfulBaseTransactionPlanResultContext & TContext;
-
 type ExecuteTransactionMessage<
     TContext extends TransactionPlanResultContext,
-    TReturn = Signature | SuccessfulTransactionPlanResultContext<TContext> | Transaction,
+    TReturn = Signature | TContext | Transaction,
 > = (
-    context: BaseTransactionPlanResultContext & TContext,
+    context: Partial<TContext>,
     transactionMessage: TransactionMessage & TransactionMessageWithFeePayer,
     config?: { abortSignal?: AbortSignal },
 ) => Promise<TReturn>;
@@ -74,8 +77,8 @@ export type TransactionPlanExecutorConfig<
     /**
      * Called whenever a transaction message must be sent to the blockchain.
      *
-     * It should return the context that the successful result must carry — which, since a
-     * successful result always has a signature, must include one. Returning a {@link Signature} or
+     * It should return the context that the successful result must carry — every property
+     * `TContext` promises, which by default includes a `signature`. Returning a {@link Signature} or
      * a {@link Transaction} instead is deprecated.
      */
     executeTransactionMessage: ExecuteTransactionMessage<TContext>;
@@ -105,7 +108,7 @@ export type TransactionPlanExecutorConfig<
  * @see {@link TransactionPlanExecutorConfig}
  */
 export function createTransactionPlanExecutor<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
 >(config: {
     executeTransactionMessage: ExecuteTransactionMessage<TContext, Signature | Transaction>;
 }): TransactionPlanExecutor<TContext>;
@@ -124,9 +127,9 @@ export function createTransactionPlanExecutor<
  * saved to the context will still be available in the plan result, which can be useful
  * for debugging failures or building recovery plans.
  *
- * The callback should return the context that a successful result must carry. Since a successful
- * result always has a signature, that context must include one — the executor derives nothing on
- * the callback's behalf. On success the returned context is merged over the one the callback
+ * The callback should return the context that a successful result must carry — every property
+ * `TContext` promises, which by default includes a `signature`, since the executor derives nothing
+ * on the callback's behalf. On success the returned context is merged over the one the callback
  * mutated, with the returned value taking precedence, so a property stored on the context but left
  * out of the return value is still reported.
  *
@@ -141,12 +144,7 @@ export function createTransactionPlanExecutor<
  * ```
  *
  * Note that the callback cannot simply return the context it was given, since every property on it
- * is optional. Build the return value from the values you have instead. Custom context properties
- * are typed by supplying `TContext` explicitly:
- *
- * ```ts
- * createTransactionPlanExecutor<{ startedAt: number }>(config);
- * ```
+ * is optional. Build the return value from the values you have instead.
  *
  * Returning a {@link Signature} or a full {@link Transaction} object instead of a context is
  * deprecated. Those return values are still honoured — a returned signature is stored as
@@ -154,6 +152,25 @@ export function createTransactionPlanExecutor<
  * signature derived from it — but deriving that signature throws
  * `SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING` when
  * the fee payer has not signed, which returning a context avoids.
+ *
+ * `TContext` is the only thing that says what a context contains — the executor adds nothing of its
+ * own on top, in either direction. It defaults to {@link TransactionPlanResultContextWithSignature},
+ * which is why the zero-type-argument spelling hands the callback the familiar `message`,
+ * `transaction` and `signature` properties and guarantees a `context.signature` on every successful
+ * result. Supply a different `TContext` and you get exactly that instead, so intersect one of the
+ * base context types in if you want those properties alongside your own:
+ *
+ * ```ts
+ * createTransactionPlanExecutor<TransactionPlanResultContextWithSignature & { startedAt: number }>(config);
+ * ```
+ *
+ * Note the asymmetry between the callback and the result it produces. A fresh context is created for
+ * every single transaction plan, so on entry it is empty and *every* property of `TContext` is
+ * optional inside the callback — populating them is the callback's job, not a guarantee the executor
+ * makes. The `TransactionPlanExecutor` this factory returns, on the other hand, reports the context
+ * as fully populated. Declare the properties you intend to set as an explicit type argument to this
+ * function; a callback cannot annotate its own context parameter with required properties, because
+ * none of them are present when it is called.
  *
  * - If that function is successful, the executor will return a successful `TransactionPlanResult`
  * for that message, carrying the context described above.
@@ -195,10 +212,10 @@ export function createTransactionPlanExecutor<
  * @see {@link TransactionPlanExecutorConfig}
  */
 export function createTransactionPlanExecutor<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
 >(config: TransactionPlanExecutorConfig<TContext>): TransactionPlanExecutor<TContext>;
 export function createTransactionPlanExecutor<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
 >(config: TransactionPlanExecutorConfig<TContext>): TransactionPlanExecutor<TContext> {
     return async (plan, { abortSignal } = {}): Promise<TransactionPlanResult<TContext>> => {
         const traverseConfig: TraverseConfig<TContext> = {
@@ -215,7 +232,7 @@ export function createTransactionPlanExecutor<
             traverseConfig.canceled = true;
         };
         abortSignal?.addEventListener('abort', cancelHandler);
-        const transactionPlanResult = await traverse(plan, traverseConfig);
+        const transactionPlanResult = await traverse<TContext>(plan, traverseConfig);
         abortSignal?.removeEventListener('abort', cancelHandler);
 
         if (traverseConfig.canceled) {
@@ -280,9 +297,13 @@ async function traverseSingle<TContext extends TransactionPlanResultContext>(
     transactionPlan: SingleTransactionPlan,
     traverseConfig: TraverseConfig<TContext>,
 ): Promise<TransactionPlanResult<TContext>> {
-    const context = {} as BaseTransactionPlanResultContext & TContext;
+    // A fresh context is created for every single transaction plan, so nothing is populated
+    // yet. Filling it in is the `executeTransactionMessage` callback's job, which is why
+    // every property of `TContext` is optional here. Note that `TContext` is the only thing
+    // that says what a context contains; the executor adds no fields of its own.
+    const context: Partial<TContext> = {};
     if (traverseConfig.canceled) {
-        return canceledSingleTransactionPlanResult(transactionPlan.message, context);
+        return canceledSingleTransactionPlanResult<TContext>(transactionPlan.message, context);
     }
 
     try {
@@ -292,38 +313,61 @@ async function traverseSingle<TContext extends TransactionPlanResultContext>(
             }),
             traverseConfig.abortSignal,
         );
+        // Only on the happy path do we claim the context is fully populated. Except when the
+        // callback returned that context itself, we cannot verify that — the callback promised
+        // these properties by way of `TContext` and we take it at its word — so this is the one
+        // place an assertion is unavoidable.
         if (typeof result === 'string') {
-            return successfulSingleTransactionPlanResult(transactionPlan.message, { ...context, signature: result });
+            return successfulSingleTransactionPlanResult<TContext>(transactionPlan.message, {
+                ...context,
+                signature: result,
+            } as unknown as TContext);
         }
-        if (isSuccessfulContext(result)) {
+        if (!isTransaction(result)) {
             // The callback told us what context the result should carry, so we take it as-is and
             // derive nothing from it. Anything it stored on the mutable context but left out of its
             // return value is kept, since dropping it would lose data the callback deliberately
             // recorded.
-            return successfulSingleTransactionPlanResult(transactionPlan.message, { ...context, ...result });
+            return successfulSingleTransactionPlanResult<TContext>(transactionPlan.message, {
+                ...context,
+                ...result,
+            });
         }
-        return successfulSingleTransactionPlanResultFromTransaction(transactionPlan.message, result, context);
+        return successfulSingleTransactionPlanResultFromTransaction<TContext>(
+            transactionPlan.message,
+            result,
+            context as unknown as TContext,
+        );
     } catch (error) {
         traverseConfig.canceled = true;
+        // `TContext` no longer promises that a stored transaction is a `Transaction`, so this
+        // reads it back through the base context's shape before narrowing it at runtime.
+        const storedTransaction = context.transaction as BaseTransactionPlanResultContext['transaction'];
         const contextWithSignature =
-            'transaction' in context && typeof context.transaction === 'object' && context.signature == null
-                ? { ...context, signature: getSignatureFromTransaction(context.transaction) }
+            'transaction' in context && typeof storedTransaction === 'object' && context.signature == null
+                ? { ...context, signature: getSignatureFromTransaction(storedTransaction) }
                 : context;
-        return failedSingleTransactionPlanResult(transactionPlan.message, error as Error, contextWithSignature);
+        return failedSingleTransactionPlanResult<TContext>(
+            transactionPlan.message,
+            error as Error,
+            contextWithSignature,
+        );
     }
 }
 
 /**
  * Tells apart the two things the `executeTransactionMessage` callback may return once a
- * {@link Signature} has been ruled out: the context a successful result should carry, or the
- * deprecated {@link Transaction}. Every returned context has a `signature` — that is what a
- * successful result guarantees — and a `Transaction` never does, since it keeps its signatures in a
- * `signatures` map, so that property is a reliable discriminator.
+ * {@link Signature} has been ruled out: the deprecated {@link Transaction}, or the context a
+ * successful result should carry. Since `TContext` alone decides what a context contains, a
+ * returned context is not guaranteed to carry any particular property — not even a `signature` —
+ * so this discriminates on the shape of a `Transaction` instead. Every `Transaction` keeps its
+ * signatures in a `signatures` map, and no context type declares one, so that property is a
+ * reliable discriminator.
  */
-function isSuccessfulContext<TContext extends TransactionPlanResultContext>(
-    returnValue: SuccessfulTransactionPlanResultContext<TContext> | Transaction,
-): returnValue is SuccessfulTransactionPlanResultContext<TContext> {
-    return 'signature' in returnValue;
+function isTransaction<TContext extends TransactionPlanResultContext>(
+    returnValue: TContext | Transaction,
+): returnValue is Transaction {
+    return 'signatures' in returnValue;
 }
 
 function assertDivisibleSequentialPlansOnly(transactionPlan: TransactionPlan): void {
@@ -363,6 +407,8 @@ function assertDivisibleSequentialPlansOnly(transactionPlan: TransactionPlan): v
  *
  * Any other errors are re-thrown as normal.
  *
+ * @typeParam TContext - The type of the context object attached to the results. Any context is
+ * accepted, since this helper never reads from it.
  * @param promise - A promise returned by a transaction plan executor.
  * @return A promise that resolves to the transaction plan result, even if some transactions failed.
  *
@@ -387,20 +433,20 @@ function assertDivisibleSequentialPlansOnly(transactionPlan: TransactionPlan): v
  * @see {@link createTransactionPlanExecutor}
  * @see {@link summarizeTransactionPlanResult}
  */
-export async function passthroughFailedTransactionPlanExecution(
-    promise: Promise<SingleTransactionPlanResult>,
-): Promise<SingleTransactionPlanResult>;
-export async function passthroughFailedTransactionPlanExecution(
-    promise: Promise<TransactionPlanResult>,
-): Promise<TransactionPlanResult>;
-export async function passthroughFailedTransactionPlanExecution(
-    promise: Promise<TransactionPlanResult>,
-): Promise<TransactionPlanResult> {
+export async function passthroughFailedTransactionPlanExecution<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
+>(promise: Promise<SingleTransactionPlanResult<TContext>>): Promise<SingleTransactionPlanResult<TContext>>;
+export async function passthroughFailedTransactionPlanExecution<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
+>(promise: Promise<TransactionPlanResult<TContext>>): Promise<TransactionPlanResult<TContext>>;
+export async function passthroughFailedTransactionPlanExecution<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
+>(promise: Promise<TransactionPlanResult<TContext>>): Promise<TransactionPlanResult<TContext>> {
     try {
         return await promise;
     } catch (error) {
         if (isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)) {
-            return error.context.transactionPlanResult as TransactionPlanResult;
+            return error.context.transactionPlanResult as TransactionPlanResult<TContext>;
         }
         throw error;
     }

--- a/packages/instruction-plans/src/transaction-plan-result.ts
+++ b/packages/instruction-plans/src/transaction-plan-result.ts
@@ -32,7 +32,7 @@ import { getSignatureFromTransaction, Transaction } from '@solana/transactions';
  * @see {@link SequentialTransactionPlanResult}
  */
 export type TransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -64,7 +64,7 @@ export type TransactionPlanResult<
  * @see {@link SuccessfulSingleTransactionPlanResult}
  */
 export type SuccessfulTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 > = TransactionPlanResult<
@@ -80,31 +80,30 @@ export type SuccessfulTransactionPlanResult<
  * transaction plan results. It allows arbitrary additional properties that
  * consumers can use to pass along extra data with their results.
  *
- * Note that base context fields such as `message`, `signature`, and
- * `transaction` are currently intersected into this type in each
- * {@link SingleTransactionPlanResult} variant. That intersection will go away in
- * the next major version, after which the context of a result is exactly the
- * `TContext` you supply.
+ * Note that base context fields such as `message`, `signature`, and `transaction` are not part of
+ * this type. They come from the context a result is parameterised with, which defaults to
+ * {@link TransactionPlanResultContextWithSignature}. Supply a different context to change or drop
+ * those guarantees.
  *
  * @see {@link SingleTransactionPlanResult}
  * @see {@link SuccessfulSingleTransactionPlanResult}
  * @see {@link FailedSingleTransactionPlanResult}
  * @see {@link CanceledSingleTransactionPlanResult}
+ * @see {@link TransactionPlanResultContextWithSignature}
  */
 export type TransactionPlanResultContext = { [key: number | string | symbol]: unknown };
 
 /**
- * The base context fields that are common to all {@link SingleTransactionPlanResult} variants.
+ * The base context fields that {@link SuccessfulBaseTransactionPlanResultContext} builds upon.
  *
  * This type provides optional fields for the transaction message, signature, and
  * full transaction object. These fields may or may not be populated depending on
  * how far execution progressed before the result was produced.
  *
- * @deprecated This type will be removed in the next major version, together with the
- * intersections that graft it onto every {@link SingleTransactionPlanResult}. The context of a
- * result is becoming entirely caller-defined — it will be exactly the `TContext` you supply — so
- * there will be no separate base shape to merge in. If you refer to this type, declare whichever
- * of its fields you need on your own context type instead:
+ * @deprecated This type will be removed in the next major version. It is no longer part of any
+ * result type — the context of a result is entirely caller-defined, exactly the `TContext` you
+ * supply — so there is no separate base shape to merge in. If you refer to this type, declare
+ * whichever of its fields you need on your own context type instead:
  * ```ts
  * type MyContext = {
  *   message?: TransactionMessage & TransactionMessageWithFeePayer;
@@ -113,8 +112,8 @@ export type TransactionPlanResultContext = { [key: number | string | symbol]: un
  * };
  * ```
  *
- * @see {@link FailedSingleTransactionPlanResult}
- * @see {@link CanceledSingleTransactionPlanResult}
+ * @see {@link TransactionPlanResultContextWithSignature}
+ * @see {@link successfulSingleTransactionPlanResultFromTransaction}
  */
 export interface BaseTransactionPlanResultContext {
     message?: TransactionMessage & TransactionMessageWithFeePayer;
@@ -129,12 +128,42 @@ export interface BaseTransactionPlanResultContext {
  * successful transaction always produces one. The transaction message and full
  * transaction object remain optional.
  *
- * @see {@link SuccessfulSingleTransactionPlanResult}
+ * @deprecated use {@link TransactionPlanResultContextWithSignature} instead as the context type argument.
+ *
+ * @see {@link TransactionPlanResultContextWithSignature}
  * @see {@link BaseTransactionPlanResultContext}
  */
 export interface SuccessfulBaseTransactionPlanResultContext extends BaseTransactionPlanResultContext {
     signature: Signature;
 }
+
+/**
+ * A {@link TransactionPlanResultContext} that is guaranteed to include a {@link Signature}.
+ *
+ * This is the default context for every transaction plan result type, which is why a successful
+ * result exposes a required `context.signature` unless a different context is supplied.
+ *
+ * @example
+ * Intersect this type into a custom context to keep the signature guarantee alongside your own
+ * properties.
+ * ```ts
+ * const executor = createTransactionPlanExecutor<
+ *     TransactionPlanResultContextWithSignature & { startedAt: number }
+ * >({
+ *     executeTransactionMessage: async context => {
+ *         context.startedAt = Date.now();
+ *         // ...
+ *     },
+ * });
+ * ```
+ *
+ * @see {@link TransactionPlanResultContext}
+ */
+export type TransactionPlanResultContextWithSignature = TransactionPlanResultContext & {
+    message?: TransactionMessage & TransactionMessageWithFeePayer;
+    signature: Signature;
+    transaction?: Transaction;
+};
 
 /**
  * A result for a sequential transaction plan.
@@ -173,7 +202,7 @@ export interface SuccessfulBaseTransactionPlanResultContext extends BaseTransact
  * @see {@link nonDivisibleSequentialTransactionPlanResult}
  */
 export type SequentialTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -211,7 +240,7 @@ export type SequentialTransactionPlanResult<
  * @see {@link parallelTransactionPlanResult}
  */
 export type ParallelTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -269,7 +298,7 @@ export type ParallelTransactionPlanResult<
  * @see {@link canceledSingleTransactionPlanResult}
  */
 export type SingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 > =
@@ -281,10 +310,10 @@ export type SingleTransactionPlanResult<
  * A {@link SingleTransactionPlanResult} with a 'successful' status.
  *
  * This type represents a single transaction that was successfully executed.
- * It includes the original planned message and a context object containing
- * the fields from {@link SuccessfulBaseTransactionPlanResultContext} — namely
- * a required transaction {@link Signature}, and optionally the
- * {@link TransactionMessage} and the full {@link Transaction} object.
+ * It includes the original planned message and a context object. That context defaults to
+ * {@link TransactionPlanResultContextWithSignature} — a required transaction {@link Signature},
+ * and optionally the {@link TransactionMessage} and the full {@link Transaction} object — but a
+ * different `TContext` may drop the signature requirement entirely.
  *
  * You may use the {@link successfulSingleTransactionPlanResult} helper to
  * create objects of this type.
@@ -308,11 +337,11 @@ export type SingleTransactionPlanResult<
  * @see {@link assertIsSuccessfulSingleTransactionPlanResult}
  */
 export type SuccessfulSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 > = {
-    context: Readonly<SuccessfulBaseTransactionPlanResultContext & TContext>;
+    context: Readonly<TContext>;
     kind: 'single';
     planType: 'transactionPlanResult';
     plannedMessage: TTransactionMessage;
@@ -324,7 +353,7 @@ export type SuccessfulSingleTransactionPlanResult<
  *
  * This type represents a single transaction that failed during execution.
  * It includes the original planned message, the {@link Error} that caused
- * the failure, and a context object containing optional
+ * the failure, and a context object in which every field is optional — including
  * {@link TransactionMessage}, {@link Signature}, and {@link Transaction}
  * fields that may or may not be populated depending on how far execution
  * progressed before the failure.
@@ -351,11 +380,11 @@ export type SuccessfulSingleTransactionPlanResult<
  * @see {@link assertIsFailedSingleTransactionPlanResult}
  */
 export type FailedSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 > = {
-    context: Readonly<BaseTransactionPlanResultContext & TContext>;
+    context: Readonly<Partial<TContext>>;
     error: Error;
     kind: 'single';
     planType: 'transactionPlanResult';
@@ -368,7 +397,7 @@ export type FailedSingleTransactionPlanResult<
  *
  * This type represents a single transaction whose execution was canceled
  * before it could complete. It includes the original planned message and
- * a context object containing optional
+ * a context object in which every field is optional — including
  * {@link TransactionMessage}, {@link Signature}, and {@link Transaction}
  * fields that may or may not be populated depending on how far execution
  * progressed before cancellation.
@@ -391,11 +420,11 @@ export type FailedSingleTransactionPlanResult<
  * @see {@link assertIsCanceledSingleTransactionPlanResult}
  */
 export type CanceledSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 > = {
-    context: Readonly<BaseTransactionPlanResultContext & TContext>;
+    context: Readonly<Partial<TContext>>;
     kind: 'single';
     planType: 'transactionPlanResult';
     plannedMessage: TTransactionMessage;
@@ -424,7 +453,7 @@ export type CanceledSingleTransactionPlanResult<
  * @see {@link SequentialTransactionPlanResult}
  */
 export function sequentialTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
 >(plans: TransactionPlanResult<TContext>[]): SequentialTransactionPlanResult<TContext> & { divisible: true } {
     return Object.freeze({ divisible: true, kind: 'sequential', planType: 'transactionPlanResult', plans });
 }
@@ -451,7 +480,7 @@ export function sequentialTransactionPlanResult<
  * @see {@link SequentialTransactionPlanResult}
  */
 export function nonDivisibleSequentialTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
 >(plans: TransactionPlanResult<TContext>[]): SequentialTransactionPlanResult<TContext> & { divisible: false } {
     return Object.freeze({ divisible: false, kind: 'sequential', planType: 'transactionPlanResult', plans });
 }
@@ -477,7 +506,7 @@ export function nonDivisibleSequentialTransactionPlanResult<
  * @see {@link ParallelTransactionPlanResult}
  */
 export function parallelTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
 >(plans: TransactionPlanResult<TContext>[]): ParallelTransactionPlanResult<TContext> {
     return Object.freeze({ kind: 'parallel', planType: 'transactionPlanResult', plans });
 }
@@ -493,7 +522,10 @@ export function parallelTransactionPlanResult<
  * @typeParam TTransactionMessage - The type of the transaction message
  * @param plannedMessage - The original transaction message
  * @param transaction - The successfully executed transaction
- * @param context - Optional context object to be included with the result
+ * @param context - Optional context object to be included with the result. The result's context
+ * claims exactly what you pass, plus the `signature` and `transaction` derived from the
+ * `transaction` argument. Anything you do pass for those two keys is overwritten by the derived
+ * values
  *
  * @example
  * ```ts
@@ -519,14 +551,17 @@ export function parallelTransactionPlanResult<
  * @see {@link SingleTransactionPlanResult}
  */
 export function successfulSingleTransactionPlanResultFromTransaction<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
     plannedMessage: TTransactionMessage,
     transaction: Transaction,
-    context?: Omit<BaseTransactionPlanResultContext, 'signature' | 'transaction'> & TContext,
-): SuccessfulSingleTransactionPlanResult<TContext, TTransactionMessage> {
+    context?: TContext,
+): SuccessfulSingleTransactionPlanResult<
+    TContext & { signature: Signature; transaction: Transaction },
+    TTransactionMessage
+> {
     const signature = getSignatureFromTransaction(transaction);
     return Object.freeze({
         context: Object.freeze({ ...((context ?? {}) as TContext), signature, transaction }),
@@ -542,12 +577,15 @@ export function successfulSingleTransactionPlanResultFromTransaction<
  *
  * This function creates a single result with a 'successful' status, indicating that
  * the transaction was successfully executed. It also includes the original transaction
- * message and a context object that must contain at least a {@link Signature}.
+ * message and a context object, which becomes the result's `context` as-is, typed as
+ * `TContext`. Passing a context containing a `signature` — the common case — yields the
+ * default {@link TransactionPlanResultContextWithSignature} shape; supply a different
+ * context shape when the transaction has no fee payer signature to report.
  *
  * @typeParam TContext - The type of the context object
  * @typeParam TTransactionMessage - The type of the transaction message
  * @param plannedMessage - The original transaction message
- * @param context - Context object to be included with the result, must include a `signature` property
+ * @param context - The context object to be included with the result, as `TContext`
  *
  * @example
  * ```ts
@@ -561,12 +599,12 @@ export function successfulSingleTransactionPlanResultFromTransaction<
  * @see {@link SingleTransactionPlanResult}
  */
 export function successfulSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
     plannedMessage: TTransactionMessage,
-    context: SuccessfulBaseTransactionPlanResultContext & TContext,
+    context: TContext,
 ): SuccessfulSingleTransactionPlanResult<TContext, TTransactionMessage> {
     return Object.freeze({
         context: Object.freeze({ ...context }),
@@ -604,16 +642,16 @@ export function successfulSingleTransactionPlanResult<
  * @see {@link SingleTransactionPlanResult}
  */
 export function failedSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
     plannedMessage: TTransactionMessage,
     error: Error,
-    context?: TContext,
+    context?: Partial<TContext>,
 ): FailedSingleTransactionPlanResult<TContext, TTransactionMessage> {
     return Object.freeze({
-        context: Object.freeze({ ...((context ?? {}) as TContext) }),
+        context: Object.freeze({ ...((context ?? {}) as Partial<TContext>) }),
         error,
         kind: 'single',
         planType: 'transactionPlanResult',
@@ -641,15 +679,15 @@ export function failedSingleTransactionPlanResult<
  * @see {@link SingleTransactionPlanResult}
  */
 export function canceledSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
     plannedMessage: TTransactionMessage,
-    context?: TContext,
+    context?: Partial<TContext>,
 ): CanceledSingleTransactionPlanResult<TContext, TTransactionMessage> {
     return Object.freeze({
-        context: Object.freeze({ ...((context ?? {}) as TContext) }),
+        context: Object.freeze({ ...((context ?? {}) as Partial<TContext>) }),
         kind: 'single',
         planType: 'transactionPlanResult',
         plannedMessage,
@@ -711,7 +749,7 @@ export function isTransactionPlanResult(value: unknown): value is TransactionPla
  * @see {@link assertIsSingleTransactionPlanResult}
  */
 export function isSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -741,7 +779,7 @@ export function isSingleTransactionPlanResult<
  * @see {@link isSingleTransactionPlanResult}
  */
 export function assertIsSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -777,7 +815,7 @@ export function assertIsSingleTransactionPlanResult<
  * @see {@link assertIsSuccessfulSingleTransactionPlanResult}
  */
 export function isSuccessfulSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
@@ -805,7 +843,7 @@ export function isSuccessfulSingleTransactionPlanResult<
  * @see {@link isSuccessfulSingleTransactionPlanResult}
  */
 export function assertIsSuccessfulSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
@@ -839,7 +877,7 @@ export function assertIsSuccessfulSingleTransactionPlanResult<
  * @see {@link assertIsFailedSingleTransactionPlanResult}
  */
 export function isFailedSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
@@ -867,7 +905,7 @@ export function isFailedSingleTransactionPlanResult<
  * @see {@link isFailedSingleTransactionPlanResult}
  */
 export function assertIsFailedSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
@@ -901,7 +939,7 @@ export function assertIsFailedSingleTransactionPlanResult<
  * @see {@link assertIsCanceledSingleTransactionPlanResult}
  */
 export function isCanceledSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
@@ -929,7 +967,7 @@ export function isCanceledSingleTransactionPlanResult<
  * @see {@link isCanceledSingleTransactionPlanResult}
  */
 export function assertIsCanceledSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
@@ -963,7 +1001,7 @@ export function assertIsCanceledSingleTransactionPlanResult<
  * @see {@link assertIsSequentialTransactionPlanResult}
  */
 export function isSequentialTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -995,7 +1033,7 @@ export function isSequentialTransactionPlanResult<
  * @see {@link isSequentialTransactionPlanResult}
  */
 export function assertIsSequentialTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -1036,7 +1074,7 @@ export function assertIsSequentialTransactionPlanResult<
  * @see {@link assertIsNonDivisibleSequentialTransactionPlanResult}
  */
 export function isNonDivisibleSequentialTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -1071,7 +1109,7 @@ export function isNonDivisibleSequentialTransactionPlanResult<
  * @see {@link isNonDivisibleSequentialTransactionPlanResult}
  */
 export function assertIsNonDivisibleSequentialTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -1109,7 +1147,7 @@ export function assertIsNonDivisibleSequentialTransactionPlanResult<
  * @see {@link assertIsParallelTransactionPlanResult}
  */
 export function isParallelTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -1141,7 +1179,7 @@ export function isParallelTransactionPlanResult<
  * @see {@link isParallelTransactionPlanResult}
  */
 export function assertIsParallelTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -1193,7 +1231,7 @@ export function assertIsParallelTransactionPlanResult<
  * @see {@link isSuccessfulSingleTransactionPlanResult}
  */
 export function isSuccessfulTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
@@ -1239,7 +1277,7 @@ export function isSuccessfulTransactionPlanResult<
  * @see {@link assertIsSuccessfulSingleTransactionPlanResult}
  */
 export function assertIsSuccessfulTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
@@ -1287,7 +1325,7 @@ export function assertIsSuccessfulTransactionPlanResult<
  * @see {@link flattenTransactionPlanResult}
  */
 export function findTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -1346,7 +1384,7 @@ export function findTransactionPlanResult<
  * @see {@link findTransactionPlanResult}
  */
 export function getFirstFailedSingleTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(
@@ -1420,7 +1458,7 @@ export function getFirstFailedSingleTransactionPlanResult<
  * @see {@link flattenTransactionPlanResult}
  */
 export function everyTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -1524,7 +1562,7 @@ export function transformTransactionPlanResult(
  * @see {@link transformTransactionPlanResult}
  */
 export function flattenTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
     TSingle extends SingleTransactionPlanResult<TContext, TTransactionMessage> = SingleTransactionPlanResult<
@@ -1546,7 +1584,7 @@ export function flattenTransactionPlanResult<
  * - `canceledTransactions`: An array of canceled transactions.
  */
 export type TransactionPlanResultSummary<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 > = Readonly<{
@@ -1565,7 +1603,7 @@ export type TransactionPlanResultSummary<
  * @returns A summary of the transaction plan result
  */
 export function summarizeTransactionPlanResult<
-    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
     TTransactionMessage extends TransactionMessage & TransactionMessageWithFeePayer = TransactionMessage &
         TransactionMessageWithFeePayer,
 >(


### PR DESCRIPTION
This PR takes a new approach to enabling the `signTransaction` executor, by removing the guarantee that `TContext` on a `SuccessfulSingleTransactionPlanResult` extends `SuccessfulBaseTransactionPlanResultContext`, which enforces `signature: Signature`. The goal is to be able to define an executor that does not return a signature, nor a transaction from which one can be obtained.

We deprecate `SuccessfulBaseTransactionPlanResultContext`, but duplicate it as a new type `TransactionPlanResultContextWithSignature`.

The `TContext` on `SuccessfulSingleTransactionPlanResult` is now simply `TransactionPlanResultContext` (a dictionary with no particular keys), but defaults to `TransactionPlanResultContextWithSignature` for backward compatibility. That is, uses that do not define their own `TContext` type can continue to rely on `result.context.signature` being defined.

However, uses that do define a context type, eg. `{startedAt: number}`, will now need to fully define the context, eg. by intersecting their type `TransactionPlanResultContextWithSignature & { startedAt: number }`, or just including what they want, `{ signature: Signature, startedAt: number }`.

Alongside this, the types are made more sound:

The executor callback now receives `Partial<TContext>`, ie the context starts empty and it's up to the callback to populate it. Previously an executor trying to read properties of its context that it hasn't written would typecheck.

Failed and Canceled results now type their context as `Readonly<Partial<TContext>>`. The executor can throw or be cancelled at any time, and there are no guarantees which parts of context will have been written. Previously reading context fields from a failed/canceled result would typecheck.

Additionally, a bunch of helpers over `TransactionPlanResult`, eg. `passthroughFailedTransactionPlanExecution`, gain a `TContext` parameter. Previously they didn't have this generic and so implicitly required the with-signature context. 

This PR **does not** include runtime changes to enable an executor to return a transaction with no signature, that is planned for a following PR. This focuses on the types. We still auto-populate `context.signature` on the success path in this PR.

This PR:

- Supersedes https://github.com/anza-xyz/kit/pull/1893

The follow-up PR would:

- Supersede #1894 and #1906
- Become the new parent of #1899 and #1902 

Updated: This PR no longer updates docs, this is moved to #1912 - we'll update docs properly using the new types after publishing. 