### PR TITLE
fix(codecs-strings): report buffer length as next offset when base-X decoder reads no bytes

### DIFF
--- a/.changeset/great-melons-camp.md
+++ b/.changeset/great-melons-camp.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-strings': patch
+---
+
+Fix `getBaseXDecoder` returning an offset of `0` instead of the buffer length when there are no bytes left to decode, which corrupted the offset of any decoder composed after it.

--- a/packages/codecs-strings/src/__tests__/base58-test.ts
+++ b/packages/codecs-strings/src/__tests__/base58-test.ts
@@ -98,4 +98,13 @@ describe('getBase58Codec', () => {
         ]);
         expect(base58.read(bytes, -(bytes.byteLength + 1))).toStrictEqual(base58.read(bytes, 0));
     });
+
+    it('returns the end of the buffer as the next offset when no bytes remain to decode', () => {
+        const base58 = getBase58Codec();
+        // Reading at an offset that leaves nothing to consume must report the end of the
+        // buffer as the next offset, like every other read() path. Rewinding to 0 here
+        // corrupts the cursor of any decoder composed after this one.
+        const bytes = new Uint8Array([255]);
+        expect(base58.read(bytes, 1)).toStrictEqual(['', 1]);
+    });
 });

--- a/packages/codecs-strings/src/baseX.ts
+++ b/packages/codecs-strings/src/baseX.ts
@@ -93,7 +93,7 @@ export const getBaseXDecoder = (alphabet: string): VariableSizeDecoder<string> =
     return createDecoder({
         read(rawBytes, offset): [string, number] {
             const bytes = offset === 0 || offset <= -rawBytes.byteLength ? rawBytes : rawBytes.slice(offset);
-            if (bytes.length === 0) return ['', 0];
+            if (bytes.length === 0) return ['', rawBytes.length];
 
             // Handle leading zeroes.
             let trailIndex = bytes.findIndex(n => n !== 0);


### PR DESCRIPTION
`getBaseXDecoder` returns an offset of `0` when the slice at the requested offset is empty, instead of the buffer length.

Every other return path in `read()` reports `rawBytes.length` as the next offset, and the sibling `getBaseXResliceCodec` does the same in `baseX-reslice.ts` (with an explicit test for it). Returning `0` here rewinds the composed-decoder cursor, so any decoder placed after a base-X decoder that reads an empty remainder restarts from offset `0` and silently mis-decodes the following fields.

This is the decoder-side counterpart of the same class fixed in #1911 (`getBitArrayEncoder` returning the wrong next offset).

Fix: return `rawBytes.length` to match the other paths. Added a regression test in `base58-test.ts` asserting `read(bytes, offset)` reports the end of the buffer when nothing remains to decode.
