### PR TITLE
Add a wallet-standard group to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,10 @@ updates:
         patterns:
           - 'undici'
           - 'undici-types'
+      wallet-standard:
+        patterns:
+          - '@wallet-standard/*'
+          - '@solana/wallet-standard-*'
   - package-ecosystem: 'npm'
     directory: '/docs'
     schedule:


### PR DESCRIPTION
This makes dependabot update the group together, avoiding compile errors from mismatched types

See failing dependabot CI: https://github.com/anza-xyz/kit/actions/runs/30989652547/job/92252488402?pr=1848 