### PR TITLE
fix: avoid deprecated waiter in airdrop

### DIFF
--- a/.changeset/soft-cycles-attend.md
+++ b/.changeset/soft-cycles-attend.md
@@ -1,0 +1,5 @@
+---
+'@solana/transaction-confirmation': minor
+---
+
+Add a new public `waitForSignatureConfirmationWithTimeout` waiter for confirming a transaction by its signature using a time-based lifetime. The previously deprecated `waitForRecentTransactionConfirmationUntilTimeout` now delegates to it.

--- a/packages/kit/src/airdrop-internal.ts
+++ b/packages/kit/src/airdrop-internal.ts
@@ -2,15 +2,15 @@ import type { Address } from '@solana/addresses';
 import type { Signature } from '@solana/keys';
 import type { RequestAirdropApi, Rpc } from '@solana/rpc';
 import type { Commitment, Lamports } from '@solana/rpc-types';
-import { waitForRecentTransactionConfirmationUntilTimeout } from '@solana/transaction-confirmation';
+import { waitForSignatureConfirmationWithTimeout } from '@solana/transaction-confirmation';
 
 type RequestAndConfirmAirdropConfig = Readonly<{
     abortSignal?: AbortSignal;
     commitment: Commitment;
     confirmSignatureOnlyTransaction: (
         config: Omit<
-            Parameters<typeof waitForRecentTransactionConfirmationUntilTimeout>[0],
-            'getRecentSignatureConfirmationPromise' | 'getTimeoutPromise'
+            Parameters<typeof waitForSignatureConfirmationWithTimeout>[0],
+            'getRecentSignatureConfirmationPromise'
         >,
     ) => Promise<void>;
     lamports: Lamports;

--- a/packages/kit/src/airdrop.ts
+++ b/packages/kit/src/airdrop.ts
@@ -3,8 +3,7 @@ import type { GetSignatureStatusesApi, RequestAirdropApi, Rpc } from '@solana/rp
 import type { RpcSubscriptions, SignatureNotificationsApi } from '@solana/rpc-subscriptions';
 import {
     createRecentSignatureConfirmationPromiseFactory,
-    getTimeoutPromise,
-    waitForRecentTransactionConfirmationUntilTimeout,
+    waitForSignatureConfirmationWithTimeout,
 } from '@solana/transaction-confirmation';
 
 import { requestAndConfirmAirdrop_INTERNAL_ONLY_DO_NOT_EXPORT } from './airdrop-internal';
@@ -60,14 +59,13 @@ export function airdropFactory<TCluster extends 'devnet' | 'mainnet' | 'testnet'
     } as Parameters<typeof createRecentSignatureConfirmationPromiseFactory>[0]);
     async function confirmSignatureOnlyTransaction(
         config: Omit<
-            Parameters<typeof waitForRecentTransactionConfirmationUntilTimeout>[0],
-            'getRecentSignatureConfirmationPromise' | 'getTimeoutPromise'
+            Parameters<typeof waitForSignatureConfirmationWithTimeout>[0],
+            'getRecentSignatureConfirmationPromise'
         >,
     ) {
-        await waitForRecentTransactionConfirmationUntilTimeout({
+        await waitForSignatureConfirmationWithTimeout({
             ...config,
             getRecentSignatureConfirmationPromise,
-            getTimeoutPromise,
         });
     }
     return async function airdrop(config) {

--- a/packages/transaction-confirmation/src/__tests__/waiters-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/waiters-test.ts
@@ -15,6 +15,7 @@ import {
     waitForDurableNonceTransactionConfirmation,
     waitForRecentTransactionConfirmation,
     waitForRecentTransactionConfirmationUntilTimeout,
+    waitForSignatureConfirmationWithTimeout,
 } from '../waiters';
 
 const FOREVER_PROMISE = new Promise(() => {
@@ -432,6 +433,95 @@ describe('waitForRecentTransactionConfirmationUntilTimeout', () => {
             commitment: 'finalized',
             getRecentSignatureConfirmationPromise,
             getTimeoutPromise,
+            signature: MOCK_SIGNATURE,
+        }).catch(() => {});
+        abortController.abort();
+        expect(handleAbortOnSignatureConfirmationPromise).toHaveBeenCalled();
+    });
+});
+
+describe('waitForSignatureConfirmationWithTimeout', () => {
+    const MOCK_SIGNATURE = '4'.repeat(44) as Signature;
+    let getRecentSignatureConfirmationPromise: jest.Mock<Promise<void>>;
+    beforeEach(() => {
+        getRecentSignatureConfirmationPromise = jest.fn().mockReturnValue(FOREVER_PROMISE);
+    });
+    it('throws when the signal is already aborted', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        abortController.abort();
+        const commitmentPromise = waitForSignatureConfirmationWithTimeout({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            signature: MOCK_SIGNATURE,
+        });
+        await expect(commitmentPromise).rejects.toThrow('aborted');
+    });
+    it('resolves when the signature confirmation promise resolves', async () => {
+        expect.assertions(1);
+        getRecentSignatureConfirmationPromise.mockResolvedValue(undefined);
+        const commitmentPromise = waitForSignatureConfirmationWithTimeout({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            signature: MOCK_SIGNATURE,
+        });
+        await expect(commitmentPromise).resolves.toBeUndefined();
+    });
+    it('rejects with a TimeoutError when the timeout wins', async () => {
+        expect.assertions(1);
+        jest.useFakeTimers();
+        const abortController = new AbortController();
+        const commitmentPromise = waitForSignatureConfirmationWithTimeout({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            signature: MOCK_SIGNATURE,
+        });
+        const caught = commitmentPromise.catch(e => e);
+        await jest.runAllTimersAsync();
+        const error = await caught;
+        jest.useRealTimers();
+        expect((error as DOMException).name).toBe('TimeoutError');
+    });
+    it('rejects with an AbortError when the caller aborts', async () => {
+        expect.assertions(1);
+        const abortController = new AbortController();
+        const commitmentPromise = waitForSignatureConfirmationWithTimeout({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            signature: MOCK_SIGNATURE,
+        }).catch(e => e);
+        abortController.abort();
+        const error = await commitmentPromise;
+        expect((error as DOMException).name).toBe('AbortError');
+    });
+    it('calls `getRecentSignatureConfirmationPromise` with the necessary input', () => {
+        waitForSignatureConfirmationWithTimeout({
+            abortSignal: new AbortController().signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
+            signature: MOCK_SIGNATURE,
+        }).catch(() => {});
+        expect(getRecentSignatureConfirmationPromise).toHaveBeenCalledWith({
+            abortSignal: expect.any(AbortSignal),
+            commitment: 'finalized',
+            signature: '4'.repeat(44),
+        });
+    });
+    it('calls the abort signal passed to `getRecentSignatureConfirmationPromise` when aborted', () => {
+        const handleAbortOnSignatureConfirmationPromise = jest.fn();
+        getRecentSignatureConfirmationPromise.mockImplementation(async ({ abortSignal }) => {
+            abortSignal.addEventListener('abort', handleAbortOnSignatureConfirmationPromise);
+            await FOREVER_PROMISE;
+        });
+        const abortController = new AbortController();
+        waitForSignatureConfirmationWithTimeout({
+            abortSignal: abortController.signal,
+            commitment: 'finalized',
+            getRecentSignatureConfirmationPromise,
             signature: MOCK_SIGNATURE,
         }).catch(() => {});
         abortController.abort();

--- a/packages/transaction-confirmation/src/waiters.ts
+++ b/packages/transaction-confirmation/src/waiters.ts
@@ -34,6 +34,20 @@ interface WaitForRecentTransactionWithTimeBasedLifetimeConfirmationConfig extend
     signature: Signature;
 }
 
+interface WaitForSignatureConfirmationWithTimeoutConfig extends BaseTransactionConfirmationStrategyConfig {
+    /**
+     * Overrides the default time-based lifetime strategy. Most callers should omit this and rely on
+     * the built-in timeout, which rejects after 30 seconds when the commitment is `processed` and 60
+     * seconds otherwise.
+     */
+    getTimeoutPromise?: typeof getTimeoutPromise;
+    /**
+     * A 64 byte Ed25519 signature, encoded as a base-58 string, that uniquely identifies a
+     * transaction by virtue of being the first or only signature in its list of signatures.
+     */
+    signature: Signature;
+}
+
 /**
  * Supply your own confirmation implementations to this function to create a custom nonce
  * transaction confirmation strategy.
@@ -120,20 +134,60 @@ export async function waitForRecentTransactionConfirmation(
     );
 }
 
-/** @deprecated */
+/**
+ * Waits for a transaction, identified by its signature, to be confirmed using a time-based
+ * lifetime. The confirmation races the standard recent-signature confirmation promise against a
+ * timeout that rejects after 30 seconds when the commitment is `processed`, and 60 seconds
+ * otherwise.
+ *
+ * @example
+ * ```ts
+ * import { waitForSignatureConfirmationWithTimeout } from '@solana/transaction-confirmation';
+ *
+ * try {
+ *     await waitForSignatureConfirmationWithTimeout({
+ *         getRecentSignatureConfirmationPromise({ abortSignal, commitment, signature }) {
+ *             // Return a promise that resolves when a transaction achieves confirmation
+ *         },
+ *         signature,
+ *     });
+ * } catch (e) {
+ *     // Handle errors.
+ * }
+ * ```
+ */
+export async function waitForSignatureConfirmationWithTimeout(
+    config: WaitForSignatureConfirmationWithTimeoutConfig,
+): Promise<void> {
+    const { getTimeoutPromise: getTimeoutPromiseImpl = getTimeoutPromise } = config;
+    await raceStrategies(config.signature, config, function getSpecificStrategiesForRace({ abortSignal, commitment }) {
+        return [
+            getTimeoutPromiseImpl({
+                abortSignal,
+                commitment,
+            }),
+        ];
+    });
+}
+
+/**
+ * @deprecated Use {@link waitForSignatureConfirmationWithTimeout} instead.
+ */
 export async function waitForRecentTransactionConfirmationUntilTimeout(
     config: WaitForRecentTransactionWithTimeBasedLifetimeConfirmationConfig,
 ): Promise<void> {
-    await raceStrategies(
-        config.signature,
-        config,
-        function getSpecificStrategiesForRace({ abortSignal, commitment, getTimeoutPromise }) {
-            return [
-                getTimeoutPromise({
-                    abortSignal,
-                    commitment,
-                }),
-            ];
-        },
-    );
+    const {
+        abortSignal,
+        commitment,
+        getRecentSignatureConfirmationPromise,
+        getTimeoutPromise: getTimeoutPromiseImpl,
+        signature,
+    } = config;
+    await waitForSignatureConfirmationWithTimeout({
+        abortSignal,
+        commitment,
+        getRecentSignatureConfirmationPromise,
+        getTimeoutPromise: getTimeoutPromiseImpl,
+        signature,
+    });
 }


### PR DESCRIPTION
## Summary

Refactors Kit's airdrop confirmation flow to stop using the deprecated `waitForRecentTransactionConfirmationUntilTimeout` waiter.

- Adds `waitForSignatureConfirmationWithTimeout` for signature-only confirmation with the existing timeout strategy.
- Updates Kit's airdrop implementation to use the new waiter.
- Keeps `waitForRecentTransactionConfirmationUntilTimeout` available and deprecated for backwards compatibility.
- Preserves the existing timeout, abort, and transaction-error behavior.

## Testing

- Added coverage for successful confirmation, timeout, abort, commitment forwarding, and strategy cancellation.
- Existing deprecated waiter tests remain passing.
- All focused transaction-confirmation tests pass.
- Typecheck, ESLint, Prettier, and `git diff --check` pass.

Fixes #1784