### PR TITLE
fix(codecs-data-structures): preserve struct fixed-size literals

### DIFF
--- a/packages/codecs-data-structures/src/__typetests__/struct-typetest.ts
+++ b/packages/codecs-data-structures/src/__typetests__/struct-typetest.ts
@@ -6,7 +6,15 @@ import {
     VariableSizeDecoder,
     VariableSizeEncoder,
 } from '@solana/codecs-core';
-import { getU32Codec, getU32Decoder, getU32Encoder } from '@solana/codecs-numbers';
+import {
+    getU8Codec,
+    getU8Decoder,
+    getU8Encoder,
+    getU32Codec,
+    getU32Decoder,
+    getU32Encoder,
+    getU64Encoder,
+} from '@solana/codecs-numbers';
 import { getUtf8Codec, getUtf8Decoder, getUtf8Encoder } from '@solana/codecs-strings';
 
 import { getStructCodec, getStructDecoder, getStructEncoder } from '../struct';
@@ -118,4 +126,45 @@ import { getStructCodec, getStructDecoder, getStructEncoder } from '../struct';
             name: string;
         }
     >;
+}
+
+{
+    // [getStructEncoder]: It sums the literal fixed sizes of its fields.
+    getStructEncoder([['age', getU32Encoder()]]) satisfies FixedSizeEncoder<{ age: bigint | number }, 4>;
+    getStructEncoder([
+        ['a', getU32Encoder()],
+        ['b', getU8Encoder()],
+    ]) satisfies FixedSizeEncoder<{ a: bigint | number; b: bigint | number }, 5>;
+    getStructEncoder([
+        ['a', getU32Encoder()],
+        ['b', getU64Encoder()],
+        ['c', getU8Encoder()],
+    ]) satisfies FixedSizeEncoder<{ a: bigint | number; b: bigint | number; c: bigint | number }, 13>;
+}
+
+{
+    // [getStructEncoder]: It widens to `number` when a field size cannot be represented precisely.
+    getStructEncoder([
+        ['a', {} as FixedSizeEncoder<string>],
+        ['b', getU8Encoder()],
+    ]) satisfies FixedSizeEncoder<{ a: string; b: bigint | number }, number>;
+    getStructEncoder([['a', {} as FixedSizeEncoder<string, 1 | 4>]]) satisfies FixedSizeEncoder<{ a: string }, number>;
+}
+
+{
+    // [getStructDecoder]: It sums the literal fixed sizes of its fields.
+    getStructDecoder([['age', getU32Decoder()]]) satisfies FixedSizeDecoder<{ age: number }, 4>;
+    getStructDecoder([
+        ['a', getU32Decoder()],
+        ['b', getU8Decoder()],
+    ]) satisfies FixedSizeDecoder<{ a: number; b: number }, 5>;
+}
+
+{
+    // [getStructCodec]: It sums the literal fixed sizes of its fields.
+    getStructCodec([['age', getU32Codec()]]) satisfies FixedSizeCodec<{ age: bigint | number }, { age: number }, 4>;
+    getStructCodec([
+        ['a', getU32Codec()],
+        ['b', getU8Codec()],
+    ]) satisfies FixedSizeCodec<{ a: bigint | number; b: bigint | number }, { a: number; b: number }, 5>;
 }

--- a/packages/codecs-data-structures/src/struct.ts
+++ b/packages/codecs-data-structures/src/struct.ts
@@ -16,7 +16,7 @@ import {
     VariableSizeEncoder,
 } from '@solana/codecs-core';
 
-import { DrainOuterGeneric, getFixedSize, getMaxSize, sumCodecSizes } from './utils';
+import { DrainOuterGeneric, getFixedSize, getMaxSize, sumCodecSizes, SumFixedCodecSizes } from './utils';
 
 /**
  * Represents a collection of named fields used in struct codecs.
@@ -84,7 +84,7 @@ type GetDecoderTypeFromFields<TFields extends Fields<Decoder<any>>> = DrainOuter
  */
 export function getStructEncoder<const TFields extends Fields<FixedSizeEncoder<any>>>(
     fields: TFields,
-): FixedSizeEncoder<GetEncoderTypeFromFields<TFields>>;
+): FixedSizeEncoder<GetEncoderTypeFromFields<TFields>, SumFixedCodecSizes<TFields>>;
 export function getStructEncoder<const TFields extends Fields<Encoder<any>>>(
     fields: TFields,
 ): VariableSizeEncoder<GetEncoderTypeFromFields<TFields>>;
@@ -146,7 +146,7 @@ export function getStructEncoder<const TFields extends Fields<Encoder<any>>>(
  */
 export function getStructDecoder<const TFields extends Fields<FixedSizeDecoder<any>>>(
     fields: TFields,
-): FixedSizeDecoder<GetDecoderTypeFromFields<TFields>>;
+): FixedSizeDecoder<GetDecoderTypeFromFields<TFields>, SumFixedCodecSizes<TFields>>;
 export function getStructDecoder<const TFields extends Fields<Decoder<any>>>(
     fields: TFields,
 ): VariableSizeDecoder<GetDecoderTypeFromFields<TFields>>;
@@ -221,7 +221,8 @@ export function getStructCodec<const TFields extends Fields<FixedSizeCodec<any>>
     fields: TFields,
 ): FixedSizeCodec<
     GetEncoderTypeFromFields<TFields>,
-    GetDecoderTypeFromFields<TFields> & GetEncoderTypeFromFields<TFields>
+    GetDecoderTypeFromFields<TFields> & GetEncoderTypeFromFields<TFields>,
+    SumFixedCodecSizes<TFields>
 >;
 export function getStructCodec<const TFields extends Fields<Codec<any>>>(
     fields: TFields,

--- a/packages/codecs-data-structures/src/utils.ts
+++ b/packages/codecs-data-structures/src/utils.ts
@@ -49,6 +49,42 @@ type GetFixedCodecSize<TItem> = TItem extends { readonly fixedSize: infer TSize 
         : never
     : never;
 
+type BuildTuple<TSize extends number, TAcc extends readonly unknown[] = []> = TAcc['length'] extends TSize
+    ? TAcc
+    : BuildTuple<TSize, [...TAcc, unknown]>;
+
+type AddSizes<TA extends number, TB extends number> = [...BuildTuple<TA>, ...BuildTuple<TB>]['length'];
+
+/**
+ * Sums the fixed sizes of a tuple of `readonly [string, codec]` fields.
+ *
+ * It recursively walks the fields, extracting each codec's precise `fixedSize` literal and adding
+ * them together. When every field has a precise numeric literal size, the result is the precise
+ * literal sum. When any field's size cannot be represented precisely (e.g. the broad `number`
+ * type or a union of sizes), the result widens to the broad `number` type. An empty tuple sums to
+ * `0`.
+ *
+ * @typeParam TFields - The tuple of `readonly [string, codec]` fields to sum.
+ */
+export type SumFixedCodecSizes<TFields extends readonly (readonly [string, unknown])[]> = TFields extends readonly [
+    infer THead,
+    ...infer TTail,
+]
+    ? TTail extends readonly (readonly [string, unknown])[]
+        ? THead extends readonly [string, infer TCodec]
+            ? GetFixedCodecSize<TCodec> extends infer THeadSize extends number
+                ? IsPreciseNumberLiteral<THeadSize> extends true
+                    ? SumFixedCodecSizes<TTail> extends infer TTailSize extends number
+                        ? IsPreciseNumberLiteral<TTailSize> extends true
+                            ? AddSizes<THeadSize, TTailSize>
+                            : number
+                        : number
+                    : number
+                : number
+            : number
+        : number
+    : 0;
+
 type GetFixedCodecSizeState<TItems extends readonly unknown[]> = TItems extends readonly []
     ? readonly ['fixed', 0]
     : TItems extends readonly [infer TOnly]


### PR DESCRIPTION
## What changed

Struct codecs were losing the precise fixed size of their fields and widening it to `number`.

This preserves the combined fixed-size literal for struct encoders, decoders, and codecs when all fields have known fixed sizes.

For example, a struct containing a `u32` and a `u8` now infers a fixed size of `5` instead of `number`.

## Tests

Added type tests for:

- Single-field fixed sizes
- Summed sizes such as `u32 + u8 = 5`
- Larger fixed-size combinations
- Widening when the size cannot be represented precisely
- Variable-size fields remaining variable-size

Verified with:

- `@solana/codecs-data-structures` typecheck
- `@solana/transaction-messages` typecheck
- ESLint

No runtime behavior was changed.