### PR TITLE
Allow v1 transactions to typecheck

### DIFF
--- a/.changeset/empty-gifts-shave.md
+++ b/.changeset/empty-gifts-shave.md
@@ -1,0 +1,7 @@
+---
+'@solana/transaction-messages': minor
+---
+
+Add support for version 1 transaction messages to `createTransactionMessage`. You can now pass `{ version: 1 }` to create an empty v1 transaction message.
+
+This means that code using version 1 transaction messages will now type check.

--- a/packages/kit/src/__typetests__/scenarios/transaction-signers-typetest.ts
+++ b/packages/kit/src/__typetests__/scenarios/transaction-signers-typetest.ts
@@ -16,21 +16,17 @@ import {
     TransactionVersion,
 } from '@solana/transaction-messages';
 
-// Temporary, until we support v1 transactions in `createTransactionMessage`
-// When this is removed, use `TransactionVersion`
-type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
-
 // [DESCRIBE] TransactionMessageWithSigners type
 {
     // It is satisfied by a transaction message from `createTransactionMessage`
     {
-        const result = createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 });
+        const result = createTransactionMessage({ version: null as unknown as TransactionVersion });
         result satisfies TransactionMessage & TransactionMessageWithSigners;
     }
 
     // It is satisfied after adding an address fee payer
     {
-        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
+        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
             setTransactionMessageFeePayer(null as unknown as Address, m),
         );
         result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
@@ -38,7 +34,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
 
     // It is satisfied after adding a signer fee payer
     {
-        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
+        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
             setTransactionMessageFeePayerSigner(null as unknown as TransactionSigner, m),
         );
         result satisfies TransactionMessage & TransactionMessageWithFeePayer & TransactionMessageWithSigners;
@@ -46,7 +42,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
 
     // It is satisfied after appending instructions
     {
-        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
+        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
             appendTransactionMessageInstructions(null as unknown as Instruction[], m),
         );
         result satisfies TransactionMessage & TransactionMessageWithSigners;
@@ -54,7 +50,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
 
     // It is satisfied after appending instructions with signers
     {
-        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
+        const result = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
             appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
         );
         result satisfies TransactionMessage & TransactionMessageWithSigners;
@@ -63,7 +59,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It is satisfied after adding a fee payer and instructions
     {
         const result = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageFeePayer(null as unknown as Address, m),
             m => appendTransactionMessageInstructions(null as unknown as Instruction[], m),
         );
@@ -73,7 +69,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It is satisfied after adding a signer fee payer and instructions
     {
         const result = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageFeePayerSigner(null as unknown as TransactionSigner, m),
             m => appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
         );
@@ -83,7 +79,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It is satisfied after adding a fee payer and instructions with signers
     {
         const result = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageFeePayer(null as unknown as Address, m),
             m => appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
         );
@@ -93,7 +89,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It is satisfied after adding a signer fee payer and instructions with signers
     {
         const result = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageFeePayerSigner(null as unknown as TransactionSigner, m),
             m => appendTransactionMessageInstructions(null as unknown as (Instruction & InstructionWithSigners)[], m),
         );

--- a/packages/transaction-messages/src/__typetests__/create-transaction-message-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/create-transaction-message-typetest.ts
@@ -4,6 +4,7 @@ import { TransactionMessageWithinSizeLimit } from '../transaction-message-size';
 
 type LegacyTransactionMessage = Extract<TransactionMessage, { version: 'legacy' }>;
 type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
+type V1TransactionMessage = Extract<TransactionMessage, { version: 1 }>;
 
 // It creates legacy transaction messages.
 {
@@ -11,6 +12,8 @@ type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
     message satisfies LegacyTransactionMessage;
     // @ts-expect-error Should not be V0.
     message satisfies V0TransactionMessage;
+    // @ts-expect-error Should not be V1.
+    message satisfies V1TransactionMessage;
 }
 
 // It creates v0 transaction messages.
@@ -19,16 +22,23 @@ type V0TransactionMessage = Extract<TransactionMessage, { version: 0 }>;
     message satisfies V0TransactionMessage;
     // @ts-expect-error Should not be legacy.
     message satisfies LegacyTransactionMessage;
+    // @ts-expect-error Should not be V1.
+    message satisfies V1TransactionMessage;
 }
 
-// It does not create v1 transaction messages.
+// It creates v1 transaction messages.
 {
-    // @ts-expect-error Does not support version 1.
-    createTransactionMessage({ version: 1 });
+    const message = createTransactionMessage({ version: 1 });
+    message satisfies V1TransactionMessage;
+    // @ts-expect-error Should not be legacy.
+    message satisfies LegacyTransactionMessage;
+    // @ts-expect-error Should not be V0.
+    message satisfies V0TransactionMessage;
 }
 
 // It returns an empty transaction message with size limit type safety.
 {
     createTransactionMessage({ version: 'legacy' }) satisfies TransactionMessageWithinSizeLimit;
     createTransactionMessage({ version: 0 }) satisfies TransactionMessageWithinSizeLimit;
+    createTransactionMessage({ version: 1 }) satisfies TransactionMessageWithinSizeLimit;
 }

--- a/packages/transaction-messages/src/__typetests__/scenarios/message-modifications-typetest.ts
+++ b/packages/transaction-messages/src/__typetests__/scenarios/message-modifications-typetest.ts
@@ -28,15 +28,11 @@ const compiledTransactionMessage = null as unknown as Parameters<typeof decompil
 const feePayer = null as unknown as Address;
 const instruction = null as unknown as Instruction;
 
-// Temporary, until we support v1 transactions in `createTransactionMessage`
-// When this is removed, use `TransactionVersion`
-type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
-
 // [DESCRIBE] setTransactionMessageLifetimeUsingBlockhash
 {
     // It sets the blockhash after `createTransactionMessage`
     {
-        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
+        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
             setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
         message satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
@@ -45,7 +41,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It sets the blockhash after other transformations
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageFeePayer(null as unknown as Address, m),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
@@ -55,7 +51,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It sets the blockhash after a durable nonce lifetime
     {
         const messageWithDurableNonce = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
         );
         messageWithDurableNonce satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
@@ -90,7 +86,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It sets the blockhash with instructions
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => appendTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstruction(instruction, m),
             m => appendTransactionMessageInstructions([instruction], m),
@@ -103,7 +99,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It sets the blockhash multiple times
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
@@ -116,7 +112,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
 {
     // It sets the durable nonce after `createTransactionMessage`
     {
-        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
+        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
             setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
         );
         message satisfies TransactionMessage & TransactionMessageWithDurableNonceLifetime;
@@ -125,7 +121,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It sets the durable nonce after other transformations
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageFeePayer(null as unknown as Address, m),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
         );
@@ -137,7 +133,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It sets the durable nonce after a blockhash lifetime
     {
         const messageWithBlockhash = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
         messageWithBlockhash satisfies TransactionMessage & TransactionMessageWithBlockhashLifetime;
@@ -172,7 +168,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It sets the durable nonce with instructions
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => appendTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstruction(instruction, m),
             m => appendTransactionMessageInstructions([instruction], m),
@@ -185,7 +181,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It sets the durable nonce multiple times
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
@@ -253,14 +249,14 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
 {
     // It sets the fee payer after `createTransactionMessage`
     {
-        const message = createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 });
+        const message = createTransactionMessage({ version: null as unknown as TransactionVersion });
         const newMessage = setTransactionMessageFeePayer(feePayer, message);
         newMessage satisfies TransactionMessage & TransactionMessageWithFeePayer;
     }
 
     // It sets the fee payer after setting a blockhash lifetime
     {
-        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
+        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
             setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
         );
         const newMessage = setTransactionMessageFeePayer(feePayer, message);
@@ -271,7 +267,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
 
     // It sets the fee payer after setting a durable nonce lifetime
     {
-        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }), m =>
+        const message = pipe(createTransactionMessage({ version: null as unknown as TransactionVersion }), m =>
             setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
         );
         const newMessage = setTransactionMessageFeePayer(feePayer, message);
@@ -283,7 +279,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It sets the fee payer multiple times
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageFeePayer(feePayer, m),
             m => setTransactionMessageFeePayer(feePayer, m),
             m => setTransactionMessageFeePayer(feePayer, m),
@@ -297,7 +293,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It can call instruction functions after `createTransactionMessage`
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => appendTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstruction(instruction, m),
             m => appendTransactionMessageInstructions([instruction], m),
@@ -309,7 +305,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It can call instruction functions after setting a blockhash lifetime
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageLifetimeUsingBlockhash(blockhashLifetime, m),
             m => appendTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstruction(instruction, m),
@@ -322,7 +318,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It can call append instruction functions after setting a durable nonce lifetime
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
             m => appendTransactionMessageInstruction(instruction, m),
             m => appendTransactionMessageInstructions([instruction], m),
@@ -334,7 +330,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // the durable nonce lifetime is stripped because the first instruction must be the AdvanceNonceAccount instruction
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageLifetimeUsingDurableNonce(durableNonceLifetime, m),
             m => prependTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstructions([instruction], m),
@@ -347,7 +343,7 @@ type TransactionVersionWithoutV1 = Exclude<TransactionVersion, 1>;
     // It can call instruction functions after setting a fee payer
     {
         const message = pipe(
-            createTransactionMessage({ version: null as unknown as TransactionVersionWithoutV1 }),
+            createTransactionMessage({ version: null as unknown as TransactionVersion }),
             m => setTransactionMessageFeePayer(feePayer, m),
             m => appendTransactionMessageInstruction(instruction, m),
             m => prependTransactionMessageInstruction(instruction, m),

--- a/packages/transaction-messages/src/create-transaction-message.ts
+++ b/packages/transaction-messages/src/create-transaction-message.ts
@@ -1,14 +1,11 @@
 import { TransactionMessage, TransactionVersion } from './transaction-message';
 import { TransactionMessageWithinSizeLimit } from './transaction-message-size';
 
-// Note: v1 transactions are not yet supported by these functions
-type SupportedTransactionVersion = Exclude<TransactionVersion, 1>;
-
-type TransactionConfig<TVersion extends SupportedTransactionVersion> = Readonly<{
+type TransactionConfig<TVersion extends TransactionVersion> = Readonly<{
     version: TVersion;
 }>;
 
-type EmptyTransactionMessage<TVersion extends SupportedTransactionVersion> = Omit<
+type EmptyTransactionMessage<TVersion extends TransactionVersion> = Omit<
     Extract<TransactionMessage, { version: TVersion }>,
     'instructions'
 > &
@@ -25,7 +22,7 @@ type EmptyTransactionMessage<TVersion extends SupportedTransactionVersion> = Omi
  * const message = createTransactionMessage({ version: 0 });
  * ```
  */
-export function createTransactionMessage<TVersion extends SupportedTransactionVersion>(
+export function createTransactionMessage<TVersion extends TransactionVersion>(
     config: TransactionConfig<TVersion>,
 ): EmptyTransactionMessage<TVersion> {
     return Object.freeze({

--- a/packages/transaction-messages/src/decompile/v1/message.ts
+++ b/packages/transaction-messages/src/decompile/v1/message.ts
@@ -39,10 +39,8 @@ export function decompileTransactionMessage(
     );
 
     return pipe(
-        // @ts-expect-error We don't expose v1 on `createTransactionMessage` yet
         createTransactionMessage({ version: 1 }),
-        // Won't need this cast after we support v1 on `createTransactionMessage`
-        m => setTransactionMessageConfig(transactionConfig, m as unknown as TransactionMessage & { version: 1 }),
+        m => setTransactionMessageConfig(transactionConfig, m),
         m => setTransactionMessageFeePayer(feePayer, m),
         m => appendTransactionMessageInstructions(instructions, m),
         m =>

--- a/packages/transactions/src/__tests__/transaction-message-size-test.ts
+++ b/packages/transactions/src/__tests__/transaction-message-size-test.ts
@@ -39,7 +39,6 @@ const OVERSIZED_TRANSACTION_MESSAGE = pipe(SMALL_TRANSACTION_MESSAGE, m =>
 );
 
 const SMALL_V1_TRANSACTION_MESSAGE = pipe(
-    // @ts-expect-error v1 not yet included in type for `createTransactionMessage`
     createTransactionMessage({ version: 1 }),
     m => setTransactionMessageLifetimeUsingBlockhash(MOCK_BLOCKHASH, m),
     m => setTransactionMessageFeePayer(address('22222222222222222222222222222222222222222222'), m),

--- a/packages/transactions/src/__tests__/transaction-size-test.ts
+++ b/packages/transactions/src/__tests__/transaction-size-test.ts
@@ -43,7 +43,6 @@ const OVERSIZED_TRANSACTION = compileTransaction(
 );
 
 const SMALL_V1_TRANSACTION_MESSAGE = pipe(
-    // @ts-expect-error v1 not yet included in type for `createTransactionMessage`
     createTransactionMessage({ version: 1 }),
     m => setTransactionMessageLifetimeUsingBlockhash(MOCK_BLOCKHASH, m),
     m => setTransactionMessageFeePayer(address('22222222222222222222222222222222222222222222'), m),


### PR DESCRIPTION
Kit has runtime support for v1 transactions, but we've been waiting until they're close to available on the network before enabling code using them to type check

This PR updates the types, removing all the `TransactionVersionWithoutV1` temporary types so that `TransactionVersion` including v1 flows through all the `TransactionMessage` types.

The plan is to include this in the kit v8 release 