### PR TITLE
Fix getBitArrayEncoder returning the wrong next offset

### DIFF
--- a/.changeset/fix-bit-array-encoder-offset.md
+++ b/.changeset/fix-bit-array-encoder-offset.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-data-structures': patch
+---
+
+Fix `getBitArrayEncoder` returning the wrong next offset. Its `write` returned `size` instead of `offset + size`, so a bit array placed before another field in a struct or tuple was overwritten by the following field. It now returns `offset + size`, matching the decoder and the other codecs.

--- a/packages/codecs-data-structures/src/__tests__/bit-array-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/bit-array-test.ts
@@ -70,6 +70,16 @@ describe('getBitArrayCodec', () => {
         );
     });
 
+    it('writes at a non-zero offset and returns the next offset', () => {
+        const a = (bits: string) => [...bits].map(bit => bit === '1');
+        // Writing at a non-zero offset must place the bytes at `offset` and
+        // return `offset + size`, so a following field is written after it
+        // rather than overwriting the bit array.
+        const bytes = new Uint8Array(2);
+        expect(bitArray(1).write(a('10100000'), bytes, 1)).toBe(2);
+        expect(bytes).toStrictEqual(b('00a0'));
+    });
+
     it('has the right sizes', () => {
         expect(bitArray(42).fixedSize).toBe(42);
     });

--- a/packages/codecs-data-structures/src/bit-array.ts
+++ b/packages/codecs-data-structures/src/bit-array.ts
@@ -83,7 +83,7 @@ export function getBitArrayEncoder<TSize extends number>(
             }
 
             bytes.set(bytesToAdd, offset);
-            return size;
+            return offset + size;
         },
     });
 }


### PR DESCRIPTION
#### Problem

`getBitArrayEncoder`'s `write` returns `size` instead of `offset + size`. Every other codec's `write` returns `offset` plus the number of bytes written, and the bit-array decoder itself returns `offset + size`, so the encoder is the only outlier.

Because `getStructEncoder`/`getTupleEncoder` chain fields with `offset = codec.write(value, bytes, offset)`, a bit array that is not the last field makes the next field write at `size` instead of `offset + size`, overwriting the bit array.

Example: a struct `[['a', u8], ['b', bitArray(1)], ['c', u8]]` with `{ a: 0x11, b: 0xa0, c: 0x22 }` encodes to `0x112200` instead of `0x11a022`.

The existing bit-array tests only call `.encode()` at offset 0, where `size === offset + size`, so this is invisible in isolation and only shows up under composition.

#### Summary of Changes

`write` now returns `offset + size`, matching the decoder and the other codecs. Added a test that writes a bit array at a non-zero offset, plus a changeset.
