### PR TITLE
feat: fill in transaction v1 (SIMD-0385) gaps

### DIFF
--- a/.changeset/khaki-suns-sit.md
+++ b/.changeset/khaki-suns-sit.md
@@ -1,0 +1,15 @@
+---
+'@solana/transaction-messages': minor
+'@solana/rpc-transformers': minor
+'@solana/rpc-graphql': minor
+'@solana/rpc-types': minor
+'@solana/rpc-api': minor
+---
+
+Fill in several gaps in transaction v1 (SIMD-0385) support.
+
+`@solana/transaction-messages` now exports its `v1-transaction-config` module, so `setTransactionMessageConfig`, the `V1TransactionConfig` type and the transaction config bit-mask helpers are importable. Previously the module was built and shipped but omitted from the package index, forcing consumers onto the four single-field setters and to derive the config type by hand.
+
+The `V1TransactionConfig.computeUnitLimit` docstring incorrectly described the legacy fallback of 200,000 compute units per instruction. On version 1 an unset `computeUnitLimit` resolves to zero and the transaction fails at execution, so the docstring now says so, as does the one for `loadedAccountsDataSizeLimit`.
+
+`@solana/rpc-types` transaction message types now carry the `transactionConfig` that the server returns for version 1 transactions, so reading a transaction's compute budget no longer requires a cast. Its three `u32` fields are typed and transformed as `number` rather than being upcast to `bigint`, leaving `priorityFee` as the only `Lamports` among them. `@solana/rpc-api` carries the same field on the message shape it uses for the `json` and `jsonParsed` encodings of `getTransaction` and `getTransactionsForAddress`. The same field is exposed on the `TransactionMessage` type in `@solana/rpc-graphql`.

--- a/packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts
+++ b/packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts
@@ -13,6 +13,13 @@ import {
 const MOCK_SIGNATURE =
     '4nHvMbxHURt2AXd7yQpKSKM5XCVKQiNbfsFmvPtHNJnJPSJHFT6cGUUNQGYK3wcxDCTvBMTLpQFf6HGqhLTUsxwj' as Signature;
 
+const MOCK_TRANSACTION_CONFIG = {
+    computeUnitLimit: 20_000,
+    heapSize: 32_768,
+    loadedAccountsDataSizeLimit: 65_536,
+    priorityFee: 5_000,
+};
+
 const MOCK_TOKEN_BALANCE = {
     accountIndex: 1,
     mint: 'So11111111111111111111111111111111111111112',
@@ -49,6 +56,23 @@ describe('the default response transformer for the Solana RPC', () => {
                 .send();
             expect(result?.version).toBe('legacy');
         });
+        it('leaves the `u32` fields of `transactionConfig` as numbers but upcasts `priorityFee`', async () => {
+            expect.assertions(4);
+            const rpc = createMockRpc<GetTransactionApi>({
+                meta: null,
+                slot: 1,
+                transaction: { message: { transactionConfig: MOCK_TRANSACTION_CONFIG } },
+                version: 1,
+            });
+            const result = await rpc
+                .getTransaction(MOCK_SIGNATURE, { encoding: 'json', maxSupportedTransactionVersion: 0 })
+                .send();
+            const transactionConfig = result?.transaction.message.transactionConfig;
+            expect(transactionConfig?.computeUnitLimit).toBe(20_000);
+            expect(transactionConfig?.heapSize).toBe(32_768);
+            expect(transactionConfig?.loadedAccountsDataSizeLimit).toBe(65_536);
+            expect(transactionConfig?.priorityFee).toBe(5_000n);
+        });
         it('leaves token balance `decimals` and `uiAmount` as numbers', async () => {
             expect.assertions(2);
             const rpc = createMockRpc<GetTransactionApi>({
@@ -72,6 +96,25 @@ describe('the default response transformer for the Solana RPC', () => {
             });
             const result = await rpc.getBlock(1n, { encoding: 'json', maxSupportedTransactionVersion: 0 }).send();
             expect(result?.transactions[0].version).toBe(0);
+        });
+        it('leaves the `u32` fields of `transactionConfig` as numbers but upcasts `priorityFee`', async () => {
+            expect.assertions(4);
+            const rpc = createMockRpc<GetBlockApi>({
+                blockhash: '4nHvMbxHURt2AXd7yQpKSKM5XCVKQiNbfsFmvPtHNJnJ',
+                transactions: [
+                    {
+                        meta: null,
+                        transaction: { message: { transactionConfig: MOCK_TRANSACTION_CONFIG } },
+                        version: 1,
+                    },
+                ],
+            });
+            const result = await rpc.getBlock(1n, { encoding: 'json', maxSupportedTransactionVersion: 0 }).send();
+            const transactionConfig = result?.transactions[0].transaction.message.transactionConfig;
+            expect(transactionConfig?.computeUnitLimit).toBe(20_000);
+            expect(transactionConfig?.heapSize).toBe(32_768);
+            expect(transactionConfig?.loadedAccountsDataSizeLimit).toBe(65_536);
+            expect(transactionConfig?.priorityFee).toBe(5_000n);
         });
         it('leaves token balance `decimals` and `uiAmount` as numbers', async () => {
             expect.assertions(1);

--- a/packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts
+++ b/packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts
@@ -65,7 +65,7 @@ describe('the default response transformer for the Solana RPC', () => {
                 version: 1,
             });
             const result = await rpc
-                .getTransaction(MOCK_SIGNATURE, { encoding: 'json', maxSupportedTransactionVersion: 0 })
+                .getTransaction(MOCK_SIGNATURE, { encoding: 'json', maxSupportedTransactionVersion: 1 })
                 .send();
             const transactionConfig = result?.transaction.message.transactionConfig;
             expect(transactionConfig?.computeUnitLimit).toBe(20_000);
@@ -109,7 +109,7 @@ describe('the default response transformer for the Solana RPC', () => {
                     },
                 ],
             });
-            const result = await rpc.getBlock(1n, { encoding: 'json', maxSupportedTransactionVersion: 0 }).send();
+            const result = await rpc.getBlock(1n, { encoding: 'json', maxSupportedTransactionVersion: 1 }).send();
             const transactionConfig = result?.transactions[0].transaction.message.transactionConfig;
             expect(transactionConfig?.computeUnitLimit).toBe(20_000);
             expect(transactionConfig?.heapSize).toBe(32_768);

--- a/packages/rpc-api/src/transaction-meta.ts
+++ b/packages/rpc-api/src/transaction-meta.ts
@@ -6,6 +6,7 @@ import type {
     Lamports,
     Reward,
     TokenBalance,
+    TransactionConfig,
     TransactionError,
     TransactionStatus,
 } from '@solana/rpc-types';
@@ -92,6 +93,13 @@ export type TransactionBase = Readonly<{
          * the nonce value.
          */
         recentBlockhash: Blockhash;
+        /**
+         * The compute budget declared by a version 1 transaction message.
+         *
+         * Omitted for legacy and version 0 transaction messages, which express their compute budget
+         * through `ComputeBudget` program instructions instead.
+         */
+        transactionConfig?: TransactionConfig;
     };
     /**
      * An ordered list of signatures belonging to the accounts required to sign this transaction.

--- a/packages/rpc-graphql/src/schema/type-defs/transaction.ts
+++ b/packages/rpc-graphql/src/schema/type-defs/transaction.ts
@@ -46,6 +46,13 @@ export const transactionTypeDefs = /* GraphQL */ `
         writableIndexes: [Int]
     }
 
+    type TransactionMessageConfig {
+        computeUnitLimit: Int
+        heapSize: Int
+        loadedAccountsDataSizeLimit: Int
+        priorityFee: BigInt
+    }
+
     type TransactionMessageHeader {
         numReadonlySignedAccounts: Int
         numReadonlyUnsignedAccounts: Int
@@ -58,6 +65,7 @@ export const transactionTypeDefs = /* GraphQL */ `
         header: TransactionMessageHeader
         instructions: [TransactionInstruction]
         recentBlockhash: Hash
+        transactionConfig: TransactionMessageConfig
     }
 
     """

--- a/packages/rpc-graphql/src/schema/type-defs/transaction.ts
+++ b/packages/rpc-graphql/src/schema/type-defs/transaction.ts
@@ -50,7 +50,7 @@ export const transactionTypeDefs = /* GraphQL */ `
         computeUnitLimit: Int
         heapSize: Int
         loadedAccountsDataSizeLimit: Int
-        priorityFee: BigInt
+        priorityFee: Lamports
     }
 
     type TransactionMessageHeader {

--- a/packages/rpc-transformers/src/response-transformer-allowed-numeric-values.ts
+++ b/packages/rpc-transformers/src/response-transformer-allowed-numeric-values.ts
@@ -65,4 +65,7 @@ export const messageConfig = [
     ['instructions', KEYPATH_WILDCARD, 'accounts', KEYPATH_WILDCARD],
     ['instructions', KEYPATH_WILDCARD, 'programIdIndex'],
     ['instructions', KEYPATH_WILDCARD, 'stackHeight'],
+    ['transactionConfig', 'computeUnitLimit'],
+    ['transactionConfig', 'heapSize'],
+    ['transactionConfig', 'loadedAccountsDataSizeLimit'],
 ] as const;

--- a/packages/rpc-types/src/__typetests__/transaction-typetest.ts
+++ b/packages/rpc-types/src/__typetests__/transaction-typetest.ts
@@ -1,0 +1,45 @@
+import type { Lamports } from '../lamports';
+import type { TransactionForFullJson, TransactionForFullJsonParsed } from '../transaction';
+
+// [DESCRIBE] TransactionForFullJson
+{
+    // The version 1 compute budget is reachable on the message without a cast
+    {
+        const transaction = null as unknown as TransactionForFullJson<0>;
+        transaction.transaction.message.transactionConfig satisfies
+            | Readonly<{
+                  computeUnitLimit: number | null;
+                  heapSize: number | null;
+                  loadedAccountsDataSizeLimit: number | null;
+                  priorityFee: Lamports | null;
+              }>
+            | undefined;
+    }
+
+    // The three `u32` fields are numbers rather than bigints
+    {
+        const transaction = null as unknown as TransactionForFullJson<0>;
+        const config = transaction.transaction.message.transactionConfig;
+        config?.computeUnitLimit satisfies number | null | undefined;
+        config?.heapSize satisfies number | null | undefined;
+        config?.loadedAccountsDataSizeLimit satisfies number | null | undefined;
+    }
+
+    // The `u64` priority fee is a `Lamports`, which is a branded bigint
+    {
+        const transaction = null as unknown as TransactionForFullJson<0>;
+        transaction.transaction.message.transactionConfig?.priorityFee satisfies Lamports | null | undefined;
+        // @ts-expect-error A `u32` field is not a bigint.
+        transaction.transaction.message.transactionConfig?.computeUnitLimit satisfies bigint | null | undefined;
+    }
+}
+
+// [DESCRIBE] TransactionForFullJsonParsed
+{
+    // The version 1 compute budget is reachable under `jsonParsed` encoding too
+    {
+        const transaction = null as unknown as TransactionForFullJsonParsed<0>;
+        transaction.transaction.message.transactionConfig?.computeUnitLimit satisfies number | null | undefined;
+        transaction.transaction.message.transactionConfig?.priorityFee satisfies Lamports | null | undefined;
+    }
+}

--- a/packages/rpc-types/src/transaction.ts
+++ b/packages/rpc-types/src/transaction.ts
@@ -85,6 +85,35 @@ type TransactionInstruction = InstructionWithData &
         programIdIndex: number;
     }>;
 
+/**
+ * The compute budget a version 1 transaction message declares inline, in place of the
+ * `ComputeBudget` program instructions used by legacy and version 0 transaction messages.
+ */
+export type TransactionConfig = Readonly<{
+    /**
+     * The maximum number of compute units the transaction may consume, or `null` if the transaction
+     * did not request one.
+     *
+     * A version 1 transaction that requests no compute unit limit is budgeted zero compute units.
+     */
+    computeUnitLimit: number | null;
+    /**
+     * The heap frame size in bytes requested for the transaction's execution, or `null` if the
+     * transaction did not request one, in which case the runtime allocated the default 32,768 bytes.
+     */
+    heapSize: number | null;
+    /**
+     * The maximum size in bytes of account data the transaction may load, or `null` if the
+     * transaction did not request one, in which case it was budgeted zero bytes.
+     */
+    loadedAccountsDataSizeLimit: number | null;
+    /**
+     * The total priority fee in {@link Lamports} the transaction paid for prioritization, or `null`
+     * if the transaction paid none.
+     */
+    priorityFee: Lamports | null;
+}>;
+
 type TransactionMessageBase = Readonly<{
     header: {
         /**
@@ -119,6 +148,13 @@ type TransactionMessageBase = Readonly<{
      * and for transactions whose lifetime is specified by a durable nonce, this is the nonce value.
      */
     recentBlockhash: Blockhash;
+    /**
+     * The compute budget declared by a version 1 transaction message.
+     *
+     * Omitted for legacy and version 0 transaction messages, which express their compute budget
+     * through `ComputeBudget` program instructions instead.
+     */
+    transactionConfig?: TransactionConfig;
 }>;
 
 type TransactionParsedAccountBase = Readonly<{

--- a/packages/transaction-messages/src/index.ts
+++ b/packages/transaction-messages/src/index.ts
@@ -46,3 +46,4 @@ export * from './loaded-accounts-data-size-limit';
 export * from './priority-fee-lamports';
 export * from './transaction-message-size';
 export * from './transaction-message';
+export * from './v1-transaction-config';

--- a/packages/transaction-messages/src/v1-transaction-config.ts
+++ b/packages/transaction-messages/src/v1-transaction-config.ts
@@ -13,8 +13,10 @@ export type V1TransactionConfig = {
     /**
      * Maximum number of compute units the transaction may consume.
      *
-     * If not specified, defaults to 200,000 CUs per instruction. The maximum
-     * allowed value is 1,400,000 CUs.
+     * Unlike legacy and version 0 transactions, which fall back to 200,000 compute units per
+     * instruction when no `SetComputeUnitLimit` instruction is present, a version 1 transaction that
+     * leaves this field unset is budgeted **zero** compute units and will fail at execution. Set it
+     * explicitly on every version 1 transaction. The maximum allowed value is 1,400,000 CUs.
      */
     computeUnitLimit?: number;
     /**
@@ -23,14 +25,28 @@ export type V1TransactionConfig = {
     heapSize?: number;
     /**
      * Maximum size in bytes for loaded account data.
+     *
+     * As with {@link V1TransactionConfig.computeUnitLimit}, leaving this field unset budgets
+     * **zero** bytes rather than applying a default, so any transaction that loads account data
+     * must set it explicitly.
      */
     loadedAccountsDataSizeLimit?: number;
     /**
      * Total priority fee in lamports to pay for transaction prioritization.
+     *
+     * Unlike legacy and version 0 transactions, where the priority fee is derived from a price per
+     * compute unit, this is the total fee paid for the whole transaction. If not specified, no
+     * priority fee is paid.
      */
     priorityFeeLamports?: bigint;
 };
 
+/**
+ * Determines whether a transaction config has no fields set.
+ *
+ * @param config - The config to inspect.
+ * @return `true` if every field of the config is `undefined`, `false` otherwise.
+ */
 export function isV1ConfigEmpty(config: V1TransactionConfig): boolean {
     return (
         config.computeUnitLimit === undefined &&
@@ -40,6 +56,13 @@ export function isV1ConfigEmpty(config: V1TransactionConfig): boolean {
     );
 }
 
+/**
+ * Determines whether two transaction configs set the same value for every field.
+ *
+ * @param config1 - The first config to compare.
+ * @param config2 - The second config to compare.
+ * @return `true` if all four fields are equal between the two configs, `false` otherwise.
+ */
 export function areV1ConfigsEqual(config1: V1TransactionConfig, config2: V1TransactionConfig) {
     return (
         config1.computeUnitLimit === config2.computeUnitLimit &&


### PR DESCRIPTION
## Summary

- Export the `v1-transaction-config` module from `@solana/transaction-messages`, which was built and published but missing from the package index, leaving `setTransactionMessageConfig` and `V1TransactionConfig` unreachable.
- Correct the `computeUnitLimit` and `loadedAccountsDataSizeLimit` docs: an unset value on a version 1 transaction is budgeted zero, not the legacy 200,000 CU per instruction.
- Add `transactionConfig` to the transaction message response types in `@solana/rpc-types` and `@solana/rpc-api` so a confirmed version 1 transaction's compute budget can be read without a cast.
- Allow-list the three `u32` config fields in the response transformer so they stay JS numbers, leaving `priorityFee` as the only `Lamports` bigint.
- Mirror the same shape in the `@solana/rpc-graphql` schema as `TransactionMessageConfig`.

Closes DEV-922
