### PR TITLE
Let transaction plan executors return a result context

### DIFF
--- a/.changeset/short-squids-repair.md
+++ b/.changeset/short-squids-repair.md
@@ -1,0 +1,30 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Let the `createTransactionPlanExecutor` callback return the context of a successful result
+
+The `executeTransactionMessage` callback may now return the context that a successful result should carry, instead of a `Signature` or a `Transaction`. When it does, that context is used as-is: nothing is derived from it, and in particular `getSignatureFromTransaction` is never called on your behalf.
+
+```diff
+const transactionPlanExecutor = createTransactionPlanExecutor({
+  executeTransactionMessage: async (context, message) => {
+    const transaction = await signTransactionMessageWithSigners(message);
+    context.transaction = transaction;
++   const signature = getSignatureFromTransaction(transaction);
+    await sendAndConfirmTransaction(transaction, { commitment: 'confirmed' });
+-   return transaction;
++   return { signature, transaction };
+  },
+});
+```
+
+Since a successful result always carries a signature, a returned context must include one — a callback that declares a custom context and forgets a property of it now fails to compile, rather than producing a result whose context is typed but `undefined` at runtime. That signature is also how the executor tells a returned context apart from a returned `Transaction`, which keeps its signatures in a `signatures` map and therefore never has one.
+
+The mutable `context` argument is unchanged and still serves the failure path: whatever the callback stores on it before it throws is preserved in the resulting `FailedSingleTransactionPlanResult`. On success the two are merged, with the returned context taking precedence, so a property stored but not returned is still reported.
+
+**Returning a `Signature` or a `Transaction` is deprecated.** Both still behave exactly as before — a returned signature is stored as `context.signature`, and a returned transaction is stored as `context.transaction` with its signature derived from it — and IDEs now flag those call sites, because `createTransactionPlanExecutor` gained a deprecated overload that only matches callbacks returning those types. Note that a config declared as `TransactionPlanExecutorConfig` up front is not flagged, since that type permits either return style.
+
+Prefer returning a context, since deriving a signature from a transaction throws `SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING` when the fee payer slot is empty. An executor that deliberately produces partially signed transactions — signed by an authority, to be paid for and submitted by a relayer later — can now succeed by returning its own signature alongside the transaction. Dropping the signature from a successful result's context altogether remains impossible, since `SuccessfulSingleTransactionPlanResult` guarantees one.
+
+Failure handling is unchanged, including the signature still derived from a `transaction` left on the context when the callback throws. Since the callback never returned anything in that case, there is nothing to bypass that derivation, so a callback working with fee-payer-unsigned transactions should avoid storing them on the context — otherwise deriving a signature from one replaces the error it meant to report.

--- a/examples/token-airdrop/src/example.ts
+++ b/examples/token-airdrop/src/example.ts
@@ -207,7 +207,9 @@ const transactionExecutor = createTransactionPlanExecutor({
             { signature },
             `[transaction executor] Transaction confirmed: https://explorer.solana.com/tx/${signature}?cluster=custom&customUrl=127.0.0.1:8899`,
         );
-        return signedTransaction;
+
+        // Return the context that the successful result should carry.
+        return { message: updatedMessage, signature, transaction: signedTransaction };
     },
 });
 

--- a/packages/instruction-plans/src/__tests__/__setup__.ts
+++ b/packages/instruction-plans/src/__tests__/__setup__.ts
@@ -66,6 +66,18 @@ export function createTransaction<TId extends string>(id: TId): Transaction & { 
     return Object.freeze({ id, signatures }) as unknown as Transaction & { id: TId };
 }
 
+/**
+ * Creates a transaction signed by someone other than its fee payer. Since the fee payer's signature
+ * slot — the first one in the signatures map — is empty, no signature can be derived from it.
+ */
+export function createPartiallySignedTransaction<TId extends string>(id: TId): Transaction & { id: TId } {
+    const signatures: SignaturesMap = {
+        ['' as Address]: null /* The fee payer has not signed this transaction yet. */,
+        ['someOtherSigner' as Address]: signatureEncoder.encode(id) as SignatureBytes,
+    };
+    return Object.freeze({ id, signatures }) as unknown as Transaction & { id: TId };
+}
+
 const signatureEncoder = getBase58Encoder();
 
 export function instructionFactory(baseSeed?: string) {

--- a/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
@@ -25,7 +25,7 @@ import {
     successfulSingleTransactionPlanResultFromTransaction,
     TransactionPlanResult,
 } from '../index';
-import { createMessage, createTransaction, FOREVER_PROMISE } from './__setup__';
+import { createMessage, createPartiallySignedTransaction, createTransaction, FOREVER_PROMISE } from './__setup__';
 
 jest.useFakeTimers();
 
@@ -167,6 +167,107 @@ describe('createTransactionPlanExecutor', () => {
                 successfulSingleTransactionPlanResult(messageA, {
                     signature: 'A' as Signature,
                     transaction: transactionA,
+                }),
+            );
+        });
+
+        it('uses the context returned by the callback for the successful context', async () => {
+            expect.assertions(1);
+            const messageA = createMessage('A');
+            const transactionA = createTransaction('A');
+            const executor = createTransactionPlanExecutor({
+                executeTransactionMessage: () =>
+                    // Note that the signature of `transactionA` is `A`; it is not derived here.
+                    Promise.resolve({ signature: 'RETURNED_SIGNATURE' as Signature, transaction: transactionA }),
+            });
+
+            const promise = executor(singleTransactionPlan(messageA));
+            await expect(promise).resolves.toStrictEqual(
+                successfulSingleTransactionPlanResult(messageA, {
+                    signature: 'RETURNED_SIGNATURE' as Signature,
+                    transaction: transactionA,
+                }),
+            );
+        });
+
+        it('keeps context properties that the callback stored but did not return', async () => {
+            expect.assertions(1);
+            const messageA = createMessage('A');
+            const messageB = createMessage('B');
+            const executor = createTransactionPlanExecutor({
+                executeTransactionMessage: context => {
+                    context.message = messageB;
+                    return Promise.resolve({ signature: 'A' as Signature });
+                },
+            });
+
+            const promise = executor(singleTransactionPlan(messageA));
+            await expect(promise).resolves.toStrictEqual(
+                successfulSingleTransactionPlanResult(messageA, {
+                    message: messageB,
+                    signature: 'A' as Signature,
+                }),
+            );
+        });
+
+        it('prefers the returned context over the context stored by the callback', async () => {
+            expect.assertions(1);
+            const messageA = createMessage('A');
+            const transactionA = createTransaction('A');
+            const executor = createTransactionPlanExecutor({
+                executeTransactionMessage: context => {
+                    context.signature = 'STALE_SIGNATURE' as Signature;
+                    context.transaction = createTransaction('B');
+                    return Promise.resolve({
+                        signature: 'RETURNED_SIGNATURE' as Signature,
+                        transaction: transactionA,
+                    });
+                },
+            });
+
+            const promise = executor(singleTransactionPlan(messageA));
+            await expect(promise).resolves.toStrictEqual(
+                successfulSingleTransactionPlanResult(messageA, {
+                    signature: 'RETURNED_SIGNATURE' as Signature,
+                    transaction: transactionA,
+                }),
+            );
+        });
+
+        it('succeeds when the transaction in the returned context has no fee payer signature', async () => {
+            expect.assertions(1);
+            const messageA = createMessage('A');
+            const partiallySignedTransactionA = createPartiallySignedTransaction('A');
+            const executor = createTransactionPlanExecutor({
+                executeTransactionMessage: () =>
+                    Promise.resolve({
+                        signature: 'RELAYER_SIGNATURE' as Signature,
+                        transaction: partiallySignedTransactionA,
+                    }),
+            });
+
+            const promise = executor(singleTransactionPlan(messageA));
+            await expect(promise).resolves.toStrictEqual(
+                successfulSingleTransactionPlanResult(messageA, {
+                    signature: 'RELAYER_SIGNATURE' as Signature,
+                    transaction: partiallySignedTransactionA,
+                }),
+            );
+        });
+
+        it('stores custom properties from the returned context', async () => {
+            expect.assertions(1);
+            const messageA = createMessage('A');
+            const executor = createTransactionPlanExecutor<{ custom: string }>({
+                executeTransactionMessage: () =>
+                    Promise.resolve({ custom: 'custom value', signature: 'A' as Signature }),
+            });
+
+            const promise = executor(singleTransactionPlan(messageA));
+            await expect(promise).resolves.toStrictEqual(
+                successfulSingleTransactionPlanResult(messageA, {
+                    custom: 'custom value',
+                    signature: 'A' as Signature,
                 }),
             );
         });

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
@@ -43,13 +43,32 @@ import {
 
 // [DESCRIBE] createTransactionPlanExecutor
 {
-    // It can return a signature or a full transaction.
+    // It can still return a signature or a full transaction, using the deprecated overload.
     {
         createTransactionPlanExecutor({
             executeTransactionMessage: () => Promise.resolve({} as Signature),
         });
         createTransactionPlanExecutor({
             executeTransactionMessage: () => Promise.resolve({} as Transaction),
+        });
+    }
+
+    // It can return the context that a successful result should carry.
+    {
+        createTransactionPlanExecutor({
+            executeTransactionMessage: () => Promise.resolve({ signature: {} as Signature }),
+        });
+        createTransactionPlanExecutor({
+            executeTransactionMessage: () =>
+                Promise.resolve({ signature: {} as Signature, transaction: {} as Transaction }),
+        });
+    }
+
+    // It requires a returned context to carry the signature a successful result guarantees.
+    {
+        createTransactionPlanExecutor({
+            // @ts-expect-error A context without a signature is neither a valid context nor a `Transaction`.
+            executeTransactionMessage: () => Promise.resolve({ sent: true, transaction: {} as Transaction }),
         });
     }
 
@@ -112,6 +131,22 @@ import {
             },
         });
         executor satisfies TransactionPlanExecutor<{ custom: string }>;
+    }
+
+    // It can return a custom context.
+    {
+        const executor = createTransactionPlanExecutor<{ custom: string }>({
+            executeTransactionMessage: () => Promise.resolve({ custom: 'custom value', signature: {} as Signature }),
+        });
+        executor satisfies TransactionPlanExecutor<{ custom: string }>;
+    }
+
+    // It requires a returned context to carry the custom context.
+    {
+        createTransactionPlanExecutor<{ custom: string }>({
+            // @ts-expect-error The returned context is missing the `custom` property.
+            executeTransactionMessage: () => Promise.resolve({ signature: {} as Signature }),
+        });
     }
 
     // It transfers the lifetime to the compiled transaction.

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -24,6 +24,7 @@ import {
     parallelTransactionPlanResult,
     sequentialTransactionPlanResult,
     SingleTransactionPlanResult,
+    type SuccessfulBaseTransactionPlanResultContext,
     successfulSingleTransactionPlanResult,
     successfulSingleTransactionPlanResultFromTransaction,
     type TransactionPlanResult,
@@ -50,11 +51,17 @@ export type TransactionPlanExecutor<TContext extends TransactionPlanResultContex
     config?: { abortSignal?: AbortSignal },
 ) => Promise<TransactionPlanResult<TContext>>;
 
-type ExecuteTransactionMessage<TContext extends TransactionPlanResultContext> = (
+type SuccessfulTransactionPlanResultContext<TContext extends TransactionPlanResultContext> =
+    SuccessfulBaseTransactionPlanResultContext & TContext;
+
+type ExecuteTransactionMessage<
+    TContext extends TransactionPlanResultContext,
+    TReturn = Signature | SuccessfulTransactionPlanResultContext<TContext> | Transaction,
+> = (
     context: BaseTransactionPlanResultContext & TContext,
     transactionMessage: TransactionMessage & TransactionMessageWithFeePayer,
     config?: { abortSignal?: AbortSignal },
-) => Promise<Signature | Transaction>;
+) => Promise<TReturn>;
 
 /**
  * Configuration object for creating a new transaction plan executor.
@@ -64,10 +71,44 @@ type ExecuteTransactionMessage<TContext extends TransactionPlanResultContext> = 
 export type TransactionPlanExecutorConfig<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
 > = {
-    /** Called whenever a transaction message must be sent to the blockchain. */
+    /**
+     * Called whenever a transaction message must be sent to the blockchain.
+     *
+     * It should return the context that the successful result must carry — which, since a
+     * successful result always has a signature, must include one. Returning a {@link Signature} or
+     * a {@link Transaction} instead is deprecated.
+     */
     executeTransactionMessage: ExecuteTransactionMessage<TContext>;
 };
 
+/**
+ * Creates a new transaction plan executor based on the provided configuration.
+ *
+ * @param config - Configuration object containing the transaction message executor function.
+ * @return A {@link TransactionPlanExecutor} function that can execute transaction plans.
+ *
+ * @deprecated Returning a `Signature` or a `Transaction` from `executeTransactionMessage` is
+ * deprecated. Return the context that the successful result must carry instead — at minimum
+ * `{ signature }`, or `{ signature, transaction }` to keep reporting the transaction:
+ * ```diff
+ *   executeTransactionMessage: async (context, message) => {
+ *       const transaction = await signTransactionMessageWithSigners(message);
+ * +     const signature = getSignatureFromTransaction(transaction);
+ *       await sendAndConfirmTransaction(transaction, { commitment: 'confirmed' });
+ * -     return transaction;
+ * +     return { signature, transaction };
+ *   }
+ * ```
+ * Unlike this deprecated path, returning a context never derives a signature from a transaction, so
+ * it also works for transactions their fee payer has not signed.
+ *
+ * @see {@link TransactionPlanExecutorConfig}
+ */
+export function createTransactionPlanExecutor<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+>(config: {
+    executeTransactionMessage: ExecuteTransactionMessage<TContext, Signature | Transaction>;
+}): TransactionPlanExecutor<TContext>;
 /**
  * Creates a new transaction plan executor based on the provided configuration.
  *
@@ -81,14 +122,48 @@ export type TransactionPlanExecutorConfig<
  * in the resulting {@link SingleTransactionPlanResult} regardless of the outcome. This
  * means that if an error is thrown at any point in the callback, any attributes already
  * saved to the context will still be available in the plan result, which can be useful
- * for debugging failures or building recovery plans. The callback must return either a
- * {@link Signature} or a full {@link Transaction} object.
+ * for debugging failures or building recovery plans.
+ *
+ * The callback should return the context that a successful result must carry. Since a successful
+ * result always has a signature, that context must include one — the executor derives nothing on
+ * the callback's behalf. On success the returned context is merged over the one the callback
+ * mutated, with the returned value taking precedence, so a property stored on the context but left
+ * out of the return value is still reported.
+ *
+ * ```ts
+ * executeTransactionMessage: async (context, message) => {
+ *     const transaction = await signTransactionMessageWithSigners(message);
+ *     context.transaction = transaction; // Recorded now, in case the next step throws.
+ *     const signature = getSignatureFromTransaction(transaction);
+ *     await sendAndConfirmTransaction(transaction, { commitment: 'confirmed' });
+ *     return { signature, transaction };
+ * }
+ * ```
+ *
+ * Note that the callback cannot simply return the context it was given, since every property on it
+ * is optional. Build the return value from the values you have instead. Custom context properties
+ * are typed by supplying `TContext` explicitly:
+ *
+ * ```ts
+ * createTransactionPlanExecutor<{ startedAt: number }>(config);
+ * ```
+ *
+ * Returning a {@link Signature} or a full {@link Transaction} object instead of a context is
+ * deprecated. Those return values are still honoured — a returned signature is stored as
+ * `context.signature`, and a returned transaction is stored as `context.transaction` with its
+ * signature derived from it — but deriving that signature throws
+ * `SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING` when
+ * the fee payer has not signed, which returning a context avoids.
  *
  * - If that function is successful, the executor will return a successful `TransactionPlanResult`
- * for that message. The returned signature or transaction is stored in the context automatically.
+ * for that message, carrying the context described above.
  * - If that function throws an error, the executor will stop processing and cancel all
  * remaining transaction messages in the plan. The context accumulated up to the point of
- * failure is preserved in the resulting {@link FailedSingleTransactionPlanResult}.
+ * failure is preserved in the resulting {@link FailedSingleTransactionPlanResult}, with a
+ * `signature` derived from any `transaction` left on it. That derivation is unaffected by what the
+ * callback returns — it never got the chance to return anything — so a callback that works with
+ * transactions their fee payer has not signed should avoid storing them on the context, lest
+ * deriving a signature from one replace the error it meant to report.
  * - If the `abortSignal` is triggered, the executor will immediately stop processing the plan and
  * return a `TransactionPlanResult` with the status set to `canceled`.
  *
@@ -110,14 +185,18 @@ export type TransactionPlanExecutorConfig<
  *   executeTransactionMessage: async (context, message) => {
  *     const transaction = await signTransactionMessageWithSigners(message);
  *     context.transaction = transaction;
+ *     const signature = getSignatureFromTransaction(transaction);
  *     await sendAndConfirmTransaction(transaction, { commitment: 'confirmed' });
- *     return transaction;
+ *     return { signature, transaction };
  *   }
  * });
  * ```
  *
  * @see {@link TransactionPlanExecutorConfig}
  */
+export function createTransactionPlanExecutor<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
+>(config: TransactionPlanExecutorConfig<TContext>): TransactionPlanExecutor<TContext>;
 export function createTransactionPlanExecutor<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
 >(config: TransactionPlanExecutorConfig<TContext>): TransactionPlanExecutor<TContext> {
@@ -213,9 +292,17 @@ async function traverseSingle<TContext extends TransactionPlanResultContext>(
             }),
             traverseConfig.abortSignal,
         );
-        return typeof result === 'string'
-            ? successfulSingleTransactionPlanResult(transactionPlan.message, { ...context, signature: result })
-            : successfulSingleTransactionPlanResultFromTransaction(transactionPlan.message, result, context);
+        if (typeof result === 'string') {
+            return successfulSingleTransactionPlanResult(transactionPlan.message, { ...context, signature: result });
+        }
+        if (isSuccessfulContext(result)) {
+            // The callback told us what context the result should carry, so we take it as-is and
+            // derive nothing from it. Anything it stored on the mutable context but left out of its
+            // return value is kept, since dropping it would lose data the callback deliberately
+            // recorded.
+            return successfulSingleTransactionPlanResult(transactionPlan.message, { ...context, ...result });
+        }
+        return successfulSingleTransactionPlanResultFromTransaction(transactionPlan.message, result, context);
     } catch (error) {
         traverseConfig.canceled = true;
         const contextWithSignature =
@@ -224,6 +311,19 @@ async function traverseSingle<TContext extends TransactionPlanResultContext>(
                 : context;
         return failedSingleTransactionPlanResult(transactionPlan.message, error as Error, contextWithSignature);
     }
+}
+
+/**
+ * Tells apart the two things the `executeTransactionMessage` callback may return once a
+ * {@link Signature} has been ruled out: the context a successful result should carry, or the
+ * deprecated {@link Transaction}. Every returned context has a `signature` — that is what a
+ * successful result guarantees — and a `Transaction` never does, since it keeps its signatures in a
+ * `signatures` map, so that property is a reliable discriminator.
+ */
+function isSuccessfulContext<TContext extends TransactionPlanResultContext>(
+    returnValue: SuccessfulTransactionPlanResultContext<TContext> | Transaction,
+): returnValue is SuccessfulTransactionPlanResultContext<TContext> {
+    return 'signature' in returnValue;
 }
 
 function assertDivisibleSequentialPlansOnly(transactionPlan: TransactionPlan): void {


### PR DESCRIPTION
This PR enables migration for #1913 

In that PR, requiring a major changeset, we will require transaction plan executors to return their `TContext` (which at that point is much more flexible than the current one), instead of returning a `Transaction` or a `Signature`.

To enable that migration, this PR allows executors to return a `TContext`, and returns it if they do so.

As of this PR, executors may still return a `Transaction` or a `Signature`, but will get a deprecation warning. The behaviour if they do so is unchanged, ie we derive a signature from the transaction.

Executors that migrate to returning `TContext` should not have any breaking changes from #1913 

If this is approved, I'll stack #1910  and #1913 on it, this will slightly simplify #1913 as there's some duplication.