### PR TITLE
Add concurrent transaction plan leaf executor

### DIFF
--- a/.changeset/polite-clubs-notice.md
+++ b/.changeset/polite-clubs-notice.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Add `createTransactionPlanExecutorWithConcurrentLeaves` to concurrently transform every transaction plan leaf while preserving the plan's result shape.

--- a/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
@@ -1,9 +1,11 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
 import {
+    isSolanaError,
     SOLANA_ERROR__INSTRUCTION_ERROR__INVALID_ARGUMENT,
     SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN,
     SOLANA_ERROR__INSTRUCTION_PLANS__NON_DIVISIBLE_TRANSACTION_PLANS_NOT_SUPPORTED,
+    SOLANA_ERROR__INVARIANT_VIOLATION__INVALID_TRANSACTION_PLAN_KIND,
     SOLANA_ERROR__TRANSACTION_ERROR__INSUFFICIENT_FUNDS_FOR_FEE,
     SolanaError,
 } from '@solana/errors';
@@ -14,15 +16,19 @@ import { Transaction } from '@solana/transactions';
 import {
     canceledSingleTransactionPlanResult,
     createTransactionPlanExecutor,
+    createTransactionPlanExecutorWithConcurrentLeaves,
     failedSingleTransactionPlanResult,
     nonDivisibleSequentialTransactionPlan,
+    nonDivisibleSequentialTransactionPlanResult,
     parallelTransactionPlan,
     parallelTransactionPlanResult,
     passthroughFailedTransactionPlanExecution,
     sequentialTransactionPlan,
     sequentialTransactionPlanResult,
+    SingleTransactionPlan,
     singleTransactionPlan,
     successfulSingleTransactionPlanResult,
+    TransactionPlan,
     TransactionPlanResult,
     TransactionPlanResultContext,
     TransactionPlanResultContextWithSignature,
@@ -49,6 +55,14 @@ async function expectFailedToExecute<TContext extends TransactionPlanResultConte
     await expect(promise).rejects.toThrow(
         expect.objectContaining({ context: expect.objectContaining({ transactionPlanResult }) }),
     );
+}
+
+function assertIsFailedToExecuteTransactionPlanError(
+    error: unknown,
+): asserts error is SolanaError<typeof SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN> {
+    if (!isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)) {
+        throw error;
+    }
 }
 
 function forwardId(
@@ -1051,6 +1065,286 @@ describe('createTransactionPlanExecutor', () => {
                 }),
             );
         });
+    });
+});
+
+describe('createTransactionPlanExecutorWithConcurrentLeaves', () => {
+    it('preserves plan nesting, order, and divisibility', async () => {
+        expect.assertions(1);
+        const messages = [createMessage('A'), createMessage('B'), createMessage('C'), createMessage('D')];
+        const transactionPlan = parallelTransactionPlan([
+            nonDivisibleSequentialTransactionPlan([messages[0], messages[1]]),
+            sequentialTransactionPlan([messages[2], messages[3]]),
+        ]);
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ index: number }>({
+            executeSingleTransactionPlan: plan =>
+                Promise.resolve(
+                    successfulSingleTransactionPlanResult(plan.message, {
+                        index: messages.indexOf(plan.message as (typeof messages)[number]),
+                    }),
+                ),
+        });
+
+        const result = await executor(transactionPlan);
+
+        expect(result).toStrictEqual(
+            parallelTransactionPlanResult([
+                nonDivisibleSequentialTransactionPlanResult([
+                    successfulSingleTransactionPlanResult(messages[0], { index: 0 }),
+                    successfulSingleTransactionPlanResult(messages[1], { index: 1 }),
+                ]),
+                sequentialTransactionPlanResult([
+                    successfulSingleTransactionPlanResult(messages[2], { index: 2 }),
+                    successfulSingleTransactionPlanResult(messages[3], { index: 3 }),
+                ]),
+            ]),
+        );
+    });
+
+    it('starts leaves in sequential plans concurrently', () => {
+        const messageA = createMessage('A');
+        const messageB = createMessage('B');
+        const executeSingleTransactionPlan = jest.fn(
+            (_plan: SingleTransactionPlan) => FOREVER_PROMISE as Promise<ReturnType<typeof successfulForwardIdResult>>,
+        );
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<TransactionPlanResultContextWithSignature>({
+            executeSingleTransactionPlan,
+        });
+
+        void executor(sequentialTransactionPlan([messageA, messageB]));
+
+        expect(executeSingleTransactionPlan).toHaveBeenCalledTimes(2);
+    });
+
+    it('aggregates thrown leaf errors without canceling other leaves', async () => {
+        expect.assertions(4);
+        const messageA = createMessage('A');
+        const messageB = createMessage('B');
+        const messageC = createMessage('C');
+        const errorA = new Error('A failed');
+        const errorC = new Error('C failed');
+        const messages = [messageA, messageB, messageC];
+        const leafPromises = [
+            Promise.reject(errorA),
+            Promise.resolve(successfulSingleTransactionPlanResult(messageB, { id: 'B' })),
+            Promise.reject(errorC),
+        ];
+        const executeSingleTransactionPlan = jest.fn(
+            (plan: SingleTransactionPlan) => leafPromises[messages.indexOf(plan.message as (typeof messages)[number])],
+        );
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ id: string }>({
+            executeSingleTransactionPlan,
+        });
+
+        const error = await executor(nonDivisibleSequentialTransactionPlan([messageA, messageB, messageC])).catch(
+            (error: unknown) => error,
+        );
+
+        expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
+        assertIsFailedToExecuteTransactionPlanError(error);
+        expect(executeSingleTransactionPlan).toHaveBeenCalledTimes(3);
+        expect(error.context.transactionPlanResult).toStrictEqual(
+            nonDivisibleSequentialTransactionPlanResult([
+                failedSingleTransactionPlanResult<{ id: string }>(messageA, errorA),
+                successfulSingleTransactionPlanResult(messageB, { id: 'B' }),
+                failedSingleTransactionPlanResult<{ id: string }>(messageC, errorC),
+            ]),
+        );
+        expect(error.cause).toBe(errorA);
+    });
+
+    it('preserves nested failures and waits for every sibling to settle', async () => {
+        expect.assertions(5);
+        const messageA = createMessage('A');
+        const messageB = createMessage('B');
+        const messageC = createMessage('C');
+        const messageD = createMessage('D');
+        const messageE = createMessage('E');
+        const errorB = new Error('B failed');
+        const errorD = new Error('D failed');
+        const messages = [messageA, messageB, messageC, messageD, messageE];
+        const resultA = successfulSingleTransactionPlanResult(messageA, { id: 'A' });
+        const resultC = successfulSingleTransactionPlanResult(messageC, { id: 'C' });
+        const resultE = successfulSingleTransactionPlanResult(messageE, { id: 'E' });
+        const delayedResultPromise = new Promise<typeof resultE>(resolve => {
+            setTimeout(() => resolve(resultE), 100);
+        });
+        const leafPromises = [
+            Promise.resolve(resultA),
+            Promise.reject(errorB),
+            Promise.resolve(resultC),
+            Promise.reject(errorD),
+            delayedResultPromise,
+        ];
+        const executeSingleTransactionPlan = jest.fn(
+            (plan: SingleTransactionPlan) => leafPromises[messages.indexOf(plan.message as (typeof messages)[number])],
+        );
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ id: string }>({
+            executeSingleTransactionPlan,
+        });
+        const transactionPlan = parallelTransactionPlan([
+            nonDivisibleSequentialTransactionPlan([messageA, parallelTransactionPlan([messageB, messageC])]),
+            sequentialTransactionPlan([messageD, messageE]),
+        ]);
+
+        const resultPromise = executor(transactionPlan);
+        const onSettled = jest.fn();
+        void resultPromise.then(onSettled, onSettled);
+        await jest.advanceTimersByTimeAsync(99);
+        expect(onSettled).not.toHaveBeenCalled();
+        await jest.advanceTimersByTimeAsync(1);
+        const error = await resultPromise.catch((error: unknown) => error);
+
+        expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
+        assertIsFailedToExecuteTransactionPlanError(error);
+        expect(executeSingleTransactionPlan).toHaveBeenCalledTimes(5);
+        expect(error.context.transactionPlanResult).toStrictEqual(
+            parallelTransactionPlanResult([
+                nonDivisibleSequentialTransactionPlanResult([
+                    resultA,
+                    parallelTransactionPlanResult([
+                        failedSingleTransactionPlanResult<{ id: string }>(messageB, errorB),
+                        resultC,
+                    ]),
+                ]),
+                sequentialTransactionPlanResult([
+                    failedSingleTransactionPlanResult<{ id: string }>(messageD, errorD),
+                    resultE,
+                ]),
+            ]),
+        );
+        expect(error.cause).toBe(errorB);
+    });
+
+    it('throws a failed execution error when a callback returns a failed result', async () => {
+        expect.assertions(2);
+        const message = createMessage('A');
+        const cause = new Error('A failed');
+        const failedResult = failedSingleTransactionPlanResult<{ attempted: boolean }>(message, cause, {
+            attempted: true,
+        });
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ attempted: boolean }>({
+            executeSingleTransactionPlan: () => Promise.resolve(failedResult),
+        });
+
+        const error = await executor(singleTransactionPlan(message)).catch((error: unknown) => error);
+
+        expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
+        assertIsFailedToExecuteTransactionPlanError(error);
+        expect(error.context.transactionPlanResult).toBe(failedResult);
+    });
+
+    it('throws a failed execution error when a callback returns a canceled result', async () => {
+        expect.assertions(2);
+        const message = createMessage('A');
+        const canceledResult = canceledSingleTransactionPlanResult<{ attempted: boolean }>(message, {
+            attempted: false,
+        });
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ attempted: boolean }>({
+            executeSingleTransactionPlan: () => Promise.resolve(canceledResult),
+        });
+
+        const error = await executor(singleTransactionPlan(message)).catch((error: unknown) => error);
+
+        expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
+        assertIsFailedToExecuteTransactionPlanError(error);
+        expect(error.context.transactionPlanResult).toBe(canceledResult);
+    });
+
+    it('can abort before executing leaves', async () => {
+        expect.assertions(4);
+        const messageA = createMessage('A');
+        const messageB = createMessage('B');
+        const abortController = new AbortController();
+        const cause = new Error('Aborted before execution');
+        const executeSingleTransactionPlan = jest.fn(() => Promise.reject(new Error('not implemented')));
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<TransactionPlanResultContext>({
+            executeSingleTransactionPlan,
+        });
+
+        abortController.abort(cause);
+        const error = await executor(parallelTransactionPlan([messageA, messageB]), {
+            abortSignal: abortController.signal,
+        }).catch((error: unknown) => error);
+
+        expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
+        assertIsFailedToExecuteTransactionPlanError(error);
+        expect(executeSingleTransactionPlan).not.toHaveBeenCalled();
+        expect(error.context.transactionPlanResult).toStrictEqual(
+            parallelTransactionPlanResult([
+                canceledSingleTransactionPlanResult<TransactionPlanResultContext>(messageA),
+                canceledSingleTransactionPlanResult<TransactionPlanResultContext>(messageB),
+            ]),
+        );
+        expect(error.context.abortReason).toBe(cause);
+    });
+
+    it('can abort active leaves while preserving completed leaves', async () => {
+        expect.assertions(4);
+        const messageA = createMessage('A');
+        const messageB = createMessage('B');
+        const messageC = createMessage('C');
+        const abortController = new AbortController();
+        const cause = new Error('Aborted during execution');
+        const messages = [messageA, messageB, messageC];
+        const resultA = successfulForwardIdResult(messageA);
+        const resultC = successfulForwardIdResult(messageC);
+        const leafPromises = [
+            Promise.resolve(resultA),
+            FOREVER_PROMISE as Promise<ReturnType<typeof successfulForwardIdResult>>,
+            Promise.resolve(resultC),
+        ];
+        const executeSingleTransactionPlan = jest.fn(
+            (plan: SingleTransactionPlan) => leafPromises[messages.indexOf(plan.message as (typeof messages)[number])],
+        );
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<TransactionPlanResultContextWithSignature>({
+            executeSingleTransactionPlan,
+        });
+
+        const resultPromise = executor(parallelTransactionPlan([messageA, messageB, messageC]), {
+            abortSignal: abortController.signal,
+        });
+        expect(executeSingleTransactionPlan).toHaveBeenCalledTimes(3);
+        await jest.runAllTimersAsync();
+        abortController.abort(cause);
+        const error = await resultPromise.catch((error: unknown) => error);
+
+        expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
+        assertIsFailedToExecuteTransactionPlanError(error);
+        expect(error.context.transactionPlanResult).toStrictEqual(
+            parallelTransactionPlanResult([resultA, failedSingleTransactionPlanResult(messageB, cause), resultC]),
+        );
+        expect(error.context.abortReason).toBe(cause);
+    });
+
+    it('forwards the abort signal to every leaf callback', async () => {
+        expect.assertions(1);
+        const message = createMessage('A');
+        const abortController = new AbortController();
+        const executeSingleTransactionPlan = jest.fn((plan: SingleTransactionPlan) =>
+            Promise.resolve(successfulSingleTransactionPlanResult(plan.message, { processed: true })),
+        );
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ processed: boolean }>({
+            executeSingleTransactionPlan,
+        });
+
+        await executor(singleTransactionPlan(message), { abortSignal: abortController.signal });
+
+        expect(executeSingleTransactionPlan).toHaveBeenCalledWith(singleTransactionPlan(message), {
+            abortSignal: abortController.signal,
+        });
+    });
+
+    it('rejects transaction plans with an unknown kind', async () => {
+        expect.assertions(1);
+        const transactionPlan = { kind: 'unknown' } as unknown as TransactionPlan;
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<TransactionPlanResultContext>({
+            executeSingleTransactionPlan: () => Promise.reject(new Error('not implemented')),
+        });
+
+        const error = await executor(transactionPlan).catch((error: unknown) => error);
+
+        expect(isSolanaError(error, SOLANA_ERROR__INVARIANT_VIOLATION__INVALID_TRANSACTION_PLAN_KIND)).toBe(true);
     });
 });
 

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
@@ -11,12 +11,16 @@ import { compileTransaction, Transaction, TransactionWithBlockhashLifetime } fro
 
 import {
     CanceledSingleTransactionPlanResult,
+    type ConcurrentLeafTransactionPlanExecutorConfig,
     createTransactionPlanExecutor,
+    createTransactionPlanExecutorWithConcurrentLeaves,
     FailedSingleTransactionPlanResult,
     flattenTransactionPlanResult,
     passthroughFailedTransactionPlanExecution,
+    type SingleTransactionPlan,
     SingleTransactionPlanResult,
     SuccessfulSingleTransactionPlanResult,
+    successfulSingleTransactionPlanResult,
     summarizeTransactionPlanResult,
     type TransactionPlan,
     type TransactionPlanExecutor,
@@ -231,6 +235,59 @@ import {
                 const transaction = compileTransaction(messageWithBlockhash);
                 transaction satisfies TransactionWithBlockhashLifetime;
                 return Promise.resolve({ signature: {} as Signature });
+            },
+        });
+    }
+}
+
+// [DESCRIBE] createTransactionPlanExecutorWithConcurrentLeaves
+{
+    // It creates an executor with the caller-defined result context.
+    {
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ transaction: Transaction }>({
+            executeSingleTransactionPlan: plan =>
+                Promise.resolve(
+                    successfulSingleTransactionPlanResult(plan.message, { transaction: {} as Transaction }),
+                ),
+        });
+        executor satisfies TransactionPlanExecutor<{ transaction: Transaction }>;
+    }
+
+    // It infers the result context from the callback when possible.
+    {
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves({
+            executeSingleTransactionPlan: plan =>
+                Promise.resolve(successfulSingleTransactionPlanResult(plan.message, { custom: 'value' })),
+        });
+        executor satisfies TransactionPlanExecutor<{ custom: string }>;
+    }
+
+    // Its config type requires the caller to define the result context.
+    {
+        // @ts-expect-error The concurrent leaf result context has no default.
+        type ConfigWithoutContext = ConcurrentLeafTransactionPlanExecutorConfig;
+        void (null as unknown as ConfigWithoutContext);
+    }
+
+    // Its callback receives a single transaction plan and the optional abort signal.
+    {
+        createTransactionPlanExecutorWithConcurrentLeaves<{ custom: string }>({
+            executeSingleTransactionPlan: (plan, config) => {
+                plan satisfies SingleTransactionPlan;
+                config?.abortSignal satisfies AbortSignal | undefined;
+                return Promise.resolve(successfulSingleTransactionPlanResult(plan.message, { custom: 'value' }));
+            },
+        });
+    }
+
+    // Its callback must return a result carrying the configured context.
+    {
+        createTransactionPlanExecutorWithConcurrentLeaves<{ custom: string }>({
+            // @ts-expect-error The returned result context is missing the `custom` property.
+            executeSingleTransactionPlan: plan => {
+                return Promise.resolve(
+                    successfulSingleTransactionPlanResult(plan.message, { signature: {} as Signature }),
+                );
             },
         });
     }

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -18,6 +18,8 @@ import { createFailedToExecuteTransactionPlanError } from './transaction-plan-er
 import {
     canceledSingleTransactionPlanResult,
     failedSingleTransactionPlanResult,
+    isSuccessfulTransactionPlanResult,
+    nonDivisibleSequentialTransactionPlanResult,
     parallelTransactionPlanResult,
     sequentialTransactionPlanResult,
     SingleTransactionPlanResult,
@@ -74,6 +76,26 @@ export type TransactionPlanExecutorConfig<
      * `TContext` promises, which by default includes a `signature`.
      */
     executeTransactionMessage: ExecuteTransactionMessage<TContext>;
+};
+
+/**
+ * Configuration for an executor that processes every transaction plan leaf concurrently.
+ *
+ * @typeParam TContext - The context carried by each single transaction plan result.
+ *
+ * @see {@link createTransactionPlanExecutorWithConcurrentLeaves}
+ */
+export type ConcurrentLeafTransactionPlanExecutorConfig<TContext extends TransactionPlanResultContext> = {
+    /**
+     * Executes a single transaction plan and returns its result.
+     *
+     * The executor calls this function concurrently for every leaf in the plan and forwards
+     * the optional abort signal.
+     */
+    executeSingleTransactionPlan: (
+        transactionPlan: SingleTransactionPlan,
+        config?: { abortSignal?: AbortSignal },
+    ) => Promise<SingleTransactionPlanResult<TContext>>;
 };
 
 /**
@@ -201,6 +223,103 @@ export function createTransactionPlanExecutor<
 
         return transactionPlanResult;
     };
+}
+
+/**
+ * Creates a transaction plan executor that processes every leaf concurrently.
+ *
+ * The executor preserves the input plan's nesting, order, and divisibility in the returned
+ * result, but it does not enforce the execution dependencies expressed by sequential plans.
+ * This makes it suitable for operations such as signing or serializing transactions that can
+ * be performed independently. All leaf callbacks are started without a concurrency limit.
+ *
+ * The optional abort signal is forwarded to every leaf callback and enforced by the executor.
+ * When the signal is already aborted, leaves are canceled without invoking their callbacks. When
+ * it is aborted during execution, the executor stops waiting for active callbacks and records
+ * failed results carrying the abort reason.
+ *
+ * Errors thrown by a callback are converted to failed single transaction plan results without
+ * canceling any other leaves. After all leaves settle, a plan containing failed or canceled results
+ * throws a failed execution error containing the complete result tree.
+ *
+ * @typeParam TContext - The caller-defined context carried by each single transaction plan result.
+ * @param config - Configuration containing the function used to execute each leaf.
+ * @return A {@link TransactionPlanExecutor} that processes all transaction plan leaves concurrently.
+ * @throws {@link SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN}
+ *   if any leaf callback throws or returns a failed or canceled result. The error context contains
+ *   a `transactionPlanResult` property with the complete result tree.
+ * @throws {@link SOLANA_ERROR__INVARIANT_VIOLATION__INVALID_TRANSACTION_PLAN_KIND} if the plan has an unknown kind.
+ *
+ * @example
+ * Signing every transaction in a plan concurrently.
+ * ```ts
+ * const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ transaction: Transaction }>({
+ *     executeSingleTransactionPlan: async (plan, { abortSignal } = {}) => {
+ *         abortSignal?.throwIfAborted();
+ *         const transaction = await signTransactionMessageWithSigners(plan.message);
+ *         return successfulSingleTransactionPlanResult(plan.message, { transaction });
+ *     },
+ * });
+ * const result = await executor(transactionPlan);
+ * ```
+ *
+ * @see {@link ConcurrentLeafTransactionPlanExecutorConfig}
+ * @see {@link createTransactionPlanExecutor}
+ */
+export function createTransactionPlanExecutorWithConcurrentLeaves<TContext extends TransactionPlanResultContext>(
+    config: ConcurrentLeafTransactionPlanExecutorConfig<TContext>,
+): TransactionPlanExecutor<TContext> {
+    return async (transactionPlan, executorConfig) => {
+        const transactionPlanResult = await traverseTransactionPlanLeavesConcurrently(
+            transactionPlan,
+            config.executeSingleTransactionPlan,
+            executorConfig,
+        );
+        if (executorConfig?.abortSignal?.aborted || !isSuccessfulTransactionPlanResult(transactionPlanResult)) {
+            const abortReason = executorConfig?.abortSignal?.aborted ? executorConfig.abortSignal.reason : undefined;
+            throw createFailedToExecuteTransactionPlanError(transactionPlanResult, abortReason);
+        }
+        return transactionPlanResult;
+    };
+}
+
+async function traverseTransactionPlanLeavesConcurrently<TContext extends TransactionPlanResultContext>(
+    transactionPlan: TransactionPlan,
+    executeSingleTransactionPlan: ConcurrentLeafTransactionPlanExecutorConfig<TContext>['executeSingleTransactionPlan'],
+    executorConfig?: { abortSignal?: AbortSignal },
+): Promise<TransactionPlanResult<TContext>> {
+    const kind = transactionPlan.kind;
+    switch (kind) {
+        case 'single':
+            if (executorConfig?.abortSignal?.aborted) {
+                return canceledSingleTransactionPlanResult<TContext>(transactionPlan.message);
+            }
+            try {
+                return await getAbortablePromise(
+                    executeSingleTransactionPlan(transactionPlan, executorConfig),
+                    executorConfig?.abortSignal,
+                );
+            } catch (error) {
+                return failedSingleTransactionPlanResult<TContext>(transactionPlan.message, error as Error);
+            }
+        case 'parallel':
+        case 'sequential': {
+            const plans = await Promise.all(
+                transactionPlan.plans.map(plan =>
+                    traverseTransactionPlanLeavesConcurrently(plan, executeSingleTransactionPlan, executorConfig),
+                ),
+            );
+            if (kind === 'parallel') {
+                return parallelTransactionPlanResult(plans);
+            }
+            return transactionPlan.divisible
+                ? sequentialTransactionPlanResult(plans)
+                : nonDivisibleSequentialTransactionPlanResult(plans);
+        }
+        default:
+            kind satisfies never;
+            throw new SolanaError(SOLANA_ERROR__INVARIANT_VIOLATION__INVALID_TRANSACTION_PLAN_KIND, { kind });
+    }
 }
 
 type TraverseConfig<TContext extends TransactionPlanResultContext> = TransactionPlanExecutorConfig<TContext> & {


### PR DESCRIPTION
This PR adds a new helper `createTransactionPlanExecutorWithConcurrentLeaves` as a sibling to `createTransactionPlanExecutor`.

This creates an intentionally much simpler executor, that ignores dependencies between transactions and concurrently executes the callback (slightly simplified) `SingleTransactionPlan -> Promise<SingleTransactionPlanResult<TContext>>` for every leaf. It returns a `TransactionPlanResult` with the same shape as the input `TransactionPlan`. It is intended for cases where dependencies are irrelevant, such as signing the transactions without executing them.

See also https://github.com/anza-xyz/kit-plugins/pull/395 which first added a similar more specific version of this function. That PR will be refactored to use this function.

Failures are aggregated, similar to `createTransactionPlanExecutor`: if a callback throws for any leaf then this is returned as a `FailedSingleTransactionPlanResult` at that leaf, independently of other callbacks. Unlike `createTransactionPlanExecutor`, this does not cancel dependent leafs, as they are treated independently. If there are any failures then we throw `SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN` with the plan.