### PR TITLE
fix: stop `getBase64Decoder` crashing on payloads larger than ~65KB

### DIFF
--- a/.changeset/every-dots-ring.md
+++ b/.changeset/every-dots-ring.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-strings': patch
+---
+
+Fixed `getBase64Decoder()` throwing `RangeError: Maximum call stack size exceeded` in browser builds when decoding byte arrays larger than roughly 65KB. The bytes are now converted to a binary string in chunks rather than spread into a single `String.fromCharCode` call.

--- a/packages/codecs-strings/src/__tests__/base64-test.ts
+++ b/packages/codecs-strings/src/__tests__/base64-test.ts
@@ -46,6 +46,14 @@ describe('getBase64Codec', () => {
         expect(base64.decode(base16.encode(base16TokenData))).toStrictEqual(base64TokenData);
     });
 
+    it('can decode byte arrays larger than the maximum function argument count', () => {
+        const bytes = new Uint8Array(200_000);
+        for (let ii = 0; ii < bytes.length; ii++) {
+            bytes[ii] = ii % 256;
+        }
+        expect(base64.encode(base64.decode(bytes))).toStrictEqual(bytes);
+    });
+
     if (__BROWSER__) {
         it('fails if base64 strings do not have the expected padding', () => {
             // This is because atob is not tolerant to missing padding.

--- a/packages/codecs-strings/src/base64.ts
+++ b/packages/codecs-strings/src/base64.ts
@@ -17,6 +17,26 @@ import { getBaseXResliceDecoder, getBaseXResliceEncoder } from './baseX-reslice'
 const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
 
 /**
+ * The number of bytes converted to characters per call to `String.fromCharCode`.
+ *
+ * Each byte is passed as its own argument, and engines cap how many arguments a single call may
+ * receive (V8 throws a `RangeError` at around 65K), so byte arrays must be converted in chunks.
+ */
+const MAX_BYTES_PER_CHAR_CODE_CALL = 0x8000;
+
+/**
+ * Converts a byte array to a string in which each character's code unit is the value of the byte at
+ * the same index. This is the form that `btoa` expects.
+ */
+function getBinaryString(bytes: Uint8Array): string {
+    let binaryString = '';
+    for (let offset = 0; offset < bytes.length; offset += MAX_BYTES_PER_CHAR_CODE_CALL) {
+        binaryString += String.fromCharCode(...bytes.subarray(offset, offset + MAX_BYTES_PER_CHAR_CODE_CALL));
+    }
+    return binaryString;
+}
+
+/**
  * Returns an encoder for base-64 strings.
  *
  * This encoder serializes strings using a base-64 encoding scheme,
@@ -104,8 +124,7 @@ export const getBase64Decoder = (): VariableSizeDecoder<string> => {
     if (__BROWSER__) {
         return createDecoder({
             read(bytes, offset = 0) {
-                const slice = bytes.slice(offset);
-                const value = (btoa as Window['btoa'])(String.fromCharCode(...slice));
+                const value = (btoa as Window['btoa'])(getBinaryString(bytes.subarray(offset)));
                 return [value, bytes.length];
             },
         });


### PR DESCRIPTION
In browser builds, `getBase64Decoder().read` converted bytes to a string via
`String.fromCharCode(...slice)`. The spread passes one argument per byte, so any
input past V8's argument limit (~65K) threw `RangeError: Maximum call stack size
exceeded` instead of returning a string.

Found this in doing some work on explorer for larger accounts.

The conversion now runs in 32KB chunks, keeping every `String.fromCharCode` call
well under the limit regardless of input size. Also swapped `bytes.slice(offset)`
for `bytes.subarray(offset)` to drop a full copy that nothing mutates.

Added a round-trip test over a 200KB array, which reproduces the `RangeError` on
`main` and passes here.