### PR TITLE
docs(sysvars): drop unsupported Fees sysvar from docs

### DIFF
--- a/packages/sysvars/README.md
+++ b/packages/sysvars/README.md
@@ -75,7 +75,6 @@ This package supports the following Solana sysvars:
 - [`Clock`](https://github.com/anza-xyz/kit/tree/main/packages/sysvars/src/clock.ts)
 - [`EpochRewards`](https://github.com/anza-xyz/kit/tree/main/packages/sysvars/src/epoch-rewards.ts)
 - [`EpochSchedule`](https://github.com/anza-xyz/kit/tree/main/packages/sysvars/src/epoch-schedule.ts)
-- [`Fees`](https://github.com/anza-xyz/kit/tree/main/packages/sysvars/src/fees.ts)
 - [`LastRestartSlot`](https://github.com/anza-xyz/kit/tree/main/packages/sysvars/src/last-restart-slot.ts)
 - [`RecentBlockhashes`](https://github.com/anza-xyz/kit/tree/main/packages/sysvars/src/recent-blockhashes.ts)
 - [`Rent`](https://github.com/anza-xyz/kit/tree/main/packages/sysvars/src/rent.ts)

--- a/packages/sysvars/src/index.ts
+++ b/packages/sysvars/src/index.ts
@@ -11,7 +11,6 @@
  * - `Clock`
  * - `EpochRewards`
  * - `EpochSchedule`
- * - `Fees`
  * - `LastRestartSlot`
  * - `RecentBlockhashes`
  * - `Rent`


### PR DESCRIPTION
`packages/sysvars` documents a `Fees` sysvar in two places — the README's "Supported Sysvars" list and the `@packageDocumentation` block in `src/index.ts` — but it isn't supported:

- there is no `src/fees.ts` module;
- `src/index.ts` exports nothing for it (clock, epoch-rewards, epoch-schedule, last-restart-slot, recent-blockhashes, rent, slot-hashes, slot-history, stake-history, sysvar — no fees);
- the README's link to `packages/sysvars/src/fees.ts` returns 404.

`Fees` is deprecated on-chain, so the omission looks intentional and it's the docs that are stale. This removes both mentions. Every other sysvar in that list has a matching module and export, so the rest is accurate.

Happy to instead implement `fees.ts` if support is actually wanted — just say so.