### PR TITLE
fix: read abort reasons from captured signals

### DIFF
--- a/.changeset/chilly-ads-retire.md
+++ b/.changeset/chilly-ads-retire.md
@@ -1,0 +1,6 @@
+---
+'@solana/rpc': patch
+'@solana/transaction-confirmation': patch
+---
+
+Fix transaction confirmation and coalesced RPC request cancellation in environments where abort events have a null target.

--- a/packages/rpc/src/__tests__/rpc-request-coalescer-test.ts
+++ b/packages/rpc/src/__tests__/rpc-request-coalescer-test.ts
@@ -96,6 +96,25 @@ describe('RPC request coalescer', () => {
             const transportAbortSignal = mockTransport.mock.lastCall![0].signal!;
             expect(transportAbortSignal.aborted).toBe(false);
         });
+        it('rejects with the signal reason when the abort event target is null', async () => {
+            expect.assertions(2);
+            const abortController = new AbortController();
+            const addEventListenerSpy = jest
+                .spyOn(abortController.signal, 'addEventListener')
+                .mockImplementation(() => {});
+            const responsePromise = coalescedTransport({
+                payload: null,
+                signal: abortController.signal,
+            });
+
+            abortController.abort('o no');
+            const abortEvent = new Event('abort');
+            expect(abortEvent.target).toBeNull();
+            const handleAbort = addEventListenerSpy.mock.calls[0][1] as EventListener;
+            handleAbort(abortEvent);
+
+            await expect(responsePromise).rejects.toBe('o no');
+        });
         describe('multiple coalesced requests each with an abort signal', () => {
             let abortControllerA: AbortController;
             let abortControllerB: AbortController;

--- a/packages/rpc/src/rpc-request-coalescer.ts
+++ b/packages/rpc/src/rpc-request-coalescer.ts
@@ -75,7 +75,7 @@ export function getRpcTransportWithRequestCoalescing<TTransport extends RpcTrans
         if (signal) {
             const responsePromise = coalescedRequest.responsePromise as Promise<RpcResponse<TResponse>>;
             return await new Promise<RpcResponse<TResponse>>((resolve, reject) => {
-                const handleAbort = (e: AbortSignalEventMap['abort']) => {
+                const handleAbort = () => {
                     signal.removeEventListener('abort', handleAbort);
                     coalescedRequest.numConsumers -= 1;
                     queueMicrotask(() => {
@@ -85,7 +85,7 @@ export function getRpcTransportWithRequestCoalescing<TTransport extends RpcTrans
                         }
                     });
                     // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
-                    reject((e.target as AbortSignal).reason);
+                    reject(signal.reason);
                 };
                 signal.addEventListener('abort', handleAbort);
                 responsePromise

--- a/packages/transaction-confirmation/src/__tests__/confirmation-strategy-timeout-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/confirmation-strategy-timeout-test.ts
@@ -30,6 +30,23 @@ describe('getTimeoutPromise', () => {
         abortController.abort();
         await expect(timeoutPromise).rejects.toThrow(/operation was aborted/);
     });
+    it('throws an abort error with the signal reason when the abort event target is null', async () => {
+        expect.assertions(2);
+        const abortController = new AbortController();
+        const addEventListenerSpy = jest.spyOn(abortController.signal, 'addEventListener').mockImplementation(() => {});
+        const timeoutPromise = getTimeoutPromise({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+        });
+
+        abortController.abort('o no');
+        const abortEvent = new Event('abort');
+        expect(abortEvent.target).toBeNull();
+        const handleAbort = addEventListenerSpy.mock.calls[0][1] as EventListener;
+        handleAbort(abortEvent);
+
+        await expect(timeoutPromise).rejects.toMatchObject({ message: 'o no', name: 'AbortError' });
+    });
     it('registers the caller abort listener with an auto-cleanup signal', () => {
         const abortController = new AbortController();
         const addEventListenerSpy = jest.spyOn(abortController.signal, 'addEventListener');

--- a/packages/transaction-confirmation/src/confirmation-strategy-timeout.ts
+++ b/packages/transaction-confirmation/src/confirmation-strategy-timeout.ts
@@ -37,9 +37,9 @@ export async function getTimeoutPromise({ abortSignal: callerAbortSignal, commit
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     try {
         return await new Promise((_, reject) => {
-            const handleAbort = (e: AbortSignalEventMap['abort']) => {
+            const handleAbort = () => {
                 clearTimeout(timeoutId);
-                const abortError = new DOMException((e.target as AbortSignal).reason, 'AbortError');
+                const abortError = new DOMException(callerAbortSignal.reason, 'AbortError');
                 reject(abortError);
             };
             callerAbortSignal.addEventListener('abort', handleAbort, { signal: abortController.signal });


### PR DESCRIPTION
#### Problem

In React Native 0.86, the abort event passed to the RPC coalescer can have `target === null`. Reading `event.target.reason` then throws: `TypeError: Cannot read property 'reason' of null`

I ran into this while testing Solana transaction confirmation in Trezor Suite: https://github.com/trezor/trezor-suite/issues/30691

The timeout confirmation code used the same pattern.

#### Summary of Changes

Use the abort signal already in scope instead of reading it from the event. Added regression tests for both places.

I ran the node and browser tests, typecheck, lint, and Prettier for both affected packages.