### PR TITLE
Preserve fixedSize for single-field struct codecs

### DIFF
--- a/.changeset/sunny-melons-do.md
+++ b/.changeset/sunny-melons-do.md
@@ -1,0 +1,5 @@
+---
+"@solana/codecs-data-structures": patch
+---
+
+Preserve the literal `fixedSize` type for single-field fixed-size struct codecs.

--- a/packages/codecs-data-structures/src/__typetests__/struct-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/struct-typetest.ts
@@ -11,6 +11,8 @@ import { getUtf8Codec, getUtf8Decoder, getUtf8Encoder } from '@solana/codecs-str
 
 import { getStructCodec, getStructDecoder, getStructEncoder } from '../struct';
 
+type IsWidenedNumber<T extends number> = number extends T ? true : false;
+
 {
     // [getStructEncoder]: It knows if the encoder is fixed size or variable size.
     getStructEncoder([
@@ -22,6 +24,7 @@ import { getStructCodec, getStructDecoder, getStructEncoder } from '../struct';
         ['age', {} as FixedSizeEncoder<number>],
     ]) satisfies VariableSizeEncoder<{ age: number; name: string }>;
     getStructEncoder([['age', getU32Encoder()]]) satisfies FixedSizeEncoder<{ age: number }>;
+    getStructEncoder([['age', getU32Encoder()]]) satisfies FixedSizeEncoder<{ age: bigint | number }, 4>;
     getStructEncoder([['name', getUtf8Encoder()]]) satisfies VariableSizeEncoder<{ name: string }>;
 }
 
@@ -36,6 +39,7 @@ import { getStructCodec, getStructDecoder, getStructEncoder } from '../struct';
         ['age', {} as FixedSizeDecoder<number>],
     ]) satisfies VariableSizeDecoder<{ age: number; name: string }>;
     getStructDecoder([['age', getU32Decoder()]]) satisfies FixedSizeDecoder<{ age: number }>;
+    getStructDecoder([['age', getU32Decoder()]]) satisfies FixedSizeDecoder<{ age: number }, 4>;
     getStructDecoder([['name', getUtf8Decoder()]]) satisfies VariableSizeDecoder<{ name: string }>;
 }
 
@@ -50,7 +54,73 @@ import { getStructCodec, getStructDecoder, getStructEncoder } from '../struct';
         ['age', {} as FixedSizeCodec<number>],
     ]) satisfies VariableSizeCodec<{ age: number; name: string }>;
     getStructCodec([['age', getU32Codec()]]) satisfies FixedSizeCodec<{ age: number }>;
+    getStructCodec([['age', getU32Codec()]]) satisfies FixedSizeCodec<{ age: bigint | number }, { age: number }, 4>;
     getStructCodec([['name', getUtf8Codec()]]) satisfies VariableSizeCodec<{ name: string }>;
+}
+
+{
+    // [getStructEncoder/Decoder/Codec]: It only preserves literal sizes for exactly one fixed-size field.
+    {
+        // It forwards a second literal size without hard-coding the U32 size.
+        getStructEncoder([['value', {} as FixedSizeEncoder<number, 8>]]) satisfies FixedSizeEncoder<
+            { value: number },
+            8
+        >;
+        getStructDecoder([['value', {} as FixedSizeDecoder<number, 8>]]) satisfies FixedSizeDecoder<
+            { value: number },
+            8
+        >;
+        getStructCodec([['value', {} as FixedSizeCodec<number, number, 8>]]) satisfies FixedSizeCodec<
+            { value: number },
+            { value: number },
+            8
+        >;
+    }
+
+    {
+        // Two fixed-size fields stay widened; their sizes are not added by the type system.
+        const encoder = getStructEncoder([
+            ['a', {} as FixedSizeEncoder<number, 4>],
+            ['b', {} as FixedSizeEncoder<number, 8>],
+        ]);
+        const decoder = getStructDecoder([
+            ['a', {} as FixedSizeDecoder<number, 4>],
+            ['b', {} as FixedSizeDecoder<number, 8>],
+        ]);
+        const codec = getStructCodec([
+            ['a', {} as FixedSizeCodec<number, number, 4>],
+            ['b', {} as FixedSizeCodec<number, number, 8>],
+        ]);
+        [encoder.fixedSize, decoder.fixedSize, codec.fixedSize] satisfies number[];
+        true satisfies IsWidenedNumber<typeof encoder.fixedSize>;
+        true satisfies IsWidenedNumber<typeof decoder.fixedSize>;
+        true satisfies IsWidenedNumber<typeof codec.fixedSize>;
+    }
+
+    {
+        // Non-tuple field arrays stay widened even when their items have a literal size.
+        const encoderFields: readonly (readonly [string, FixedSizeEncoder<number, 4>])[] = [];
+        const decoderFields: readonly (readonly [string, FixedSizeDecoder<number, 4>])[] = [];
+        const codecFields: readonly (readonly [string, FixedSizeCodec<number, number, 4>])[] = [];
+        const encoder = getStructEncoder(encoderFields);
+        const decoder = getStructDecoder(decoderFields);
+        const codec = getStructCodec(codecFields);
+        [encoder.fixedSize, decoder.fixedSize, codec.fixedSize] satisfies number[];
+        true satisfies IsWidenedNumber<typeof encoder.fixedSize>;
+        true satisfies IsWidenedNumber<typeof decoder.fixedSize>;
+        true satisfies IsWidenedNumber<typeof codec.fixedSize>;
+    }
+
+    {
+        // Empty structs preserve their existing widened fixed-size classification.
+        const encoder = getStructEncoder([]);
+        const decoder = getStructDecoder([]);
+        const codec = getStructCodec([]);
+        [encoder.fixedSize, decoder.fixedSize, codec.fixedSize] satisfies number[];
+        true satisfies IsWidenedNumber<typeof encoder.fixedSize>;
+        true satisfies IsWidenedNumber<typeof decoder.fixedSize>;
+        true satisfies IsWidenedNumber<typeof codec.fixedSize>;
+    }
 }
 
 {

--- a/packages/codecs-data-structures/src/__typetests__/struct-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/struct-typetest.ts
@@ -11,7 +11,29 @@ import { getUtf8Codec, getUtf8Decoder, getUtf8Encoder } from '@solana/codecs-str
 
 import { getStructCodec, getStructDecoder, getStructEncoder } from '../struct';
 
-type IsWidenedNumber<T extends number> = number extends T ? true : false;
+/**
+ * Strict type-equality helper used by typetests below. Resolves to `true` only
+ * if `A` and `B` are mutually assignable AND share the same modifier set (`?`,
+ * `readonly`); otherwise resolves to `false`.
+ *
+ * This is stricter than `satisfies` for two reasons:
+ *
+ * 1. **Bidirectionality.** `A satisfies B` only checks that `A` is assignable
+ *    to `B`. A test using `satisfies` passes if the actual type has extra
+ *    members beyond what we asserted — which would silently mask a regression
+ *    that re-introduced a nested `Omit<...>` wrapper, since `Omit<X, K> & A`
+ *    is still structurally assignable to a flat literal.
+ * 2. **Modifier strictness.** `A satisfies B` tolerates losing `?` (required
+ *    is assignable to optional) and losing `readonly` (readonly is assignable
+ *    to mutable). `Equal` distinguishes `{ x: T }` from `{ x?: T }` and from
+ *    `{ readonly x: T }` because the inferred-position generic comparison
+ *    uses identity rather than assignability for the type parameters.
+ *
+ * Use `Equal` when the exact shape (including modifiers) matters. Use
+ * `satisfies` when one-way assignability is the actual requirement (e.g.
+ * "this value is usable where `Disposable & X` is expected").
+ */
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
 
 {
     // [getStructEncoder]: It knows if the encoder is fixed size or variable size.
@@ -59,68 +81,97 @@ type IsWidenedNumber<T extends number> = number extends T ? true : false;
 }
 
 {
-    // [getStructEncoder/Decoder/Codec]: It only preserves literal sizes for exactly one fixed-size field.
-    {
-        // It forwards a second literal size without hard-coding the U32 size.
-        getStructEncoder([['value', {} as FixedSizeEncoder<number, 8>]]) satisfies FixedSizeEncoder<
-            { value: number },
-            8
-        >;
-        getStructDecoder([['value', {} as FixedSizeDecoder<number, 8>]]) satisfies FixedSizeDecoder<
-            { value: number },
-            8
-        >;
-        getStructCodec([['value', {} as FixedSizeCodec<number, number, 8>]]) satisfies FixedSizeCodec<
-            { value: number },
-            { value: number },
-            8
-        >;
-    }
+    // [getStructEncoder]: It forwards a second literal size without hard-coding the U32 size.
+    getStructEncoder([['value', {} as FixedSizeEncoder<number, 8>]]) satisfies FixedSizeEncoder<{ value: number }, 8>;
+}
 
-    {
-        // Two fixed-size fields stay widened; their sizes are not added by the type system.
-        const encoder = getStructEncoder([
-            ['a', {} as FixedSizeEncoder<number, 4>],
-            ['b', {} as FixedSizeEncoder<number, 8>],
-        ]);
-        const decoder = getStructDecoder([
-            ['a', {} as FixedSizeDecoder<number, 4>],
-            ['b', {} as FixedSizeDecoder<number, 8>],
-        ]);
-        const codec = getStructCodec([
-            ['a', {} as FixedSizeCodec<number, number, 4>],
-            ['b', {} as FixedSizeCodec<number, number, 8>],
-        ]);
-        [encoder.fixedSize, decoder.fixedSize, codec.fixedSize] satisfies number[];
-        true satisfies IsWidenedNumber<typeof encoder.fixedSize>;
-        true satisfies IsWidenedNumber<typeof decoder.fixedSize>;
-        true satisfies IsWidenedNumber<typeof codec.fixedSize>;
-    }
+{
+    // [getStructDecoder]: It forwards a second literal size without hard-coding the U32 size.
+    getStructDecoder([['value', {} as FixedSizeDecoder<number, 8>]]) satisfies FixedSizeDecoder<{ value: number }, 8>;
+}
 
-    {
-        // Non-tuple field arrays stay widened even when their items have a literal size.
-        const encoderFields: readonly (readonly [string, FixedSizeEncoder<number, 4>])[] = [];
-        const decoderFields: readonly (readonly [string, FixedSizeDecoder<number, 4>])[] = [];
-        const codecFields: readonly (readonly [string, FixedSizeCodec<number, number, 4>])[] = [];
-        const encoder = getStructEncoder(encoderFields);
-        const decoder = getStructDecoder(decoderFields);
-        const codec = getStructCodec(codecFields);
-        [encoder.fixedSize, decoder.fixedSize, codec.fixedSize] satisfies number[];
-        true satisfies IsWidenedNumber<typeof encoder.fixedSize>;
-        true satisfies IsWidenedNumber<typeof decoder.fixedSize>;
-        true satisfies IsWidenedNumber<typeof codec.fixedSize>;
-    }
+{
+    // [getStructCodec]: It forwards a second literal size without hard-coding the U32 size.
+    getStructCodec([['value', {} as FixedSizeCodec<number, number, 8>]]) satisfies FixedSizeCodec<
+        { value: number },
+        { value: number },
+        8
+    >;
+}
 
-    {
-        // Empty structs preserve their existing widened fixed-size classification.
-        const encoder = getStructEncoder([]);
-        const decoder = getStructDecoder([]);
-        const codec = getStructCodec([]);
-        [encoder.fixedSize, decoder.fixedSize, codec.fixedSize] satisfies number[];
-        true satisfies IsWidenedNumber<typeof encoder.fixedSize>;
-        true satisfies IsWidenedNumber<typeof decoder.fixedSize>;
-        true satisfies IsWidenedNumber<typeof codec.fixedSize>;
-    }
+{
+    // [getStructEncoder]: Two fixed-size fields keep a widened size; it is not narrowed to a literal.
+    const encoder = getStructEncoder([
+        ['a', {} as FixedSizeEncoder<number, 4>],
+        ['b', {} as FixedSizeEncoder<number, 8>],
+    ]);
+    encoder satisfies FixedSizeEncoder<{ a: number; b: number }>;
+    true satisfies Equal<typeof encoder.fixedSize, number>;
+}
+
+{
+    // [getStructDecoder]: Two fixed-size fields keep a widened size; it is not narrowed to a literal.
+    const decoder = getStructDecoder([
+        ['a', {} as FixedSizeDecoder<number, 4>],
+        ['b', {} as FixedSizeDecoder<number, 8>],
+    ]);
+    decoder satisfies FixedSizeDecoder<{ a: number; b: number }>;
+    true satisfies Equal<typeof decoder.fixedSize, number>;
+}
+
+{
+    // [getStructCodec]: Two fixed-size fields keep a widened size; it is not narrowed to a literal.
+    const codec = getStructCodec([
+        ['a', {} as FixedSizeCodec<number, number, 4>],
+        ['b', {} as FixedSizeCodec<number, number, 8>],
+    ]);
+    codec satisfies FixedSizeCodec<{ a: number; b: number }>;
+    true satisfies Equal<typeof codec.fixedSize, number>;
+}
+
+{
+    // [getStructEncoder]: A non-tuple field array keeps a widened size even when its items have a literal size.
+    const fields: readonly (readonly [string, FixedSizeEncoder<number, 4>])[] = [];
+    const encoder = getStructEncoder(fields);
+    encoder.fixedSize satisfies number;
+    true satisfies Equal<typeof encoder.fixedSize, number>;
+}
+
+{
+    // [getStructDecoder]: A non-tuple field array keeps a widened size even when its items have a literal size.
+    const fields: readonly (readonly [string, FixedSizeDecoder<number, 4>])[] = [];
+    const decoder = getStructDecoder(fields);
+    decoder.fixedSize satisfies number;
+    true satisfies Equal<typeof decoder.fixedSize, number>;
+}
+
+{
+    // [getStructCodec]: A non-tuple field array keeps a widened size even when its items have a literal size.
+    const fields: readonly (readonly [string, FixedSizeCodec<number, number, 4>])[] = [];
+    const codec = getStructCodec(fields);
+    codec.fixedSize satisfies number;
+    true satisfies Equal<typeof codec.fixedSize, number>;
+}
+
+{
+    // [getStructEncoder]: An empty struct preserves its existing widened fixed-size classification.
+    const encoder = getStructEncoder([]);
+    encoder.fixedSize satisfies number;
+    true satisfies Equal<typeof encoder.fixedSize, number>;
+}
+
+{
+    // [getStructDecoder]: An empty struct preserves its existing widened fixed-size classification.
+    const decoder = getStructDecoder([]);
+    decoder.fixedSize satisfies number;
+    true satisfies Equal<typeof decoder.fixedSize, number>;
+}
+
+{
+    // [getStructCodec]: An empty struct preserves its existing widened fixed-size classification.
+    const codec = getStructCodec([]);
+    codec.fixedSize satisfies number;
+    true satisfies Equal<typeof codec.fixedSize, number>;
 }
 
 {

--- a/packages/codecs-data-structures/src/struct.ts
+++ b/packages/codecs-data-structures/src/struct.ts
@@ -82,6 +82,9 @@ type GetDecoderTypeFromFields<TFields extends Fields<Decoder<any>>> = DrainOuter
  *
  * @see {@link getStructCodec}
  */
+export function getStructEncoder<const TFields extends readonly [readonly [string, FixedSizeEncoder<any>]]>(
+    fields: TFields,
+): FixedSizeEncoder<GetEncoderTypeFromFields<TFields>, TFields[0][1]['fixedSize']>;
 export function getStructEncoder<const TFields extends Fields<FixedSizeEncoder<any>>>(
     fields: TFields,
 ): FixedSizeEncoder<GetEncoderTypeFromFields<TFields>>;
@@ -144,6 +147,9 @@ export function getStructEncoder<const TFields extends Fields<Encoder<any>>>(
  *
  * @see {@link getStructCodec}
  */
+export function getStructDecoder<const TFields extends readonly [readonly [string, FixedSizeDecoder<any>]]>(
+    fields: TFields,
+): FixedSizeDecoder<GetDecoderTypeFromFields<TFields>, TFields[0][1]['fixedSize']>;
 export function getStructDecoder<const TFields extends Fields<FixedSizeDecoder<any>>>(
     fields: TFields,
 ): FixedSizeDecoder<GetDecoderTypeFromFields<TFields>>;
@@ -217,6 +223,13 @@ export function getStructDecoder<const TFields extends Fields<Decoder<any>>>(
  * @see {@link getStructEncoder}
  * @see {@link getStructDecoder}
  */
+export function getStructCodec<const TFields extends readonly [readonly [string, FixedSizeCodec<any>]]>(
+    fields: TFields,
+): FixedSizeCodec<
+    GetEncoderTypeFromFields<TFields>,
+    GetDecoderTypeFromFields<TFields> & GetEncoderTypeFromFields<TFields>,
+    TFields[0][1]['fixedSize']
+>;
 export function getStructCodec<const TFields extends Fields<FixedSizeCodec<any>>>(
     fields: TFields,
 ): FixedSizeCodec<


### PR DESCRIPTION
#### Problem

Single fixed-size field structs currently widen their literal `fixedSize` to `number`.

#### Context

A broader type-arithmetic solution was explored in #1761. Maintainer feedback identified exactly-one-fixed-size-field support as a simpler middle ground.

#### Summary of Changes

Add narrow overloads that forward the only field's existing literal `fixedSize` for `getStructEncoder`, `getStructDecoder`, and `getStructCodec`. Add focused typetests and a patch changeset for `@solana/codecs-data-structures`.

Multi-field structs intentionally retain their existing `number` behavior. This introduces no type arithmetic and no runtime behavior changes.

#### Tests

- `pnpm --filter @solana/codecs-data-structures test:typecheck`
- `pnpm turbo compile:typedefs --filter=@solana/codecs-data-structures...`
- `pnpm --filter @solana/codecs-data-structures test:lint`
- `pnpm --filter @solana/codecs-data-structures test:prettier`
- `pnpm --filter @solana/codecs-data-structures test:unit:node`
- `pnpm --filter @solana/codecs-data-structures test:unit:browser`
- `pnpm --filter @solana/codecs-data-structures compile:js`, with Node, browser, and native runtime bundles byte-identical to the pristine build
- Generated declaration consumer typecheck
- `pnpm changeset status`
- `git diff --check`

#### AI assistance

AI assistance was used during implementation and verification. Shin reviewed the final change and owns the submission.

Fixes #1738
