### PR TITLE
fix: preserve per-account types in assertAccountsDecoded

### DIFF
--- a/.changeset/dark-points-kick.md
+++ b/.changeset/dark-points-kick.md
@@ -1,0 +1,5 @@
+---
+'@solana/accounts': patch
+---
+
+Fix `assertAccountsDecoded` so it preserves each account's address and decoded data type instead of collapsing the array to a single shared type parameter.

--- a/packages/accounts/README.md
+++ b/packages/accounts/README.md
@@ -297,14 +297,18 @@ account satisfies MaybeAccount<MockData>;
 
 This function asserts that all input accounts store decoded data, ie not a Uint8Array. As with `assertAccountDecoded` it does not check the shape of the data matches the decoded type, only that it is not a Uint8Array.
 
-```ts
-type MyAccountData = { name: string; age: number };
+When the input is a tuple, each element's address and decoded data type is preserved.
 
-const myAccounts: Account<MyAccountData | Uint8Array, Address>[];
+```ts
+type TokenData = { mint: Address };
+type MintData = { supply: bigint };
+
+const myAccounts: [Account<TokenData | Uint8Array, '1111..'>, Account<MintData | Uint8Array, '2222..'>] = [
+    {} as Account<TokenData | Uint8Array, '1111..'>,
+    {} as Account<MintData | Uint8Array, '2222..'>,
+];
 assertAccountsDecoded(myAccounts);
 
-// now the account data can be used as MyAccountData
-for (const a of account) {
-    account.data satisfies MyAccountData;
-}
+myAccounts[0] satisfies Account<TokenData, '1111..'>;
+myAccounts[1] satisfies Account<MintData, '2222..'>;
 ```

--- a/packages/accounts/src/__typetests__/decode-account-typetest.ts
+++ b/packages/accounts/src/__typetests__/decode-account-typetest.ts
@@ -5,7 +5,32 @@ import { Account, EncodedAccount } from '../account';
 import { assertAccountDecoded, assertAccountsDecoded, decodeAccount } from '../decode-account';
 import { MaybeAccount, MaybeEncodedAccount } from '../maybe-account';
 
+/**
+ * Strict type-equality helper used by typetests below. Resolves to `true` only
+ * if `A` and `B` are mutually assignable AND share the same modifier set (`?`,
+ * `readonly`); otherwise resolves to `false`.
+ *
+ * This is stricter than `satisfies` for two reasons:
+ *
+ * 1. **Bidirectionality.** `A satisfies B` only checks that `A` is assignable
+ *    to `B`. A test using `satisfies` passes if the actual type has extra
+ *    members beyond what we asserted — which would silently mask a regression
+ *    that re-introduced a nested `Omit<...>` wrapper, since `Omit<X, K> & A`
+ *    is still structurally assignable to a flat literal.
+ * 2. **Modifier strictness.** `A satisfies B` tolerates losing `?` (required
+ *    is assignable to optional) and losing `readonly` (readonly is assignable
+ *    to mutable). `Equal` distinguishes `{ x: T }` from `{ x?: T }` and from
+ *    `{ readonly x: T }` because the inferred-position generic comparison
+ *    uses identity rather than assignability for the type parameters.
+ *
+ * Use `Equal` when the exact shape (including modifiers) matters. Use
+ * `satisfies` when one-way assignability is the actual requirement (e.g.
+ * "this value is usable where `Disposable & X` is expected").
+ */
+type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+
 type MockData = { foo: 42 };
+type OtherMockData = { bar: 24 };
 type MockDataDecoder = Decoder<MockData>;
 
 {
@@ -41,5 +66,68 @@ type MockDataDecoder = Decoder<MockData>;
     accounts satisfies Account<MockData, Address>[];
     for (const a of accounts) {
         a.data satisfies MockData;
+    }
+}
+
+{
+    // It narrows a homogeneous array without requiring a tuple annotation.
+    const accounts = [] as Account<MockData | ReadonlyUint8Array, Address>[];
+    assertAccountsDecoded(accounts);
+    accounts satisfies Account<MockData, Address>[];
+}
+
+// [DESCRIBE] assertAccountsDecoded per-element types
+{
+    // It preserves a distinct address on each tuple element after narrowing.
+    {
+        const accounts: [
+            Account<MockData | ReadonlyUint8Array, '1111'>,
+            Account<MockData | ReadonlyUint8Array, '2222'>,
+            Account<MockData | ReadonlyUint8Array, '3333'>,
+        ] = [
+            {} as Account<MockData | ReadonlyUint8Array, '1111'>,
+            {} as Account<MockData | ReadonlyUint8Array, '2222'>,
+            {} as Account<MockData | ReadonlyUint8Array, '3333'>,
+        ];
+        assertAccountsDecoded(accounts);
+        true satisfies Equal<
+            typeof accounts,
+            [Account<MockData, '1111'>, Account<MockData, '2222'>, Account<MockData, '3333'>]
+        >;
+        // @ts-expect-error The first account must not be typed with the second address.
+        true satisfies Equal<
+            typeof accounts,
+            [Account<MockData, '2222'>, Account<MockData, '2222'>, Account<MockData, '3333'>]
+        >;
+    }
+
+    // It preserves a distinct data type on each tuple element after narrowing.
+    {
+        const accounts: [
+            Account<MockData | ReadonlyUint8Array, '1111'>,
+            Account<OtherMockData | ReadonlyUint8Array, '2222'>,
+        ] = [
+            {} as Account<MockData | ReadonlyUint8Array, '1111'>,
+            {} as Account<OtherMockData | ReadonlyUint8Array, '2222'>,
+        ];
+        assertAccountsDecoded(accounts);
+        true satisfies Equal<typeof accounts, [Account<MockData, '1111'>, Account<OtherMockData, '2222'>]>;
+        accounts[0].data satisfies MockData;
+        accounts[1].data satisfies OtherMockData;
+        // @ts-expect-error The first account must not be typed with the second data type.
+        accounts[0].data satisfies OtherMockData;
+    }
+
+    // It preserves per-element addresses on a MaybeAccount tuple.
+    {
+        const accounts: [
+            MaybeAccount<MockData | ReadonlyUint8Array, '1111'>,
+            MaybeAccount<OtherMockData | ReadonlyUint8Array, '2222'>,
+        ] = [
+            {} as MaybeAccount<MockData | ReadonlyUint8Array, '1111'>,
+            {} as MaybeAccount<OtherMockData | ReadonlyUint8Array, '2222'>,
+        ];
+        assertAccountsDecoded(accounts);
+        true satisfies Equal<typeof accounts, [MaybeAccount<MockData, '1111'>, MaybeAccount<OtherMockData, '2222'>]>;
     }
 }

--- a/packages/accounts/src/decode-account.ts
+++ b/packages/accounts/src/decode-account.ts
@@ -108,34 +108,61 @@ export function assertAccountDecoded<TData extends object, TAddress extends stri
     }
 }
 
+type DecodedAccountData<TData> =
+    Exclude<TData, ReadonlyUint8Array | Uint8Array> extends infer TDecoded
+        ? TDecoded extends object
+            ? TDecoded
+            : never
+        : never;
+
+type AssertedDecodedAccount<TAccount> = [TAccount] extends [MaybeAccount<infer TData, infer TAddress>]
+    ? [TAccount] extends [Account<ReadonlyUint8Array | object, string>]
+        ? Account<DecodedAccountData<TData>, TAddress>
+        : MaybeAccount<DecodedAccountData<TData>, TAddress>
+    : [TAccount] extends [Account<infer TData, infer TAddress>]
+      ? Account<DecodedAccountData<TData>, TAddress>
+      : TAccount;
+
+type AssertedDecodedAccounts<TAccounts extends readonly unknown[]> = {
+    -readonly [P in keyof TAccounts]: AssertedDecodedAccount<TAccounts[P]>;
+};
+
 /**
  * Asserts that all input accounts store decoded data, ie. not a `Uint8Array`.
  *
  * As with {@link assertAccountDecoded} it does not check the shape of the data matches the decoded
  * type, only that it is not a `Uint8Array`.
  *
+ * When called with a tuple of accounts, each element's address and decoded data type is preserved
+ * instead of collapsing to a single shared type parameter.
+ *
+ * @typeParam TAccounts - The tuple or array of accounts to narrow. Each element's address and
+ * decoded data type is preserved.
+ *
  * @example
  * ```ts
- * type MyAccountData = { name: string; age: number };
+ * type TokenData = { mint: Address };
+ * type MintData = { supply: bigint };
  *
- * const myAccounts: Account<MyAccountData | Uint8Array, Address>[];
+ * const myAccounts: [
+ *     Account<TokenData | Uint8Array, '1111..'>,
+ *     Account<MintData | Uint8Array, '2222..'>,
+ * ] = [
+ *     {} as Account<TokenData | Uint8Array, '1111..'>,
+ *     {} as Account<MintData | Uint8Array, '2222..'>,
+ * ];
  * assertAccountsDecoded(myAccounts);
  *
- * // now the account data can be used as MyAccountData
- * for (const a of account) {
- *     account.data satisfies MyAccountData;
- * }
+ * myAccounts[0] satisfies Account<TokenData, '1111..'>;
+ * myAccounts[1] satisfies Account<MintData, '2222..'>;
  * ```
  */
-export function assertAccountsDecoded<TData extends object, TAddress extends string = string>(
-    accounts: Account<ReadonlyUint8Array | TData, TAddress>[],
-): asserts accounts is Account<TData, TAddress>[];
-export function assertAccountsDecoded<TData extends object, TAddress extends string = string>(
-    accounts: MaybeAccount<ReadonlyUint8Array | TData, TAddress>[],
-): asserts accounts is MaybeAccount<TData, TAddress>[];
-export function assertAccountsDecoded<TData extends object, TAddress extends string = string>(
-    accounts: (Account<ReadonlyUint8Array | TData, TAddress> | MaybeAccount<ReadonlyUint8Array | TData, TAddress>)[],
-): asserts accounts is (Account<TData, TAddress> | MaybeAccount<TData, TAddress>)[] {
+export function assertAccountsDecoded<
+    TAccounts extends readonly (
+        | Account<ReadonlyUint8Array | object, string>
+        | MaybeAccount<ReadonlyUint8Array | object, string>
+    )[],
+>(accounts: AssertedDecodedAccounts<TAccounts> | TAccounts): asserts accounts is AssertedDecodedAccounts<TAccounts> {
     const encoded = accounts.filter(a => accountExists(a) && a.data instanceof Uint8Array);
     if (encoded.length > 0) {
         const encodedAddresses = encoded.map(a => a.address);


### PR DESCRIPTION
#### Problem

`assertAccountsDecoded` treated every account in the array as sharing one address type and one data type. A tuple of accounts with different addresses therefore narrowed to a union, and a tuple with different data types failed to type-check.

#### Summary of Changes

The helper now maps over the input tuple or array and strips encoded `Uint8Array` data from each element, so each index keeps its original address and decoded data type. Homogeneous arrays still narrow as they did before. Runtime behavior is unchanged.

Fixes #49