### PR TITLE
Fix webcrypto-ed25519-polyfill mishandling non-Uint8Array view payloads

### DIFF
--- a/.changeset/soft-hats-march.md
+++ b/.changeset/soft-hats-march.md
@@ -1,0 +1,5 @@
+---
+'@solana/webcrypto-ed25519-polyfill': patch
+---
+
+Fixed an issue in `signPolyfill` and `verifyPolyfill` where payloads supplied as a view other than a `Uint8Array` (for instance, a `DataView`) were read from the start of the underlying buffer instead of the viewed range, producing signatures over the wrong bytes.

--- a/packages/webcrypto-ed25519-polyfill/src/__tests__/secrets-test.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/__tests__/secrets-test.ts
@@ -852,6 +852,13 @@ describe('signPolyfill', () => {
         expect.assertions(1);
         await expect(signPolyfill(privateKey, MOCK_DATA)).resolves.toHaveProperty('byteLength', 64);
     });
+    it('produces the expected signature when the payload is a DataView over an offset buffer', async () => {
+        expect.assertions(1);
+        const padded = new Uint8Array(5 + MOCK_DATA.length);
+        padded.set(MOCK_DATA, 5);
+        const view = new DataView(padded.buffer, 5, MOCK_DATA.length);
+        await expect(signPolyfill(privateKey, view)).resolves.toEqualArrayBuffer(MOCK_DATA_SIGNATURE.buffer);
+    });
 });
 
 describe('verifyPolyfill', () => {
@@ -894,5 +901,12 @@ describe('verifyPolyfill', () => {
         expect.assertions(1);
         const badSignature = MOCK_DATA_SIGNATURE.slice(0, 63);
         await expect(verifyPolyfill(publicKey, badSignature, MOCK_DATA)).resolves.toBe(false);
+    });
+    it('returns `true` when the payload is a DataView over an offset buffer', async () => {
+        expect.assertions(1);
+        const padded = new Uint8Array(5 + MOCK_DATA.length);
+        padded.set(MOCK_DATA, 5);
+        const view = new DataView(padded.buffer, 5, MOCK_DATA.length);
+        await expect(verifyPolyfill(publicKey, MOCK_DATA_SIGNATURE, view)).resolves.toBe(true);
     });
 });

--- a/packages/webcrypto-ed25519-polyfill/src/secrets.ts
+++ b/packages/webcrypto-ed25519-polyfill/src/secrets.ts
@@ -59,7 +59,12 @@ const ED25519_PKCS8_HEADER =
     ];
 
 function bufferSourceToUint8Array(data: BufferSource): Uint8Array {
-    return data instanceof Uint8Array ? data : new Uint8Array(ArrayBuffer.isView(data) ? data.buffer : data);
+    if (data instanceof Uint8Array) return data;
+    // Wrap views with their own offset and length; constructing from the raw
+    // backing buffer would read bytes before and after the view.
+    return ArrayBuffer.isView(data)
+        ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+        : new Uint8Array(data);
 }
 
 let storageKeyBySecretKey_INTERNAL_ONLY_DO_NOT_EXPORT: WeakMap<CryptoKey, Uint8Array> | undefined;


### PR DESCRIPTION
## What

`bufferSourceToUint8Array` in `@solana/webcrypto-ed25519-polyfill` wrapped any non-`Uint8Array` view in `new Uint8Array(data.buffer)`, discarding the view's own `byteOffset` and `byteLength`.

## Why

WebCrypto's `BufferSource` semantics operate on the viewed range only. With the old wrapper, a `DataView` (or any typed array other than `Uint8Array`) placed at a nonzero offset inside a larger buffer made `signPolyfill` sign, and `verifyPolyfill` verify, the whole backing buffer instead of the intended payload, so signatures were wrong and verifications spuriously failed. This is the same view-versus-buffer confusion fixed for `toArrayBuffer` in #1957; that fix did not touch this helper.

Passing a plain `Uint8Array` subarray was never affected, since that branch already returns the view as is.

## Change

Wrap views with their own offset and length:

```ts
return ArrayBuffer.isView(data)
    ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
    : new Uint8Array(data);
```

Regression tests sign and verify a `DataView` positioned at offset 5 inside a larger buffer. Both tests fail against the previous implementation and pass with this change.