### PR TITLE
Fix toArrayBuffer returning the whole backing buffer for offset-zero views

### DIFF
--- a/.changeset/long-words-obey.md
+++ b/.changeset/long-words-obey.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-core': patch
+---
+
+Fix `toArrayBuffer` returning the entire backing buffer when given a `Uint8Array` view that starts at byte offset zero but is shorter than its underlying `ArrayBuffer`. This caused `signBytes` and `verifySignature` to operate on the wrong bytes — and `getBase64Decoder().decode()` to include trailing data — for such views, most notably the `messageBytes` of a decoded version 1 transaction, whose wire envelope places the message first and the signatures last

--- a/packages/codecs-core/src/__tests__/array-buffers-test.ts
+++ b/packages/codecs-core/src/__tests__/array-buffers-test.ts
@@ -21,6 +21,18 @@ describe('toArrayBuffer', () => {
             expect(toArrayBuffer(byteArray, offset, length)).toBe(byteArray.buffer);
         },
     );
+    it('returns a new buffer when the byte array is an offset-zero view over a larger buffer', () => {
+        const byteArray = new Uint8Array([1, 2, 3, 4, 5]).subarray(0, 3);
+        const arrayBuffer = toArrayBuffer(byteArray);
+        expect(arrayBuffer).not.toBe(byteArray.buffer);
+        expect(new Uint8Array(arrayBuffer)).toStrictEqual(new Uint8Array([1, 2, 3]));
+    });
+    it('returns a new buffer when the specified slice encompasses an entire offset-zero view over a larger buffer', () => {
+        const byteArray = new Uint8Array([1, 2, 3, 4, 5]).subarray(0, 3);
+        const arrayBuffer = toArrayBuffer(byteArray, 0, 3);
+        expect(arrayBuffer).not.toBe(byteArray.buffer);
+        expect(new Uint8Array(arrayBuffer)).toStrictEqual(new Uint8Array([1, 2, 3]));
+    });
     it.each([
         [-3, 0],
         [-3, 1],

--- a/packages/codecs-core/src/array-buffers.ts
+++ b/packages/codecs-core/src/array-buffers.ts
@@ -19,7 +19,7 @@ export function toArrayBuffer(bytes: ReadonlyUint8Array | Uint8Array, offset?: n
     } else {
         buffer = bytes.buffer;
     }
-    return (bytesOffset === 0 || bytesOffset === -bytes.byteLength) && bytesLength === bytes.byteLength
+    return (bytesOffset === 0 || bytesOffset === -buffer.byteLength) && bytesLength === buffer.byteLength
         ? buffer
         : buffer.slice(bytesOffset, bytesOffset + bytesLength);
 }


### PR DESCRIPTION
`toArrayBuffer` is a function that converts a `Uint8Array` to a `ArrayBuffer`, and then returns an (optional) offset/length slice. If the offset/length encompasses the entire array then the buffer should correspond to the entire array. It does this by using `bytes.buffer` to get the underlying buffer.

It has a short-circuit path, when the requested slice covers all of the buffer. In this case it does not do `buffer.slice` and just returns buffer. But this check was comparing against the **bytes** length instead of the buffer, and then returning the buffer.

The problem is that if we do `arr.subarray(0,3)`, this returns a `Uint8Array` with length 3, backed by a buffer with the original length:

```ts
> const arr = new Uint8Array([1,2,3,4,5])
> arr.buffer
ArrayBuffer { [Uint8Contents]: <01 02 03 04 05>, [byteLength]: 5 }
> arr.subarray(0,3).buffer
ArrayBuffer { [Uint8Contents]: <01 02 03 04 05>, [byteLength]: 5 }
```

This means that if we passed something like `decodedTransaction.subarray(0, len - 64*numSigs)` and requested the whole array as a buffer, it would return `decodedtransaction.buffer`, ie the entire decoded transaction including the signatures.

The fast path now compares offsets and lengths against the **buffer** length, instead of the **input bytes**. 

This fixes a bug when decoding v1 transactions, where an app might use subarray to account for the signatures being at the end.

This is a pre-existing bug, but was not triggered by the same logic for legacy or v0 transactions because they have signatures first, so `bytesOffset` would be non-zero if you wanted to skip the signatures.