### PR TITLE
Fix CI: Revert changesets/action to v1 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,3 +65,8 @@ updates:
       interval: daily
     cooldown:
       default-days: 3
+    ignore:
+      # changesets/action v2 requires Changesets CLI v3, but this repo uses
+      # CLI v2. Remove this once the CLI is upgraded to v3.
+      - dependency-name: "changesets/action"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Create Changesets Pull Request or Publish to NPM
         id: changesets
-        uses: changesets/action@198f833dd7d863100ea6e28967bc9a9fdefadb0a # v2.1.0
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           publish: pnpm changeset:publish
         env:


### PR DESCRIPTION
#### Problem

Every push run of the publish-packages workflow has failed since #1922. Dependabot bumped changesets/action from 1.9.0 to 2.0.0 (and then to 2.1.0 in #1927), but v2 of the action is a breaking release designed for Changesets CLI v3, which causes the CI to fail. See eg https://github.com/anza-xyz/kit/actions/runs/32125013770/job/95673510806

#### Summary of Changes

Reverts the changesets/action pin to the v1.9.0 SHA a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d
Note that this is the exact pin we had before it bumped to 2.0, see https://github.com/anza-xyz/kit/pull/1922/changes

We also add `changesets/action` to dependabot ignore for now, to avoid it repeating this. We'll need to upgrade the CLI when we want to upgrade, and handle the breaking changes. 