### PR TITLE
fix: accept class-based signers in `@solana/signers` type guards

### DIFF
--- a/.changeset/pretty-pears-joke.md
+++ b/.changeset/pretty-pears-joke.md
@@ -1,0 +1,5 @@
+---
+'@solana/signers': patch
+---
+
+Relaxed the parameter type of the signer type guards (`isMessagePartialSigner`, `isTransactionSigner`, `isKeyPairSigner`, their siblings, and the `assertIs*` variants) so that class instances implementing a signer interface can be passed without casts. The guards now accept any `TValue extends { address: Address }` and narrow to `TValue & Signer`, whereas the previous parameter type required an implicit index signature, which TypeScript never grants to class instances.

--- a/packages/signers/src/__typetests__/keypair-signer-typetest.ts
+++ b/packages/signers/src/__typetests__/keypair-signer-typetest.ts
@@ -20,3 +20,38 @@ const signTransactions = () => {};
     assertIsKeyPairSigner(potentialSigner);
     potentialSigner satisfies KeyPairSigner<'1'>;
 }
+
+{
+    // [isKeyPairSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements KeyPairSigner<'1'> {
+        readonly address = address('1');
+        readonly keyPair = {} as CryptoKeyPair;
+        signMessages() {
+            return Promise.resolve([]);
+        }
+        signTransactions() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
+    if (isKeyPairSigner(potentialSigner)) {
+        potentialSigner satisfies KeyPairSigner<'1'>;
+    }
+}
+
+{
+    // [assertIsKeyPairSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements KeyPairSigner<'1'> {
+        readonly address = address('1');
+        readonly keyPair = {} as CryptoKeyPair;
+        signMessages() {
+            return Promise.resolve([]);
+        }
+        signTransactions() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
+    assertIsKeyPairSigner(potentialSigner);
+    potentialSigner satisfies KeyPairSigner<'1'>;
+}

--- a/packages/signers/src/__typetests__/message-modifying-signer-typetest.ts
+++ b/packages/signers/src/__typetests__/message-modifying-signer-typetest.ts
@@ -22,3 +22,30 @@ const modifyAndSignMessages = () => {};
     assertIsMessageModifyingSigner(potentialSigner);
     potentialSigner satisfies MessageModifyingSigner<'1'>;
 }
+
+{
+    // [isMessageModifyingSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements MessageModifyingSigner<'1'> {
+        readonly address = address('1');
+        modifyAndSignMessages() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
+    if (isMessageModifyingSigner(potentialSigner)) {
+        potentialSigner satisfies MessageModifyingSigner<'1'>;
+    }
+}
+
+{
+    // [assertIsMessageModifyingSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements MessageModifyingSigner<'1'> {
+        readonly address = address('1');
+        modifyAndSignMessages() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
+    assertIsMessageModifyingSigner(potentialSigner);
+    potentialSigner satisfies MessageModifyingSigner<'1'>;
+}

--- a/packages/signers/src/__typetests__/message-partial-signer-typetest.ts
+++ b/packages/signers/src/__typetests__/message-partial-signer-typetest.ts
@@ -18,3 +18,19 @@ const signMessages = () => {};
     assertIsMessagePartialSigner(potentialSigner);
     potentialSigner satisfies MessagePartialSigner<'1'>;
 }
+
+{
+    // [isMessagePartialSigner]: It accepts class instances, which have no implicit index signature.
+    class MyMessagePartialSigner implements MessagePartialSigner<'1'> {
+        readonly address = address('1');
+        signMessages() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner: MyMessagePartialSigner = new MyMessagePartialSigner();
+    if (isMessagePartialSigner(potentialSigner)) {
+        potentialSigner satisfies MessagePartialSigner<'1'>;
+    }
+    assertIsMessagePartialSigner(potentialSigner);
+    potentialSigner satisfies MessagePartialSigner<'1'>;
+}

--- a/packages/signers/src/__typetests__/message-partial-signer-typetest.ts
+++ b/packages/signers/src/__typetests__/message-partial-signer-typetest.ts
@@ -20,17 +20,28 @@ const signMessages = () => {};
 }
 
 {
-    // [isMessagePartialSigner]: It accepts class instances, which have no implicit index signature.
-    class MyMessagePartialSigner implements MessagePartialSigner<'1'> {
+    // [isMessagePartialSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements MessagePartialSigner<'1'> {
         readonly address = address('1');
         signMessages() {
             return Promise.resolve([]);
         }
     }
-    const potentialSigner: MyMessagePartialSigner = new MyMessagePartialSigner();
+    const potentialSigner = null as unknown as MyClassBasedSigner;
     if (isMessagePartialSigner(potentialSigner)) {
         potentialSigner satisfies MessagePartialSigner<'1'>;
     }
+}
+
+{
+    // [assertIsMessagePartialSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements MessagePartialSigner<'1'> {
+        readonly address = address('1');
+        signMessages() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
     assertIsMessagePartialSigner(potentialSigner);
     potentialSigner satisfies MessagePartialSigner<'1'>;
 }

--- a/packages/signers/src/__typetests__/message-signer-typetest.ts
+++ b/packages/signers/src/__typetests__/message-signer-typetest.ts
@@ -1,5 +1,6 @@
 import { address } from '@solana/addresses';
 
+import { MessagePartialSigner } from '../message-partial-signer';
 import { assertIsMessageSigner, isMessageSigner, MessageSigner } from '../message-signer';
 
 const signMessages = () => {};
@@ -15,6 +16,33 @@ const signMessages = () => {};
 {
     // [assertIsMessageSigner]: It keeps track of the address type parameter when the address is a valid Address.
     const potentialSigner = { address: address('1'), signMessages };
+    assertIsMessageSigner(potentialSigner);
+    potentialSigner satisfies MessageSigner<'1'>;
+}
+
+{
+    // [isMessageSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements MessagePartialSigner<'1'> {
+        readonly address = address('1');
+        signMessages() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
+    if (isMessageSigner(potentialSigner)) {
+        potentialSigner satisfies MessageSigner<'1'>;
+    }
+}
+
+{
+    // [assertIsMessageSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements MessagePartialSigner<'1'> {
+        readonly address = address('1');
+        signMessages() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
     assertIsMessageSigner(potentialSigner);
     potentialSigner satisfies MessageSigner<'1'>;
 }

--- a/packages/signers/src/__typetests__/transaction-modifying-signer-typetest.ts
+++ b/packages/signers/src/__typetests__/transaction-modifying-signer-typetest.ts
@@ -22,3 +22,30 @@ const modifyAndSignTransactions = () => {};
     assertIsTransactionModifyingSigner(potentialSigner);
     potentialSigner satisfies TransactionModifyingSigner<'1'>;
 }
+
+{
+    // [isTransactionModifyingSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements TransactionModifyingSigner<'1'> {
+        readonly address = address('1');
+        modifyAndSignTransactions() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
+    if (isTransactionModifyingSigner(potentialSigner)) {
+        potentialSigner satisfies TransactionModifyingSigner<'1'>;
+    }
+}
+
+{
+    // [assertIsTransactionModifyingSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements TransactionModifyingSigner<'1'> {
+        readonly address = address('1');
+        modifyAndSignTransactions() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
+    assertIsTransactionModifyingSigner(potentialSigner);
+    potentialSigner satisfies TransactionModifyingSigner<'1'>;
+}

--- a/packages/signers/src/__typetests__/transaction-partial-signer-typetest.ts
+++ b/packages/signers/src/__typetests__/transaction-partial-signer-typetest.ts
@@ -22,3 +22,30 @@ const signTransactions = () => {};
     assertIsTransactionPartialSigner(potentialSigner);
     potentialSigner satisfies TransactionPartialSigner<'1'>;
 }
+
+{
+    // [isTransactionPartialSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements TransactionPartialSigner<'1'> {
+        readonly address = address('1');
+        signTransactions() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
+    if (isTransactionPartialSigner(potentialSigner)) {
+        potentialSigner satisfies TransactionPartialSigner<'1'>;
+    }
+}
+
+{
+    // [assertIsTransactionPartialSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements TransactionPartialSigner<'1'> {
+        readonly address = address('1');
+        signTransactions() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
+    assertIsTransactionPartialSigner(potentialSigner);
+    potentialSigner satisfies TransactionPartialSigner<'1'>;
+}

--- a/packages/signers/src/__typetests__/transaction-sending-signer-typetest.ts
+++ b/packages/signers/src/__typetests__/transaction-sending-signer-typetest.ts
@@ -22,3 +22,30 @@ const signAndSendTransactions = () => {};
     assertIsTransactionSendingSigner(potentialSigner);
     potentialSigner satisfies TransactionSendingSigner<'1'>;
 }
+
+{
+    // [isTransactionSendingSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements TransactionSendingSigner<'1'> {
+        readonly address = address('1');
+        signAndSendTransactions() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
+    if (isTransactionSendingSigner(potentialSigner)) {
+        potentialSigner satisfies TransactionSendingSigner<'1'>;
+    }
+}
+
+{
+    // [assertIsTransactionSendingSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements TransactionSendingSigner<'1'> {
+        readonly address = address('1');
+        signAndSendTransactions() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
+    assertIsTransactionSendingSigner(potentialSigner);
+    potentialSigner satisfies TransactionSendingSigner<'1'>;
+}

--- a/packages/signers/src/__typetests__/transaction-signer-typetest.ts
+++ b/packages/signers/src/__typetests__/transaction-signer-typetest.ts
@@ -1,5 +1,6 @@
 import { address } from '@solana/addresses';
 
+import { TransactionPartialSigner } from '../transaction-partial-signer';
 import { assertIsTransactionSigner, isTransactionSigner, TransactionSigner } from '../transaction-signer';
 
 const signTransactions = () => {};
@@ -15,6 +16,33 @@ const signTransactions = () => {};
 {
     // [assertIsTransactionSigner]: It keeps track of the address type parameter when the address is a valid Address.
     const potentialSigner = { address: address('1'), signTransactions };
+    assertIsTransactionSigner(potentialSigner);
+    potentialSigner satisfies TransactionSigner<'1'>;
+}
+
+{
+    // [isTransactionSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements TransactionPartialSigner<'1'> {
+        readonly address = address('1');
+        signTransactions() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
+    if (isTransactionSigner(potentialSigner)) {
+        potentialSigner satisfies TransactionSigner<'1'>;
+    }
+}
+
+{
+    // [assertIsTransactionSigner]: It accepts a class instance, which has no implicit index signature.
+    class MyClassBasedSigner implements TransactionPartialSigner<'1'> {
+        readonly address = address('1');
+        signTransactions() {
+            return Promise.resolve([]);
+        }
+    }
+    const potentialSigner = null as unknown as MyClassBasedSigner;
     assertIsTransactionSigner(potentialSigner);
     potentialSigner satisfies TransactionSigner<'1'>;
 }

--- a/packages/signers/src/keypair-signer.ts
+++ b/packages/signers/src/keypair-signer.ts
@@ -51,10 +51,9 @@ export type KeyPairSigner<TAddress extends string = string> = MessagePartialSign
  * isKeyPairSigner({ address: address('1234..5678') }); // false
  * ```
  */
-export function isKeyPairSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): value is KeyPairSigner<TAddress> {
+export function isKeyPairSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): value is KeyPairSigner<TAddress> & TValue {
     return (
         'keyPair' in value &&
         typeof value.keyPair === 'object' &&
@@ -77,10 +76,9 @@ export function isKeyPairSigner<TAddress extends string>(value: {
  * assertIsKeyPairSigner({ address: address('1234..5678') }); // Throws an error.
  * ```
  */
-export function assertIsKeyPairSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): asserts value is KeyPairSigner<TAddress> {
+export function assertIsKeyPairSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): asserts value is KeyPairSigner<TAddress> & TValue {
     if (!isKeyPairSigner(value)) {
         throw new SolanaError(SOLANA_ERROR__SIGNER__EXPECTED_KEY_PAIR_SIGNER, {
             address: value.address,

--- a/packages/signers/src/message-modifying-signer.ts
+++ b/packages/signers/src/message-modifying-signer.ts
@@ -77,10 +77,9 @@ export type MessageModifyingSigner<TAddress extends string = string> = Readonly<
  *
  * @see {@link assertIsMessageModifyingSigner}
  */
-export function isMessageModifyingSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): value is MessageModifyingSigner<TAddress> {
+export function isMessageModifyingSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): value is MessageModifyingSigner<TAddress> & TValue {
     return (
         isAddress(value.address) &&
         'modifyAndSignMessages' in value &&
@@ -105,10 +104,9 @@ export function isMessageModifyingSigner<TAddress extends string>(value: {
  *
  * @see {@link isMessageModifyingSigner}
  */
-export function assertIsMessageModifyingSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): asserts value is MessageModifyingSigner<TAddress> {
+export function assertIsMessageModifyingSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): asserts value is MessageModifyingSigner<TAddress> & TValue {
     if (!isMessageModifyingSigner(value)) {
         throw new SolanaError(SOLANA_ERROR__SIGNER__EXPECTED_MESSAGE_MODIFYING_SIGNER, {
             address: value.address,

--- a/packages/signers/src/message-partial-signer.ts
+++ b/packages/signers/src/message-partial-signer.ts
@@ -72,10 +72,9 @@ export type MessagePartialSigner<TAddress extends string = string> = Readonly<{
  *
  * @see {@link assertIsMessagePartialSigner}
  */
-export function isMessagePartialSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): value is MessagePartialSigner<TAddress> {
+export function isMessagePartialSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): value is MessagePartialSigner<TAddress> & TValue {
     return 'signMessages' in value && typeof value.signMessages === 'function';
 }
 
@@ -96,10 +95,9 @@ export function isMessagePartialSigner<TAddress extends string>(value: {
  *
  * @see {@link isMessagePartialSigner}
  */
-export function assertIsMessagePartialSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): asserts value is MessagePartialSigner<TAddress> {
+export function assertIsMessagePartialSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): asserts value is MessagePartialSigner<TAddress> & TValue {
     if (!isMessagePartialSigner(value)) {
         throw new SolanaError(SOLANA_ERROR__SIGNER__EXPECTED_MESSAGE_PARTIAL_SIGNER, {
             address: value.address,

--- a/packages/signers/src/message-signer.ts
+++ b/packages/signers/src/message-signer.ts
@@ -34,10 +34,9 @@ export type MessageSigner<TAddress extends string = string> =
  *
  * @see {@link assertIsMessageSigner}
  */
-export function isMessageSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): value is MessageSigner<TAddress> {
+export function isMessageSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): value is MessageSigner<TAddress> & TValue {
     return isMessagePartialSigner(value) || isMessageModifyingSigner(value);
 }
 
@@ -59,10 +58,9 @@ export function isMessageSigner<TAddress extends string>(value: {
  *
  * @see {@link isMessageSigner}
  */
-export function assertIsMessageSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): asserts value is MessageSigner<TAddress> {
+export function assertIsMessageSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): asserts value is MessageSigner<TAddress> & TValue {
     if (!isMessageSigner(value)) {
         throw new SolanaError(SOLANA_ERROR__SIGNER__EXPECTED_MESSAGE_SIGNER, {
             address: value.address,

--- a/packages/signers/src/transaction-modifying-signer.ts
+++ b/packages/signers/src/transaction-modifying-signer.ts
@@ -79,10 +79,9 @@ export type TransactionModifyingSigner<TAddress extends string = string> = Reado
  *
  * @see {@link assertIsTransactionModifyingSigner}
  */
-export function isTransactionModifyingSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): value is TransactionModifyingSigner<TAddress> {
+export function isTransactionModifyingSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): value is TransactionModifyingSigner<TAddress> & TValue {
     return 'modifyAndSignTransactions' in value && typeof value.modifyAndSignTransactions === 'function';
 }
 
@@ -103,10 +102,10 @@ export function isTransactionModifyingSigner<TAddress extends string>(value: {
  *
  * @see {@link isTransactionModifyingSigner}
  */
-export function assertIsTransactionModifyingSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): asserts value is TransactionModifyingSigner<TAddress> {
+export function assertIsTransactionModifyingSigner<
+    TAddress extends string,
+    TValue extends { address: Address<TAddress> },
+>(value: TValue): asserts value is TransactionModifyingSigner<TAddress> & TValue {
     if (!isTransactionModifyingSigner(value)) {
         throw new SolanaError(SOLANA_ERROR__SIGNER__EXPECTED_TRANSACTION_MODIFYING_SIGNER, {
             address: value.address,

--- a/packages/signers/src/transaction-partial-signer.ts
+++ b/packages/signers/src/transaction-partial-signer.ts
@@ -71,10 +71,9 @@ export type TransactionPartialSigner<TAddress extends string = string> = Readonl
  *
  * @see {@link assertIsTransactionPartialSigner}
  */
-export function isTransactionPartialSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): value is TransactionPartialSigner<TAddress> {
+export function isTransactionPartialSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): value is TransactionPartialSigner<TAddress> & TValue {
     return 'signTransactions' in value && typeof value.signTransactions === 'function';
 }
 
@@ -95,10 +94,10 @@ export function isTransactionPartialSigner<TAddress extends string>(value: {
  *
  * @see {@link isTransactionPartialSigner}
  */
-export function assertIsTransactionPartialSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): asserts value is TransactionPartialSigner<TAddress> {
+export function assertIsTransactionPartialSigner<
+    TAddress extends string,
+    TValue extends { address: Address<TAddress> },
+>(value: TValue): asserts value is TransactionPartialSigner<TAddress> & TValue {
     if (!isTransactionPartialSigner(value)) {
         throw new SolanaError(SOLANA_ERROR__SIGNER__EXPECTED_TRANSACTION_PARTIAL_SIGNER, {
             address: value.address,

--- a/packages/signers/src/transaction-sending-signer.ts
+++ b/packages/signers/src/transaction-sending-signer.ts
@@ -83,10 +83,9 @@ export type TransactionSendingSigner<TAddress extends string = string> = Readonl
  *
  * @see {@link assertIsTransactionSendingSigner}
  */
-export function isTransactionSendingSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): value is TransactionSendingSigner<TAddress> {
+export function isTransactionSendingSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): value is TransactionSendingSigner<TAddress> & TValue {
     return 'signAndSendTransactions' in value && typeof value.signAndSendTransactions === 'function';
 }
 
@@ -107,10 +106,10 @@ export function isTransactionSendingSigner<TAddress extends string>(value: {
  *
  * @see {@link isTransactionSendingSigner}
  */
-export function assertIsTransactionSendingSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): asserts value is TransactionSendingSigner<TAddress> {
+export function assertIsTransactionSendingSigner<
+    TAddress extends string,
+    TValue extends { address: Address<TAddress> },
+>(value: TValue): asserts value is TransactionSendingSigner<TAddress> & TValue {
     if (!isTransactionSendingSigner(value)) {
         throw new SolanaError(SOLANA_ERROR__SIGNER__EXPECTED_TRANSACTION_SENDING_SIGNER, {
             address: value.address,

--- a/packages/signers/src/transaction-signer.ts
+++ b/packages/signers/src/transaction-signer.ts
@@ -38,10 +38,9 @@ export type TransactionSigner<TAddress extends string = string> =
  *
  * @see {@link assertIsTransactionSigner}
  */
-export function isTransactionSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): value is TransactionSigner<TAddress> {
+export function isTransactionSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): value is TransactionSigner<TAddress> & TValue {
     return (
         isTransactionPartialSigner(value) || isTransactionModifyingSigner(value) || isTransactionSendingSigner(value)
     );
@@ -66,10 +65,9 @@ export function isTransactionSigner<TAddress extends string>(value: {
  *
  * @see {@link isTransactionSigner}
  */
-export function assertIsTransactionSigner<TAddress extends string>(value: {
-    [key: string]: unknown;
-    address: Address<TAddress>;
-}): asserts value is TransactionSigner<TAddress> {
+export function assertIsTransactionSigner<TAddress extends string, TValue extends { address: Address<TAddress> }>(
+    value: TValue,
+): asserts value is TransactionSigner<TAddress> & TValue {
     if (!isTransactionSigner(value)) {
         throw new SolanaError(SOLANA_ERROR__SIGNER__EXPECTED_TRANSACTION_SIGNER, {
             address: value.address,


### PR DESCRIPTION
The signer type guards declared their parameter as `{ [key: string]: unknown; address: Address<TAddress> }`. TypeScript only grants implicit index signatures to object-literal and mapped types, so class instances implementing a signer interface failed to compile when passed to a guard even though the check passes at runtime. This forced web3.js v3's `Keypair` to add a `readonly [key: string]: unknown` index signature as a workaround, weakening typo detection for its consumers.

```ts
export class Keypair implements KeyPairSigner<KitAddress> {
   readonly [key: string]: unknown; // <-- not awesome, let me delete it plz!
   // ...
```
[ref](https://github.com/solana-foundation/solana-web3.js/blob/6cc68377587a2a158260d82967b1b1dc8686d626/src/keypair.ts#L26-L35)

The guards are now generic over `TValue extends { address: Address<TAddress> }` and narrow to `TValue & <Signer>`, so any addressable value — plain object or class instance — is accepted, and narrowing preserves the input's other properties. Guard bodies are unchanged since `in` narrowing works without index signatures. A typetest covers a class-based `MessagePartialSigner` passing both guard forms without casts.