### PR TITLE
Add the `getAgGenesisCert` RPC method

### DIFF
--- a/.changeset/large-sites-occur.md
+++ b/.changeset/large-sites-occur.md
@@ -1,0 +1,6 @@
+---
+'@solana/rpc-transport-http': minor
+'@solana/rpc-api': minor
+---
+
+Added support for the `getAgGenesisCert` RPC method, which returns the Alpenglow genesis certificate from nodes that have one

--- a/.changeset/thick-dodos-travel.md
+++ b/.changeset/thick-dodos-travel.md
@@ -1,0 +1,5 @@
+---
+'@solana/rpc-transport-http': patch
+---
+
+Fixed a bug where responses to `getTransactionsForAddress` requests were parsed without `bigint` support, risking precision loss on large integer values

--- a/packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts
+++ b/packages/rpc-api/src/__tests__/allowed-numeric-keypaths-test.ts
@@ -4,6 +4,7 @@ import { createRpc, type Rpc } from '@solana/rpc-spec';
 
 import {
     createSolanaRpcApi,
+    GetAgGenesisCertApi,
     GetBlockApi,
     GetTransactionApi,
     GetTransactionsForAddressApi,
@@ -39,6 +40,20 @@ function createMockRpc<TApi>(result: unknown): Rpc<TApi> {
 }
 
 describe('the default response transformer for the Solana RPC', () => {
+    describe('getAgGenesisCert', () => {
+        it('upcasts the slot to a `bigint` but leaves the byte arrays as numbers', async () => {
+            expect.assertions(4);
+            const rpc = createMockRpc<GetAgGenesisCertApi>({
+                block: { blockId: [1, 2, 3], slot: 42 },
+                signature: { bitmap: [7, 8, 9], signature: [4, 5, 6] },
+            });
+            const result = await rpc.getAgGenesisCert().send();
+            expect(result?.block.slot).toBe(42n);
+            expect(result?.block.blockId).toStrictEqual([1, 2, 3]);
+            expect(result?.signature.signature).toStrictEqual([4, 5, 6]);
+            expect(result?.signature.bitmap).toStrictEqual([7, 8, 9]);
+        });
+    });
     describe('getTransaction', () => {
         it('leaves `version` as a number', async () => {
             expect.assertions(1);

--- a/packages/rpc-api/src/__tests__/get-ag-genesis-cert-test.ts
+++ b/packages/rpc-api/src/__tests__/get-ag-genesis-cert-test.ts
@@ -1,0 +1,21 @@
+import type { Rpc } from '@solana/rpc-spec';
+
+import { GetAgGenesisCertApi } from '../index';
+import { createLocalhostSolanaRpc } from './__setup__';
+
+describe('getAgGenesisCert', () => {
+    let rpc: Rpc<GetAgGenesisCertApi>;
+    beforeEach(() => {
+        rpc = createLocalhostSolanaRpc();
+    });
+
+    describe('when sent to a local validator with no Alpenglow genesis certificate', () => {
+        it('returns null', async () => {
+            expect.assertions(1);
+            const certPromise = rpc.getAgGenesisCert().send();
+            await expect(certPromise).resolves.toBeNull();
+        });
+    });
+
+    it.todo('when sent to a local validator with an Alpenglow genesis certificate');
+});

--- a/packages/rpc-api/src/__typetests__/get-ag-genesis-cert-typetest.ts
+++ b/packages/rpc-api/src/__typetests__/get-ag-genesis-cert-typetest.ts
@@ -1,0 +1,22 @@
+import type { Rpc } from '@solana/rpc-spec';
+import type { Slot } from '@solana/rpc-types';
+
+import type { GetAgGenesisCertApi } from '../getAgGenesisCert';
+
+const rpc = null as unknown as Rpc<GetAgGenesisCertApi>;
+
+void (async () => {
+    {
+        const result = await rpc.getAgGenesisCert().send();
+        result satisfies Readonly<{
+            block: Readonly<{
+                blockId: readonly number[];
+                slot: Slot;
+            }>;
+            signature: Readonly<{
+                bitmap: readonly number[];
+                signature: readonly number[];
+            }>;
+        }> | null;
+    }
+});

--- a/packages/rpc-api/src/getAgGenesisCert.ts
+++ b/packages/rpc-api/src/getAgGenesisCert.ts
@@ -1,0 +1,34 @@
+import type { Slot } from '@solana/rpc-types';
+
+/**
+ * The Alpenglow genesis certificate, as gossiped between validators.
+ *
+ * This mirrors the `WireBlockCertMessage` type in the Agave validator.
+ */
+type GetAgGenesisCertApiResponse = Readonly<{
+    /** The block that the certificate is certifying */
+    block: Readonly<{
+        /** The block id of the certified block, as a 32-byte array */
+        blockId: readonly number[];
+        /** The slot of the certified block */
+        slot: Slot;
+    }>;
+    /** The signature of the certificate message */
+    signature: Readonly<{
+        /** Bitmap of the ranks of the validators included in the aggregate signature */
+        bitmap: readonly number[];
+        /** The 192-byte aggregate BLS signature */
+        signature: readonly number[];
+    }>;
+}>;
+
+export type GetAgGenesisCertApi = {
+    /**
+     * Returns the Alpenglow genesis certificate, or `null` if the node does not have one.
+     *
+     * @returns The certificate over the block at which the Alpenglow consensus protocol was
+     * activated.
+     * @see https://solana.com/docs/rpc/http/getaggenesiscert
+     */
+    getAgGenesisCert(): GetAgGenesisCertApiResponse | null;
+};

--- a/packages/rpc-api/src/index.ts
+++ b/packages/rpc-api/src/index.ts
@@ -38,6 +38,7 @@ import {
 } from '@solana/rpc-transformers';
 
 import { GetAccountInfoApi } from './getAccountInfo';
+import { GetAgGenesisCertApi } from './getAgGenesisCert';
 import { GetBalanceApi } from './getBalance';
 import { GetBlockApi } from './getBlock';
 import { GetBlockCommitmentApi } from './getBlockCommitment';
@@ -98,6 +99,7 @@ import { SendTransactionApi } from './sendTransaction';
 import { SimulateTransactionApi } from './simulateTransaction';
 
 type SolanaRpcApiForAllClusters = GetAccountInfoApi &
+    GetAgGenesisCertApi &
     GetBalanceApi &
     GetBlockApi &
     GetBlockCommitmentApi &
@@ -178,6 +180,7 @@ export type SolanaRpcApiMainnet = SolanaRpcApiForAllClusters;
 
 export type {
     GetAccountInfoApi,
+    GetAgGenesisCertApi,
     GetBalanceApi,
     GetBlockApi,
     GetBlockCommitmentApi,
@@ -270,6 +273,11 @@ function getAllowedNumericKeypaths(): AllowedNumericKeypaths<RpcApi<SolanaRpcApi
     if (!memoizedKeypaths) {
         memoizedKeypaths = {
             getAccountInfo: jsonParsedAccountsConfigs.map(c => ['value', ...c]),
+            getAgGenesisCert: [
+                ['block', 'blockId', KEYPATH_WILDCARD],
+                ['signature', 'bitmap', KEYPATH_WILDCARD],
+                ['signature', 'signature', KEYPATH_WILDCARD],
+            ],
             getBlock: [
                 ...tokenBalancesConfigs.flatMap(c => [
                     ['transactions', KEYPATH_WILDCARD, 'meta', 'preTokenBalances', KEYPATH_WILDCARD, ...c],

--- a/packages/rpc-transport-http/src/__tests__/is-solana-request-test.ts
+++ b/packages/rpc-transport-http/src/__tests__/is-solana-request-test.ts
@@ -5,6 +5,14 @@ describe('isSolanaRequest', () => {
         const payload = { jsonrpc: '2.0', method: 'getBalance', params: ['1234..5678'] };
         expect(isSolanaRequest(payload)).toBe(true);
     });
+    it('returns true for the `getAgGenesisCert` method', () => {
+        const payload = { jsonrpc: '2.0', method: 'getAgGenesisCert', params: [] };
+        expect(isSolanaRequest(payload)).toBe(true);
+    });
+    it('returns true for the `getTransactionsForAddress` method', () => {
+        const payload = { jsonrpc: '2.0', method: 'getTransactionsForAddress', params: ['1234..5678'] };
+        expect(isSolanaRequest(payload)).toBe(true);
+    });
     it('returns false if the method name is not from the Solana RPC API', () => {
         const payload = { jsonrpc: '2.0', method: 'getAssetsByAuthority', params: ['1234..5678'] };
         expect(isSolanaRequest(payload)).toBe(false);

--- a/packages/rpc-transport-http/src/is-solana-request.ts
+++ b/packages/rpc-transport-http/src/is-solana-request.ts
@@ -2,6 +2,7 @@ import { isJsonRpcPayload } from '@solana/rpc-spec';
 
 const SOLANA_RPC_METHODS = [
     'getAccountInfo',
+    'getAgGenesisCert',
     'getBalance',
     'getBlock',
     'getBlockCommitment',
@@ -46,6 +47,7 @@ const SOLANA_RPC_METHODS = [
     'getTokenSupply',
     'getTransaction',
     'getTransactionCount',
+    'getTransactionsForAddress',
     'getVersion',
     'getVoteAccounts',
     'index',


### PR DESCRIPTION
This is a new RPC method giving information on Alpenglow for the cluster

Also adds `getTransactionsForAddress` to the `isSolanaRequest` check, which was previously missed

Supersedes #1703