### PR TITLE
Add a note in CLAUDE.md about docs using published packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,12 @@ RPC method response types live in `packages/rpc-api/src/<methodName>.ts`; types 
 - **Bundle size**: Monitored via BundleMon on every PR.
 - **Publishing**: On merge to `main`, changesets action creates a "Version Packages" PR or publishes to npm. Canary snapshots are published on every push to `main`.
 
+## Docs
+
+- The docs are built against the **published** version of `@solana/kit`.
+- They cannot use new types that are not yet in a published version. Doing so will fail in CI.
+- This means that some docs updates need to be delayed until after a version is published and cannot be part of a PR.
+
 <!-- skills-inject:start -->
 
 ## Skill Instructions


### PR DESCRIPTION
I've noticed that Claude is quite eager to update docs which is good, but doesn't recognise that they won't compile when they reference new types that aren't yet published.

This PR adds some notes on this to CLAUDE.md so that it'll hopefully keep updating docs when appropriate, but not try to add docs using new unreleased types.