### PR TITLE
Make the docs build check gate merges for all pull requests

### DIFF
--- a/.github/workflows/preview-docs-skipped.yml
+++ b/.github/workflows/preview-docs-skipped.yml
@@ -1,0 +1,28 @@
+# Companion to preview-docs.yml, following GitHub's documented pattern for
+# path-filtered required status checks ("Handling skipped but required
+# checks"). It reports a passing "Build Documentation Preview" check on pull
+# requests that don't touch the docs, so that the check can be marked as
+# required in the branch ruleset without blocking those pull requests forever
+# on a check that never runs.
+#
+# The paths-ignore list below must stay the mirror image of the paths list in
+# preview-docs.yml.
+name: Preview Documentation (skipped)
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '.github/workflows/preview-docs.yml'
+      - '.github/workflows/preview-docs-skipped.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  preview-docs:
+    runs-on: ubuntu-latest
+    name: Build Documentation Preview
+    steps:
+      - name: Report Success
+        run: echo "No documentation changes detected. Nothing to build."

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,10 +1,12 @@
 name: Preview Documentation
 
 on:
+  merge_group:
   pull_request:
     paths:
       - 'docs/**'
       - '.github/workflows/preview-docs.yml'
+      - '.github/workflows/preview-docs-skipped.yml'
 
 permissions:
   contents: read
@@ -29,22 +31,30 @@ jobs:
     runs-on: ubuntu-latest
     name: Build Documentation Preview
     steps:
+      # Every step below is skipped on merge_group events, so the job reports
+      # success immediately there. This required check already gated the pull
+      # request itself; rebuilding the docs in the merge queue would only slow
+      # every queue entry down.
       - name: Checkout
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Dependencies
+        if: github.event_name == 'pull_request'
         uses: ./.github/workflows/actions/install-dependencies
 
       - name: Install Isolated Docs Dependencies
+        if: github.event_name == 'pull_request'
         working-directory: ./docs/
         shell: bash
         run: pnpm install --ignore-workspace
 
       - name: Install Vercel CLI
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         run: pnpm install -g vercel
 
       - name: Deploy to Vercel
-        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         shell: bash
         id: vercel_deploy
         env:
@@ -63,6 +73,16 @@ jobs:
           fi
           DEPLOY_URL=$(echo "$DEPLOY_OUTPUT" | grep -o 'https://[a-zA-Z0-9.-]*\.vercel\.app' | tail -1)
           echo "preview_url=$DEPLOY_URL" >> "$GITHUB_OUTPUT"
+
+      # Dependabot and fork pull requests cannot read the Vercel secrets, so
+      # build the docs without deploying a preview. This keeps the check
+      # meaningful for those pull requests: a broken docs build fails here
+      # instead of being silently skipped.
+      - name: Build Documentation (no deploy)
+        if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name != github.repository || github.actor == 'dependabot[bot]')
+        working-directory: ./docs/
+        shell: bash
+        run: pnpm build
 
       - name: Comment on PR with Preview URL
         if: steps.vercel_deploy.outcome == 'success'


### PR DESCRIPTION
Follow-up to #1968. The `Build Documentation Preview` check failed on #1965 but the PR merged anyway, because the check is not in the `main` ruleset's required status checks. This PR prepares the check to be marked required.

Three things stood in the way of just flipping it to required:

1. **The build was silently skipped for the riskiest PRs.** The Vercel deploy step needs secrets that dependabot and fork PRs cannot read, so for those PRs the job passed green without building anything. A new fallback step now runs a plain `pnpm build` (no secrets, no deploy) whenever the deploy step would be skipped, so a broken docs build fails the check for every PR that touches `docs/`.

2. **Path filtering vs. required checks.** The workflow only runs when `docs/**` changes; a required check that never reports would block every non-docs PR forever. A companion no-op workflow (`preview-docs-skipped.yml`, GitHub's documented [skipped-but-required-checks pattern](https://docs.github.com/en/actions/using-workflows/required-workflows)) reports a passing check of the same name on PRs that don't touch the docs. This deliberately keeps the docs build excluded from non-docs PRs, since it can be memory-hungry and occasionally flaky.

3. **The merge queue.** Required checks must also report on `merge_group` events or queue entries stall and time out. The workflow now triggers on `merge_group` and reports success immediately there — the check already gated the PR itself, and rebuilding the docs in the queue would slow every entry down.

**After this merges, one manual step activates the gate:** add `Build Documentation Preview` to the required status checks in the `main` branch ruleset (Settings → Rules → Rulesets). Note that open PRs created before this merges will need a push or re-run to produce the newly required check.

No changeset: CI config only.