### PR TITLE
fix: stop upcasting token balance `uiAmount` and related numerics to `bigint`

### DIFF
--- a/.changeset/lovely-baths-add.md
+++ b/.changeset/lovely-baths-add.md
@@ -1,0 +1,13 @@
+---
+'@solana/rpc-transformers': minor
+'@solana/rpc-api': patch
+---
+
+Stop upcasting token balance `uiAmount` and related numerics to `bigint`
+
+The response transformer upcasts every JSON integer to a `bigint` unless its keypath appears in an allow-list. Because the upcast only applies to integers, `uiTokenAmount.uiAmount` — an `f64` on the server — arrived as a `bigint` when the balance happened to be a whole number and as a `number` when it was fractional, so its declared type was correct for some values and wrong for others.
+
+- `uiTokenAmount.uiAmount` is now allow-listed on `getTransaction`, `getBlock`, and `getTransactionsForAddress` token balances.
+- `simulateTransaction` had no token balance keypaths allow-listed at all, so `accountIndex` and `uiTokenAmount.decimals` were upcast there as well. All three are now allow-listed.
+
+`@solana/rpc-transformers` additionally exports a new `tokenBalancesConfigs` array of token-balance-relative keypaths, alongside the existing `innerInstructionsConfigs` and `messageConfig`.

--- a/packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts
+++ b/packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts
@@ -2,10 +2,27 @@ import type { Address } from '@solana/addresses';
 import type { Signature } from '@solana/keys';
 import { createRpc, type Rpc } from '@solana/rpc-spec';
 
-import { createSolanaRpcApi, GetBlockApi, GetTransactionApi, GetTransactionsForAddressApi } from '../index';
+import {
+    createSolanaRpcApi,
+    GetBlockApi,
+    GetTransactionApi,
+    GetTransactionsForAddressApi,
+    SimulateTransactionApi,
+} from '../index';
 
 const MOCK_SIGNATURE =
     '4nHvMbxHURt2AXd7yQpKSKM5XCVKQiNbfsFmvPtHNJnJPSJHFT6cGUUNQGYK3wcxDCTvBMTLpQFf6HGqhLTUsxwj' as Signature;
+
+const MOCK_TOKEN_BALANCE = {
+    accountIndex: 1,
+    mint: 'So11111111111111111111111111111111111111112',
+    uiTokenAmount: {
+        amount: '1000000000',
+        decimals: 9,
+        uiAmount: 1,
+        uiAmountString: '1',
+    },
+};
 
 function createMockRpc<TApi>(result: unknown): Rpc<TApi> {
     return createRpc({
@@ -32,6 +49,18 @@ describe('the default response transformer for the Solana RPC', () => {
                 .send();
             expect(result?.version).toBe('legacy');
         });
+        it('leaves token balance `decimals` and `uiAmount` as numbers', async () => {
+            expect.assertions(2);
+            const rpc = createMockRpc<GetTransactionApi>({
+                meta: { postTokenBalances: [MOCK_TOKEN_BALANCE], preTokenBalances: [MOCK_TOKEN_BALANCE] },
+                slot: 1,
+            });
+            const result = await rpc
+                .getTransaction(MOCK_SIGNATURE, { encoding: 'json', maxSupportedTransactionVersion: 0 })
+                .send();
+            expect(result?.meta?.preTokenBalances?.[0].uiTokenAmount).toMatchObject({ decimals: 9, uiAmount: 1 });
+            expect(result?.meta?.postTokenBalances?.[0].uiTokenAmount).toMatchObject({ decimals: 9, uiAmount: 1 });
+        });
     });
 
     describe('getBlock', () => {
@@ -43,6 +72,18 @@ describe('the default response transformer for the Solana RPC', () => {
             });
             const result = await rpc.getBlock(1n, { encoding: 'json', maxSupportedTransactionVersion: 0 }).send();
             expect(result?.transactions[0].version).toBe(0);
+        });
+        it('leaves token balance `decimals` and `uiAmount` as numbers', async () => {
+            expect.assertions(1);
+            const rpc = createMockRpc<GetBlockApi>({
+                blockhash: '4nHvMbxHURt2AXd7yQpKSKM5XCVKQiNbfsFmvPtHNJnJ',
+                transactions: [{ meta: { preTokenBalances: [MOCK_TOKEN_BALANCE] } }],
+            });
+            const result = await rpc.getBlock(1n, { encoding: 'json', maxSupportedTransactionVersion: 0 }).send();
+            expect(result?.transactions[0].meta?.preTokenBalances?.[0].uiTokenAmount).toMatchObject({
+                decimals: 9,
+                uiAmount: 1,
+            });
         });
     });
 
@@ -60,6 +101,25 @@ describe('the default response transformer for the Solana RPC', () => {
                 })
                 .send();
             expect(result.data[0].version).toBe(0);
+        });
+    });
+
+    describe('simulateTransaction', () => {
+        it('leaves token balance `accountIndex`, `decimals` and `uiAmount` as numbers', async () => {
+            expect.assertions(2);
+            const rpc = createMockRpc<SimulateTransactionApi>({
+                context: { slot: 1 },
+                value: { postTokenBalances: [MOCK_TOKEN_BALANCE], preTokenBalances: [MOCK_TOKEN_BALANCE] },
+            });
+            const result = await rpc.simulateTransaction('' as never, { encoding: 'base64' as const }).send();
+            expect(result.value.preTokenBalances?.[0]).toMatchObject({
+                accountIndex: 1,
+                uiTokenAmount: { decimals: 9, uiAmount: 1 },
+            });
+            expect(result.value.postTokenBalances?.[0]).toMatchObject({
+                accountIndex: 1,
+                uiTokenAmount: { decimals: 9, uiAmount: 1 },
+            });
         });
     });
 });

--- a/packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts
+++ b/packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts
@@ -102,6 +102,27 @@ describe('the default response transformer for the Solana RPC', () => {
                 .send();
             expect(result.data[0].version).toBe(0);
         });
+        it('leaves token balance `decimals` and `uiAmount` as numbers', async () => {
+            expect.assertions(2);
+            const rpc = createMockRpc<GetTransactionsForAddressApi>({
+                data: [{ meta: { postTokenBalances: [MOCK_TOKEN_BALANCE], preTokenBalances: [MOCK_TOKEN_BALANCE] } }],
+            });
+            const result = await rpc
+                .getTransactionsForAddress('11111111111111111111111111111111' as Address, {
+                    encoding: 'json',
+                    maxSupportedTransactionVersion: 0,
+                    transactionDetails: 'full',
+                })
+                .send();
+            expect(result.data[0].meta?.preTokenBalances?.[0].uiTokenAmount).toMatchObject({
+                decimals: 9,
+                uiAmount: 1,
+            });
+            expect(result.data[0].meta?.postTokenBalances?.[0].uiTokenAmount).toMatchObject({
+                decimals: 9,
+                uiAmount: 1,
+            });
+        });
     });
 
     describe('simulateTransaction', () => {

--- a/packages/rpc-api/src/index.ts
+++ b/packages/rpc-api/src/index.ts
@@ -34,6 +34,7 @@ import {
     KEYPATH_WILDCARD,
     messageConfig,
     RequestTransformerConfig,
+    tokenBalancesConfigs,
 } from '@solana/rpc-transformers';
 
 import { GetAccountInfoApi } from './getAccountInfo';
@@ -270,26 +271,10 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
         memoizedKeypaths = {
             getAccountInfo: jsonParsedAccountsConfigs.map(c => ['value', ...c]),
             getBlock: [
-                ['transactions', KEYPATH_WILDCARD, 'meta', 'preTokenBalances', KEYPATH_WILDCARD, 'accountIndex'],
-                [
-                    'transactions',
-                    KEYPATH_WILDCARD,
-                    'meta',
-                    'preTokenBalances',
-                    KEYPATH_WILDCARD,
-                    'uiTokenAmount',
-                    'decimals',
-                ],
-                ['transactions', KEYPATH_WILDCARD, 'meta', 'postTokenBalances', KEYPATH_WILDCARD, 'accountIndex'],
-                [
-                    'transactions',
-                    KEYPATH_WILDCARD,
-                    'meta',
-                    'postTokenBalances',
-                    KEYPATH_WILDCARD,
-                    'uiTokenAmount',
-                    'decimals',
-                ],
+                ...tokenBalancesConfigs.flatMap(c => [
+                    ['transactions', KEYPATH_WILDCARD, 'meta', 'preTokenBalances', KEYPATH_WILDCARD, ...c],
+                    ['transactions', KEYPATH_WILDCARD, 'meta', 'postTokenBalances', KEYPATH_WILDCARD, ...c],
+                ]),
                 ['transactions', KEYPATH_WILDCARD, 'meta', 'rewards', KEYPATH_WILDCARD, 'commission'],
                 ...innerInstructionsConfigs.map(c => [
                     'transactions',
@@ -342,10 +327,10 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
                 ['value', 'uiAmount'],
             ],
             getTransaction: [
-                ['meta', 'preTokenBalances', KEYPATH_WILDCARD, 'accountIndex'],
-                ['meta', 'preTokenBalances', KEYPATH_WILDCARD, 'uiTokenAmount', 'decimals'],
-                ['meta', 'postTokenBalances', KEYPATH_WILDCARD, 'accountIndex'],
-                ['meta', 'postTokenBalances', KEYPATH_WILDCARD, 'uiTokenAmount', 'decimals'],
+                ...tokenBalancesConfigs.flatMap(c => [
+                    ['meta', 'preTokenBalances', KEYPATH_WILDCARD, ...c],
+                    ['meta', 'postTokenBalances', KEYPATH_WILDCARD, ...c],
+                ]),
                 ['meta', 'rewards', KEYPATH_WILDCARD, 'commission'],
                 ...innerInstructionsConfigs.map(c => ['meta', 'innerInstructions', KEYPATH_WILDCARD, ...c]),
                 ...messageConfig.map(c => ['transaction', 'message', ...c] as const),
@@ -353,10 +338,10 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
             ],
             getTransactionsForAddress: [
                 ['data', KEYPATH_WILDCARD, 'transactionIndex'],
-                ['data', KEYPATH_WILDCARD, 'meta', 'preTokenBalances', KEYPATH_WILDCARD, 'accountIndex'],
-                ['data', KEYPATH_WILDCARD, 'meta', 'preTokenBalances', KEYPATH_WILDCARD, 'uiTokenAmount', 'decimals'],
-                ['data', KEYPATH_WILDCARD, 'meta', 'postTokenBalances', KEYPATH_WILDCARD, 'accountIndex'],
-                ['data', KEYPATH_WILDCARD, 'meta', 'postTokenBalances', KEYPATH_WILDCARD, 'uiTokenAmount', 'decimals'],
+                ...tokenBalancesConfigs.flatMap(c => [
+                    ['data', KEYPATH_WILDCARD, 'meta', 'preTokenBalances', KEYPATH_WILDCARD, ...c],
+                    ['data', KEYPATH_WILDCARD, 'meta', 'postTokenBalances', KEYPATH_WILDCARD, ...c],
+                ]),
                 ['data', KEYPATH_WILDCARD, 'meta', 'rewards', KEYPATH_WILDCARD, 'commission'],
                 ...innerInstructionsConfigs.map(c => [
                     'data',
@@ -380,6 +365,10 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
                 ['value', 'loadedAccountsDataSize'],
                 ...jsonParsedAccountsConfigs.map(c => ['value', 'accounts', KEYPATH_WILDCARD, ...c]),
                 ...innerInstructionsConfigs.map(c => ['value', 'innerInstructions', KEYPATH_WILDCARD, ...c]),
+                ...tokenBalancesConfigs.flatMap(c => [
+                    ['value', 'preTokenBalances', KEYPATH_WILDCARD, ...c],
+                    ['value', 'postTokenBalances', KEYPATH_WILDCARD, ...c],
+                ]),
             ],
         };
     }

--- a/packages/rpc-transformers/src/response-transformer-allowed-numeric-values.ts
+++ b/packages/rpc-transformers/src/response-transformer-allowed-numeric-values.ts
@@ -46,6 +46,16 @@ export const innerInstructionsConfigs = [
     ['instructions', KEYPATH_WILDCARD, 'programIdIndex'],
     ['instructions', KEYPATH_WILDCARD, 'stackHeight'],
 ];
+/**
+ * Keypaths, relative to a token balance, at the end of which you will find a numeric value that
+ * should not be upcast to a `bigint`. `accountIndex` and `decimals` are small bounded integers, and
+ * `uiAmount` is an `f64`.
+ */
+export const tokenBalancesConfigs = [
+    ['accountIndex'],
+    ['uiTokenAmount', 'decimals'],
+    ['uiTokenAmount', 'uiAmount'],
+] as const;
 export const messageConfig = [
     ['addressTableLookups', KEYPATH_WILDCARD, 'writableIndexes', KEYPATH_WILDCARD],
     ['addressTableLookups', KEYPATH_WILDCARD, 'readonlyIndexes', KEYPATH_WILDCARD],


### PR DESCRIPTION
Follow-up to #1917, which allow-listed `version`. This covers the token balance numerics found in the same audit.

Opened as a draft because it carries a `minor` bump for `@solana/rpc-transformers` (it adds a public export) and you may prefer a different shape — see "Alternative" below.

## The bug

The response transformer upcasts every JSON integer to a `bigint` unless the field's keypath appears in a per-method allow-list. The guard is `Number.isInteger`, so a float whose value happens to be whole is upcast while a fractional one passes through untouched.

`uiTokenAmount.uiAmount` is an `f64` on the server and was not allow-listed on `getTransaction`, `getBlock`, or `getTransactionsForAddress`. So its runtime type depended on the value, not the field. Reproduced against the published `7.0.0`, all four rows from a single `getTransaction` response:

```
where                         value   typeof   verdict
meta.preTokenBalances  bob    1.5     number   OK
meta.preTokenBalances  alice  1n      bigint   BUG
meta.postTokenBalances bob    2n      bigint   BUG
meta.postTokenBalances alice  0.5     number   OK
```

The same balance fetched through `getTokenAccountBalance` returns `2` rather than `2n`, because that method already allow-lists `uiAmount`. So the same field had two different runtime types depending on which method you called.

`simulateTransaction` had no token balance keypaths allow-listed at all despite returning `preTokenBalances` and `postTokenBalances`, so `accountIndex` and `uiTokenAmount.decimals` were affected there too.

## Changes

- Allow-list `uiTokenAmount.uiAmount` on `getTransaction`, `getBlock`, and `getTransactionsForAddress` token balances.
- Allow-list the full token balance set on `simulateTransaction`.
- Extract the token balance keypaths into a shared `tokenBalancesConfigs` fragment, alongside the existing `innerInstructionsConfigs` and `messageConfig`, since they are now used at four call sites. This is the new export from `@solana/rpc-transformers`, and the reason for the `minor`.

## Alternative, if you would rather not take a `minor`

The keypaths can be inlined at all four call sites instead, keeping this a pure `patch` to `@solana/rpc-api` with no change to `@solana/rpc-transformers`. That trades the deduplication for the smaller bump. Happy to switch — say the word.

## Testing

Extends the tests added in #1917. Eight cases total in `packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts`, pushing canned responses through `createSolanaRpcApi()` and asserting the values arrive as numbers. Verified the token balance cases fail against the unpatched allow-list.

## Still outstanding

`@solana/rpc-subscriptions-api` has the same symptom from a different root cause, and is not addressed here. Its allow-list is keyed by notification method name (`blockNotifications`), but the response transformer is invoked with the subscribe request, whose `methodName` is `blockSubscribe` (`rpc-subscriptions-pubsub-plan.ts:96`). The lookup never matches, so the entire subscriptions allow-list is dead code and every field it names is upcast. There is a second defect underneath: the publisher is memoized per `(channel, responseTransformer)` and its closure captures the first `subscribeRequest`, so the transform resolves per channel where it needs to be per subscription. Fixing it flips affected fields from `bigint` to `number` at runtime, which is breaking for anyone who adapted, so it wants its own change and its own bump. Happy to take it on if you want it.

