### PR TITLE
Remove the retry we added to docs CI

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -53,30 +53,8 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          # `vercel build` fails intermittently — it can be killed when `next build` exhausts the
-          # runner's memory
-          retry() {
-            # Label attempts with the command and subcommand (eg. `vercel build`) but not the
-            # remaining arguments, which include the Vercel token
-            local label="$1 $2"
-            local attempt
-            for attempt in 1 2 3; do
-              if "$@"; then
-                return 0
-              fi
-              if [ "$attempt" -lt 3 ]; then
-                echo "::warning::'$label' failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
-                sleep "$((attempt * 15))"
-              fi
-            done
-            echo "::error::'$label' failed after 3 attempts"
-            return 1
-          }
-          retry vercel pull --token="$VERCEL_TOKEN" --yes --environment=production
-          retry vercel build --token="$VERCEL_TOKEN" --prod
-          # Deliberately not retried: this uploads the prebuilt output, so it's not subject to the
-          # memory issue above, and a failure *after* the deployment was created would result in a
-          # second deployment on retry
+          vercel pull --token="$VERCEL_TOKEN" --yes --environment=production
+          vercel build --token="$VERCEL_TOKEN" --prod
           vercel deploy --token="$VERCEL_TOKEN" --archive=tgz --prebuilt --prod
 
       - name: Synchronize InKeep Search Index

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -54,30 +54,8 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_DOCS_PROJECT_ID }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
-          # `vercel build` fails intermittently — it can be killed when `next build` exhausts the
-          # runner's memory
-          retry() {
-            # Label attempts with the command and subcommand (eg. `vercel build`) but not the
-            # remaining arguments, which include the Vercel token
-            local label="$1 $2"
-            local attempt
-            for attempt in 1 2 3; do
-              if "$@"; then
-                return 0
-              fi
-              if [ "$attempt" -lt 3 ]; then
-                echo "::warning::'$label' failed (attempt $attempt of 3); retrying in $((attempt * 15))s"
-                sleep "$((attempt * 15))"
-              fi
-            done
-            echo "::error::'$label' failed after 3 attempts"
-            return 1
-          }
-          retry vercel pull --token="$VERCEL_TOKEN" --yes --environment=preview
-          retry vercel build --token="$VERCEL_TOKEN" --target=preview
-          # Deliberately not retried: this uploads the prebuilt output, so it's not subject to the
-          # memory issue above, and a failure *after* the deployment was created would result in a
-          # second deployment on retry
+          vercel pull --token="$VERCEL_TOKEN" --yes --environment=preview
+          vercel build --token="$VERCEL_TOKEN" --target=preview
           if ! DEPLOY_OUTPUT=$(vercel deploy --token="$VERCEL_TOKEN" --archive=tgz --env GITHUB_PR_NUMBER="$PR_NUMBER" --env GITHUB_PR_BRANCH="$BRANCH_NAME" --prebuilt --target=preview 2>&1); then
             echo "Vercel deploy failed:"
             echo "$DEPLOY_OUTPUT"


### PR DESCRIPTION
This doesn't work because the failure case is the runner running out of memory, and it just gets killed

Retrying is just wasting time when the build legitimately fails, for example with a compile error
