### PR TITLE
fix(codecs-numbers): reject truncated and overlong shortU16 encodings

### DIFF
--- a/.changeset/quiet-shorts-refuse.md
+++ b/.changeset/quiet-shorts-refuse.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-numbers': patch
+---
+
+Fixed `getShortU16Decoder()` silently accepting malformed input: a truncated buffer decoded to garbage with an offset past the end of the byte array, and continuation chains longer than the documented three-byte encoding produced values outside the u16 domain. Truncated input now throws `SOLANA_ERROR__CODECS__INVALID_BYTE_LENGTH` and overlong chains throw `SOLANA_ERROR__CODECS__NUMBER_OUT_OF_RANGE`, matching the guards every other number decoder already uses.

--- a/packages/codecs-numbers/src/__tests__/short-u16-test.ts
+++ b/packages/codecs-numbers/src/__tests__/short-u16-test.ts
@@ -1,3 +1,9 @@
+import {
+    SOLANA_ERROR__CODECS__INVALID_BYTE_LENGTH,
+    SOLANA_ERROR__CODECS__NUMBER_OUT_OF_RANGE,
+    SolanaError,
+} from '@solana/errors';
+
 import { getShortU16Codec } from '../short-u16';
 import { assertRangeError, assertValid, assertValidEncode } from './__setup__';
 
@@ -52,6 +58,37 @@ describe('getShortU16Codec', () => {
             const bytes = codec.encode(i);
             expect(codec.decode(bytes)).toBe(i);
         }
+    });
+
+    it('throws when the buffer ends before the continuation chain terminates', () => {
+        expect.hasAssertions();
+        // Continuation bit set, but no further bytes.
+        expect(() => shortU16().decode(new Uint8Array([0x80]))).toThrow(
+            new SolanaError(SOLANA_ERROR__CODECS__INVALID_BYTE_LENGTH, {
+                bytesLength: 1,
+                codecDescription: 'shortU16',
+                expected: 2,
+            }),
+        );
+        expect(() => shortU16().decode(new Uint8Array([0x80, 0x80]))).toThrow(
+            new SolanaError(SOLANA_ERROR__CODECS__INVALID_BYTE_LENGTH, {
+                bytesLength: 2,
+                codecDescription: 'shortU16',
+                expected: 3,
+            }),
+        );
+    });
+
+    it('rejects continuation chains that exceed the three-byte encoding', () => {
+        expect.hasAssertions();
+        expect(() => shortU16().decode(new Uint8Array([0xff, 0xff, 0xff, 0x00]))).toThrow(
+            new SolanaError(SOLANA_ERROR__CODECS__NUMBER_OUT_OF_RANGE, {
+                codecDescription: 'shortU16',
+                max: MAX,
+                min: MIN,
+                value: 0x7f | (0x7f << 7) | (0x7f << 14),
+            }),
+        );
     });
 
     it('has the right sizes', () => {

--- a/packages/codecs-numbers/src/short-u16.ts
+++ b/packages/codecs-numbers/src/short-u16.ts
@@ -1,4 +1,5 @@
 import {
+    assertByteArrayHasEnoughBytesForCodec,
     combineCodec,
     createDecoder,
     createEncoder,
@@ -8,6 +9,8 @@ import {
     VariableSizeDecoder,
     VariableSizeEncoder,
 } from '@solana/codecs-core';
+
+import { SOLANA_ERROR__CODECS__NUMBER_OUT_OF_RANGE, SolanaError } from '@solana/errors';
 
 import { assertNumberIsBetweenForCodec } from './assertions';
 
@@ -90,7 +93,8 @@ export const getShortU16Decoder = (): VariableSizeDecoder<number> =>
         read: (bytes: ReadonlyUint8Array | Uint8Array, offset): [number, Offset] => {
             let value = 0;
             let byteCount = 0;
-            while (++byteCount) {
+            while (++byteCount <= 3) {
+                assertByteArrayHasEnoughBytesForCodec('shortU16', byteCount, bytes, offset);
                 const byteIndex = byteCount - 1;
                 const currentByte = bytes[offset + byteIndex];
                 const nextSevenBits = 0b1111111 & currentByte;
@@ -98,10 +102,17 @@ export const getShortU16Decoder = (): VariableSizeDecoder<number> =>
                 value |= nextSevenBits << (byteIndex * 7);
                 if ((currentByte & 0b10000000) === 0) {
                     // This byte does not have its continuation bit set. We're done.
-                    break;
+                    return [value, offset + byteCount];
                 }
             }
-            return [value, offset + byteCount];
+            // Every encoded shortU16 fits in at most three bytes. A continuation bit on
+            // what would be the fourth byte implies a value outside the u16 domain.
+            throw new SolanaError(SOLANA_ERROR__CODECS__NUMBER_OUT_OF_RANGE, {
+                codecDescription: 'shortU16',
+                max: 65535,
+                min: 0,
+                value,
+            });
         },
     });
 


### PR DESCRIPTION
## Problem

The `shortU16` decoder loop had no upper bound, violating the codec's own documented contract of a **1 to 3 byte** encoding (`maxSize: 3`). Two concrete failure modes:

1. **Overlong chains accepted**: an input like `80 80 80 80 ...` with continuation bits keeps decoding, producing values far outside the `0..65535` domain the encoder asserts via `assertNumberIsBetweenForCodec`.
2. **Truncated input silently misread**: once the chain ran past the end of the buffer, `bytes[offset + byteIndex]` returned `undefined`; `undefined & 0b10000000 === 0` terminated the loop, so truncated input decoded to garbage and returned an offset beyond `bytes.length` instead of failing. For example, `decode(new Uint8Array([0x80]))` currently returns `[0, 2]`.

Every other number decoder guards its reads through `assertByteArrayHasEnoughBytesForCodec`; `shortU16` was the odd one out.

## Change

- Bound the read loop at three bytes and assert per-byte availability with `assertByteArrayHasEnoughBytesForCodec('shortU16', ...)`, so truncation throws `INVALID_BYTE_LENGTH` exactly like the fixed-size number decoders.
- If a continuation bit is still set after three bytes, throw `NUMBER_OUT_OF_RANGE`, mirroring the encoder's own range assertion for the same domain violation.

## Test plan

Two regression tests fail on current main and pass with this change:

- `decode([0x80])` and `decode([0x80, 0x80])` (truncated chains) now throw `SOLANA_ERROR__CODECS__INVALID_BYTE_LENGTH`.
- `decode([0xff, 0xff, 0xff, 0x00])` (four-byte chain) now throws `SOLANA_ERROR__CODECS__NUMBER_OUT_OF_RANGE`.

Full `codecs-numbers` suite passes (28/28), including the existing round-trip sweep over all `\[0, 0xffff\]` values; package typecheck is clean.