### PR TITLE
Unify the concurrent leaf executor’s callback contract with `createTransactionPlanExecutor`

### DIFF
--- a/.changeset/five-forks-unite.md
+++ b/.changeset/five-forks-unite.md
@@ -1,0 +1,5 @@
+---
+'@solana/instruction-plans': minor
+---
+
+Align `createTransactionPlanExecutorWithConcurrentLeaves` with `createTransactionPlanExecutor` by giving both the same `TransactionPlanExecutorConfig`. Its `executeTransactionMessage` callback now receives a mutable per-leaf `context` object and returns the context of a successful result, instead of building a whole `SingleTransactionPlanResult` itself. The executor builds the results: on success it merges the returned context over the stored one, and when the callback throws — or the abort signal fires before it settles — it preserves the stored context on the failed result, matching the partial-context behaviour of `createTransactionPlanExecutor`. The `ConcurrentLeafTransactionPlanExecutorConfig` type is removed. This is a breaking change to the `createTransactionPlanExecutorWithConcurrentLeaves` API introduced in 8.1.0.

--- a/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
+++ b/packages/instruction-plans/src/__tests__/transaction-plan-executor-test.ts
@@ -25,7 +25,6 @@ import {
     passthroughFailedTransactionPlanExecution,
     sequentialTransactionPlan,
     sequentialTransactionPlanResult,
-    SingleTransactionPlan,
     singleTransactionPlan,
     successfulSingleTransactionPlanResult,
     TransactionPlan,
@@ -1076,26 +1075,19 @@ describe('createTransactionPlanExecutorWithConcurrentLeaves', () => {
             nonDivisibleSequentialTransactionPlan([messages[0], messages[1]]),
             sequentialTransactionPlan([messages[2], messages[3]]),
         ]);
-        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ index: number }>({
-            executeSingleTransactionPlan: plan =>
-                Promise.resolve(
-                    successfulSingleTransactionPlanResult(plan.message, {
-                        index: messages.indexOf(plan.message as (typeof messages)[number]),
-                    }),
-                ),
-        });
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves({ executeTransactionMessage: forwardId });
 
         const result = await executor(transactionPlan);
 
         expect(result).toStrictEqual(
             parallelTransactionPlanResult([
                 nonDivisibleSequentialTransactionPlanResult([
-                    successfulSingleTransactionPlanResult(messages[0], { index: 0 }),
-                    successfulSingleTransactionPlanResult(messages[1], { index: 1 }),
+                    successfulForwardIdResult(messages[0]),
+                    successfulForwardIdResult(messages[1]),
                 ]),
                 sequentialTransactionPlanResult([
-                    successfulSingleTransactionPlanResult(messages[2], { index: 2 }),
-                    successfulSingleTransactionPlanResult(messages[3], { index: 3 }),
+                    successfulForwardIdResult(messages[2]),
+                    successfulForwardIdResult(messages[3]),
                 ]),
             ]),
         );
@@ -1104,16 +1096,14 @@ describe('createTransactionPlanExecutorWithConcurrentLeaves', () => {
     it('starts leaves in sequential plans concurrently', () => {
         const messageA = createMessage('A');
         const messageB = createMessage('B');
-        const executeSingleTransactionPlan = jest.fn(
-            (_plan: SingleTransactionPlan) => FOREVER_PROMISE as Promise<ReturnType<typeof successfulForwardIdResult>>,
+        const executeTransactionMessage = jest.fn(
+            () => FOREVER_PROMISE as Promise<TransactionPlanResultContextWithSignature>,
         );
-        const executor = createTransactionPlanExecutorWithConcurrentLeaves<TransactionPlanResultContextWithSignature>({
-            executeSingleTransactionPlan,
-        });
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves({ executeTransactionMessage });
 
         void executor(sequentialTransactionPlan([messageA, messageB]));
 
-        expect(executeSingleTransactionPlan).toHaveBeenCalledTimes(2);
+        expect(executeTransactionMessage).toHaveBeenCalledTimes(2);
     });
 
     it('aggregates thrown leaf errors without canceling other leaves', async () => {
@@ -1124,16 +1114,13 @@ describe('createTransactionPlanExecutorWithConcurrentLeaves', () => {
         const errorA = new Error('A failed');
         const errorC = new Error('C failed');
         const messages = [messageA, messageB, messageC];
-        const leafPromises = [
-            Promise.reject(errorA),
-            Promise.resolve(successfulSingleTransactionPlanResult(messageB, { id: 'B' })),
-            Promise.reject(errorC),
-        ];
-        const executeSingleTransactionPlan = jest.fn(
-            (plan: SingleTransactionPlan) => leafPromises[messages.indexOf(plan.message as (typeof messages)[number])],
+        const leafPromises = [Promise.reject(errorA), Promise.resolve({ id: 'B' }), Promise.reject(errorC)];
+        const executeTransactionMessage = jest.fn(
+            (_context: Partial<{ id: string }>, message: TransactionMessage & TransactionMessageWithFeePayer) =>
+                leafPromises[messages.indexOf(message as (typeof messages)[number])],
         );
         const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ id: string }>({
-            executeSingleTransactionPlan,
+            executeTransactionMessage,
         });
 
         const error = await executor(nonDivisibleSequentialTransactionPlan([messageA, messageB, messageC])).catch(
@@ -1142,7 +1129,7 @@ describe('createTransactionPlanExecutorWithConcurrentLeaves', () => {
 
         expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
         assertIsFailedToExecuteTransactionPlanError(error);
-        expect(executeSingleTransactionPlan).toHaveBeenCalledTimes(3);
+        expect(executeTransactionMessage).toHaveBeenCalledTimes(3);
         expect(error.context.transactionPlanResult).toStrictEqual(
             nonDivisibleSequentialTransactionPlanResult([
                 failedSingleTransactionPlanResult<{ id: string }>(messageA, errorA),
@@ -1163,24 +1150,22 @@ describe('createTransactionPlanExecutorWithConcurrentLeaves', () => {
         const errorB = new Error('B failed');
         const errorD = new Error('D failed');
         const messages = [messageA, messageB, messageC, messageD, messageE];
-        const resultA = successfulSingleTransactionPlanResult(messageA, { id: 'A' });
-        const resultC = successfulSingleTransactionPlanResult(messageC, { id: 'C' });
-        const resultE = successfulSingleTransactionPlanResult(messageE, { id: 'E' });
-        const delayedResultPromise = new Promise<typeof resultE>(resolve => {
-            setTimeout(() => resolve(resultE), 100);
+        const delayedContextPromise = new Promise<{ id: string }>(resolve => {
+            setTimeout(() => resolve({ id: 'E' }), 100);
         });
         const leafPromises = [
-            Promise.resolve(resultA),
+            Promise.resolve({ id: 'A' }),
             Promise.reject(errorB),
-            Promise.resolve(resultC),
+            Promise.resolve({ id: 'C' }),
             Promise.reject(errorD),
-            delayedResultPromise,
+            delayedContextPromise,
         ];
-        const executeSingleTransactionPlan = jest.fn(
-            (plan: SingleTransactionPlan) => leafPromises[messages.indexOf(plan.message as (typeof messages)[number])],
+        const executeTransactionMessage = jest.fn(
+            (_context: Partial<{ id: string }>, message: TransactionMessage & TransactionMessageWithFeePayer) =>
+                leafPromises[messages.indexOf(message as (typeof messages)[number])],
         );
         const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ id: string }>({
-            executeSingleTransactionPlan,
+            executeTransactionMessage,
         });
         const transactionPlan = parallelTransactionPlan([
             nonDivisibleSequentialTransactionPlan([messageA, parallelTransactionPlan([messageB, messageC])]),
@@ -1197,58 +1182,23 @@ describe('createTransactionPlanExecutorWithConcurrentLeaves', () => {
 
         expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
         assertIsFailedToExecuteTransactionPlanError(error);
-        expect(executeSingleTransactionPlan).toHaveBeenCalledTimes(5);
+        expect(executeTransactionMessage).toHaveBeenCalledTimes(5);
         expect(error.context.transactionPlanResult).toStrictEqual(
             parallelTransactionPlanResult([
                 nonDivisibleSequentialTransactionPlanResult([
-                    resultA,
+                    successfulSingleTransactionPlanResult(messageA, { id: 'A' }),
                     parallelTransactionPlanResult([
                         failedSingleTransactionPlanResult<{ id: string }>(messageB, errorB),
-                        resultC,
+                        successfulSingleTransactionPlanResult(messageC, { id: 'C' }),
                     ]),
                 ]),
                 sequentialTransactionPlanResult([
                     failedSingleTransactionPlanResult<{ id: string }>(messageD, errorD),
-                    resultE,
+                    successfulSingleTransactionPlanResult(messageE, { id: 'E' }),
                 ]),
             ]),
         );
         expect(error.cause).toBe(errorB);
-    });
-
-    it('throws a failed execution error when a callback returns a failed result', async () => {
-        expect.assertions(2);
-        const message = createMessage('A');
-        const cause = new Error('A failed');
-        const failedResult = failedSingleTransactionPlanResult<{ attempted: boolean }>(message, cause, {
-            attempted: true,
-        });
-        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ attempted: boolean }>({
-            executeSingleTransactionPlan: () => Promise.resolve(failedResult),
-        });
-
-        const error = await executor(singleTransactionPlan(message)).catch((error: unknown) => error);
-
-        expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
-        assertIsFailedToExecuteTransactionPlanError(error);
-        expect(error.context.transactionPlanResult).toBe(failedResult);
-    });
-
-    it('throws a failed execution error when a callback returns a canceled result', async () => {
-        expect.assertions(2);
-        const message = createMessage('A');
-        const canceledResult = canceledSingleTransactionPlanResult<{ attempted: boolean }>(message, {
-            attempted: false,
-        });
-        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ attempted: boolean }>({
-            executeSingleTransactionPlan: () => Promise.resolve(canceledResult),
-        });
-
-        const error = await executor(singleTransactionPlan(message)).catch((error: unknown) => error);
-
-        expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
-        assertIsFailedToExecuteTransactionPlanError(error);
-        expect(error.context.transactionPlanResult).toBe(canceledResult);
     });
 
     it('can abort before executing leaves', async () => {
@@ -1257,9 +1207,9 @@ describe('createTransactionPlanExecutorWithConcurrentLeaves', () => {
         const messageB = createMessage('B');
         const abortController = new AbortController();
         const cause = new Error('Aborted before execution');
-        const executeSingleTransactionPlan = jest.fn(() => Promise.reject(new Error('not implemented')));
+        const executeTransactionMessage = jest.fn(() => Promise.reject(new Error('not implemented')));
         const executor = createTransactionPlanExecutorWithConcurrentLeaves<TransactionPlanResultContext>({
-            executeSingleTransactionPlan,
+            executeTransactionMessage,
         });
 
         abortController.abort(cause);
@@ -1269,7 +1219,7 @@ describe('createTransactionPlanExecutorWithConcurrentLeaves', () => {
 
         expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
         assertIsFailedToExecuteTransactionPlanError(error);
-        expect(executeSingleTransactionPlan).not.toHaveBeenCalled();
+        expect(executeTransactionMessage).not.toHaveBeenCalled();
         expect(error.context.transactionPlanResult).toStrictEqual(
             parallelTransactionPlanResult([
                 canceledSingleTransactionPlanResult<TransactionPlanResultContext>(messageA),
@@ -1287,24 +1237,23 @@ describe('createTransactionPlanExecutorWithConcurrentLeaves', () => {
         const abortController = new AbortController();
         const cause = new Error('Aborted during execution');
         const messages = [messageA, messageB, messageC];
-        const resultA = successfulForwardIdResult(messageA);
-        const resultC = successfulForwardIdResult(messageC);
         const leafPromises = [
-            Promise.resolve(resultA),
-            FOREVER_PROMISE as Promise<ReturnType<typeof successfulForwardIdResult>>,
-            Promise.resolve(resultC),
+            Promise.resolve({ signature: 'A' as Signature, transaction: createTransaction('A') }),
+            FOREVER_PROMISE as Promise<TransactionPlanResultContextWithSignature>,
+            Promise.resolve({ signature: 'C' as Signature, transaction: createTransaction('C') }),
         ];
-        const executeSingleTransactionPlan = jest.fn(
-            (plan: SingleTransactionPlan) => leafPromises[messages.indexOf(plan.message as (typeof messages)[number])],
+        const executeTransactionMessage = jest.fn(
+            (
+                _context: Partial<TransactionPlanResultContextWithSignature>,
+                message: TransactionMessage & TransactionMessageWithFeePayer,
+            ) => leafPromises[messages.indexOf(message as (typeof messages)[number])],
         );
-        const executor = createTransactionPlanExecutorWithConcurrentLeaves<TransactionPlanResultContextWithSignature>({
-            executeSingleTransactionPlan,
-        });
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves({ executeTransactionMessage });
 
         const resultPromise = executor(parallelTransactionPlan([messageA, messageB, messageC]), {
             abortSignal: abortController.signal,
         });
-        expect(executeSingleTransactionPlan).toHaveBeenCalledTimes(3);
+        expect(executeTransactionMessage).toHaveBeenCalledTimes(3);
         await jest.runAllTimersAsync();
         abortController.abort(cause);
         const error = await resultPromise.catch((error: unknown) => error);
@@ -1312,34 +1261,136 @@ describe('createTransactionPlanExecutorWithConcurrentLeaves', () => {
         expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
         assertIsFailedToExecuteTransactionPlanError(error);
         expect(error.context.transactionPlanResult).toStrictEqual(
-            parallelTransactionPlanResult([resultA, failedSingleTransactionPlanResult(messageB, cause), resultC]),
+            parallelTransactionPlanResult([
+                successfulForwardIdResult(messageA),
+                failedSingleTransactionPlanResult(messageB, cause),
+                successfulForwardIdResult(messageC),
+            ]),
         );
         expect(error.context.abortReason).toBe(cause);
     });
 
-    it('forwards the abort signal to every leaf callback', async () => {
+    it('passes the abort signal to the `executeTransactionMessage` function', async () => {
         expect.assertions(1);
+        const messageA = createMessage('A');
+        const abortController = new AbortController();
+        const abortSignal = abortController.signal;
+        const executeTransactionMessage = jest.fn().mockImplementation(forwardId);
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves({ executeTransactionMessage });
+
+        await executor(singleTransactionPlan(messageA), { abortSignal });
+        expect(executeTransactionMessage).toHaveBeenNthCalledWith(1, expect.any(Object), messageA, { abortSignal });
+    });
+
+    it('preserves the context mutated by a leaf callback that throws', async () => {
+        expect.assertions(2);
+        const message = createMessage('A');
+        const cause = new Error('A failed');
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ attempted: boolean }>({
+            executeTransactionMessage: context => {
+                context.attempted = true;
+                return Promise.reject(cause);
+            },
+        });
+
+        const error = await executor(singleTransactionPlan(message)).catch((error: unknown) => error);
+
+        expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
+        assertIsFailedToExecuteTransactionPlanError(error);
+        expect(error.context.transactionPlanResult).toStrictEqual(
+            failedSingleTransactionPlanResult<{ attempted: boolean }>(message, cause, { attempted: true }),
+        );
+    });
+
+    it('preserves the context mutated by a leaf callback that is aborted mid-flight', async () => {
+        expect.assertions(2);
         const message = createMessage('A');
         const abortController = new AbortController();
-        const executeSingleTransactionPlan = jest.fn((plan: SingleTransactionPlan) =>
-            Promise.resolve(successfulSingleTransactionPlanResult(plan.message, { processed: true })),
+        const cause = new Error('Aborted during execution');
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ attempted: boolean }>({
+            executeTransactionMessage: context => {
+                context.attempted = true;
+                return FOREVER_PROMISE as Promise<never>;
+            },
+        });
+
+        const resultPromise = executor(singleTransactionPlan(message), { abortSignal: abortController.signal });
+        await jest.runAllTimersAsync();
+        abortController.abort(cause);
+        const error = await resultPromise.catch((error: unknown) => error);
+
+        expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
+        assertIsFailedToExecuteTransactionPlanError(error);
+        expect(error.context.transactionPlanResult).toStrictEqual(
+            failedSingleTransactionPlanResult<{ attempted: boolean }>(message, cause, { attempted: true }),
         );
-        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ processed: boolean }>({
-            executeSingleTransactionPlan,
+    });
+
+    it('gives every leaf callback its own context', async () => {
+        expect.assertions(2);
+        const messageA = createMessage('A');
+        const messageB = createMessage('B');
+        const cause = new Error('failed');
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ id: string }>({
+            executeTransactionMessage: (context, message) => {
+                context.id = (message as TransactionMessage & TransactionMessageWithFeePayer & { id: string }).id;
+                return Promise.reject(cause);
+            },
         });
 
-        await executor(singleTransactionPlan(message), { abortSignal: abortController.signal });
+        const error = await executor(parallelTransactionPlan([messageA, messageB])).catch((error: unknown) => error);
 
-        expect(executeSingleTransactionPlan).toHaveBeenCalledWith(singleTransactionPlan(message), {
-            abortSignal: abortController.signal,
+        expect(isSolanaError(error, SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN)).toBe(true);
+        assertIsFailedToExecuteTransactionPlanError(error);
+        expect(error.context.transactionPlanResult).toStrictEqual(
+            parallelTransactionPlanResult([
+                failedSingleTransactionPlanResult<{ id: string }>(messageA, cause, { id: 'A' }),
+                failedSingleTransactionPlanResult<{ id: string }>(messageB, cause, { id: 'B' }),
+            ]),
+        );
+    });
+
+    it('keeps context properties that the callback stored but did not return', async () => {
+        expect.assertions(1);
+        const messageA = createMessage('A');
+        const transactionA = createTransaction('A');
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves({
+            executeTransactionMessage: context => {
+                context.transaction = transactionA;
+                return Promise.resolve({ signature: 'A' as Signature });
+            },
         });
+
+        const promise = executor(singleTransactionPlan(messageA));
+        await expect(promise).resolves.toStrictEqual(
+            successfulSingleTransactionPlanResult(messageA, {
+                signature: 'A' as Signature,
+                transaction: transactionA,
+            }),
+        );
+    });
+
+    it('prefers the returned context over the one stored on the context', async () => {
+        expect.assertions(1);
+        const messageA = createMessage('A');
+        const executor = createTransactionPlanExecutorWithConcurrentLeaves({
+            executeTransactionMessage: context => {
+                context.signature = 'stale' as Signature;
+                return Promise.resolve({ signature: 'A' as Signature });
+            },
+        });
+
+        const promise = executor(singleTransactionPlan(messageA));
+        await expect(promise).resolves.toStrictEqual(
+            successfulSingleTransactionPlanResult(messageA, { signature: 'A' as Signature }),
+        );
     });
 
     it('rejects transaction plans with an unknown kind', async () => {
         expect.assertions(1);
         const transactionPlan = { kind: 'unknown' } as unknown as TransactionPlan;
         const executor = createTransactionPlanExecutorWithConcurrentLeaves<TransactionPlanResultContext>({
-            executeSingleTransactionPlan: () => Promise.reject(new Error('not implemented')),
+            executeTransactionMessage: () => Promise.reject(new Error('not implemented')),
         });
 
         const error = await executor(transactionPlan).catch((error: unknown) => error);

--- a/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
+++ b/packages/instruction-plans/src/__typetests__/transaction-plan-executor-typetest.ts
@@ -11,19 +11,17 @@ import { compileTransaction, Transaction, TransactionWithBlockhashLifetime } fro
 
 import {
     CanceledSingleTransactionPlanResult,
-    type ConcurrentLeafTransactionPlanExecutorConfig,
     createTransactionPlanExecutor,
     createTransactionPlanExecutorWithConcurrentLeaves,
     FailedSingleTransactionPlanResult,
     flattenTransactionPlanResult,
     passthroughFailedTransactionPlanExecution,
-    type SingleTransactionPlan,
     SingleTransactionPlanResult,
     SuccessfulSingleTransactionPlanResult,
-    successfulSingleTransactionPlanResult,
     summarizeTransactionPlanResult,
     type TransactionPlan,
     type TransactionPlanExecutor,
+    type TransactionPlanExecutorConfig,
     type TransactionPlanResult,
     type TransactionPlanResultContextWithSignature,
 } from '../index';
@@ -242,53 +240,80 @@ import {
 
 // [DESCRIBE] createTransactionPlanExecutorWithConcurrentLeaves
 {
+    // It shares its configuration type with `createTransactionPlanExecutor`.
+    {
+        const config = null as unknown as TransactionPlanExecutorConfig<{ custom: string }>;
+        createTransactionPlanExecutor(config) satisfies TransactionPlanExecutor<{ custom: string }>;
+        createTransactionPlanExecutorWithConcurrentLeaves(config) satisfies TransactionPlanExecutor<{
+            custom: string;
+        }>;
+    }
+
     // It creates an executor with the caller-defined result context.
     {
         const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ transaction: Transaction }>({
-            executeSingleTransactionPlan: plan =>
-                Promise.resolve(
-                    successfulSingleTransactionPlanResult(plan.message, { transaction: {} as Transaction }),
-                ),
+            executeTransactionMessage: () => Promise.resolve({ transaction: {} as Transaction }),
         });
         executor satisfies TransactionPlanExecutor<{ transaction: Transaction }>;
     }
 
-    // It infers the result context from the callback when possible.
+    // When the callback declares no parameters, `TContext` is inferred from the context it
+    // returns rather than falling back to the default. Declaring a parameter — which any callback
+    // that needs the message must do — makes the callback context-sensitive, at which point the
+    // default applies and the returned context must satisfy it. This matches
+    // `createTransactionPlanExecutor`.
     {
         const executor = createTransactionPlanExecutorWithConcurrentLeaves({
-            executeSingleTransactionPlan: plan =>
-                Promise.resolve(successfulSingleTransactionPlanResult(plan.message, { custom: 'value' })),
+            executeTransactionMessage: () => Promise.resolve({ custom: 'value' }),
         });
         executor satisfies TransactionPlanExecutor<{ custom: string }>;
+
+        createTransactionPlanExecutorWithConcurrentLeaves({
+            // @ts-expect-error The default context applies here, and it requires a signature.
+            executeTransactionMessage: (_, _message) => Promise.resolve({ transaction: {} as Transaction }),
+        });
     }
 
-    // Its config type requires the caller to define the result context.
-    {
-        // @ts-expect-error The concurrent leaf result context has no default.
-        type ConfigWithoutContext = ConcurrentLeafTransactionPlanExecutorConfig;
-        void (null as unknown as ConfigWithoutContext);
-    }
-
-    // Its callback receives a single transaction plan and the optional abort signal.
+    // Its callback receives a mutable context, the transaction message and the optional abort
+    // signal, exactly as in `createTransactionPlanExecutor`.
     {
         createTransactionPlanExecutorWithConcurrentLeaves<{ custom: string }>({
-            executeSingleTransactionPlan: (plan, config) => {
-                plan satisfies SingleTransactionPlan;
+            executeTransactionMessage: (context, message, config) => {
+                context satisfies Partial<{ custom: string }>;
+                message satisfies TransactionMessage & TransactionMessageWithFeePayer;
                 config?.abortSignal satisfies AbortSignal | undefined;
-                return Promise.resolve(successfulSingleTransactionPlanResult(plan.message, { custom: 'value' }));
+                return Promise.resolve({ custom: 'value' });
             },
         });
     }
 
-    // Its callback must return a result carrying the configured context.
+    // Every property of the context it hands the callback is optional and mutable.
     {
         createTransactionPlanExecutorWithConcurrentLeaves<{ custom: string }>({
-            // @ts-expect-error The returned result context is missing the `custom` property.
-            executeSingleTransactionPlan: plan => {
-                return Promise.resolve(
-                    successfulSingleTransactionPlanResult(plan.message, { signature: {} as Signature }),
-                );
+            executeTransactionMessage: context => {
+                context.custom satisfies string | undefined;
+                context.custom = 'value';
+                return Promise.resolve({ custom: 'value' });
             },
+        });
+    }
+
+    // It does not accept a context property that the configured context does not declare.
+    {
+        createTransactionPlanExecutorWithConcurrentLeaves<{ custom: string }>({
+            executeTransactionMessage: context => {
+                // @ts-expect-error The configured context has no `unknownProperty` property.
+                context.unknownProperty = 'value';
+                return Promise.resolve({ custom: 'value' });
+            },
+        });
+    }
+
+    // Its callback must return the complete configured context.
+    {
+        createTransactionPlanExecutorWithConcurrentLeaves<{ custom: string }>({
+            // @ts-expect-error The returned context is missing the `custom` property.
+            executeTransactionMessage: () => Promise.resolve({ signature: {} as Signature }),
         });
     }
 }

--- a/packages/instruction-plans/src/transaction-plan-executor.ts
+++ b/packages/instruction-plans/src/transaction-plan-executor.ts
@@ -65,37 +65,18 @@ type ExecuteTransactionMessage<TContext extends TransactionPlanResultContext> = 
  * Configuration object for creating a new transaction plan executor.
  *
  * @see {@link createTransactionPlanExecutor}
+ * @see {@link createTransactionPlanExecutorWithConcurrentLeaves}
  */
 export type TransactionPlanExecutorConfig<
     TContext extends TransactionPlanResultContext = TransactionPlanResultContext,
 > = {
     /**
-     * Called whenever a transaction message must be sent to the blockchain.
+     * Called whenever a transaction message must be executed.
      *
      * It should return the context that the successful result must carry — every property
      * `TContext` promises, which by default includes a `signature`.
      */
     executeTransactionMessage: ExecuteTransactionMessage<TContext>;
-};
-
-/**
- * Configuration for an executor that processes every transaction plan leaf concurrently.
- *
- * @typeParam TContext - The context carried by each single transaction plan result.
- *
- * @see {@link createTransactionPlanExecutorWithConcurrentLeaves}
- */
-export type ConcurrentLeafTransactionPlanExecutorConfig<TContext extends TransactionPlanResultContext> = {
-    /**
-     * Executes a single transaction plan and returns its result.
-     *
-     * The executor calls this function concurrently for every leaf in the plan and forwards
-     * the optional abort signal.
-     */
-    executeSingleTransactionPlan: (
-        transactionPlan: SingleTransactionPlan,
-        config?: { abortSignal?: AbortSignal },
-    ) => Promise<SingleTransactionPlanResult<TContext>>;
 };
 
 /**
@@ -228,51 +209,58 @@ export function createTransactionPlanExecutor<
 /**
  * Creates a transaction plan executor that processes every leaf concurrently.
  *
- * The executor preserves the input plan's nesting, order, and divisibility in the returned
- * result, but it does not enforce the execution dependencies expressed by sequential plans.
- * This makes it suitable for operations such as signing or serializing transactions that can
- * be performed independently. All leaf callbacks are started without a concurrency limit.
+ * It takes the same configuration as {@link createTransactionPlanExecutor} and its
+ * `executeTransactionMessage` callback follows the same contract: it receives a fresh mutable
+ * context object for every leaf and returns the complete `TContext` a successful result must
+ * carry. On success the two are merged with the returned value taking precedence; on a throw
+ * the context accumulated so far is preserved in the failed result.
+ *
+ * The difference is the traversal. This executor preserves the input plan's nesting, order, and
+ * divisibility in the returned result, but it does not enforce the execution dependencies
+ * expressed by sequential plans: every leaf callback is started immediately, without a concurrency
+ * limit. This makes it suitable for operations such as signing or serializing transactions that
+ * can be performed independently. For the same reason, a callback that throws does not cancel the
+ * other leaves — each one runs to completion — and non-divisible sequential plans are supported.
  *
  * The optional abort signal is forwarded to every leaf callback and enforced by the executor.
  * When the signal is already aborted, leaves are canceled without invoking their callbacks. When
  * it is aborted during execution, the executor stops waiting for active callbacks and records
- * failed results carrying the abort reason.
+ * failed results carrying the abort reason and the context accumulated so far — a value the
+ * callback resolves with afterwards is discarded.
  *
- * Errors thrown by a callback are converted to failed single transaction plan results without
- * canceling any other leaves. After all leaves settle, a plan containing failed or canceled results
- * throws a failed execution error containing the complete result tree.
+ * After all leaves settle, a plan containing failed or canceled results throws a failed execution
+ * error containing the complete result tree.
  *
- * @typeParam TContext - The caller-defined context carried by each single transaction plan result.
- * @param config - Configuration containing the function used to execute each leaf.
+ * @typeParam TContext - The context carried by each single transaction plan result.
+ * @param config - Configuration object containing the transaction message executor function.
  * @return A {@link TransactionPlanExecutor} that processes all transaction plan leaves concurrently.
  * @throws {@link SOLANA_ERROR__INSTRUCTION_PLANS__FAILED_TO_EXECUTE_TRANSACTION_PLAN}
- *   if any leaf callback throws or returns a failed or canceled result. The error context contains
- *   a `transactionPlanResult` property with the complete result tree.
+ *   if any leaf callback throws, any leaf is canceled, or the abort signal fires. The error
+ *   context contains a `transactionPlanResult` property with the complete result tree.
  * @throws {@link SOLANA_ERROR__INVARIANT_VIOLATION__INVALID_TRANSACTION_PLAN_KIND} if the plan has an unknown kind.
  *
  * @example
  * Signing every transaction in a plan concurrently.
  * ```ts
  * const executor = createTransactionPlanExecutorWithConcurrentLeaves<{ transaction: Transaction }>({
- *     executeSingleTransactionPlan: async (plan, { abortSignal } = {}) => {
- *         abortSignal?.throwIfAborted();
- *         const transaction = await signTransactionMessageWithSigners(plan.message);
- *         return successfulSingleTransactionPlanResult(plan.message, { transaction });
+ *     executeTransactionMessage: async (_context, message) => {
+ *         const transaction = await signTransactionMessageWithSigners(message);
+ *         return { transaction };
  *     },
  * });
  * const result = await executor(transactionPlan);
  * ```
  *
- * @see {@link ConcurrentLeafTransactionPlanExecutorConfig}
+ * @see {@link TransactionPlanExecutorConfig}
  * @see {@link createTransactionPlanExecutor}
  */
-export function createTransactionPlanExecutorWithConcurrentLeaves<TContext extends TransactionPlanResultContext>(
-    config: ConcurrentLeafTransactionPlanExecutorConfig<TContext>,
-): TransactionPlanExecutor<TContext> {
+export function createTransactionPlanExecutorWithConcurrentLeaves<
+    TContext extends TransactionPlanResultContext = TransactionPlanResultContextWithSignature,
+>(config: TransactionPlanExecutorConfig<TContext>): TransactionPlanExecutor<TContext> {
     return async (transactionPlan, executorConfig) => {
         const transactionPlanResult = await traverseTransactionPlanLeavesConcurrently(
             transactionPlan,
-            config.executeSingleTransactionPlan,
+            config.executeTransactionMessage,
             executorConfig,
         );
         if (executorConfig?.abortSignal?.aborted || !isSuccessfulTransactionPlanResult(transactionPlanResult)) {
@@ -285,28 +273,41 @@ export function createTransactionPlanExecutorWithConcurrentLeaves<TContext exten
 
 async function traverseTransactionPlanLeavesConcurrently<TContext extends TransactionPlanResultContext>(
     transactionPlan: TransactionPlan,
-    executeSingleTransactionPlan: ConcurrentLeafTransactionPlanExecutorConfig<TContext>['executeSingleTransactionPlan'],
+    executeTransactionMessage: ExecuteTransactionMessage<TContext>,
     executorConfig?: { abortSignal?: AbortSignal },
 ): Promise<TransactionPlanResult<TContext>> {
     const kind = transactionPlan.kind;
     switch (kind) {
-        case 'single':
+        case 'single': {
+            // A fresh context is created for every leaf, so nothing is populated yet. Filling it in
+            // is the `executeTransactionMessage` callback's job, which is why every property of
+            // `TContext` is optional here.
+            const context: Partial<TContext> = {};
             if (executorConfig?.abortSignal?.aborted) {
-                return canceledSingleTransactionPlanResult<TContext>(transactionPlan.message);
+                return canceledSingleTransactionPlanResult<TContext>(transactionPlan.message, context);
             }
             try {
-                return await getAbortablePromise(
-                    executeSingleTransactionPlan(transactionPlan, executorConfig),
+                const returnedContext = await getAbortablePromise(
+                    executeTransactionMessage(context, transactionPlan.message, {
+                        abortSignal: executorConfig?.abortSignal,
+                    }),
                     executorConfig?.abortSignal,
                 );
+                // Anything the callback stored on the mutable context but left out of its return
+                // value is kept, since dropping it would lose data it deliberately recorded.
+                return successfulSingleTransactionPlanResult<TContext>(transactionPlan.message, {
+                    ...context,
+                    ...returnedContext,
+                });
             } catch (error) {
-                return failedSingleTransactionPlanResult<TContext>(transactionPlan.message, error as Error);
+                return failedSingleTransactionPlanResult<TContext>(transactionPlan.message, error as Error, context);
             }
+        }
         case 'parallel':
         case 'sequential': {
             const plans = await Promise.all(
                 transactionPlan.plans.map(plan =>
-                    traverseTransactionPlanLeavesConcurrently(plan, executeSingleTransactionPlan, executorConfig),
+                    traverseTransactionPlanLeavesConcurrently(plan, executeTransactionMessage, executorConfig),
                 ),
             );
             if (kind === 'parallel') {


### PR DESCRIPTION
I think this API as published was a mistake. Its callback has each leaf return a `SingleTransactionPlanResult`, which worked as a specialised helper in the kit-plugins PRs, but diverges from `createTransactionPlanExecutor`.

This PR changes it to use the same config (so, the same callback shape) as `createTransactionPlanExecutor`: it returns whatever it specified as `TContext`. The executor handles wrapping this in a successful response. It receives the mutable `Partial<TContext>` and is able to set values on it during execution. If it fails/is cancelled, the partial context is made available on the result.

This is a breaking change to the new API, but I've made it a minor because it's brand new and unused. I think it's worth aligning this now, making its consumers simpler and making it more straightforward for anyone else using it.
