### PR TITLE
docs: use number predicates in getPatternMatchCodec example

### DIFF
--- a/docs/content/docs/advanced-guides/codecs.mdx
+++ b/docs/content/docs/advanced-guides/codecs.mdx
@@ -2575,17 +2575,17 @@ import { getPatternMatchCodec, getU8Codec, getU16Codec, getU32Codec, Codec } fro
 
 const codec: Codec<number> = getPatternMatchCodec([
     [
-        (value: number | bigint) => value < 256,
+        (value: number) => value < 256,
         bytes => bytes.length === 1,
         getU8Codec(),
     ],
     [
-        (value: number | bigint) => value < 2 ** 16,
+        (value: number) => value < 2 ** 16,
         bytes => bytes.length === 2,
         getU16Codec(),
     ],
     [
-        (value: number | bigint) => value < 2 ** 32,
+        (value: number) => value < 2 ** 32,
         bytes => bytes.length <= 4,
         getU32Codec(),
     ],


### PR DESCRIPTION
## Summary

After #1809 landed and shipped, `getPatternMatchCodec` predicates can narrow to `number` again when the codec is typed as `Codec<number>`. The advanced codecs guide still shows `value: number | bigint` in that example from the v7 docs pass.

## Changes

- Update the `getPatternMatchCodec` example in `docs/content/docs/advanced-guides/codecs.mdx` so each encode predicate uses `value: number`.

## Why

Keeps the docs aligned with the patch in #1809 / current published Kit, as tracked in #1810.

## Test plan

- [x] Diff limited to the three predicate signatures in that example
- [ ] Docs build / twoslash in CI if enabled for this file

Fixes #1810