### PR TITLE
docs: add kit-plugin-wallet to the plugin catalog and React guides

### DIFF
--- a/docs/content/docs/guides/react/index.mdx
+++ b/docs/content/docs/guides/react/index.mdx
@@ -149,6 +149,16 @@ Once a provider is mounted, pick a hook by what you are trying to do:
 
 The [SWR](/docs/guides/react/swr) and [TanStack Query](/docs/guides/react/query) adapters route the read hooks through those libraries' caches. These add features such as deduplication and devtools.
 
+## Plugin hooks
+
+Some plugins ship React bindings from a `/react` subpath of their own package. Those hooks take the client as an argument rather than reading `ClientProvider`, so they stay colocated with the plugin that owns the state.
+
+| You want to…                     | Package                           | Guide                                     |
+| -------------------------------- | --------------------------------- | ----------------------------------------- |
+| Connect a Wallet Standard wallet | `@solana/kit-plugin-wallet/react` | [Wallet hooks](/docs/guides/react/wallet) |
+
+Browser apps typically install [`walletSigner()`](/docs/guides/setting-up-signers#use-a-browser-wallet) instead of `generatedSigner()` on the client they pass to `ClientProvider`.
+
 ## Server rendering
 
 Every hook is safe to render on the server. The fetch or subscription is committed in an effect, which never runs during SSR, so no request opens and no socket connects until the component hydrates on the client. On the server - and on the first client render, before hydration - each hook reports its pre-fetch status: `fetching` for `useRequest`, `loading` for `useSubscription` and `useTrackedData`, and `idle` for `useAction` (which only ever fires on demand). Server and client markup therefore match, and the live work begins after hydration.

--- a/docs/content/docs/guides/react/meta.json
+++ b/docs/content/docs/guides/react/meta.json
@@ -3,6 +3,7 @@
     "pages": [
         "index",
         "core-hooks",
+        "wallet",
         "query",
         "swr"
     ]

--- a/docs/content/docs/guides/react/wallet.mdx
+++ b/docs/content/docs/guides/react/wallet.mdx
@@ -1,0 +1,188 @@
+---
+title: Wallet hooks
+description: React hooks from @solana/kit-plugin-wallet
+---
+
+`@solana/kit-plugin-wallet/react` is the React binding for the [wallet plugin](/docs/guides/setting-up-signers#use-a-browser-wallet). The hooks live next to the plugin rather than in `@solana/react`, and every one of them takes your wallet-enabled client as its first argument. That is the same pattern other plugin packages will follow for their own React APIs.
+
+```package-install
+@solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-wallet @solana/react
+```
+
+## Set up the client
+
+Install `walletSigner(...)` on the client you already pass to `ClientProvider`. Export the client's type so components can call `useClient<AppClient>()` and then hand that client to the wallet hooks.
+
+```ts twoslash
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { walletSigner } from '@solana/kit-plugin-wallet';
+
+export const client = createClient()
+    .use(walletSigner({ chain: 'solana:devnet' }))
+    .use(solanaDevnetRpc());
+
+export type AppClient = Awaited<typeof client>;
+```
+
+The hooks subscribe to `client.wallet` directly. They do not read `ClientProvider`, so they still work if you pass the client down as a prop — using `useClient` just keeps the client identity in lockstep with the rest of `@solana/react`.
+
+## Choosing a hook
+
+| You want to…                                    | Hook / component         | What you get back                                                              |
+| ----------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------ |
+| Know whether auto-reconnect has settled         | `useIsWalletReady`       | `false` during `'pending'` / `'reconnecting'`, then `true`.                    |
+| Hide a subtree until that warm-up finishes      | `WalletReadyGate`        | Renders `fallback`, then `children`. Synchronous — no `<Suspense>` needed.     |
+| List discovered wallets                         | `useWallets`             | The wallets that support the client's chain.                                   |
+| Read the active connection                      | `useConnectedWallet`     | `{ account, signer, wallet }` or `null`.                                       |
+| Read the connection status                      | `useWalletStatus`        | `'pending'`, `'disconnected'`, `'connecting'`, `'connected'`, …                |
+| See which persisted account is reconnecting     | `useReconnectingAccount` | That account, or `null`.                                                       |
+| Connect / disconnect / sign in / sign a message | `useConnect` and friends | An [`ActionResult`](/docs/guides/react/core-hooks#useaction) from `useAction`. |
+| Switch account without reconnecting             | `useSelectAccount`       | The synchronous `selectAccount` callback.                                      |
+
+## Gate UI on the initial warm-up
+
+A freshly built client silently reconnects to the last persisted wallet. It passes through `'pending'` and `'reconnecting'` before it settles, and rendering a connect button during that window flashes "disconnected" for a frame. Hold wallet-dependent UI back until the warm-up finishes.
+
+```tsx twoslash
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { walletSigner } from '@solana/kit-plugin-wallet';
+const client = createClient()
+    .use(walletSigner({ chain: 'solana:devnet' }))
+    .use(solanaDevnetRpc());
+type AppClient = Awaited<typeof client>;
+function Dashboard() {
+    return null;
+}
+// ---cut-before---
+import { useClient } from '@solana/react';
+import { WalletReadyGate } from '@solana/kit-plugin-wallet/react';
+
+function App() {
+    const client = useClient<AppClient>();
+    return (
+        <WalletReadyGate client={client} fallback={<p>Loading wallets…</p>}>
+            <Dashboard />
+        </WalletReadyGate>
+    );
+}
+```
+
+`WalletReadyGate` is a thin wrapper over `useIsWalletReady`. Use the boolean directly when you want finer control, such as disabling a button rather than hiding a whole subtree.
+
+```tsx twoslash
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { walletSigner } from '@solana/kit-plugin-wallet';
+const client = createClient()
+    .use(walletSigner({ chain: 'solana:devnet' }))
+    .use(solanaDevnetRpc());
+type AppClient = Awaited<typeof client>;
+// ---cut-before---
+import { useClient } from '@solana/react';
+import { useIsWalletReady } from '@solana/kit-plugin-wallet/react';
+
+function ConnectButton() {
+    const client = useClient<AppClient>();
+    const isReady = useIsWalletReady(client);
+    return <button disabled={!isReady}>Connect</button>;
+}
+```
+
+Neither helper waits on user-initiated `'connecting'` / `'disconnecting'`, so a normal connect stays interactive.
+
+## Reading wallet state
+
+Each state hook subscribes to a single slice of `client.wallet.getState()`, so a component only re-renders when that slice changes.
+
+### `useWallets` / `useConnectedWallet` / `useConnect`
+
+```tsx twoslash
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { walletSigner } from '@solana/kit-plugin-wallet';
+const client = createClient()
+    .use(walletSigner({ chain: 'solana:devnet' }))
+    .use(solanaDevnetRpc());
+type AppClient = Awaited<typeof client>;
+// ---cut-before---
+import { useClient } from '@solana/react';
+import {
+    useConnect,
+    useConnectedWallet,
+    useDisconnect,
+    useWallets,
+} from '@solana/kit-plugin-wallet/react';
+
+function WalletButton() {
+    const client = useClient<AppClient>();
+    const wallets = useWallets(client);
+    const connected = useConnectedWallet(client);
+    const { dispatch: connect, isRunning } = useConnect(client);
+    const { dispatch: disconnect } = useDisconnect(client);
+
+    if (connected) {
+        return (
+            <div>
+                <p>Connected: {connected.account.address}</p>
+                <button onClick={() => disconnect()}>Disconnect</button>
+            </div>
+        );
+    }
+
+    return wallets.map((wallet) => (
+        <button key={wallet.name} disabled={isRunning} onClick={() => connect(wallet)}>
+            Connect {wallet.name}
+        </button>
+    ));
+}
+```
+
+`connect` / `disconnect` / `signIn` / `signMessage` wrap the matching `client.wallet` methods with [`useAction`](/docs/guides/react/core-hooks#useaction). `dispatch` is fire-and-forget and never throws; use `dispatchAsync` when you need the resolved value or to propagate errors. A newer dispatch aborts the in-flight one — filter that rejection with `isAbortError` from `@solana/kit`.
+
+If another `connect` or `signIn` starts before the current one resolves (an accidental double-click, for example), the newer request wins. The superseded call rejects with an abort error, and a failed attempt to connect a _different_ wallet leaves the existing connection in place.
+
+### `useSignIn` / `useSignMessage` / `useSelectAccount`
+
+`useSignIn` is Sign In With Solana as connect: it establishes a full connection, then calls `solana:signIn`. Pass `{}` when you do not need to customize the input.
+
+```tsx twoslash
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { walletSigner } from '@solana/kit-plugin-wallet';
+const client = createClient()
+    .use(walletSigner({ chain: 'solana:devnet' }))
+    .use(solanaDevnetRpc());
+type AppClient = Awaited<typeof client>;
+declare const wallet: import('@wallet-standard/ui').UiWallet;
+declare const account: import('@wallet-standard/ui').UiWalletAccount;
+// ---cut-before---
+import { useClient } from '@solana/react';
+import { useSelectAccount, useSignIn, useSignMessage } from '@solana/kit-plugin-wallet/react';
+
+function WalletActions() {
+    const client = useClient<AppClient>();
+    const { dispatch: signIn } = useSignIn(client);
+    const { dispatch: signMessage } = useSignMessage(client);
+    const selectAccount = useSelectAccount(client);
+
+    return (
+        <>
+            <button onClick={() => signIn(wallet, { domain: 'example.com' })}>Sign in</button>
+            <button onClick={() => signMessage(new TextEncoder().encode('Hello'))}>
+                Sign message
+            </button>
+            <button onClick={() => selectAccount(account)}>Use this account</button>
+        </>
+    );
+}
+```
+
+`useSelectAccount` is the odd one out: `selectAccount` is synchronous, so the hook returns the bound function directly rather than an `ActionResult`. The account may belong to any currently authorized wallet, not only the active one.
+
+## Next steps
+
+- [Setting up signers](/docs/guides/setting-up-signers#use-a-browser-wallet) — plugin variants, persistence, and the framework-agnostic `client.wallet` API.
+- [Core hooks](/docs/guides/react/core-hooks) — `useClient`, `useAction`, and the read/subscribe hooks.
+- [Available plugins](/docs/plugins/available-plugins#wallet-plugins) — the four wallet plugin variants at a glance.

--- a/docs/content/docs/guides/setting-up-signers.mdx
+++ b/docs/content/docs/guides/setting-up-signers.mdx
@@ -75,11 +75,91 @@ This is convenient for command-line tools, scripts, and backend services that al
     excluded from version control and from any production build artifact.
 </Callout>
 
-## Use a browser wallet signer
+## Use a browser wallet
 
-A dedicated wallet signer plugin is on its way and will be documented here once it lands. It will use the [Wallet Standard](https://github.com/wallet-standard/wallet-standard) under the hood and expose a framework-agnostic reactive layer, so it can be used from any UI framework — not just React.
+The [`@solana/kit-plugin-wallet`](https://www.npmjs.com/package/@solana/kit-plugin-wallet) package discovers [Wallet Standard](https://github.com/wallet-standard/wallet-standard) wallets in the browser, manages connect / disconnect / sign-in, and can install the connected wallet as the client's `payer` and/or `identity`. The same `client.wallet` namespace works from any UI framework; React bindings live in [`@solana/kit-plugin-wallet/react`](/docs/guides/react/wallet).
 
-Until then, the [`@solana/react`](/api) hooks can produce a `TransactionSigner` from a connected wallet account, and you can install that signer on a Kit client with the `signer(...)`, `payer(...)`, or `identity(...)` plugins shown above.
+```package-install
+@solana/kit @solana/kit-plugin-wallet
+```
+
+`walletSigner(...)` is the usual choice for a dApp: it installs `client.wallet` and syncs the connected wallet to both `payer` and `identity`. Pass the [Wallet Standard chain identifier](https://github.com/solana-labs/wallet-standard) that matches the RPC cluster you will talk to — one client targets one chain.
+
+```ts twoslash
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { walletSigner } from '@solana/kit-plugin-wallet';
+
+const client = createClient()
+    .use(walletSigner({ chain: 'solana:devnet' }))
+    .use(solanaDevnetRpc());
+```
+
+Read discovered wallets from `client.wallet.getState()` and connect one. Once a signing-capable wallet is connected, `client.payer` and `client.identity` are that wallet's signer, so `client.sendTransaction(...)` prompts the wallet as usual.
+
+```ts twoslash
+import { createClient } from '@solana/kit';
+import { solanaDevnetRpc } from '@solana/kit-plugin-rpc';
+import { walletSigner } from '@solana/kit-plugin-wallet';
+const client = createClient()
+    .use(walletSigner({ chain: 'solana:devnet' }))
+    .use(solanaDevnetRpc());
+declare const selectedWallet: import('@wallet-standard/ui').UiWallet;
+// ---cut-before---
+const { wallets } = client.wallet.getState();
+
+await client.wallet.connect(selectedWallet);
+
+// `client.payer` and `client.identity` are now the connected wallet's signer.
+```
+
+Accessing `client.payer` or `client.identity` **throws** while disconnected or when the connected wallet is read-only. Gate any send on `getState().connected?.signer` (or the React equivalents) so you never read those getters too early.
+
+The other three plugin variants cover the cases where fee payment and user identity should not both come from the wallet:
+
+| Plugin                | `client.payer` | `client.identity` | When to use                                                          |
+| --------------------- | -------------- | ----------------- | -------------------------------------------------------------------- |
+| `walletSigner`        | wallet signer  | wallet signer     | Most dApps — the wallet pays fees and signs as the user.             |
+| `walletPayer`         | wallet signer  | —                 | The wallet pays fees; identity is installed separately.              |
+| `walletIdentity`      | —              | wallet signer     | A relayer or backend key pays fees; the wallet is the user identity. |
+| `walletWithoutSigner` | —              | —                 | Wallet state only; read `getState().connected?.signer` yourself.     |
+
+```ts twoslash
+import { createClient, generateKeyPairSigner } from '@solana/kit';
+import { payer } from '@solana/kit-plugin-signer';
+import { walletIdentity } from '@solana/kit-plugin-wallet';
+
+const relayer = await generateKeyPairSigner();
+
+const client = createClient()
+    .use(payer(relayer))
+    .use(walletIdentity({ chain: 'solana:devnet' }));
+
+// `client.payer` is always the relayer.
+// `client.identity` is the connected wallet's signer.
+```
+
+By default the plugin persists the last connected account in `localStorage` and silently reconnects on the next page load. Pass `storage: null` to disable that, or `autoConnect: false` to persist without reconnecting. `filter` lets you keep only wallets that advertise a given feature.
+
+```ts twoslash
+import { walletSigner } from '@solana/kit-plugin-wallet';
+
+walletSigner({
+    chain: 'solana:devnet',
+    autoConnect: true,
+    storage: null, // disable persistence
+    filter: (w) => w.features.includes('solana:signAndSendTransaction'),
+});
+```
+
+`client.wallet` also exposes `disconnect`, `selectAccount`, `signMessage`, and `signIn` (Sign In With Solana). Subscribe with `client.wallet.subscribe` to bind the same state to Vue, Svelte, or any other UI library. In React, prefer the [wallet hooks](/docs/guides/react/wallet) instead of wiring `useSyncExternalStore` yourself.
+
+<Callout type="info">
+    All four wallet plugins are safe to include in a client that is created on the server. On the
+    server — and in React Native, where Wallet Standard browser discovery is not available —
+    `status` stays `'pending'`, actions throw, and no storage or registry listeners are touched. In
+    the browser the plugin initializes normally.
+</Callout>
 
 ## Generate signers for tests
 
@@ -118,6 +198,7 @@ The order matters: the signer must exist before the RPC bundle is added (so the 
 
 ## Next steps
 
+- [React — Wallet hooks](/docs/guides/react/wallet) — connect, disconnect, and gate UI on auto-reconnect from React.
 - [Sending transactions](/docs/guides/sending-transactions) — use your client to send and confirm transactions.
 - [Testing and local development](/docs/guides/testing-and-local-development) — set up local validators or LiteSVM for testing.
 - [Advanced guides — Signers](/docs/advanced-guides/signers) — learn the signer interfaces in depth.

--- a/docs/content/docs/plugins/available-plugins.mdx
+++ b/docs/content/docs/plugins/available-plugins.mdx
@@ -19,6 +19,17 @@ Signer plugins install a `TransactionSigner` on the client as the `payer`, the `
 | [Anza](https://www.anza.xyz/) | [`@solana/kit-plugin-signer`](https://www.npmjs.com/package/@solana/kit-plugin-signer) | `generatedSignerWithSol`, `generatedPayerWithSol`, `generatedIdentityWithSol` | Generate a signer and airdrop SOL to it in one step.             |
 | [Anza](https://www.anza.xyz/) | [`@solana/kit-plugin-signer`](https://www.npmjs.com/package/@solana/kit-plugin-signer) | `airdropSigner`, `airdropPayer`, `airdropIdentity`                            | Airdrop SOL to a signer that is already installed on the client. |
 
+## Wallet plugins
+
+Wallet plugins discover [Wallet Standard](https://github.com/wallet-standard/wallet-standard) wallets in the browser, manage the connection lifecycle, and optionally install the connected wallet as the client's `payer` and/or `identity`. See [Setting up signers](/docs/guides/setting-up-signers#use-a-browser-wallet) for the client API and [React — Wallet hooks](/docs/guides/react/wallet) for the React bindings.
+
+| Maintainer                    | Package                                                                                | Plugins               | Description                                                                    |
+| ----------------------------- | -------------------------------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------ |
+| [Anza](https://www.anza.xyz/) | [`@solana/kit-plugin-wallet`](https://www.npmjs.com/package/@solana/kit-plugin-wallet) | `walletSigner`        | Discover wallets and sync the connected wallet to both `payer` and `identity`. |
+| [Anza](https://www.anza.xyz/) | [`@solana/kit-plugin-wallet`](https://www.npmjs.com/package/@solana/kit-plugin-wallet) | `walletPayer`         | Discover wallets and sync the connected wallet to `payer` only.                |
+| [Anza](https://www.anza.xyz/) | [`@solana/kit-plugin-wallet`](https://www.npmjs.com/package/@solana/kit-plugin-wallet) | `walletIdentity`      | Discover wallets and sync the connected wallet to `identity` only.             |
+| [Anza](https://www.anza.xyz/) | [`@solana/kit-plugin-wallet`](https://www.npmjs.com/package/@solana/kit-plugin-wallet) | `walletWithoutSigner` | Discover wallets without setting `payer` or `identity`.                        |
+
 ## RPC plugins
 
 RPC plugins install Solana RPC connectivity on the client. LiteSVM is included here because it implements a subset of the same RPC API in-process, with no network involved.

--- a/docs/package.json
+++ b/docs/package.json
@@ -37,6 +37,7 @@
         "@solana/kit-plugin-litesvm": "^0.15.0",
         "@solana/kit-plugin-rpc": "^0.16.0",
         "@solana/kit-plugin-signer": "^0.13.0",
+        "@solana/kit-plugin-wallet": "^0.17.0",
         "@solana/react": "7.1.0",
         "@solana/wallet-account-signer": "7.1.0",
         "@solana/web3.js": "^1.98.4",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@solana/kit-plugin-signer':
         specifier: ^0.13.0
         version: 0.13.0(@solana/kit@7.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))
+      '@solana/kit-plugin-wallet':
+        specifier: ^0.17.0
+        version: 0.17.0(@solana/kit@7.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/react@7.1.0(@solana/kit@7.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@tanstack/react-query@5.101.4(react@19.2.8))(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(swr@2.5.1(react@19.2.8))(typescript@5.9.3))(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.8)(typescript@5.9.3)
       '@solana/react':
         specifier: 7.1.0
         version: 7.1.0(@solana/kit@7.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@tanstack/react-query@5.101.4(react@19.2.8))(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(swr@2.5.1(react@19.2.8))(typescript@5.9.3)
@@ -2708,6 +2711,18 @@ packages:
     peerDependencies:
       '@solana/kit': ^7.0.0
 
+  '@solana/kit-plugin-wallet@0.17.0':
+    resolution: {integrity: sha512-a3escg+u11Cva7Bjwca0Pjkg6FawVMVvdCWOVvrsKW0AAhgYEjo2PtvtlP/61bW7cc7BXcw16wJOcsNbOSBlHg==}
+    peerDependencies:
+      '@solana/kit': ^7.0.0
+      '@solana/react': ^7.1.0
+      react: ^19.2.8
+    peerDependenciesMeta:
+      '@solana/react':
+        optional: true
+      react:
+        optional: true
+
   '@solana/kit@6.10.0':
     resolution: {integrity: sha512-/WnnQp3uARh2JCFSfAakejTAqwmXVuMVTcRn5r2yDwY2yzZ4R6mt/Cl59VPimVLNSoTyN/KsEwhv9omr3ERazQ==}
     engines: {node: '>=20.18.0'}
@@ -3232,6 +3247,10 @@ packages:
     resolution: {integrity: sha512-Us3TgL4eMVoVWhuC4UrePlYnpWN+lwteCBlhZDUhFZBJ5UMGh94mYPXno3Ho7+iHPYRtuCi/ePvPcYBqCGuBOw==}
     engines: {node: '>=16'}
 
+  '@solana/wallet-standard-chains@1.1.2':
+    resolution: {integrity: sha512-EZobEGclDBAFplpJC5F3d/s8Xnlqc5isNKuPrd5o9ZPZ7tWN84O0e68yIZ8MAOj9V7ieRadNiHtql7uIXCTyXg==}
+    engines: {node: '>=22'}
+
   '@solana/wallet-standard-features@1.4.0':
     resolution: {integrity: sha512-f0tAdqwM2aL6CiFbIgt9h5zKFp+mgY/iNGwoxPMTj9VSTeQj7d1GGSmWhZw0XWoZ4N/1tnKTKmYFq+Dyq08jRw==}
     engines: {node: '>=22'}
@@ -3703,6 +3722,10 @@ packages:
     resolution: {integrity: sha512-3CijvrO9utx598kjr45hTbbeeykQrQfKmSnxeWOgU25TOEpvcipD/bYDQWIqUv1Oc6KK4YStokSMu/FBNecGUQ==}
     engines: {node: '>=16'}
 
+  '@wallet-standard/app@1.1.1':
+    resolution: {integrity: sha512-WDGwoByhP5gwHH01r5EaLgQdLVkACPCdOMQhmhn8rsm10h/siSgTorShzBxrn0ExSPof+Lu+C3TfgqBrPa1xoQ==}
+    engines: {node: '>=22'}
+
   '@wallet-standard/base@1.1.0':
     resolution: {integrity: sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ==}
     engines: {node: '>=16'}
@@ -3728,6 +3751,10 @@ packages:
   '@wallet-standard/features@1.1.0':
     resolution: {integrity: sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg==}
     engines: {node: '>=16'}
+
+  '@wallet-standard/features@1.1.1':
+    resolution: {integrity: sha512-aCWYmVeSCGViyEU5k7GMoW8zxE4Gs+C1s1Pp2XLesvSNlnZ4PMES9HUnTB3hl0b3RVj7C61yze3IWyrncqg4MA==}
+    engines: {node: '>=22'}
 
   '@wallet-standard/react-core@1.0.1':
     resolution: {integrity: sha512-g+vZaLlAGlYMwZEoKsmjjI5qz1D8P3FF1aqiI3WLooWOVk55Nszbpk01QCbIFdIMF0UDhxia2FU667TCv509iw==}
@@ -8983,6 +9010,25 @@ snapshots:
     dependencies:
       '@solana/kit': 7.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
 
+  '@solana/kit-plugin-wallet@0.17.0(@solana/kit@7.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@solana/react@7.1.0(@solana/kit@7.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@tanstack/react-query@5.101.4(react@19.2.8))(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(swr@2.5.1(react@19.2.8))(typescript@5.9.3))(fastestsmallesttextencoderdecoder@1.0.22)(react@19.2.8)(typescript@5.9.3)':
+    dependencies:
+      '@solana/kit': 7.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@solana/wallet-account-signer': 7.1.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
+      '@solana/wallet-standard-chains': 1.1.2
+      '@solana/wallet-standard-features': 1.4.0
+      '@wallet-standard/app': 1.1.1
+      '@wallet-standard/base': 1.1.1
+      '@wallet-standard/features': 1.1.1
+      '@wallet-standard/ui': 1.0.3
+      '@wallet-standard/ui-features': 1.0.3
+      '@wallet-standard/ui-registry': 1.1.1
+    optionalDependencies:
+      '@solana/react': 7.1.0(@solana/kit@7.1.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10))(@tanstack/react-query@5.101.4(react@19.2.8))(fastestsmallesttextencoderdecoder@1.0.22)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(swr@2.5.1(react@19.2.8))(typescript@5.9.3)
+      react: 19.2.8
+    transitivePeerDependencies:
+      - fastestsmallesttextencoderdecoder
+      - typescript
+
   '@solana/kit@6.10.0(bufferutil@4.0.9)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@solana/accounts': 6.10.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -9736,10 +9782,14 @@ snapshots:
     dependencies:
       '@wallet-standard/base': 1.1.1
 
+  '@solana/wallet-standard-chains@1.1.2':
+    dependencies:
+      '@wallet-standard/base': 1.1.1
+
   '@solana/wallet-standard-features@1.4.0':
     dependencies:
       '@wallet-standard/base': 1.1.1
-      '@wallet-standard/features': 1.1.0
+      '@wallet-standard/features': 1.1.1
 
   '@solana/web3.js@1.98.4(bufferutil@4.0.9)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -10407,6 +10457,10 @@ snapshots:
     dependencies:
       '@wallet-standard/base': 1.1.1
 
+  '@wallet-standard/app@1.1.1':
+    dependencies:
+      '@wallet-standard/base': 1.1.1
+
   '@wallet-standard/base@1.1.0': {}
 
   '@wallet-standard/base@1.1.1': {}
@@ -10426,6 +10480,10 @@ snapshots:
       '@wallet-standard/base': 1.1.1
 
   '@wallet-standard/features@1.1.0':
+    dependencies:
+      '@wallet-standard/base': 1.1.1
+
+  '@wallet-standard/features@1.1.1':
     dependencies:
       '@wallet-standard/base': 1.1.1
 


### PR DESCRIPTION
#### Problem

The docs catalog other Kit plugins at https://www.solanakit.com/docs/plugins/available-plugins, but `@solana/kit-plugin-wallet` is missing. The signers guide still describes the wallet plugin as forthcoming, and the React section has no place for plugin-owned hooks.

#### Summary of Changes

- List the four wallet plugin variants (`walletSigner`, `walletPayer`, `walletIdentity`, `walletWithoutSigner`) on the available plugins page.
- Replace the placeholder in Setting up signers with the published `client.wallet` API, persistence/auto-reconnect notes, and the payer/identity split.
- Add a React "Wallet hooks" page for `@solana/kit-plugin-wallet/react`, and a Plugin hooks section on the React overview so later plugin packages (instruction-plan hooks, etc.) can follow the same `/react` subpath pattern.
- Install `@solana/kit-plugin-wallet` in the docs site so the twoslash examples type-check.

Fixes #1839


