### PR TITLE
feat: add reconstructEncodedTransactionFromOriginalTransaction

### DIFF
--- a/.changeset/giant-worms-clean.md
+++ b/.changeset/giant-worms-clean.md
@@ -1,0 +1,5 @@
+---
+'@solana/transactions': minor
+---
+
+Add `reconstructEncodedTransactionFromOriginalTransaction` to restore a lifetime constraint after a modifying signer returns encoded bytes

--- a/packages/react/src/__tests__/useWalletAccountTransactionSigner-test.ts
+++ b/packages/react/src/__tests__/useWalletAccountTransactionSigner-test.ts
@@ -1,17 +1,22 @@
 import {
     Address,
+    assertIsTransactionWithinSizeLimit,
     Blockhash,
+    bytesEqual,
     CompiledTransactionMessage,
     CompiledTransactionMessageWithLifetime,
     getCompiledTransactionMessageDecoder,
     getTransactionCodec,
     getTransactionLifetimeConstraintFromCompiledTransactionMessage,
+    type ReadonlyUint8Array,
+    reconstructEncodedTransactionFromOriginalTransaction,
     SignatureBytes,
     SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED,
     SOLANA_ERROR__TRANSACTION__NONCE_ACCOUNT_CANNOT_BE_IN_LOOKUP_TABLE,
     SolanaError,
     Transaction,
     TransactionMessageBytes,
+    TransactionWithLifetime,
     type VariableSizeCodec,
     type VariableSizeDecoder,
 } from '@solana/kit';
@@ -27,8 +32,43 @@ jest.mock('@solana/kit', () => ({
     getCompiledTransactionMessageDecoder: jest.fn(),
     getTransactionCodec: jest.fn(),
     getTransactionLifetimeConstraintFromCompiledTransactionMessage: jest.fn(),
+    reconstructEncodedTransactionFromOriginalTransaction: jest.fn(),
 }));
 jest.mock('../useSignTransaction');
+
+async function mockReconstructEncodedTransactionFromOriginalTransaction(
+    originalTransaction: Transaction | (Transaction & TransactionWithLifetime),
+    encodedTransaction: ReadonlyUint8Array | Uint8Array,
+) {
+    const decodedSignedTransaction = getTransactionCodec().decode(encodedTransaction);
+    assertIsTransactionWithinSizeLimit(decodedSignedTransaction);
+    const existingLifetime =
+        'lifetimeConstraint' in originalTransaction ? originalTransaction.lifetimeConstraint : undefined;
+    if (existingLifetime && bytesEqual(decodedSignedTransaction.messageBytes, originalTransaction.messageBytes)) {
+        return Object.freeze({
+            ...decodedSignedTransaction,
+            lifetimeConstraint: existingLifetime,
+        });
+    }
+    const compiledTransactionMessage = getCompiledTransactionMessageDecoder().decode(
+        decodedSignedTransaction.messageBytes,
+    );
+    if (existingLifetime) {
+        const currentToken = 'blockhash' in existingLifetime ? existingLifetime.blockhash : existingLifetime.nonce;
+        if (compiledTransactionMessage.lifetimeToken === currentToken) {
+            return Object.freeze({
+                ...decodedSignedTransaction,
+                lifetimeConstraint: existingLifetime,
+            });
+        }
+    }
+    const lifetimeConstraint =
+        await getTransactionLifetimeConstraintFromCompiledTransactionMessage(compiledTransactionMessage);
+    return Object.freeze({
+        ...decodedSignedTransaction,
+        lifetimeConstraint,
+    });
+}
 
 describe('useWalletAccountTransactionSigner', () => {
     let mockSignTransaction: jest.Mock;
@@ -60,6 +100,9 @@ describe('useWalletAccountTransactionSigner', () => {
             '~uiWalletHandle': null as unknown as UiWalletAccount['~uiWalletHandle'],
         };
         jest.mocked(useSignTransaction).mockReturnValue(mockSignTransaction);
+        jest.mocked(reconstructEncodedTransactionFromOriginalTransaction).mockImplementation(
+            mockReconstructEncodedTransactionFromOriginalTransaction,
+        );
         // Suppresses console output when an `ErrorBoundary` is hit.
         // See https://stackoverflow.com/a/72632884/802047
         jest.spyOn(console, 'error').mockImplementation();

--- a/packages/react/src/useWalletAccountTransactionSigner.ts
+++ b/packages/react/src/useWalletAccountTransactionSigner.ts
@@ -1,10 +1,7 @@
 import {
     address,
-    assertIsTransactionWithinSizeLimit,
-    bytesEqual,
-    getCompiledTransactionMessageDecoder,
     getTransactionCodec,
-    getTransactionLifetimeConstraintFromCompiledTransactionMessage,
+    reconstructEncodedTransactionFromOriginalTransaction,
     SOLANA_ERROR__SIGNER__WALLET_MULTISIGN_UNIMPLEMENTED,
     SolanaError,
     Transaction,
@@ -89,57 +86,11 @@ export function useWalletAccountTransactionSigner<TWalletAccount extends UiWalle
                     transaction: wireTransactionBytes as Uint8Array,
                 };
                 const { signedTransaction } = await getAbortablePromise(signTransaction(inputWithOptions), abortSignal);
-                const decodedSignedTransaction = transactionCodec.decode(
+                const transactionWithLifetime = await reconstructEncodedTransactionFromOriginalTransaction(
+                    transaction,
                     signedTransaction,
-                ) as (typeof transactions)[number];
-
-                assertIsTransactionWithinSizeLimit(decodedSignedTransaction);
-
-                const existingLifetime =
-                    'lifetimeConstraint' in transaction
-                        ? (transaction as TransactionWithLifetime).lifetimeConstraint
-                        : undefined;
-
-                if (existingLifetime) {
-                    if (bytesEqual(decodedSignedTransaction.messageBytes, transaction.messageBytes)) {
-                        // If the transaction has identical bytes, the lifetime won't have changed
-                        return Object.freeze([
-                            {
-                                ...decodedSignedTransaction,
-                                lifetimeConstraint: existingLifetime,
-                            },
-                        ]);
-                    }
-
-                    // If the transaction has changed, check the lifetime constraint field
-                    const compiledTransactionMessage = getCompiledTransactionMessageDecoder().decode(
-                        decodedSignedTransaction.messageBytes,
-                    );
-                    const currentToken =
-                        'blockhash' in existingLifetime ? existingLifetime.blockhash : existingLifetime.nonce;
-
-                    if (compiledTransactionMessage.lifetimeToken === currentToken) {
-                        return Object.freeze([
-                            {
-                                ...decodedSignedTransaction,
-                                lifetimeConstraint: existingLifetime,
-                            },
-                        ]);
-                    }
-                }
-
-                // If we get here then there is no existing lifetime, or the lifetime has changed. We need to attach a new lifetime
-                const compiledTransactionMessage = getCompiledTransactionMessageDecoder().decode(
-                    decodedSignedTransaction.messageBytes,
                 );
-                const lifetimeConstraint =
-                    await getTransactionLifetimeConstraintFromCompiledTransactionMessage(compiledTransactionMessage);
-                return Object.freeze([
-                    {
-                        ...decodedSignedTransaction,
-                        lifetimeConstraint,
-                    },
-                ]);
+                return Object.freeze([transactionWithLifetime]);
             },
         }),
         [uiWalletAccount.address, signTransaction],

--- a/packages/transactions/README.md
+++ b/packages/transactions/README.md
@@ -80,6 +80,25 @@ const signedTransaction = await signTransaction([myPrivateKey], tx);
 
 This function is the same as `signTransaction()` but does not require the transaction to be signed by all signers. A partially signed transaction cannot be landed on the network, but can be serialized and deserialized.
 
+## Restoring a lifetime after a modifying signer
+
+A `TransactionModifyingSigner` can change a transaction before signing it. The signed bytes that come back do not include `lifetimeConstraint`, so callers need to restore or recompute it.
+
+### Functions
+
+#### `reconstructEncodedTransactionFromOriginalTransaction()`
+
+Decodes the signed bytes, asserts the transaction is within the size limit, and attaches a lifetime constraint. If the original transaction already has a lifetime and the compiled lifetime token did not change, that lifetime is reused. Otherwise a new constraint is derived from the compiled message.
+
+```ts
+import { reconstructEncodedTransactionFromOriginalTransaction } from '@solana/transactions';
+
+const transactionWithLifetime = await reconstructEncodedTransactionFromOriginalTransaction(
+    originalTransaction,
+    signedTransactionBytes,
+);
+```
+
 ## Serializing transactions
 
 Before sending a transaction to be landed on the network, you must serialize it in a particular way. You can use these types and functions to serialize a signed transaction into a binary format suitable for transit over the wire.

--- a/packages/transactions/src/__tests__/reconstruct-encoded-transaction-from-original-transaction-test.ts
+++ b/packages/transactions/src/__tests__/reconstruct-encoded-transaction-from-original-transaction-test.ts
@@ -1,0 +1,197 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import { address } from '@solana/addresses';
+import { bytesEqual } from '@solana/codecs-core';
+import { Blockhash } from '@solana/rpc-types';
+import { getCompiledTransactionMessageDecoder, Nonce } from '@solana/transaction-messages';
+
+import { getTransactionCodec } from '../codecs';
+import {
+    getTransactionLifetimeConstraintFromCompiledTransactionMessage,
+    TransactionBlockhashLifetime,
+    TransactionDurableNonceLifetime,
+} from '../lifetime';
+import { reconstructEncodedTransactionFromOriginalTransaction } from '../reconstruct-encoded-transaction-from-original-transaction';
+import type { Transaction, TransactionMessageBytes } from '../transaction';
+import { assertIsTransactionWithinSizeLimit } from '../transaction-size';
+
+jest.mock('@solana/codecs-core', () => ({
+    ...jest.requireActual('@solana/codecs-core'),
+    bytesEqual: jest.fn(),
+}));
+jest.mock('@solana/transaction-messages', () => ({
+    ...jest.requireActual('@solana/transaction-messages'),
+    getCompiledTransactionMessageDecoder: jest.fn(),
+}));
+jest.mock('../codecs', () => ({
+    getTransactionCodec: jest.fn(),
+}));
+jest.mock('../lifetime', () => ({
+    ...jest.requireActual('../lifetime'),
+    getTransactionLifetimeConstraintFromCompiledTransactionMessage: jest.fn(),
+}));
+jest.mock('../transaction-size', () => ({
+    ...jest.requireActual('../transaction-size'),
+    assertIsTransactionWithinSizeLimit: jest.fn(),
+}));
+
+describe('reconstructEncodedTransactionFromOriginalTransaction', () => {
+    const encodedTransaction = new Uint8Array([9, 8, 7]);
+    const originalMessageBytes = new Uint8Array([1, 2, 3]) as unknown as TransactionMessageBytes;
+    const signedMessageBytes = new Uint8Array([4, 5, 6]) as unknown as TransactionMessageBytes;
+    const decodedSignedTransaction = {
+        messageBytes: signedMessageBytes,
+        signatures: {},
+    } as Transaction;
+    const existingLifetime: TransactionBlockhashLifetime = {
+        blockhash: 'abc' as Blockhash,
+        lastValidBlockHeight: 123n,
+    };
+    const newLifetime: TransactionBlockhashLifetime = {
+        blockhash: 'def' as Blockhash,
+        lastValidBlockHeight: 456n,
+    };
+
+    beforeEach(() => {
+        jest.mocked(getTransactionCodec).mockReturnValue({
+            decode: jest.fn().mockReturnValue(decodedSignedTransaction),
+        } as unknown as ReturnType<typeof getTransactionCodec>);
+        jest.mocked(assertIsTransactionWithinSizeLimit).mockImplementation(() => {});
+        jest.mocked(getCompiledTransactionMessageDecoder).mockReturnValue({
+            decode: jest.fn().mockReturnValue({ lifetimeToken: 'def' }),
+        } as unknown as ReturnType<typeof getCompiledTransactionMessageDecoder>);
+        jest.mocked(getTransactionLifetimeConstraintFromCompiledTransactionMessage).mockResolvedValue(newLifetime);
+        jest.mocked(bytesEqual).mockReturnValue(false);
+    });
+
+    it('reuses the original lifetime when message bytes are unchanged', async () => {
+        expect.assertions(2);
+        jest.mocked(bytesEqual).mockReturnValue(true);
+        const originalTransaction = {
+            lifetimeConstraint: existingLifetime,
+            messageBytes: originalMessageBytes,
+            signatures: {},
+        } as Transaction & { lifetimeConstraint: typeof existingLifetime };
+
+        const result = await reconstructEncodedTransactionFromOriginalTransaction(
+            originalTransaction,
+            encodedTransaction,
+        );
+
+        expect(result).toEqual({
+            ...decodedSignedTransaction,
+            lifetimeConstraint: existingLifetime,
+        });
+        expect(getTransactionLifetimeConstraintFromCompiledTransactionMessage).not.toHaveBeenCalled();
+    });
+
+    it('reuses the original lifetime when the compiled lifetime token is unchanged', async () => {
+        expect.assertions(2);
+        jest.mocked(getCompiledTransactionMessageDecoder).mockReturnValue({
+            decode: jest.fn().mockReturnValue({ lifetimeToken: 'abc' }),
+        } as unknown as ReturnType<typeof getCompiledTransactionMessageDecoder>);
+        const originalTransaction = {
+            lifetimeConstraint: existingLifetime,
+            messageBytes: originalMessageBytes,
+            signatures: {},
+        } as Transaction & { lifetimeConstraint: typeof existingLifetime };
+
+        const result = await reconstructEncodedTransactionFromOriginalTransaction(
+            originalTransaction,
+            encodedTransaction,
+        );
+
+        expect(result).toEqual({
+            ...decodedSignedTransaction,
+            lifetimeConstraint: existingLifetime,
+        });
+        expect(getTransactionLifetimeConstraintFromCompiledTransactionMessage).not.toHaveBeenCalled();
+    });
+
+    it('reuses a durable nonce lifetime when the compiled lifetime token matches the nonce', async () => {
+        expect.assertions(1);
+        const nonceLifetime: TransactionDurableNonceLifetime = {
+            nonce: 'nonce-token' as Nonce,
+            nonceAccountAddress: address('11111111111111111111111111111111'),
+        };
+        jest.mocked(getCompiledTransactionMessageDecoder).mockReturnValue({
+            decode: jest.fn().mockReturnValue({ lifetimeToken: 'nonce-token' }),
+        } as unknown as ReturnType<typeof getCompiledTransactionMessageDecoder>);
+        const originalTransaction = {
+            lifetimeConstraint: nonceLifetime,
+            messageBytes: originalMessageBytes,
+            signatures: {},
+        } as Transaction & { lifetimeConstraint: typeof nonceLifetime };
+
+        const result = await reconstructEncodedTransactionFromOriginalTransaction(
+            originalTransaction,
+            encodedTransaction,
+        );
+
+        expect(result.lifetimeConstraint).toBe(nonceLifetime);
+    });
+
+    it('derives a new lifetime when the original transaction has none', async () => {
+        expect.assertions(1);
+        const originalTransaction = {
+            messageBytes: originalMessageBytes,
+            signatures: {},
+        } as Transaction;
+
+        const result = await reconstructEncodedTransactionFromOriginalTransaction(
+            originalTransaction,
+            encodedTransaction,
+        );
+
+        expect(result).toEqual({
+            ...decodedSignedTransaction,
+            lifetimeConstraint: newLifetime,
+        });
+    });
+
+    it('derives a new lifetime when the compiled lifetime token changed', async () => {
+        expect.assertions(1);
+        const originalTransaction = {
+            lifetimeConstraint: existingLifetime,
+            messageBytes: originalMessageBytes,
+            signatures: {},
+        } as Transaction & { lifetimeConstraint: typeof existingLifetime };
+
+        const result = await reconstructEncodedTransactionFromOriginalTransaction(
+            originalTransaction,
+            encodedTransaction,
+        );
+
+        expect(result).toEqual({
+            ...decodedSignedTransaction,
+            lifetimeConstraint: newLifetime,
+        });
+    });
+
+    it('asserts that the decoded transaction is within the size limit', async () => {
+        expect.assertions(1);
+        const originalTransaction = {
+            messageBytes: originalMessageBytes,
+            signatures: {},
+        } as Transaction;
+
+        await reconstructEncodedTransactionFromOriginalTransaction(originalTransaction, encodedTransaction);
+
+        expect(assertIsTransactionWithinSizeLimit).toHaveBeenCalledWith(decodedSignedTransaction);
+    });
+
+    it('freezes the returned transaction', async () => {
+        expect.assertions(1);
+        const originalTransaction = {
+            messageBytes: originalMessageBytes,
+            signatures: {},
+        } as Transaction;
+
+        const result = await reconstructEncodedTransactionFromOriginalTransaction(
+            originalTransaction,
+            encodedTransaction,
+        );
+
+        expect(result).toBeFrozenObject();
+    });
+});

--- a/packages/transactions/src/__typetests__/reconstruct-encoded-transaction-from-original-transaction-typetest.ts
+++ b/packages/transactions/src/__typetests__/reconstruct-encoded-transaction-from-original-transaction-typetest.ts
@@ -1,0 +1,31 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import type { ReadonlyUint8Array } from '@solana/codecs-core';
+
+import type { TransactionWithLifetime } from '../lifetime';
+import { reconstructEncodedTransactionFromOriginalTransaction } from '../reconstruct-encoded-transaction-from-original-transaction';
+import type { Transaction } from '../transaction';
+import type { TransactionWithinSizeLimit } from '../transaction-size';
+
+// [DESCRIBE] reconstructEncodedTransactionFromOriginalTransaction
+{
+    // It accepts a transaction without a lifetime and encoded bytes.
+    {
+        const originalTransaction = {} as Transaction;
+        const encodedTransaction = {} as Uint8Array;
+        reconstructEncodedTransactionFromOriginalTransaction(originalTransaction, encodedTransaction) satisfies Promise<
+            Transaction & TransactionWithinSizeLimit & TransactionWithLifetime
+        >;
+    }
+
+    // It accepts a transaction that already has a lifetime.
+    {
+        const originalTransaction = {} as Transaction & TransactionWithLifetime;
+        const encodedTransaction = {} as ReadonlyUint8Array;
+        reconstructEncodedTransactionFromOriginalTransaction(originalTransaction, encodedTransaction) satisfies Promise<
+            Transaction & TransactionWithinSizeLimit & TransactionWithLifetime
+        >;
+    }
+
+    // @ts-expect-error The first argument must be a Transaction.
+    reconstructEncodedTransactionFromOriginalTransaction({}, new Uint8Array());
+}

--- a/packages/transactions/src/index.ts
+++ b/packages/transactions/src/index.ts
@@ -10,6 +10,7 @@
  */
 export * from './codecs';
 export * from './lifetime';
+export * from './reconstruct-encoded-transaction-from-original-transaction';
 export * from './compile-transaction';
 export * from './signatures';
 export * from './wire-transaction';

--- a/packages/transactions/src/reconstruct-encoded-transaction-from-original-transaction.ts
+++ b/packages/transactions/src/reconstruct-encoded-transaction-from-original-transaction.ts
@@ -1,0 +1,79 @@
+import { bytesEqual, type ReadonlyUint8Array } from '@solana/codecs-core';
+import { getCompiledTransactionMessageDecoder } from '@solana/transaction-messages';
+
+import { getTransactionCodec } from './codecs';
+import {
+    getTransactionLifetimeConstraintFromCompiledTransactionMessage,
+    type TransactionWithLifetime,
+} from './lifetime';
+import type { Transaction } from './transaction';
+import { assertIsTransactionWithinSizeLimit, type TransactionWithinSizeLimit } from './transaction-size';
+
+/**
+ * Rebuilds a signed transaction from wallet-returned bytes and attaches a lifetime constraint.
+ *
+ * Wallet `TransactionModifyingSigner` implementations typically receive encoded bytes back from
+ * the wallet. Decoding those bytes alone loses `lifetimeConstraint`. This helper restores it from
+ * the original transaction when the compiled lifetime token is unchanged, and otherwise derives a
+ * new constraint from the compiled message.
+ *
+ * @param originalTransaction - The transaction that was sent to the wallet, with or without a
+ * lifetime constraint.
+ * @param encodedTransaction - The signed transaction bytes returned by the wallet.
+ * @return The decoded signed transaction, asserted to be within the size limit, with a lifetime
+ * constraint attached.
+ * @throws {SolanaError} If the decoded transaction exceeds the size limit, or if a new durable
+ * nonce lifetime cannot be derived from the compiled message.
+ *
+ * @example
+ * ```ts
+ * import { reconstructEncodedTransactionFromOriginalTransaction } from '@solana/transactions';
+ *
+ * const transactionWithLifetime = await reconstructEncodedTransactionFromOriginalTransaction(
+ *     originalTransaction,
+ *     signedTransactionBytes,
+ * );
+ * transactionWithLifetime.lifetimeConstraint;
+ * ```
+ *
+ * @see {@link assertIsTransactionWithinSizeLimit}
+ * @see {@link getTransactionLifetimeConstraintFromCompiledTransactionMessage}
+ */
+export async function reconstructEncodedTransactionFromOriginalTransaction(
+    originalTransaction: Transaction | (Transaction & TransactionWithLifetime),
+    encodedTransaction: ReadonlyUint8Array | Uint8Array,
+): Promise<Transaction & TransactionWithinSizeLimit & TransactionWithLifetime> {
+    const decodedSignedTransaction = getTransactionCodec().decode(encodedTransaction);
+    assertIsTransactionWithinSizeLimit(decodedSignedTransaction);
+
+    const existingLifetime =
+        'lifetimeConstraint' in originalTransaction ? originalTransaction.lifetimeConstraint : undefined;
+
+    if (existingLifetime && bytesEqual(decodedSignedTransaction.messageBytes, originalTransaction.messageBytes)) {
+        return Object.freeze({
+            ...decodedSignedTransaction,
+            lifetimeConstraint: existingLifetime,
+        });
+    }
+
+    const compiledTransactionMessage = getCompiledTransactionMessageDecoder().decode(
+        decodedSignedTransaction.messageBytes,
+    );
+
+    if (existingLifetime) {
+        const currentToken = 'blockhash' in existingLifetime ? existingLifetime.blockhash : existingLifetime.nonce;
+        if (compiledTransactionMessage.lifetimeToken === currentToken) {
+            return Object.freeze({
+                ...decodedSignedTransaction,
+                lifetimeConstraint: existingLifetime,
+            });
+        }
+    }
+
+    const lifetimeConstraint =
+        await getTransactionLifetimeConstraintFromCompiledTransactionMessage(compiledTransactionMessage);
+    return Object.freeze({
+        ...decodedSignedTransaction,
+        lifetimeConstraint,
+    });
+}

--- a/packages/wallet-account-signer/src/__tests__/wallet-account-transaction-signer-test.ts
+++ b/packages/wallet-account-signer/src/__tests__/wallet-account-transaction-signer-test.ts
@@ -1,6 +1,6 @@
 import type { Address } from '@solana/addresses';
 import { address } from '@solana/addresses';
-import { bytesEqual } from '@solana/codecs-core';
+import { bytesEqual, type ReadonlyUint8Array } from '@solana/codecs-core';
 import { SOLANA_ERROR__TRANSACTION__NONCE_ACCOUNT_CANNOT_BE_IN_LOOKUP_TABLE, SolanaError } from '@solana/errors';
 import { TransactionModifyingSigner } from '@solana/signers';
 import { getCompiledTransactionMessageDecoder } from '@solana/transaction-messages';
@@ -8,9 +8,12 @@ import {
     assertIsTransactionWithinSizeLimit,
     getTransactionCodec,
     getTransactionLifetimeConstraintFromCompiledTransactionMessage,
+    reconstructEncodedTransactionFromOriginalTransaction,
+    Transaction,
     TransactionBlockhashLifetime,
     TransactionDurableNonceLifetime,
     TransactionMessageBytes,
+    TransactionWithLifetime,
 } from '@solana/transactions';
 import { SolanaSignTransaction, SolanaSignTransactionFeature } from '@solana/wallet-standard-features';
 import { WalletStandardError } from '@wallet-standard/errors';
@@ -29,6 +32,40 @@ jest.mock('@solana/codecs-core');
 
 type InputTransaction = Parameters<TransactionModifyingSigner['modifyAndSignTransactions']>[0][number];
 
+async function mockReconstructEncodedTransactionFromOriginalTransaction(
+    originalTransaction: Transaction | (Transaction & TransactionWithLifetime),
+    encodedTransaction: ReadonlyUint8Array | Uint8Array,
+) {
+    const decodedSignedTransaction = getTransactionCodec().decode(encodedTransaction);
+    assertIsTransactionWithinSizeLimit(decodedSignedTransaction);
+    const existingLifetime =
+        'lifetimeConstraint' in originalTransaction ? originalTransaction.lifetimeConstraint : undefined;
+    if (existingLifetime && bytesEqual(decodedSignedTransaction.messageBytes, originalTransaction.messageBytes)) {
+        return Object.freeze({
+            ...decodedSignedTransaction,
+            lifetimeConstraint: existingLifetime,
+        });
+    }
+    const compiledTransactionMessage = getCompiledTransactionMessageDecoder().decode(
+        decodedSignedTransaction.messageBytes,
+    );
+    if (existingLifetime) {
+        const currentToken = 'blockhash' in existingLifetime ? existingLifetime.blockhash : existingLifetime.nonce;
+        if (compiledTransactionMessage.lifetimeToken === currentToken) {
+            return Object.freeze({
+                ...decodedSignedTransaction,
+                lifetimeConstraint: existingLifetime,
+            });
+        }
+    }
+    const lifetimeConstraint =
+        await getTransactionLifetimeConstraintFromCompiledTransactionMessage(compiledTransactionMessage);
+    return Object.freeze({
+        ...decodedSignedTransaction,
+        lifetimeConstraint,
+    });
+}
+
 describe('createSignerFromWalletAccount', () => {
     const mockAddress = 'Gp7YgHcJciP4px5FdFnywUiMG4UcfMZV9UagSAZzDxdy' as Address;
 
@@ -44,6 +81,9 @@ describe('createSignerFromWalletAccount', () => {
     beforeEach(() => {
         jest.clearAllMocks();
         jest.mocked(address).mockImplementation(addr => addr as Address);
+        jest.mocked(reconstructEncodedTransactionFromOriginalTransaction).mockImplementation(
+            mockReconstructEncodedTransactionFromOriginalTransaction,
+        );
     });
 
     it('throws if chain is unsupported', () => {

--- a/packages/wallet-account-signer/src/wallet-account-transaction-signer.ts
+++ b/packages/wallet-account-signer/src/wallet-account-transaction-signer.ts
@@ -1,12 +1,9 @@
 import { address } from '@solana/addresses';
-import { bytesEqual } from '@solana/codecs-core';
 import { getAbortablePromise } from '@solana/promises';
 import { TransactionModifyingSigner } from '@solana/signers';
-import { getCompiledTransactionMessageDecoder } from '@solana/transaction-messages';
 import {
-    assertIsTransactionWithinSizeLimit,
     getTransactionCodec,
-    getTransactionLifetimeConstraintFromCompiledTransactionMessage,
+    reconstructEncodedTransactionFromOriginalTransaction,
     Transaction,
     TransactionWithinSizeLimit,
     TransactionWithLifetime,
@@ -92,57 +89,9 @@ export function createTransactionSignerFromWalletAccount<TWalletAccount extends 
 
             const results = await getAbortablePromise(
                 Promise.all(
-                    outputs.map(async ({ signedTransaction }, index) => {
-                        const decodedSignedTransaction = transactionCodec.decode(
-                            signedTransaction,
-                        ) as (typeof transactions)[number];
-
-                        assertIsTransactionWithinSizeLimit(decodedSignedTransaction);
-
-                        const inputTransaction = transactions[index];
-                        const existingLifetime =
-                            inputTransaction && 'lifetimeConstraint' in inputTransaction
-                                ? (inputTransaction as TransactionWithLifetime).lifetimeConstraint
-                                : undefined;
-
-                        // Fast path: identical bytes means the lifetime hasn't changed
-                        if (
-                            existingLifetime &&
-                            bytesEqual(decodedSignedTransaction.messageBytes, inputTransaction.messageBytes)
-                        ) {
-                            return Object.freeze({
-                                ...decodedSignedTransaction,
-                                lifetimeConstraint: existingLifetime,
-                            });
-                        }
-
-                        // Decode once to inspect the lifetime token
-                        const compiledTransactionMessage = getCompiledTransactionMessageDecoder().decode(
-                            decodedSignedTransaction.messageBytes,
-                        );
-
-                        // If the token matches the existing lifetime, reuse it
-                        if (existingLifetime) {
-                            const currentToken =
-                                'blockhash' in existingLifetime ? existingLifetime.blockhash : existingLifetime.nonce;
-                            if (compiledTransactionMessage.lifetimeToken === currentToken) {
-                                return Object.freeze({
-                                    ...decodedSignedTransaction,
-                                    lifetimeConstraint: existingLifetime,
-                                });
-                            }
-                        }
-
-                        // No existing lifetime or it has changed — fetch a new one
-                        const lifetimeConstraint =
-                            await getTransactionLifetimeConstraintFromCompiledTransactionMessage(
-                                compiledTransactionMessage,
-                            );
-                        return Object.freeze({
-                            ...decodedSignedTransaction,
-                            lifetimeConstraint,
-                        });
-                    }),
+                    outputs.map(({ signedTransaction }, index) =>
+                        reconstructEncodedTransactionFromOriginalTransaction(transactions[index], signedTransaction),
+                    ),
                 ),
                 abortSignal,
             );


### PR DESCRIPTION
#### Problem

Wallet `TransactionModifyingSigner` implementations receive encoded bytes back from the wallet. Decoding those bytes loses `lifetimeConstraint`, so `@solana/react` and `@solana/wallet-account-signer` each reimplemented the same restore-or-recompute logic.

#### Summary of Changes

Add `reconstructEncodedTransactionFromOriginalTransaction` to `@solana/transactions`. It decodes the signed bytes, asserts the size limit, reuses the original lifetime when the compiled lifetime token is unchanged, and otherwise derives a new constraint from the compiled message. The React hook and wallet-account signer now call this helper.

Fixes #1466