### PR TITLE
Fix SharedArrayBuffer view slicing

### DIFF
--- a/.changeset/calm-buffers-slice.md
+++ b/.changeset/calm-buffers-slice.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-core': patch
+---
+
+Fix `toArrayBuffer` slicing SharedArrayBuffer-backed views from a non-zero byte offset.

--- a/packages/codecs-core/src/__tests__/array-buffers-test.ts
+++ b/packages/codecs-core/src/__tests__/array-buffers-test.ts
@@ -7,6 +7,24 @@ describe('toArrayBuffer', () => {
         const arrayBuffer = toArrayBuffer(byteArray);
         expect(arrayBuffer).not.toBeInstanceOf(SharedArrayBuffer);
     });
+    it('copies a non-zero-offset shared array buffer view without applying its offset twice', () => {
+        const sharedArrayBuffer = new SharedArrayBuffer(5);
+        const byteArray = new Uint8Array(sharedArrayBuffer);
+        byteArray.set([1, 2, 3, 4, 5]);
+
+        const arrayBuffer = toArrayBuffer(byteArray.subarray(2, 5));
+
+        expect(new Uint8Array(arrayBuffer)).toStrictEqual(new Uint8Array([3, 4, 5]));
+    });
+    it('applies an explicit slice relative to a non-zero-offset shared array buffer view', () => {
+        const sharedArrayBuffer = new SharedArrayBuffer(5);
+        const byteArray = new Uint8Array(sharedArrayBuffer);
+        byteArray.set([1, 2, 3, 4, 5]);
+
+        const arrayBuffer = toArrayBuffer(byteArray.subarray(1, 5), 1, 2);
+
+        expect(new Uint8Array(arrayBuffer)).toStrictEqual(new Uint8Array([3, 4]));
+    });
     it('returns the buffer without modification when no slice is specified', () => {
         const byteArray = new Uint8Array([1, 2, 3]);
         expect(toArrayBuffer(byteArray)).toBe(byteArray.buffer);

--- a/packages/codecs-core/src/array-buffers.ts
+++ b/packages/codecs-core/src/array-buffers.ts
@@ -8,7 +8,7 @@ import { ReadonlyUint8Array } from './readonly-uint8array';
  * Source: https://stackoverflow.com/questions/37228285/uint8array-to-arraybuffer
  */
 export function toArrayBuffer(bytes: ReadonlyUint8Array | Uint8Array, offset?: number, length?: number): ArrayBuffer {
-    const bytesOffset = bytes.byteOffset + (offset ?? 0);
+    let bytesOffset = bytes.byteOffset + (offset ?? 0);
     const bytesLength = length ?? bytes.byteLength;
     let buffer: ArrayBuffer;
     if (typeof SharedArrayBuffer === 'undefined') {
@@ -16,6 +16,7 @@ export function toArrayBuffer(bytes: ReadonlyUint8Array | Uint8Array, offset?: n
     } else if (bytes.buffer instanceof SharedArrayBuffer) {
         buffer = new ArrayBuffer(bytes.length);
         new Uint8Array(buffer).set(new Uint8Array(bytes));
+        bytesOffset = offset ?? 0;
     } else {
         buffer = bytes.buffer;
     }


### PR DESCRIPTION
#### Problem

`toArrayBuffer` copies a SharedArrayBuffer-backed view into a new zero-offset ArrayBuffer, but then slices that copy using the original view's `byteOffset`. A view beginning after byte zero therefore has its offset applied twice and returns truncated or empty data.

#### Summary of Changes

- Treat the copied SharedArrayBuffer view as a zero-offset buffer before applying the optional caller-provided slice.
- Add regressions for both a whole non-zero-offset view and an explicit slice relative to that view.
- Add the patch changeset for `@solana/codecs-core`.

Local verification:

```
pnpm --filter @solana/codecs-core test:unit:node -- --runInBand src/__tests__/array-buffers-test.ts
pnpm --filter @solana/codecs-core test:lint
pnpm --filter @solana/codecs-core test:prettier
pnpm turbo compile:typedefs --filter=@solana/codecs-core...
pnpm --filter @solana/codecs-core test:typecheck
pnpm changeset status
git diff --check
```

Fixes #1959
