### PR TITLE
fix: stop upcasting transaction `version` to `bigint`

### DIFF
--- a/.changeset/small-birds-cheer.md
+++ b/.changeset/small-birds-cheer.md
@@ -1,0 +1,9 @@
+---
+'@solana/rpc-api': patch
+---
+
+Stop upcasting transaction `version` to `bigint`
+
+The response transformer upcasts every JSON integer to a `bigint` unless its keypath appears in an allow-list. `version` was missing from that allow-list on `getTransaction`, `getBlock` transactions, and `getTransactionsForAddress`, so it arrived at runtime as `0n` while still typechecking as `TransactionVersion` (`'legacy' | 0 | 1`).
+
+A check like `if (transaction.version === 0)` therefore compiled cleanly and was always false, with no compiler error and no runtime error. The keypath is now allow-listed and `version` arrives as a number, matching its declared type.

--- a/packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts
+++ b/packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts
@@ -1,0 +1,65 @@
+import type { Address } from '@solana/addresses';
+import type { Signature } from '@solana/keys';
+import { createRpc, type Rpc } from '@solana/rpc-spec';
+
+import { createSolanaRpcApi, GetBlockApi, GetTransactionApi, GetTransactionsForAddressApi } from '../index';
+
+const MOCK_SIGNATURE =
+    '4nHvMbxHURt2AXd7yQpKSKM5XCVKQiNbfsFmvPtHNJnJPSJHFT6cGUUNQGYK3wcxDCTvBMTLpQFf6HGqhLTUsxwj' as Signature;
+
+function createMockRpc<TApi>(result: unknown): Rpc<TApi> {
+    return createRpc({
+        api: createSolanaRpcApi<never>(),
+        transport: jest.fn().mockResolvedValue({ result }),
+    });
+}
+
+describe('the default response transformer for the Solana RPC', () => {
+    describe('getTransaction', () => {
+        it('leaves `version` as a number', async () => {
+            expect.assertions(1);
+            const rpc = createMockRpc<GetTransactionApi>({ meta: null, slot: 1, version: 0 });
+            const result = await rpc
+                .getTransaction(MOCK_SIGNATURE, { encoding: 'json', maxSupportedTransactionVersion: 0 })
+                .send();
+            expect(result?.version).toBe(0);
+        });
+        it('leaves the string `version` of a legacy transaction alone', async () => {
+            expect.assertions(1);
+            const rpc = createMockRpc<GetTransactionApi>({ meta: null, slot: 1, version: 'legacy' });
+            const result = await rpc
+                .getTransaction(MOCK_SIGNATURE, { encoding: 'json', maxSupportedTransactionVersion: 0 })
+                .send();
+            expect(result?.version).toBe('legacy');
+        });
+    });
+
+    describe('getBlock', () => {
+        it('leaves the `version` of each transaction as a number', async () => {
+            expect.assertions(1);
+            const rpc = createMockRpc<GetBlockApi>({
+                blockhash: '4nHvMbxHURt2AXd7yQpKSKM5XCVKQiNbfsFmvPtHNJnJ',
+                transactions: [{ meta: null, version: 0 }],
+            });
+            const result = await rpc.getBlock(1n, { encoding: 'json', maxSupportedTransactionVersion: 0 }).send();
+            expect(result?.transactions[0].version).toBe(0);
+        });
+    });
+
+    describe('getTransactionsForAddress', () => {
+        it('leaves the `version` of each transaction as a number', async () => {
+            expect.assertions(1);
+            const rpc = createMockRpc<GetTransactionsForAddressApi>({
+                data: [{ meta: null, version: 0 }],
+            });
+            const result = await rpc
+                .getTransactionsForAddress('11111111111111111111111111111111' as Address, {
+                    encoding: 'json',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                })
+                .send();
+            expect(result.data[0].version).toBe(0);
+        });
+    });
+});

--- a/packages/rpc-api/src/index.ts
+++ b/packages/rpc-api/src/index.ts
@@ -300,6 +300,7 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
                     ...c,
                 ]),
                 ...messageConfig.map(c => ['transactions', KEYPATH_WILDCARD, 'transaction', 'message', ...c] as const),
+                ['transactions', KEYPATH_WILDCARD, 'version'],
                 ['rewards', KEYPATH_WILDCARD, 'commission'],
             ],
             getClusterNodes: [
@@ -348,6 +349,7 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
                 ['meta', 'rewards', KEYPATH_WILDCARD, 'commission'],
                 ...innerInstructionsConfigs.map(c => ['meta', 'innerInstructions', KEYPATH_WILDCARD, ...c]),
                 ...messageConfig.map(c => ['transaction', 'message', ...c] as const),
+                ['version'],
             ],
             getTransactionsForAddress: [
                 ['data', KEYPATH_WILDCARD, 'transactionIndex'],
@@ -365,6 +367,7 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
                     ...c,
                 ]),
                 ...messageConfig.map(c => ['data', KEYPATH_WILDCARD, 'transaction', 'message', ...c] as const),
+                ['data', KEYPATH_WILDCARD, 'version'],
             ],
             getVersion: [['feature-set']],
             getVoteAccounts: [


### PR DESCRIPTION
Kit's RPC response transformer upcasts every JSON integer to a `bigint` unless the field's keypath appears in a per-method allow-list (`getAllowedNumericKeypaths()` in `packages/rpc-api/src/index.ts`). `version` was missing from that list on `getTransaction`, `getBlock` transactions, and `getTransactionsForAddress`, so it arrives at runtime as `0n` while still typechecking as `TransactionVersion` (`'legacy' | 0 | 1`).

The result is a silent mismatch between the declared type and the runtime value:

```ts
if (transaction.version === 0) {
    // never runs: the value is `0n`, and `0n === 0` is false
}
```

There is no compiler error and no runtime error; the branch simply never runs. This was found in Explorer, where it silently disabled an entire feature.

## Changes

Allow-list `version` on all three methods. Three added keypaths.

## Testing

New unit tests in `packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts` push canned responses through `createSolanaRpcApi()` and assert `version` arrives as a number. Three of the four fail against the unpatched allow-list; the fourth covers the `'legacy'` string case, which was never affected and guards against over-correcting.

## Follow-ups, deliberately not in this PR

**Token balance numerics.** The same audit found that `uiTokenAmount.uiAmount` is missing from the allow-list on these same three methods, and that `simulateTransaction` has no token balance keypaths allow-listed at all. `uiAmount` is an `f64`, and the transformer's guard is `Number.isInteger`, so a whole-number balance was upcast while a fractional one was not. That fix is ready and will follow immediately after this merges. It is kept separate because it adds a new public export to `@solana/rpc-transformers` and so carries a `minor` bump, whereas this change is a pure `patch`.

**`@solana/rpc-subscriptions-api`.** Same class of bug, different root cause. Its allow-list is keyed by notification method name (`blockNotifications`), but the response transformer is invoked with the subscribe request, whose `methodName` is `blockSubscribe` (`rpc-subscriptions-pubsub-plan.ts:96`). The lookup never matches, so the entire subscriptions allow-list is dead code and every field it names is upcast. There is a second defect underneath: the publisher is memoized per `(channel, responseTransformer)` and its closure captures the first `subscribeRequest`, so the transform is resolved per channel where it needs to be per subscription. Fixing it flips affected fields from `bigint` to `number` at runtime, which is breaking for anyone who adapted, so it needs its own change and its own bump. Adding correct keypaths to a list that is never consulted would ship an inert change that reads as fixed.
