### PR TITLE
docs: restore number predicates in getPatternMatchCodec example

### DIFF
--- a/docs/content/docs/advanced-guides/codecs.mdx
+++ b/docs/content/docs/advanced-guides/codecs.mdx
@@ -2575,17 +2575,17 @@ import { getPatternMatchCodec, getU8Codec, getU16Codec, getU32Codec, Codec } fro
 
 const codec: Codec<number> = getPatternMatchCodec([
     [
-        (value: number | bigint) => value < 256,
+        (value: number) => value < 256,
         bytes => bytes.length === 1,
         getU8Codec(),
     ],
     [
-        (value: number | bigint) => value < 2 ** 16,
+        (value: number) => value < 2 ** 16,
         bytes => bytes.length === 2,
         getU16Codec(),
     ],
     [
-        (value: number | bigint) => value < 2 ** 32,
+        (value: number) => value < 2 ** 32,
         bytes => bytes.length <= 4,
         getU32Codec(),
     ],


### PR DESCRIPTION
## Summary

PR #1808 refreshed the docs for v7 and left the `getPatternMatchCodec` example using `number | bigint` encode predicates even though the returned codec is typed as `Codec<number>`. PR #1809 (already merged) allows those predicates to narrow back to `number`.

This updates the advanced codecs guide example to use `value: number` again so the docs match the fixed API.

## What changed

- In `docs/content/docs/advanced-guides/codecs.mdx`, change the three `getPatternMatchCodec` encode predicates from `(value: number | bigint)` to `(value: number)`.

## Why

After #1809, the narrower predicates type-check for a `Codec<number>` example. Keeping `number | bigint` in the guide is leftover from the temporary regression and confuses readers copying the snippet.

## How tested

- Confirmed the example block is the one cited in #1810.
- No runtime code changed; docs-only update.

Fixes #1810