### PR TITLE
Add createLazyKeyPairSignerFromBytes to @solana/signers

### DIFF
--- a/.changeset/pink-queens-switch.md
+++ b/.changeset/pink-queens-switch.md
@@ -1,0 +1,5 @@
+---
+'@solana/signers': minor
+---
+
+Add `createLazyKeyPairSignerFromBytes`, a synchronous counterpart to `createKeyPairSignerFromBytes`. It derives the signer's address directly from the public key half of the 64-byte secret key and defers the asynchronous `CryptoKey` import until the first message or transaction is signed (memoising the result). This is useful when a signer must be created in a synchronous context whilst signing can remain asynchronous. Because the key import is deferred, the returned signer implements both `MessagePartialSigner` and `TransactionPartialSigner` but does not expose a `keyPair` property, and the cryptographic validation of the secret key happens on the first signing attempt rather than at creation time. The internal copy of the secret key is zeroed once the import succeeds, and a failed import is not cached so signing can be retried.

--- a/packages/signers/README.md
+++ b/packages/signers/README.md
@@ -329,6 +329,23 @@ const keypairBytes = new Uint8Array(JSON.parse(keypairFile.toString()));
 const signer = await createKeyPairSignerFromBytes(keypairBytes);
 ```
 
+#### `createLazyKeyPairSignerFromBytes()`
+
+A **synchronous** counterpart to `createKeyPairSignerFromBytes()`. Instead of awaiting the `CryptoKey` import up front, it derives the signer's address directly from the public key half of the 64-bytes secret key and defers the import until the first message or transaction is signed (memoising the result so it only happens once). This is useful when a signer must be created in a synchronous context — such as registering signers up front — whilst signing itself can remain asynchronous.
+
+```ts
+import { createLazyKeyPairSignerFromBytes } from '@solana/signers';
+
+// Returns synchronously — no `await` required.
+const signer = createLazyKeyPairSignerFromBytes(keypairBytes);
+signer.address; // Available immediately.
+
+// The CryptoKey import happens here, on first use, and is reused thereafter.
+const [transactionSignatures] = await signer.signTransactions([transaction]);
+```
+
+Because the import is deferred, the returned signer implements both `MessagePartialSigner` and `TransactionPartialSigner` but does **not** expose a `keyPair` property, so it is not a full `KeyPairSigner`. Only the 64-bytes length is validated synchronously; the cryptographic public/private-key match (which `createKeyPairSignerFromBytes()` checks eagerly) is verified on the first signing attempt instead. The internal copy of the secret key is zeroed once the import succeeds.
+
 #### `createKeyPairSignerFromPrivateKeyBytes()`
 
 A convenience function that creates a new KeyPair from a 32-bytes `Uint8Array` private key and immediately creates a `KeyPairSigner` from it.

--- a/packages/signers/src/__tests__/lazy-keypair-signer-test.ts
+++ b/packages/signers/src/__tests__/lazy-keypair-signer-test.ts
@@ -1,0 +1,181 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import { getAddressDecoder, getAddressFromPublicKey } from '@solana/addresses';
+import { SOLANA_ERROR__KEYS__INVALID_KEY_PAIR_BYTE_LENGTH, SolanaError } from '@solana/errors';
+import { createKeyPairFromBytes, SignatureBytes, signBytes } from '@solana/keys';
+import {
+    partiallySignTransaction,
+    Transaction,
+    TransactionWithinSizeLimit,
+    TransactionWithLifetime,
+} from '@solana/transactions';
+
+import { createLazyKeyPairSignerFromBytes } from '../lazy-keypair-signer';
+import { createSignableMessage } from '../signable-message';
+
+// Partial mocks of the async crypto boundary that the lazy signer defers to.
+jest.mock('@solana/addresses', () => ({
+    ...jest.requireActual('@solana/addresses'),
+    getAddressFromPublicKey: jest.fn(),
+}));
+jest.mock('@solana/keys', () => ({
+    ...jest.requireActual('@solana/keys'),
+    createKeyPairFromBytes: jest.fn(),
+    signBytes: jest.fn(),
+}));
+jest.mock('@solana/transactions', () => ({
+    ...jest.requireActual('@solana/transactions'),
+    partiallySignTransaction: jest.fn(),
+}));
+
+// A valid 64-byte secret key (private key + public key).
+const MOCK_KEY_BYTES = new Uint8Array([
+    0xeb, 0xfa, 0x65, 0xeb, 0x93, 0xdc, 0x79, 0x15, 0x7a, 0xba, 0xde, 0xa2, 0xf7, 0x94, 0x37, 0x9d, 0xfc, 0x07, 0x1d,
+    0x68, 0x86, 0x87, 0x37, 0x6d, 0xc5, 0xd5, 0xa0, 0x54, 0x12, 0x1d, 0x34, 0x4a, 0x1d, 0x0e, 0x93, 0x86, 0x4d, 0xcc,
+    0x81, 0x5f, 0xc3, 0xf2, 0x86, 0x18, 0x09, 0x11, 0xd0, 0x0a, 0x3f, 0xd2, 0x06, 0xde, 0x31, 0xa1, 0xc9, 0x42, 0x87,
+    0xcb, 0x43, 0xf0, 0x5f, 0xc9, 0xf2, 0xb5,
+]);
+
+// The address is the base58 encoding of the last 32 bytes (the public key half).
+const EXPECTED_ADDRESS = getAddressDecoder().decode(MOCK_KEY_BYTES.slice(32));
+
+const getMockCryptoKeyPair = () => ({ privateKey: {}, publicKey: {} }) as CryptoKeyPair;
+
+describe('createLazyKeyPairSignerFromBytes', () => {
+    beforeEach(() => {
+        // By default, the deferred crypto boundary resolves to a mock key pair and address.
+        jest.mocked(createKeyPairFromBytes).mockResolvedValue(getMockCryptoKeyPair());
+        jest.mocked(getAddressFromPublicKey).mockResolvedValue(EXPECTED_ADDRESS);
+    });
+
+    it('derives the address synchronously from the public key half of the secret key', () => {
+        const signer = createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES);
+        expect(signer.address).toBe(EXPECTED_ADDRESS);
+    });
+
+    it('returns a frozen signer implementing both partial signer interfaces', () => {
+        const signer = createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES);
+        expect(signer).toBeFrozenObject();
+        expect(typeof signer.signMessages).toBe('function');
+        expect(typeof signer.signTransactions).toBe('function');
+    });
+
+    it('does not expose a keyPair property', () => {
+        const signer = createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES);
+        expect(signer).not.toHaveProperty('keyPair');
+    });
+
+    it('throws synchronously when the secret key is not 64 bytes long', () => {
+        expect(() => createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES.slice(0, 63))).toThrow(
+            new SolanaError(SOLANA_ERROR__KEYS__INVALID_KEY_PAIR_BYTE_LENGTH, { byteLength: 63 }),
+        );
+    });
+
+    it('defers the key pair import until the first signature is requested', async () => {
+        expect.assertions(2);
+        const signer = createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES);
+
+        // The import has not happened yet.
+        expect(jest.mocked(createKeyPairFromBytes)).not.toHaveBeenCalled();
+
+        await signer.signTransactions([]);
+        expect(jest.mocked(createKeyPairFromBytes)).toHaveBeenCalledTimes(1);
+    });
+
+    it('imports the key pair only once across multiple sequential signing calls', async () => {
+        expect.assertions(1);
+        const signer = createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES);
+
+        await signer.signTransactions([]);
+        await signer.signTransactions([]);
+        await signer.signMessages([]);
+
+        expect(jest.mocked(createKeyPairFromBytes)).toHaveBeenCalledTimes(1);
+    });
+
+    it('imports the key pair only once across concurrent signing calls', async () => {
+        expect.assertions(1);
+        const signer = createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES);
+
+        // Because the promise (not just its result) is memoised, concurrent calls share one import.
+        await Promise.all([signer.signTransactions([]), signer.signMessages([]), signer.signTransactions([])]);
+
+        expect(jest.mocked(createKeyPairFromBytes)).toHaveBeenCalledTimes(1);
+    });
+
+    it('forwards the extractable option to the underlying key pair import', async () => {
+        expect.assertions(1);
+        const signer = createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES, true);
+
+        await signer.signTransactions([]);
+
+        expect(jest.mocked(createKeyPairFromBytes)).toHaveBeenCalledWith(expect.any(Uint8Array), true);
+    });
+
+    it('zeroes its internal copy of the secret key once the import succeeds', async () => {
+        expect.assertions(2);
+        const signer = createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES);
+
+        await signer.signTransactions([]);
+
+        // Grab the exact byte array the import received (Jest stores the reference).
+        const importedBytes = jest.mocked(createKeyPairFromBytes).mock.calls[0][0] as Uint8Array;
+        expect(importedBytes).toHaveLength(64);
+        expect([...importedBytes].every(byte => byte === 0)).toBe(true);
+    });
+
+    it('retries the import on a subsequent call when the first import fails', async () => {
+        expect.assertions(3);
+        const signer = createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES);
+
+        // The first import fails, so the first signing attempt rejects.
+        jest.mocked(createKeyPairFromBytes).mockRejectedValueOnce(new Error('Transient failure'));
+        await expect(signer.signTransactions([])).rejects.toThrow('Transient failure');
+
+        // The failure is not cached, so a second attempt re-imports and succeeds.
+        await expect(signer.signTransactions([])).resolves.toBeDefined();
+        expect(jest.mocked(createKeyPairFromBytes)).toHaveBeenCalledTimes(2);
+    });
+
+    it('signs messages by delegating to the deferred key pair', async () => {
+        expect.assertions(2);
+        const mockSignature = new Uint8Array([101, 101, 101]) as SignatureBytes;
+        jest.mocked(signBytes).mockResolvedValue(mockSignature);
+        const signer = createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES);
+
+        const messages = [createSignableMessage(new Uint8Array([1, 2, 3]))];
+        const [signatures] = await signer.signMessages(messages);
+
+        expect(signatures).toStrictEqual({ [EXPECTED_ADDRESS]: mockSignature });
+        expect(jest.mocked(signBytes)).toHaveBeenCalledTimes(1);
+    });
+
+    it('signs transactions by delegating to the deferred key pair', async () => {
+        expect.assertions(2);
+        const mockTransaction = {} as Transaction & TransactionWithinSizeLimit & TransactionWithLifetime;
+        const mockSignature = new Uint8Array([201, 201, 201]) as SignatureBytes;
+        jest.mocked(partiallySignTransaction).mockResolvedValue({
+            ...mockTransaction,
+            signatures: { [EXPECTED_ADDRESS]: mockSignature },
+        });
+        const signer = createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES);
+
+        const [signatures] = await signer.signTransactions([mockTransaction]);
+
+        expect(signatures).toStrictEqual({ [EXPECTED_ADDRESS]: mockSignature });
+        expect(jest.mocked(partiallySignTransaction)).toHaveBeenCalledTimes(1);
+    });
+
+    it('constructs synchronously but rejects on the first signing attempt when the import fails', async () => {
+        expect.assertions(2);
+        // Simulate the deferred validation failing (e.g. mismatched public/private key halves).
+        jest.mocked(createKeyPairFromBytes).mockRejectedValue(new Error('Invalid key pair'));
+        const signer = createLazyKeyPairSignerFromBytes(MOCK_KEY_BYTES);
+
+        // Construction still succeeded synchronously.
+        expect(signer.address).toBe(EXPECTED_ADDRESS);
+
+        // The failure surfaces on the first signing attempt.
+        await expect(signer.signTransactions([])).rejects.toThrow('Invalid key pair');
+    });
+});

--- a/packages/signers/src/__typetests__/lazy-keypair-signer-typetest.ts
+++ b/packages/signers/src/__typetests__/lazy-keypair-signer-typetest.ts
@@ -1,0 +1,32 @@
+import { Address } from '@solana/addresses';
+
+import { createLazyKeyPairSignerFromBytes } from '../lazy-keypair-signer';
+import { MessagePartialSigner } from '../message-partial-signer';
+import { TransactionPartialSigner } from '../transaction-partial-signer';
+
+{
+    // [createLazyKeyPairSignerFromBytes]: It returns a signer implementing both partial signer interfaces.
+    const signer = createLazyKeyPairSignerFromBytes(new Uint8Array(64));
+    signer satisfies MessagePartialSigner & TransactionPartialSigner;
+}
+
+{
+    // [createLazyKeyPairSignerFromBytes]: It exposes its address synchronously (not wrapped in a promise).
+    const signer = createLazyKeyPairSignerFromBytes(new Uint8Array(64));
+    signer.address satisfies Address;
+}
+
+{
+    // [createLazyKeyPairSignerFromBytes]: It keeps track of the address type parameter.
+    const signer = createLazyKeyPairSignerFromBytes<'1'>(new Uint8Array(64));
+    signer satisfies MessagePartialSigner<'1'> & TransactionPartialSigner<'1'>;
+    signer.address satisfies Address<'1'>;
+}
+
+{
+    // [createLazyKeyPairSignerFromBytes]: It does not return a full KeyPairSigner (no `keyPair` property).
+    const signer = createLazyKeyPairSignerFromBytes(new Uint8Array(64));
+    // @ts-expect-error The lazy signer does not expose a `keyPair` property.
+    const keyPair = signer.keyPair;
+    void keyPair;
+}

--- a/packages/signers/src/index.ts
+++ b/packages/signers/src/index.ts
@@ -79,6 +79,7 @@ export * from './add-signers';
 export * from './fee-payer-signer';
 export * from './grind-keypair-signer';
 export * from './keypair-signer';
+export * from './lazy-keypair-signer';
 export * from './message-modifying-signer';
 export * from './message-partial-signer';
 export * from './message-signer';

--- a/packages/signers/src/lazy-keypair-signer.ts
+++ b/packages/signers/src/lazy-keypair-signer.ts
@@ -1,0 +1,105 @@
+import { Address, getAddressDecoder } from '@solana/addresses';
+import { ReadonlyUint8Array } from '@solana/codecs-core';
+import { SOLANA_ERROR__KEYS__INVALID_KEY_PAIR_BYTE_LENGTH, SolanaError } from '@solana/errors';
+
+import { createKeyPairSignerFromBytes, KeyPairSigner } from './keypair-signer';
+import { MessagePartialSigner } from './message-partial-signer';
+import { TransactionPartialSigner } from './transaction-partial-signer';
+
+/**
+ * Creates a signer from a 64-bytes `Uint8Array` secret key (private key and public key) **synchronously**.
+ *
+ * Unlike {@link createKeyPairSignerFromBytes}, this helper returns without awaiting. It derives the
+ * signer's {@link MessagePartialSigner#address | address} directly from the public key half of the
+ * secret key (the last 32 bytes) and defers the asynchronous {@link CryptoKey} import until the first
+ * time a message or transaction is signed. The imported key pair is memoised so the import only
+ * happens once, no matter how many times the signer is used.
+ *
+ * This is useful when a signer must be created in a synchronous context — for instance, when
+ * registering signers up front — whilst the actual signing can remain asynchronous.
+ *
+ * @typeParam TAddress - Supply a string literal to define a signer having a particular address.
+ *
+ * @param bytes - A 64-bytes secret key, the first 32 of which represent the private key and the last
+ * 32 of which represent its associated public key.
+ * @param extractable - Setting this to `true` makes it possible to extract the bytes of the private
+ * key using the [`crypto.subtle.exportKey()`](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/exportKey)
+ * API. Defaults to `false`. Note that, because the import is deferred, this helper keeps a copy of the
+ * secret key bytes in memory until the first signing call completes, regardless of this setting.
+ *
+ * @returns A signer implementing both the {@link MessagePartialSigner} and {@link TransactionPartialSigner}
+ * interfaces. Note that, because the {@link CryptoKeyPair} is imported lazily, this signer does not
+ * expose a `keyPair` property and is therefore not a full {@link KeyPairSigner}.
+ *
+ * @throws {@link SolanaError} with code `SOLANA_ERROR__KEYS__INVALID_KEY_PAIR_BYTE_LENGTH` if the
+ * provided `bytes` are not exactly 64 bytes long. This check is performed synchronously.
+ *
+ * @example
+ * ```ts
+ * import fs from 'fs';
+ * import { createLazyKeyPairSignerFromBytes } from '@solana/signers';
+ *
+ * // Get bytes from local keypair file.
+ * const keypairFile = fs.readFileSync('~/.config/solana/id.json');
+ * const keypairBytes = new Uint8Array(JSON.parse(keypairFile.toString()));
+ *
+ * // Create a signer from the bytes synchronously.
+ * const signer = createLazyKeyPairSignerFromBytes(keypairBytes);
+ * signer.address; // Available immediately, no `await` required.
+ * const [transactionSignatures] = await signer.signTransactions([transaction]);
+ * ```
+ *
+ * @remarks
+ * Because the {@link CryptoKey} import is deferred, the cryptographic check that the public key half
+ * of the secret key matches its private key half — which {@link createKeyPairSignerFromBytes}
+ * performs eagerly — is also deferred. A mismatched or corrupt secret key therefore throws on the
+ * first signing attempt rather than at creation time. Only the 64-bytes length is validated
+ * synchronously.
+ *
+ * Since the import is deferred, the provided `bytes` are copied on creation so that the signer keeps
+ * working even if the caller mutates or zeroes their buffer before the first signing attempt. This
+ * internal copy is zeroed as soon as the import succeeds, so the plaintext secret key does not linger
+ * in memory beyond the first signing call.
+ *
+ * If the deferred import fails, the failure is **not** cached: the next signing call will attempt the
+ * import again. This means a transient failure can be retried, whilst a genuinely mismatched or
+ * corrupt secret key will fail on every attempt.
+ *
+ * @see {@link createKeyPairSignerFromBytes} for the asynchronous variant that eagerly validates the
+ * secret key and exposes the {@link CryptoKeyPair} via a `keyPair` property.
+ */
+export function createLazyKeyPairSignerFromBytes<TAddress extends string = string>(
+    bytes: ReadonlyUint8Array,
+    extractable?: boolean,
+): MessagePartialSigner<TAddress> & TransactionPartialSigner<TAddress> {
+    if (bytes.byteLength !== 64) {
+        throw new SolanaError(SOLANA_ERROR__KEYS__INVALID_KEY_PAIR_BYTE_LENGTH, { byteLength: bytes.byteLength });
+    }
+
+    // Copy the bytes so the signer keeps working if the caller mutates or zeroes their buffer before
+    // the deferred import runs.
+    const secretKeyBytes = Uint8Array.from(bytes);
+    const address = getAddressDecoder().decode(secretKeyBytes, 32) as Address<TAddress>;
+
+    let keyPairSignerPromise: Promise<KeyPairSigner> | undefined;
+    const getKeyPairSigner = () =>
+        (keyPairSignerPromise ??= createKeyPairSignerFromBytes(secretKeyBytes, extractable).then(
+            signer => {
+                // The import copied the bytes it needed, so release our plaintext copy now.
+                secretKeyBytes.fill(0);
+                return signer;
+            },
+            error => {
+                // Don't cache the failure; allow a subsequent call to retry the import.
+                keyPairSignerPromise = undefined;
+                throw error;
+            },
+        ));
+
+    return Object.freeze({
+        address,
+        signMessages: async (messages, config) => await (await getKeyPairSigner()).signMessages(messages, config),
+        signTransactions: async (transactions, config) =>
+            await (await getKeyPairSigner()).signTransactions(transactions, config),
+    });
+}


### PR DESCRIPTION
This PR adds `createLazyKeyPairSignerFromBytes`, a synchronous counterpart to `createKeyPairSignerFromBytes`. It derives the address from the public key half of the 64-byte secret key up front, then defers the async `CryptoKey` import until the first signature is requested (memoised so it runs once).

```ts
// Returns synchronously — no `await`.
const signer = createLazyKeyPairSignerFromBytes(keypairBytes);
signer.address; // Available immediately.

// The CryptoKey import happens here, on first use, and is reused thereafter.
const [signatures] = await signer.signTransactions([transaction]);
```

This is useful when a signer must be created in a synchronous context (e.g. registering signers up front, as in the Anchor v2 integration) whilst signing itself stays async.

The returned signer implements both `MessagePartialSigner` and `TransactionPartialSigner`, but — because the `CryptoKeyPair` is imported lazily — it does not expose a `keyPair` property and is therefore not a full `KeyPairSigner`. Only the 64-byte length is validated synchronously; the cryptographic public/private-key match (which the eager variant checks up front) surfaces on the first signing attempt instead.