### PR TITLE
Add tap codec helpers for observing values and bytes

### DIFF
--- a/.changeset/easy-results-sink.md
+++ b/.changeset/easy-results-sink.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-core': minor
+---
+
+Add `tap` codec helpers for observing values and bytes without modifying them. The value family (`tapEncoder`/`tapDecoder`/`tapCodec`) observes the input value before encoding and the decoded value after decoding, whilst the bytes family (`tapEncoderBytes`/`tapDecoderBytes`/`tapCodecBytes`) observes the raw bytes after encoding and before decoding. Any tap may throw to abort the operation, making these helpers ideal for adding validation guards to existing codecs without an identity `transformEncoder`. For example, `tapDecoderBytes(getBooleanDecoder(), (bytes, offset) => { if (bytes[offset] > 1) throw new Error('Expected a 0 or a 1 for booleans'); })`.

--- a/packages/codecs-core/README.md
+++ b/packages/codecs-core/README.md
@@ -43,7 +43,7 @@ There is a significant library of composable codecs at your disposal, enabling y
 - [`@solana/codecs-data-structures`](https://github.com/anza-xyz/kit/tree/main/packages/codecs-data-structures) for many data structure codecs such as objects, arrays, tuples, sets, maps, enums, discriminated unions, booleans, etc.
 - [`@solana/options`](https://github.com/anza-xyz/kit/tree/main/packages/options) for a Rust-like `Option` type and associated codec.
 
-You may also be interested in some of the helpers of this `@solana/codecs-core` library such as `transformCodec`, `fixCodecSize` or `reverseCodec` that create new codecs from existing ones.
+You may also be interested in some of the helpers of this `@solana/codecs-core` library such as `transformCodec`, `tapCodec`, `fixCodecSize` or `reverseCodec` that create new codecs from existing ones.
 
 Note that all of these libraries are included in the [`@solana/codecs` package](https://github.com/anza-xyz/kit/tree/main/packages/codecs) as well as the main `@solana/kit` package for your convenience.
 
@@ -337,6 +337,48 @@ const getStringU32Encoder = () =>
     transformEncoder(getU32Encoder(), (integerAsString: string): number => parseInt(integerAsString));
 const getStringU32Decoder = () => transformDecoder(getU32Decoder(), (integer: number): string => integer.toString());
 const getStringU32Codec = () => combineCodec(getStringU32Encoder(), getStringU32Decoder());
+```
+
+## Tapping codecs
+
+Whilst transforming codecs lets you _change_ the values or bytes that flow through them, tapping codecs lets you _observe_ them without changing anything. This is mostly useful for adding validation guards to existing codecs: a tap that throws aborts the operation, whilst a tap that returns normally lets the value or bytes pass through untouched.
+
+The `tapEncoder`, `tapDecoder` and `tapCodec` helpers observe the **value**. The encoder taps the input value before encoding it and the decoder taps the decoded value after decoding it.
+
+```ts
+// Reject out-of-range input before it is encoded.
+const boundedU8 = tapEncoder(getU8Encoder(), value => {
+    if (value > 100) throw new Error('Value must not exceed 100');
+});
+
+// Validate the decoded result.
+const nonZeroU8 = tapDecoder(getU8Decoder(), value => {
+    if (value === 0) throw new Error('Value must not be zero');
+});
+```
+
+The `tapEncoderBytes`, `tapDecoderBytes` and `tapCodecBytes` helpers observe the raw **bytes** instead. The encoder taps the encoded bytes after writing them — alongside the offsets before and after the value was written — and the decoder taps the bytes before reading them. In both cases the bytes are provided as a `ReadonlyUint8Array` so they cannot be modified.
+
+```ts
+// Guard malformed boolean bytes before decoding.
+const safeBoolean = tapDecoderBytes(getBooleanDecoder(), (bytes, offset) => {
+    if (bytes[offset] > 1) throw new Error('Expected a 0 or a 1 for booleans');
+});
+```
+
+The `tapCodec` and `tapCodecBytes` helpers accept a tap for each side — the encode-side tap is required whilst the decode-side tap is optional — mirroring the `transformCodec` signature. Since each helper preserves the exact type of the codec it wraps, you can also compose separate encoder and decoder taps using `combineCodec`.
+
+```ts
+const safeBooleanCodec = combineCodec(
+    // Guard the value on the encode side.
+    tapEncoder(getBooleanEncoder(), value => {
+        if (typeof value !== 'boolean') throw new Error('Expected a boolean');
+    }),
+    // Guard the raw bytes on the decode side.
+    tapDecoderBytes(getBooleanDecoder(), (bytes, offset) => {
+        if (bytes[offset] > 1) throw new Error('Expected a 0 or a 1 for booleans');
+    }),
+);
 ```
 
 ## Fixing the size of codecs

--- a/packages/codecs-core/src/__tests__/tap-codec-bytes-test.ts
+++ b/packages/codecs-core/src/__tests__/tap-codec-bytes-test.ts
@@ -1,0 +1,156 @@
+import {
+    createCodec,
+    createDecoder,
+    createEncoder,
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+} from '../codec';
+import { ReadonlyUint8Array } from '../readonly-uint8array';
+import { tapCodecBytes, tapDecoderBytes, tapEncoderBytes } from '../tap-codec-bytes';
+
+const numberCodec: FixedSizeCodec<number, number, 1> = createCodec({
+    fixedSize: 1,
+    read: (bytes: ReadonlyUint8Array | Uint8Array, offset = 0): [number, number] => [bytes[offset], offset + 1],
+    write: (value: number, bytes, offset) => {
+        bytes.set([value], offset);
+        return offset + 1;
+    },
+});
+
+const numberEncoder: FixedSizeEncoder<number, 1> = createEncoder({
+    fixedSize: 1,
+    write: (value: number, bytes, offset) => {
+        bytes.set([value], offset);
+        return offset + 1;
+    },
+});
+
+const numberDecoder: FixedSizeDecoder<number, 1> = createDecoder({
+    fixedSize: 1,
+    read: (bytes: ReadonlyUint8Array | Uint8Array, offset = 0): [number, number] => [bytes[offset], offset + 1],
+});
+
+describe('tapEncoderBytes', () => {
+    it('observes the encoded bytes and offsets after writing without modifying them', () => {
+        const windows: number[][] = [];
+        const encoder = tapEncoderBytes(numberEncoder, (bytes, preOffset, postOffset) => {
+            windows.push([...bytes.slice(preOffset, postOffset)]);
+        });
+
+        expect(encoder.encode(42)).toStrictEqual(new Uint8Array([42]));
+        expect(windows).toStrictEqual([[42]]);
+    });
+
+    it('reports the correct pre and post offsets', () => {
+        const offsets: [number, number][] = [];
+        const encoder = tapEncoderBytes(numberEncoder, (_bytes, preOffset, postOffset) => {
+            offsets.push([preOffset, postOffset]);
+        });
+
+        encoder.write(42, new Uint8Array(4), 2);
+        expect(offsets).toStrictEqual([[2, 3]]);
+    });
+
+    it('aborts encoding when the tap throws', () => {
+        const encoder = tapEncoderBytes(numberEncoder, bytes => {
+            // eslint-disable-next-line jest/no-conditional-in-test
+            if (bytes[0] > 1) throw new Error('Expected a 0 or a 1');
+        });
+
+        expect(() => encoder.encode(2)).toThrow('Expected a 0 or a 1');
+    });
+
+    it('preserves the fixed size of the encoder', () => {
+        const encoder = tapEncoderBytes(numberEncoder, () => {});
+        expect(encoder.fixedSize).toBe(1);
+    });
+});
+
+describe('tapDecoderBytes', () => {
+    it('observes the raw bytes before decoding without modifying them', () => {
+        const observed: number[] = [];
+        const decoder = tapDecoderBytes(numberDecoder, (bytes, offset) => {
+            observed.push(bytes[offset]);
+        });
+
+        expect(decoder.decode(new Uint8Array([42]))).toBe(42);
+        expect(observed).toStrictEqual([42]);
+    });
+
+    it('observes the raw bytes at a non-zero offset', () => {
+        const observed: number[] = [];
+        const decoder = tapDecoderBytes(numberDecoder, (bytes, offset) => {
+            observed.push(bytes[offset]);
+        });
+
+        expect(decoder.read(new Uint8Array([0, 0, 42]), 2)).toStrictEqual([42, 3]);
+        expect(observed).toStrictEqual([42]);
+    });
+
+    it('aborts decoding when the tap throws', () => {
+        const decoder = tapDecoderBytes(numberDecoder, (bytes, offset) => {
+            // eslint-disable-next-line jest/no-conditional-in-test
+            if (bytes[offset] > 1) throw new Error('Expected a 0 or a 1 for booleans');
+        });
+
+        expect(() => decoder.decode(new Uint8Array([2]))).toThrow('Expected a 0 or a 1 for booleans');
+    });
+
+    it('preserves the fixed size of the decoder', () => {
+        const decoder = tapDecoderBytes(numberDecoder, () => {});
+        expect(decoder.fixedSize).toBe(1);
+    });
+});
+
+describe('tapCodecBytes', () => {
+    it('observes bytes on both sides and round-trips unchanged', () => {
+        const encoded: number[] = [];
+        const decoded: number[] = [];
+        const codec = tapCodecBytes(
+            numberCodec,
+            (bytes, preOffset, postOffset) => {
+                encoded.push(...bytes.slice(preOffset, postOffset));
+            },
+            (bytes, offset) => {
+                decoded.push(bytes[offset]);
+            },
+        );
+
+        const bytes = codec.encode(42);
+        expect(bytes).toStrictEqual(new Uint8Array([42]));
+        expect(codec.decode(bytes)).toBe(42);
+        expect(encoded).toStrictEqual([42]);
+        expect(decoded).toStrictEqual([42]);
+    });
+
+    it('leaves decoding untouched when no decode tap is provided', () => {
+        const codec = tapCodecBytes(numberCodec, () => {
+            throw new Error('should not be called on decode');
+        });
+
+        expect(codec.decode(new Uint8Array([42]))).toBe(42);
+    });
+
+    it('aborts encoding when the encode tap throws', () => {
+        const codec = tapCodecBytes(numberCodec, bytes => {
+            // eslint-disable-next-line jest/no-conditional-in-test
+            if (bytes[0] > 1) throw new Error('Expected a 0 or a 1 for booleans');
+        });
+
+        expect(() => codec.encode(2)).toThrow('Expected a 0 or a 1 for booleans');
+    });
+
+    it('aborts decoding when the decode tap throws', () => {
+        const codec = tapCodecBytes(
+            numberCodec,
+            () => {},
+            (bytes, offset) => {
+                // eslint-disable-next-line jest/no-conditional-in-test
+                if (bytes[offset] > 1) throw new Error('Expected a 0 or a 1 for booleans');
+            },
+        );
+
+        expect(() => codec.decode(new Uint8Array([2]))).toThrow('Expected a 0 or a 1 for booleans');
+    });
+});

--- a/packages/codecs-core/src/__tests__/tap-codec-test.ts
+++ b/packages/codecs-core/src/__tests__/tap-codec-test.ts
@@ -1,0 +1,146 @@
+import {
+    createCodec,
+    createDecoder,
+    createEncoder,
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+} from '../codec';
+import { ReadonlyUint8Array } from '../readonly-uint8array';
+import { tapCodec, tapDecoder, tapEncoder } from '../tap-codec';
+
+const numberCodec: FixedSizeCodec<number, number, 1> = createCodec({
+    fixedSize: 1,
+    read: (bytes: ReadonlyUint8Array | Uint8Array, offset = 0): [number, number] => [bytes[offset], offset + 1],
+    write: (value: number, bytes, offset) => {
+        bytes.set([value], offset);
+        return offset + 1;
+    },
+});
+
+const numberEncoder: FixedSizeEncoder<number, 1> = createEncoder({
+    fixedSize: 1,
+    write: (value: number, bytes, offset) => {
+        bytes.set([value], offset);
+        return offset + 1;
+    },
+});
+
+const numberDecoder: FixedSizeDecoder<number, 1> = createDecoder({
+    fixedSize: 1,
+    read: (bytes: ReadonlyUint8Array | Uint8Array, offset = 0): [number, number] => [bytes[offset], offset + 1],
+});
+
+describe('tapEncoder', () => {
+    it('observes the input value before encoding without modifying it', () => {
+        const observed: number[] = [];
+        const encoder = tapEncoder(numberEncoder, value => {
+            observed.push(value);
+        });
+
+        expect(encoder.encode(42)).toStrictEqual(new Uint8Array([42]));
+        expect(observed).toStrictEqual([42]);
+    });
+
+    it('aborts encoding when the tap throws', () => {
+        const encoder = tapEncoder(numberEncoder, value => {
+            // eslint-disable-next-line jest/no-conditional-in-test
+            if (value > 100) throw new Error('Value must not exceed 100');
+        });
+
+        expect(() => encoder.encode(200)).toThrow('Value must not exceed 100');
+    });
+
+    it('preserves the fixed size of the encoder', () => {
+        const encoder = tapEncoder(numberEncoder, () => {});
+        expect(encoder.fixedSize).toBe(1);
+    });
+});
+
+describe('tapDecoder', () => {
+    it('observes the decoded value without modifying it', () => {
+        const observed: number[] = [];
+        const decoder = tapDecoder(numberDecoder, value => {
+            observed.push(value);
+        });
+
+        expect(decoder.decode(new Uint8Array([42]))).toBe(42);
+        expect(observed).toStrictEqual([42]);
+    });
+
+    it('observes the decoded value at a non-zero offset', () => {
+        const observed: number[] = [];
+        const decoder = tapDecoder(numberDecoder, value => {
+            observed.push(value);
+        });
+
+        expect(decoder.read(new Uint8Array([0, 0, 42]), 2)).toStrictEqual([42, 3]);
+        expect(observed).toStrictEqual([42]);
+    });
+
+    it('aborts decoding when the tap throws', () => {
+        const decoder = tapDecoder(numberDecoder, value => {
+            // eslint-disable-next-line jest/no-conditional-in-test
+            if (value === 0) throw new Error('Value must not be zero');
+        });
+
+        expect(() => decoder.decode(new Uint8Array([0]))).toThrow('Value must not be zero');
+    });
+
+    it('preserves the fixed size of the decoder', () => {
+        const decoder = tapDecoder(numberDecoder, () => {});
+        expect(decoder.fixedSize).toBe(1);
+    });
+});
+
+describe('tapCodec', () => {
+    it('observes values on both sides and round-trips unchanged', () => {
+        const encoded: number[] = [];
+        const decoded: number[] = [];
+        const codec = tapCodec(
+            numberCodec,
+            value => {
+                encoded.push(value);
+            },
+            value => {
+                decoded.push(value);
+            },
+        );
+
+        const bytes = codec.encode(42);
+        expect(bytes).toStrictEqual(new Uint8Array([42]));
+        expect(codec.decode(bytes)).toBe(42);
+        expect(encoded).toStrictEqual([42]);
+        expect(decoded).toStrictEqual([42]);
+    });
+
+    it('leaves decoding untouched when no decode tap is provided', () => {
+        const codec = tapCodec(numberCodec, () => {
+            throw new Error('should not be called on decode');
+        });
+
+        expect(codec.decode(new Uint8Array([42]))).toBe(42);
+    });
+
+    it('aborts encoding when the encode tap throws', () => {
+        const codec = tapCodec(numberCodec, value => {
+            // eslint-disable-next-line jest/no-conditional-in-test
+            if (value > 100) throw new Error('Value must not exceed 100');
+        });
+
+        expect(() => codec.encode(200)).toThrow('Value must not exceed 100');
+    });
+
+    it('aborts decoding when the decode tap throws', () => {
+        const codec = tapCodec(
+            numberCodec,
+            () => {},
+            value => {
+                // eslint-disable-next-line jest/no-conditional-in-test
+                if (value === 0) throw new Error('Value must not be zero');
+            },
+        );
+
+        expect(() => codec.decode(new Uint8Array([0]))).toThrow('Value must not be zero');
+    });
+});

--- a/packages/codecs-core/src/__typetests__/tap-codec-bytes-typetest.ts
+++ b/packages/codecs-core/src/__typetests__/tap-codec-bytes-typetest.ts
@@ -1,0 +1,147 @@
+import {
+    Codec,
+    Decoder,
+    Encoder,
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+    Offset,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
+} from '../codec';
+import { ReadonlyUint8Array } from '../readonly-uint8array';
+import { tapCodecBytes, tapDecoderBytes, tapEncoderBytes } from '../tap-codec-bytes';
+
+/**
+ * Strict type-equality helper used by typetests below. Resolves to `true` only
+ * if `A` and `B` are mutually assignable AND share the same modifier set (`?`,
+ * `readonly`); otherwise resolves to `false`.
+ *
+ * This is stricter than `satisfies` for two reasons:
+ *
+ * 1. **Bidirectionality.** `A satisfies B` only checks that `A` is assignable
+ *    to `B`. A test using `satisfies` passes if the actual type has extra
+ *    members beyond what we asserted — which would silently mask a regression
+ *    that widened the type.
+ * 2. **Modifier strictness.** `A satisfies B` tolerates losing `?` (required
+ *    is assignable to optional) and losing `readonly` (readonly is assignable
+ *    to mutable). `Equal` distinguishes `{ x: T }` from `{ x?: T }` and from
+ *    `{ readonly x: T }` because the inferred-position generic comparison
+ *    uses identity rather than assignability for the type parameters.
+ *
+ * Use `Equal` when the exact shape (including modifiers) matters. Use
+ * `satisfies` when one-way assignability is the actual requirement.
+ */
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+// [DESCRIBE] tapEncoderBytes
+{
+    // It preserves the exact fixed-size encoder type, including extra custom properties.
+    {
+        type MyEncoder = FixedSizeEncoder<string, 42> & { custom: 42 };
+        const encoder = tapEncoderBytes({} as MyEncoder, () => {});
+        encoder satisfies MyEncoder;
+        true satisfies Equal<typeof encoder, MyEncoder>;
+    }
+
+    // It preserves the exact variable-size encoder type.
+    {
+        const encoder = tapEncoderBytes({} as VariableSizeEncoder<string>, () => {});
+        encoder satisfies VariableSizeEncoder<string>;
+        true satisfies Equal<typeof encoder, VariableSizeEncoder<string>>;
+    }
+
+    // It preserves the exact base encoder type.
+    {
+        const encoder = tapEncoderBytes({} as Encoder<string>, () => {});
+        encoder satisfies Encoder<string>;
+        true satisfies Equal<typeof encoder, Encoder<string>>;
+    }
+
+    // The tap receives readonly bytes and both offsets.
+    {
+        tapEncoderBytes({} as Encoder<string>, (bytes, preOffset, postOffset) => {
+            bytes satisfies ReadonlyUint8Array;
+            preOffset satisfies Offset;
+            postOffset satisfies Offset;
+        });
+    }
+}
+
+// [DESCRIBE] tapDecoderBytes
+{
+    // It preserves the exact fixed-size decoder type, including extra custom properties.
+    {
+        type MyDecoder = FixedSizeDecoder<string, 42> & { custom: 42 };
+        const decoder = tapDecoderBytes({} as MyDecoder, () => {});
+        decoder satisfies MyDecoder;
+        true satisfies Equal<typeof decoder, MyDecoder>;
+    }
+
+    // It preserves the exact variable-size decoder type.
+    {
+        const decoder = tapDecoderBytes({} as VariableSizeDecoder<string>, () => {});
+        decoder satisfies VariableSizeDecoder<string>;
+        true satisfies Equal<typeof decoder, VariableSizeDecoder<string>>;
+    }
+
+    // It preserves the exact base decoder type.
+    {
+        const decoder = tapDecoderBytes({} as Decoder<string>, () => {});
+        decoder satisfies Decoder<string>;
+        true satisfies Equal<typeof decoder, Decoder<string>>;
+    }
+
+    // The tap receives readonly bytes and the offset.
+    {
+        tapDecoderBytes({} as Decoder<string>, (bytes, offset) => {
+            bytes satisfies ReadonlyUint8Array;
+            offset satisfies Offset;
+        });
+    }
+}
+
+// [DESCRIBE] tapCodecBytes
+{
+    // It preserves the exact fixed-size codec type, including extra custom properties.
+    {
+        type MyCodec = FixedSizeCodec<string, string, 42> & { custom: 42 };
+        const codec = tapCodecBytes(
+            {} as MyCodec,
+            () => {},
+            () => {},
+        );
+        codec satisfies MyCodec;
+        true satisfies Equal<typeof codec, MyCodec>;
+    }
+
+    // It preserves the exact variable-size codec type.
+    {
+        const codec = tapCodecBytes(
+            {} as VariableSizeCodec<string>,
+            () => {},
+            () => {},
+        );
+        codec satisfies VariableSizeCodec<string>;
+        true satisfies Equal<typeof codec, VariableSizeCodec<string>>;
+    }
+
+    // It preserves the exact base codec type.
+    {
+        const codec = tapCodecBytes(
+            {} as Codec<string>,
+            () => {},
+            () => {},
+        );
+        codec satisfies Codec<string>;
+        true satisfies Equal<typeof codec, Codec<string>>;
+    }
+
+    // The decode tap is optional.
+    {
+        const codec = tapCodecBytes({} as Codec<string>, () => {});
+        codec satisfies Codec<string>;
+        true satisfies Equal<typeof codec, Codec<string>>;
+    }
+}

--- a/packages/codecs-core/src/__typetests__/tap-codec-typetest.ts
+++ b/packages/codecs-core/src/__typetests__/tap-codec-typetest.ts
@@ -1,0 +1,155 @@
+import {
+    Codec,
+    Decoder,
+    Encoder,
+    FixedSizeCodec,
+    FixedSizeDecoder,
+    FixedSizeEncoder,
+    VariableSizeCodec,
+    VariableSizeDecoder,
+    VariableSizeEncoder,
+} from '../codec';
+import { tapCodec, tapDecoder, tapEncoder } from '../tap-codec';
+
+/**
+ * Strict type-equality helper used by typetests below. Resolves to `true` only
+ * if `A` and `B` are mutually assignable AND share the same modifier set (`?`,
+ * `readonly`); otherwise resolves to `false`.
+ *
+ * This is stricter than `satisfies` for two reasons:
+ *
+ * 1. **Bidirectionality.** `A satisfies B` only checks that `A` is assignable
+ *    to `B`. A test using `satisfies` passes if the actual type has extra
+ *    members beyond what we asserted — which would silently mask a regression
+ *    that widened the type.
+ * 2. **Modifier strictness.** `A satisfies B` tolerates losing `?` (required
+ *    is assignable to optional) and losing `readonly` (readonly is assignable
+ *    to mutable). `Equal` distinguishes `{ x: T }` from `{ x?: T }` and from
+ *    `{ readonly x: T }` because the inferred-position generic comparison
+ *    uses identity rather than assignability for the type parameters.
+ *
+ * Use `Equal` when the exact shape (including modifiers) matters. Use
+ * `satisfies` when one-way assignability is the actual requirement.
+ */
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
+// [DESCRIBE] tapEncoder
+{
+    // It preserves the exact fixed-size encoder type, including extra custom properties.
+    {
+        type MyEncoder = FixedSizeEncoder<string, 42> & { custom: 42 };
+        const encoder = tapEncoder({} as MyEncoder, _ => {});
+        encoder satisfies MyEncoder;
+        true satisfies Equal<typeof encoder, MyEncoder>;
+    }
+
+    // It preserves the exact variable-size encoder type.
+    {
+        const encoder = tapEncoder({} as VariableSizeEncoder<string>, _ => {});
+        encoder satisfies VariableSizeEncoder<string>;
+        true satisfies Equal<typeof encoder, VariableSizeEncoder<string>>;
+    }
+
+    // It preserves the exact base encoder type.
+    {
+        const encoder = tapEncoder({} as Encoder<string>, _ => {});
+        encoder satisfies Encoder<string>;
+        true satisfies Equal<typeof encoder, Encoder<string>>;
+    }
+
+    // It infers the tapped value type from the encoder.
+    {
+        tapEncoder({} as Encoder<string>, value => {
+            value satisfies string;
+        });
+    }
+}
+
+// [DESCRIBE] tapDecoder
+{
+    // It preserves the exact fixed-size decoder type, including extra custom properties.
+    {
+        type MyDecoder = FixedSizeDecoder<string, 42> & { custom: 42 };
+        const decoder = tapDecoder({} as MyDecoder, _ => {});
+        decoder satisfies MyDecoder;
+        true satisfies Equal<typeof decoder, MyDecoder>;
+    }
+
+    // It preserves the exact variable-size decoder type.
+    {
+        const decoder = tapDecoder({} as VariableSizeDecoder<string>, _ => {});
+        decoder satisfies VariableSizeDecoder<string>;
+        true satisfies Equal<typeof decoder, VariableSizeDecoder<string>>;
+    }
+
+    // It preserves the exact base decoder type.
+    {
+        const decoder = tapDecoder({} as Decoder<string>, _ => {});
+        decoder satisfies Decoder<string>;
+        true satisfies Equal<typeof decoder, Decoder<string>>;
+    }
+
+    // It infers the tapped value type from the decoder.
+    {
+        tapDecoder({} as Decoder<string>, value => {
+            value satisfies string;
+        });
+    }
+}
+
+// [DESCRIBE] tapCodec
+{
+    // It preserves the exact fixed-size codec type, including extra custom properties.
+    {
+        type MyCodec = FixedSizeCodec<string, string, 42> & { custom: 42 };
+        const codec = tapCodec(
+            {} as MyCodec,
+            _ => {},
+            _ => {},
+        );
+        codec satisfies MyCodec;
+        true satisfies Equal<typeof codec, MyCodec>;
+    }
+
+    // It preserves the exact variable-size codec type.
+    {
+        const codec = tapCodec(
+            {} as VariableSizeCodec<string>,
+            _ => {},
+            _ => {},
+        );
+        codec satisfies VariableSizeCodec<string>;
+        true satisfies Equal<typeof codec, VariableSizeCodec<string>>;
+    }
+
+    // It preserves the exact base codec type.
+    {
+        const codec = tapCodec(
+            {} as Codec<string>,
+            _ => {},
+            _ => {},
+        );
+        codec satisfies Codec<string>;
+        true satisfies Equal<typeof codec, Codec<string>>;
+    }
+
+    // The decode tap is optional.
+    {
+        const codec = tapCodec({} as Codec<string>, _ => {});
+        codec satisfies Codec<string>;
+        true satisfies Equal<typeof codec, Codec<string>>;
+    }
+
+    // It infers the tapped value types from the codec: `TFrom` on encode, `TTo` on decode.
+    {
+        tapCodec(
+            {} as Codec<number | string, string>,
+            value => {
+                value satisfies number | string;
+            },
+            value => {
+                value satisfies string;
+            },
+        );
+    }
+}

--- a/packages/codecs-core/src/index.ts
+++ b/packages/codecs-core/src/index.ts
@@ -665,4 +665,6 @@ export * from './pad-codec';
 export * from './readonly-uint8array';
 export * from './resize-codec';
 export * from './reverse-codec';
+export * from './tap-codec';
+export * from './tap-codec-bytes';
 export * from './transform-codec';

--- a/packages/codecs-core/src/tap-codec-bytes.ts
+++ b/packages/codecs-core/src/tap-codec-bytes.ts
@@ -1,0 +1,174 @@
+import { Codec, createCodec, createDecoder, createEncoder, Decoder, Encoder, Offset } from './codec';
+import { ReadonlyUint8Array } from './readonly-uint8array';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyEncoder = Encoder<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyDecoder = Decoder<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyCodec = Codec<any>;
+
+/**
+ * Observes the encoded bytes of an encoder after it writes them, without modifying them.
+ *
+ * This function takes an existing encoder and returns a new encoder of the exact same type that
+ * calls the provided `tap` function with the byte array after each value is written. The bytes are
+ * provided as a {@link ReadonlyUint8Array} and are passed through unchanged, making this useful for
+ * adding validation guards, logging, or other read-only side effects on the encoded bytes.
+ *
+ * The `tap` function receives the entire byte array alongside the offsets before and after the value
+ * was written, so it can inspect the window `[preOffset, postOffset)` that was just encoded.
+ *
+ * If the `tap` function throws, the encoding is aborted and the error propagates to the caller.
+ *
+ * @typeParam TEncoder - The type of the encoder being tapped. The returned encoder has the same type.
+ *
+ * @param encoder - The encoder whose encoded bytes should be observed.
+ * @param tap - A function called with the byte array and offsets after writing. It may throw to abort encoding.
+ * @returns A new encoder of the same type that observes its encoded bytes.
+ *
+ * @throws Whatever error the `tap` function throws, aborting the encoding.
+ *
+ * @example
+ * Observing the bytes written by a `u8` encoder.
+ * ```ts
+ * const encoder = tapEncoderBytes(getU8Encoder(), (bytes, preOffset, postOffset) => {
+ *     console.log(bytes.slice(preOffset, postOffset));
+ * });
+ * ```
+ *
+ * @remarks
+ * The tap fires after the encoder's `write` step. For variable-size encoders, this means the encoded
+ * size is still computed from the value (via `getSizeFromValue`) *before* the tap runs, so a custom
+ * `getSizeFromValue` that rejects the value will throw before the tap has a chance to.
+ *
+ * To observe the input value instead of the encoded bytes, use {@link tapEncoder}.
+ *
+ * @see {@link tapCodecBytes}
+ * @see {@link tapDecoderBytes}
+ * @see {@link tapEncoder}
+ */
+export function tapEncoderBytes<TEncoder extends AnyEncoder>(
+    encoder: TEncoder,
+    tap: (bytes: ReadonlyUint8Array, preOffset: Offset, postOffset: Offset) => void,
+): TEncoder {
+    return createEncoder({
+        ...encoder,
+        write: (value, bytes, offset) => {
+            const postOffset = encoder.write(value, bytes, offset);
+            tap(bytes, offset, postOffset);
+            return postOffset;
+        },
+    }) as TEncoder;
+}
+
+/**
+ * Observes the raw bytes of a decoder before it decodes them, without modifying them.
+ *
+ * This function takes an existing decoder and returns a new decoder of the exact same type that
+ * calls the provided `tap` function with the byte array before each value is read. The bytes are
+ * provided as a {@link ReadonlyUint8Array} and are passed through unchanged, making this useful for
+ * adding validation guards, logging, or other read-only side effects on the raw bytes.
+ *
+ * If the `tap` function throws, the decoding is aborted and the error propagates to the caller.
+ *
+ * @typeParam TDecoder - The type of the decoder being tapped. The returned decoder has the same type.
+ *
+ * @param decoder - The decoder whose raw bytes should be observed.
+ * @param tap - A function called with the byte array and offset before reading. It may throw to abort decoding.
+ * @returns A new decoder of the same type that observes its raw bytes.
+ *
+ * @throws Whatever error the `tap` function throws, aborting the decoding.
+ *
+ * @example
+ * Guarding the raw bytes of a boolean decoder.
+ * ```ts
+ * const decoder = tapDecoderBytes(getBooleanDecoder(), (bytes, offset) => {
+ *     if (bytes[offset] > 1) throw new Error('Expected a 0 or a 1 for booleans');
+ * });
+ * decoder.decode(new Uint8Array([1])); // true
+ * decoder.decode(new Uint8Array([2])); // Throws 'Expected a 0 or a 1 for booleans'
+ * ```
+ *
+ * @remarks
+ * To observe the decoded value instead of the raw bytes, use {@link tapDecoder}.
+ *
+ * @see {@link tapCodecBytes}
+ * @see {@link tapEncoderBytes}
+ * @see {@link tapDecoder}
+ */
+export function tapDecoderBytes<TDecoder extends AnyDecoder>(
+    decoder: TDecoder,
+    tap: (bytes: ReadonlyUint8Array, offset: Offset) => void,
+): TDecoder {
+    return createDecoder({
+        ...decoder,
+        read: (bytes, offset) => {
+            tap(bytes, offset);
+            return decoder.read(bytes, offset);
+        },
+    }) as TDecoder;
+}
+
+/**
+ * Observes the raw bytes of a codec on both sides, without modifying them.
+ *
+ * This function takes an existing codec and returns a new codec of the exact same type that:
+ * - Calls `encodeTap` with the byte array after each value is written.
+ * - Calls `decodeTap` (if provided) with the byte array before each value is read.
+ *
+ * The bytes are provided as {@link ReadonlyUint8Array | ReadonlyUint8Arrays} and are passed through
+ * unchanged, making this useful for adding validation guards, logging, or other read-only side effects.
+ * If either tap function throws, the corresponding operation is aborted and the error propagates to
+ * the caller.
+ *
+ * @typeParam TCodec - The type of the codec being tapped. The returned codec has the same type.
+ *
+ * @param codec - The codec whose raw bytes should be observed.
+ * @param encodeTap - A function called with the byte array and offsets after writing. It may throw to abort encoding.
+ * @param decodeTap - An optional function called with the byte array and offset before reading. It may throw to abort decoding.
+ * @returns A new codec of the same type that observes its raw bytes.
+ *
+ * @throws Whatever error the tap functions throw, aborting the corresponding operation.
+ *
+ * @example
+ * Guarding the raw bytes of a boolean codec before decoding.
+ * ```ts
+ * const codec = tapCodecBytes(
+ *     getBooleanCodec(),
+ *     () => {},
+ *     (bytes, offset) => {
+ *         if (bytes[offset] > 1) throw new Error('Expected a 0 or a 1 for booleans');
+ *     },
+ * );
+ * ```
+ *
+ * @remarks
+ * If only the encoded bytes need observing, use {@link tapEncoderBytes}.
+ * If only the raw bytes before decoding need observing, use {@link tapDecoderBytes}.
+ * To observe the values instead of the raw bytes, use {@link tapCodec}.
+ *
+ * @see {@link tapEncoderBytes}
+ * @see {@link tapDecoderBytes}
+ * @see {@link tapCodec}
+ */
+export function tapCodecBytes<TCodec extends AnyCodec>(
+    codec: TCodec,
+    encodeTap: (bytes: ReadonlyUint8Array, preOffset: Offset, postOffset: Offset) => void,
+    decodeTap?: (bytes: ReadonlyUint8Array, offset: Offset) => void,
+): TCodec {
+    return createCodec({
+        ...codec,
+        read: decodeTap
+            ? (bytes, offset) => {
+                  decodeTap(bytes, offset);
+                  return codec.read(bytes, offset);
+              }
+            : codec.read,
+        write: (value, bytes, offset) => {
+            const postOffset = codec.write(value, bytes, offset);
+            encodeTap(bytes, offset, postOffset);
+            return postOffset;
+        },
+    }) as TCodec;
+}

--- a/packages/codecs-core/src/tap-codec.ts
+++ b/packages/codecs-core/src/tap-codec.ts
@@ -1,0 +1,173 @@
+import { Codec, createCodec, createDecoder, createEncoder, Decoder, Encoder } from './codec';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyEncoder = Encoder<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyDecoder = Decoder<any>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyCodec = Codec<any>;
+
+/**
+ * Observes the input value of an encoder before it is encoded, without modifying it.
+ *
+ * This function takes an existing encoder and returns a new encoder of the exact same type that
+ * calls the provided `tap` function with each value before delegating to the original encoder.
+ * The value is passed through unchanged, making this useful for adding validation guards, logging,
+ * or other read-only side effects on the input value.
+ *
+ * If the `tap` function throws, the encoding is aborted and the error propagates to the caller.
+ *
+ * @typeParam TEncoder - The type of the encoder being tapped. The returned encoder has the same type.
+ *
+ * @param encoder - The encoder whose input value should be observed.
+ * @param tap - A function called with each value before encoding. It may throw to abort encoding.
+ * @returns A new encoder of the same type that observes its input value before encoding.
+ *
+ * @throws Whatever error the `tap` function throws, aborting the encoding.
+ *
+ * @example
+ * Guarding the input value of a `u8` encoder.
+ * ```ts
+ * const encoder = tapEncoder(getU8Encoder(), value => {
+ *     if (value > 100) throw new Error('Value must not exceed 100');
+ * });
+ * encoder.encode(42); // 0x2a
+ * encoder.encode(200); // Throws 'Value must not exceed 100'
+ * ```
+ *
+ * @remarks
+ * The tap fires from within the encoder's `write` step. For variable-size encoders, this means the
+ * encoded size is computed from the unvalidated value (via `getSizeFromValue`) *before* the tap runs,
+ * so a custom `getSizeFromValue` that rejects the value will throw before the tap has a chance to.
+ *
+ * To observe the encoded bytes instead of the input value, use {@link tapEncoderBytes}.
+ *
+ * @see {@link tapCodec}
+ * @see {@link tapDecoder}
+ * @see {@link tapEncoderBytes}
+ */
+export function tapEncoder<TEncoder extends AnyEncoder>(
+    encoder: TEncoder,
+    tap: (value: TEncoder extends Encoder<infer TFrom> ? TFrom : never) => void,
+): TEncoder {
+    return createEncoder({
+        ...encoder,
+        write: (value, bytes, offset) => {
+            tap(value);
+            return encoder.write(value, bytes, offset);
+        },
+    }) as TEncoder;
+}
+
+/**
+ * Observes the decoded value of a decoder after it is decoded, without modifying it.
+ *
+ * This function takes an existing decoder and returns a new decoder of the exact same type that
+ * calls the provided `tap` function with each decoded value before returning it. The value is
+ * passed through unchanged, making this useful for adding validation guards, logging, or other
+ * read-only side effects on the decoded value.
+ *
+ * If the `tap` function throws, the decoding is aborted and the error propagates to the caller.
+ *
+ * @typeParam TDecoder - The type of the decoder being tapped. The returned decoder has the same type.
+ *
+ * @param decoder - The decoder whose decoded value should be observed.
+ * @param tap - A function called with each decoded value. It may throw to abort decoding.
+ * @returns A new decoder of the same type that observes its decoded value.
+ *
+ * @throws Whatever error the `tap` function throws, aborting the decoding.
+ *
+ * @example
+ * Guarding the decoded value of a `u8` decoder.
+ * ```ts
+ * const decoder = tapDecoder(getU8Decoder(), value => {
+ *     if (value === 0) throw new Error('Value must not be zero');
+ * });
+ * decoder.decode(new Uint8Array([42])); // 42
+ * decoder.decode(new Uint8Array([0])); // Throws 'Value must not be zero'
+ * ```
+ *
+ * @remarks
+ * To observe the raw bytes before decoding instead of the decoded value, use {@link tapDecoderBytes}.
+ *
+ * @see {@link tapCodec}
+ * @see {@link tapEncoder}
+ * @see {@link tapDecoderBytes}
+ */
+export function tapDecoder<TDecoder extends AnyDecoder>(
+    decoder: TDecoder,
+    tap: (value: TDecoder extends Decoder<infer TTo> ? TTo : never) => void,
+): TDecoder {
+    return createDecoder({
+        ...decoder,
+        read: (bytes, offset) => {
+            const [value, newOffset] = decoder.read(bytes, offset);
+            tap(value);
+            return [value, newOffset];
+        },
+    }) as TDecoder;
+}
+
+/**
+ * Observes the values of a codec on both sides, without modifying them.
+ *
+ * This function takes an existing codec and returns a new codec of the exact same type that:
+ * - Calls `encodeTap` with each value before encoding it.
+ * - Calls `decodeTap` (if provided) with each decoded value after decoding it.
+ *
+ * Values are passed through unchanged, making this useful for adding validation guards, logging,
+ * or other read-only side effects. If either tap function throws, the corresponding operation is
+ * aborted and the error propagates to the caller.
+ *
+ * @typeParam TCodec - The type of the codec being tapped. The returned codec has the same type.
+ *
+ * @param codec - The codec whose values should be observed.
+ * @param encodeTap - A function called with each value before encoding. It may throw to abort encoding.
+ * @param decodeTap - An optional function called with each decoded value. It may throw to abort decoding.
+ * @returns A new codec of the same type that observes its values.
+ *
+ * @throws Whatever error the tap functions throw, aborting the corresponding operation.
+ *
+ * @example
+ * Guarding both the encoded and decoded values of a `u8` codec.
+ * ```ts
+ * const codec = tapCodec(
+ *     getU8Codec(),
+ *     value => {
+ *         if (value > 100) throw new Error('Value must not exceed 100');
+ *     },
+ *     value => {
+ *         if (value === 0) throw new Error('Value must not be zero');
+ *     },
+ * );
+ * ```
+ *
+ * @remarks
+ * If only the input value needs observing, use {@link tapEncoder}.
+ * If only the decoded value needs observing, use {@link tapDecoder}.
+ * To observe the raw bytes instead of the values, use {@link tapCodecBytes}.
+ *
+ * @see {@link tapEncoder}
+ * @see {@link tapDecoder}
+ * @see {@link tapCodecBytes}
+ */
+export function tapCodec<TCodec extends AnyCodec>(
+    codec: TCodec,
+    encodeTap: (value: TCodec extends Encoder<infer TFrom> ? TFrom : never) => void,
+    decodeTap?: (value: TCodec extends Decoder<infer TTo> ? TTo : never) => void,
+): TCodec {
+    return createCodec({
+        ...codec,
+        read: decodeTap
+            ? (bytes, offset) => {
+                  const [value, newOffset] = codec.read(bytes, offset);
+                  decodeTap(value);
+                  return [value, newOffset];
+              }
+            : codec.read,
+        write: (value, bytes, offset) => {
+            encodeTap(value);
+            return codec.write(value, bytes, offset);
+        },
+    }) as TCodec;
+}


### PR DESCRIPTION
This PR adds six `tap` helpers to `@solana/codecs-core` for observing the values and bytes flowing through a codec without modifying them. Any tap may throw to abort the operation, making them ideal for adding validation guards to existing codecs without resorting to an identity `transformEncoder`.

The **value family** observes the input value before encoding and the decoded value after decoding:

```ts
// Reject out-of-range input before it is encoded.
const boundedU8 = tapEncoder(getU8Encoder(), value => {
  if (value > 100) throw new Error('Value must not exceed 100');
});

// Validate the decoded result.
const nonZeroU8 = tapDecoder(getU8Decoder(), value => {
  if (value === 0n) throw new Error('Value must not be zero');
});
```

The **bytes family** observes the raw bytes after encoding and before decoding. Bytes are exposed as a `ReadonlyUint8Array`, so taps are pure observers:

```ts
// Guard malformed boolean bytes before decoding.
const safeBool = tapDecoderBytes(getBooleanDecoder(), (bytes, offset) => {
  if (bytes[offset] > 1) throw new Error('Expected a 0 or a 1 for booleans');
});
```

The `tapCodec` and `tapCodecBytes` variants mirror `transformCodec`'s `(codec, encodeTap, decodeTap?)` shape, and mixed guards compose cleanly:

```ts
// Guard the input value on encode and the raw bytes on decode.
const codec = combineCodec(
  tapEncoder(getBooleanEncoder(), value => { /* ... */ }),
  tapDecoderBytes(getBooleanDecoder(), (bytes, offset) => {
    if (bytes[offset] > 1) throw new Error('Expected a 0 or a 1 for booleans');
  }),
);
```

Each helper uses a single passthrough generic so the exact input type, including any extra properties, is preserved.

Documentation is intentionally deferred to a follow-up, since the docs site builds against the published `@solana/kit` and cannot reference the new symbols until a release ships.