### PR TITLE
fix(codecs-core): resolve negative toArrayBuffer offsets against the end of the buffer

### DIFF
--- a/.changeset/proud-otters-shave.md
+++ b/.changeset/proud-otters-shave.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-core': patch
+---
+
+Fix `toArrayBuffer` returning an empty buffer for negative offsets whose slice extends to the end of the data. A negative offset is now resolved against the end of the buffer before the end index is derived, matching `Array.prototype.slice`.

--- a/packages/codecs-core/src/__tests__/array-buffers-test.ts
+++ b/packages/codecs-core/src/__tests__/array-buffers-test.ts
@@ -56,4 +56,32 @@ describe('toArrayBuffer', () => {
         const byteArray = new Uint8Array([1, 2, 3]);
         expect(toArrayBuffer(byteArray, offset, length)).not.toBe(byteArray.buffer);
     });
+    it.each([
+        [-1, 1, [5]],
+        [-2, 2, [4, 5]],
+        [-2, 1, [4]],
+        [-3, 1, [3]],
+        [-3, 3, [3, 4, 5]],
+        [-5, 2, [1, 2]],
+        [-10, 2, [1, 2]],
+    ])(
+        'resolves a negative offset against the end of the buffer (offset: %d, length: %d)',
+        (offset, length, expected) => {
+            const byteArray = new Uint8Array([1, 2, 3, 4, 5]);
+            const arrayBuffer = toArrayBuffer(byteArray, offset, length);
+            expect(new Uint8Array(arrayBuffer)).toStrictEqual(new Uint8Array(expected));
+        },
+    );
+    it.each([
+        [-1, 1],
+        [-2, 2],
+        [-3, 1],
+        [-5, 5],
+        [2, 2],
+        [0, 3],
+    ])('matches native `slice` semantics for a negative offset (offset: %d, length: %d)', (offset, length) => {
+        const byteArray = new Uint8Array([1, 2, 3, 4, 5]);
+        const arrayBuffer = toArrayBuffer(byteArray, offset, length);
+        expect(new Uint8Array(arrayBuffer)).toStrictEqual(byteArray.slice(offset).slice(0, length));
+    });
 });

--- a/packages/codecs-core/src/array-buffers.ts
+++ b/packages/codecs-core/src/array-buffers.ts
@@ -19,7 +19,14 @@ export function toArrayBuffer(bytes: ReadonlyUint8Array | Uint8Array, offset?: n
     } else {
         buffer = bytes.buffer;
     }
-    return (bytesOffset === 0 || bytesOffset === -buffer.byteLength) && bytesLength === buffer.byteLength
+    // Resolve the offset against the end of the buffer before deriving the end index, the same way
+    // `Array.prototype.slice` does. Passing a negative `bytesOffset` straight to `buffer.slice()`
+    // would compute an end index of `bytesOffset + bytesLength` that can cross zero — e.g. an offset
+    // of -1 and a length of 1 becomes `slice(-1, 0)`, which yields an empty buffer instead of the
+    // final byte.
+    const startIndex =
+        bytesOffset < 0 ? Math.max(buffer.byteLength + bytesOffset, 0) : Math.min(bytesOffset, buffer.byteLength);
+    return startIndex === 0 && bytesLength === buffer.byteLength
         ? buffer
-        : buffer.slice(bytesOffset, bytesOffset + bytesLength);
+        : buffer.slice(startIndex, startIndex + bytesLength);
 }


### PR DESCRIPTION
#### Problem

`toArrayBuffer` forwards a negative offset straight to `buffer.slice()`, so the derived end index `bytesOffset + bytesLength` can cross zero. An offset of -1 with a length of 1 becomes `slice(-1, 0)`, which returns an empty buffer rather than the final byte. Offsets whose end index stays negative, such as -3 with a length of 1, happen to return the right bytes, which is likely why this went unnoticed.

The existing `it.each` block does cover `(-1, 1)` and `(-2, 1)`, but only asserts `.not.toBe(byteArray.buffer)` — it checks identity, never contents — so it passes against the broken behaviour.

#### Summary of Changes

The offset is now resolved against the end of the buffer before the end index is derived, the same way `Array.prototype.slice` does. This also subsumes the previous `bytesOffset === -buffer.byteLength` special case, since that offset normalises to `0`, which is why the early-return condition gets simpler rather than gaining a branch.

The new tests assert the returned contents for negative offsets and check parity with native `slice`. Six of them fail on `main` and pass with this change. No internal caller is affected: of the two call sites that pass an offset, `packages/fixed-points/src/codecs.ts` and `packages/codecs-numbers/src/utils.ts`, both take it from decoder read positions, which are never negative.

Verified with the full `@solana/codecs-core` suite in both Node and browser environments (137 tests each), typecheck, lint, and prettier, plus the unit suites of the four downstream packages that call `toArrayBuffer` (`codecs-numbers`, `fixed-points`, `codecs-strings`, `keys`).

One coordination note: #1970 is open against the same function for #1959. The changes are independent — that one touches the `SharedArrayBuffer` branch, this one touches the return — but they overlap textually. Happy to rebase on top of it once it lands.

Fixes #1960
