### PR TITLE
Fix getTransactionSizeLimit misclassifying single-signer legacy transactions as v1

### DIFF
--- a/.changeset/clear-rings-taste.md
+++ b/.changeset/clear-rings-taste.md
@@ -1,0 +1,5 @@
+---
+'@solana/transactions': patch
+---
+
+Fix `getTransactionSizeLimit` misclassifying single-signer legacy transactions as version 1. A legacy message has no version byte, so its first byte is the number of required signatures — `1` for every single-signer transaction — which was mistaken for a v1 version byte. As a result, `isTransactionWithinSizeLimit`, `assertIsTransactionWithinSizeLimit`, and `assertIsSendableTransaction` accepted legacy transactions of up to 4096 bytes that the network rejects at 1232 bytes. The version flag (high bit) of the first message byte is now required to be set before treating a transaction as version 1

--- a/packages/transactions/src/__tests__/transaction-size-test.ts
+++ b/packages/transactions/src/__tests__/transaction-size-test.ts
@@ -13,6 +13,7 @@ import { compileTransaction } from '../compile-transaction';
 import {
     assertIsTransactionWithinSizeLimit,
     getTransactionSize,
+    getTransactionSizeLimit,
     isTransactionWithinSizeLimit,
 } from '../transaction-size';
 import { LEGACY_TRANSACTION_SIZE_LIMIT, V1_TRANSACTION_SIZE_LIMIT } from '../transaction-size-limits';
@@ -32,6 +33,29 @@ const SMALL_TRANSACTION = compileTransaction(SMALL_TRANSACTION_MESSAGE);
 
 const OVERSIZED_TRANSACTION = compileTransaction(
     pipe(SMALL_TRANSACTION_MESSAGE, m =>
+        appendTransactionMessageInstruction(
+            {
+                data: new Uint8Array(LEGACY_TRANSACTION_SIZE_LIMIT + 1),
+                programAddress: address('33333333333333333333333333333333333333333333'),
+            },
+            m,
+        ),
+    ),
+);
+
+const SMALL_LEGACY_TRANSACTION_MESSAGE = pipe(
+    createTransactionMessage({ version: 'legacy' }),
+    m => setTransactionMessageLifetimeUsingBlockhash(MOCK_BLOCKHASH, m),
+    m => setTransactionMessageFeePayer(address('22222222222222222222222222222222222222222222'), m),
+);
+
+const SMALL_LEGACY_TRANSACTION = compileTransaction(SMALL_LEGACY_TRANSACTION_MESSAGE);
+
+// A single-signer legacy transaction whose size exceeds the legacy limit.
+// Its first message byte is a `num_required_signatures` of 1, which must
+// not be mistaken for a v1 version byte.
+const LEGACY_TRANSACTION_OVER_LEGACY_LIMIT = compileTransaction(
+    pipe(SMALL_LEGACY_TRANSACTION_MESSAGE, m =>
         appendTransactionMessageInstruction(
             {
                 data: new Uint8Array(LEGACY_TRANSACTION_SIZE_LIMIT + 1),
@@ -84,7 +108,27 @@ describe('getTransactionSize', () => {
     });
 });
 
+describe('getTransactionSizeLimit', () => {
+    it('returns the legacy size limit for a single-signer legacy transaction', () => {
+        expect(getTransactionSizeLimit(SMALL_LEGACY_TRANSACTION)).toBe(LEGACY_TRANSACTION_SIZE_LIMIT);
+    });
+
+    it('returns the legacy size limit for a v0 transaction', () => {
+        expect(getTransactionSizeLimit(SMALL_TRANSACTION)).toBe(LEGACY_TRANSACTION_SIZE_LIMIT);
+    });
+
+    it('returns the v1 size limit for a v1 transaction', () => {
+        expect(getTransactionSizeLimit(compileTransaction(SMALL_V1_TRANSACTION_MESSAGE))).toBe(
+            V1_TRANSACTION_SIZE_LIMIT,
+        );
+    });
+});
+
 describe('isTransactionWithinSizeLimit', () => {
+    it('returns false for a single-signer legacy transaction whose size exceeds the legacy limit', () => {
+        expect(isTransactionWithinSizeLimit(LEGACY_TRANSACTION_OVER_LEGACY_LIMIT)).toBe(false);
+    });
+
     it('returns true when the transaction size is under the transaction size limit', () => {
         expect(isTransactionWithinSizeLimit(SMALL_TRANSACTION)).toBe(true);
     });
@@ -103,6 +147,15 @@ describe('isTransactionWithinSizeLimit', () => {
 });
 
 describe('assertIsTransactionWithinSizeLimit', () => {
+    it('throws for a single-signer legacy transaction whose size exceeds the legacy limit', () => {
+        expect(() => assertIsTransactionWithinSizeLimit(LEGACY_TRANSACTION_OVER_LEGACY_LIMIT)).toThrow(
+            new SolanaError(SOLANA_ERROR__TRANSACTION__EXCEEDS_SIZE_LIMIT, {
+                transactionSize: 1403,
+                transactionSizeLimit: LEGACY_TRANSACTION_SIZE_LIMIT,
+            }),
+        );
+    });
+
     it('does not throw when the transaction size is under the transaction size limit', () => {
         expect(() => assertIsTransactionWithinSizeLimit(SMALL_TRANSACTION)).not.toThrow();
     });

--- a/packages/transactions/src/transaction-size.ts
+++ b/packages/transactions/src/transaction-size.ts
@@ -54,9 +54,13 @@ export type SetTransactionWithinSizeLimitFromTransactionMessage<
  * @see {@link assertIsTransactionWithinSizeLimit}
  */
 export function getTransactionSizeLimit(transaction: Transaction): number {
-    const VERSION_FLAG_MASK = 0b01111111;
+    const VERSION_FLAG_MASK = 0b10000000;
+    const VERSION_NUMBER_MASK = 0b01111111;
     const firstByte = transaction.messageBytes[0];
-    return (firstByte & VERSION_FLAG_MASK) === 1 ? V1_TRANSACTION_SIZE_LIMIT : LEGACY_TRANSACTION_SIZE_LIMIT;
+    // Legacy messages have no version byte — their first byte is the number of required
+    // signatures, which has the version flag (high bit) unset.
+    const isVersionOne = (firstByte & VERSION_FLAG_MASK) !== 0 && (firstByte & VERSION_NUMBER_MASK) === 1;
+    return isVersionOne ? V1_TRANSACTION_SIZE_LIMIT : LEGACY_TRANSACTION_SIZE_LIMIT;
 }
 
 /**


### PR DESCRIPTION
`getTransactionSizeLimit` identifies the transaction version by looking at the first byte:

- for legacy, it's the number of signatures, <128
- for v0 it's 128 (0 | 0x80)
- for v1 it's 129 (1 | 0x80)

The byte arithmetic used was `versionByte & 0b01111111` (ie 127)

But this doesn't work for a legacy transaction with a single signer, because their first byte is 1 for 1 signer:

```ts
> 1 & 0b01111111
1
```

This means that the assertions treated a single signer legacy transaction as a v1 transaction, and would allow a legacy transaction with one signature to have >1232 bytes. 

The check now mirrors the envelope detection in the transaction codec: a transaction is only treated as v1 when the version flag (high bit) of the first message byte is set and the version number is 1.

Note that `getTransactionMessageSizeLimit` (message-based) was unaffected — it switches on `transactionMessage.version` directly.