### PR TITLE
Add a requireSizePrefix option to the array, map and set codecs

### DIFF
--- a/.changeset/plenty-horses-stick.md
+++ b/.changeset/plenty-horses-stick.md
@@ -1,0 +1,5 @@
+---
+'@solana/codecs-data-structures': minor
+---
+
+Add a `requireSizePrefix` option to the array, map and set codecs. By default, decoding an exhausted byte array yields an empty collection so that collections can be appended to existing data layouts; with `requireSizePrefix: true`, a missing size prefix throws instead.

--- a/packages/codecs-data-structures/README.md
+++ b/packages/codecs-data-structures/README.md
@@ -54,6 +54,13 @@ getArrayCodec(getU8Codec(), { size: 'remainder' }).encode([1, 2, 3]);
 //   └-- 3 items of 1 byte each. The size is inferred from the remainder of the bytes.
 ```
 
+When the size is stored as a prefix, decoding an exhausted byte array yields an empty array instead of failing. This allows arrays to be appended to existing data layouts without breaking the decoding of older data. Use the `requireSizePrefix` option to throw instead.
+
+```ts
+getArrayCodec(getU8Codec()).decode(new Uint8Array([])); // []
+getArrayCodec(getU8Codec(), { requireSizePrefix: true }).decode(new Uint8Array([])); // Throws: missing size prefix.
+```
+
 Separate `getArrayEncoder` and `getArrayDecoder` functions are also available.
 
 ```ts
@@ -70,7 +77,7 @@ const bytes = getSetCodec(getU8Codec()).encode(new Set([1, 2, 3]));
 const set = getSetCodec(getU8Codec()).decode(bytes);
 ```
 
-Just like the array codec, it uses a `u32` size prefix by default but can be configured using the `size` option. [See the array codec](#array-codec) for more details.
+Just like the array codec, it uses a `u32` size prefix by default but can be configured using the `size` and `requireSizePrefix` options. [See the array codec](#array-codec) for more details.
 
 ```ts
 getSetCodec(getU8Codec(), { size: getU16Codec() }).encode(new Set([1, 2, 3]));
@@ -114,7 +121,7 @@ getMapCodec(keyCodec, valueCodec).encode(myMap);
 //   └-- 4-byte prefix telling us to read 2 map entries.
 ```
 
-However, it can be configured using the `size` option. [See the `size` option of the array codec](#array-codec) for more details.
+However, it can be configured using the `size` and `requireSizePrefix` options. [See the array codec](#array-codec) for more details.
 
 ```ts
 getMapCodec(keyCodec, valueCodec, { size: getU16Codec() }).encode(myMap);

--- a/packages/codecs-data-structures/src/__tests__/array-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/array-test.ts
@@ -1,7 +1,12 @@
 import { addCodecSizePrefix, fixCodecSize, offsetCodec, resizeCodec } from '@solana/codecs-core';
 import { getU8Codec, getU16Codec, getU32Codec, getU64Codec } from '@solana/codecs-numbers';
 import { getUtf8Codec } from '@solana/codecs-strings';
-import { SOLANA_ERROR__CODECS__INVALID_NUMBER_OF_ITEMS, SolanaError } from '@solana/errors';
+import {
+    SOLANA_ERROR__CODECS__CANNOT_DECODE_EMPTY_BYTE_ARRAY,
+    SOLANA_ERROR__CODECS__INVALID_BYTE_LENGTH,
+    SOLANA_ERROR__CODECS__INVALID_NUMBER_OF_ITEMS,
+    SolanaError,
+} from '@solana/errors';
 
 import { getArrayCodec } from '../array';
 import { b } from './__setup__';
@@ -133,6 +138,49 @@ describe('getArrayCodec', () => {
         expect(codec.encode([65, 66, 67])).toStrictEqual(b('03000000000041000042000043'));
         expect(codec.read(b('03000000000041000042000043'), 0)).toStrictEqual([[65, 66, 67], 13]);
         expect(codec.read(b('ffff03000000000041000042000043'), 2)).toStrictEqual([[65, 66, 67], 15]);
+    });
+
+    it('decodes an exhausted byte array as an empty array by default', () => {
+        // With a size prefix, missing bytes are treated as an empty array so that
+        // arrays can be appended to existing data layouts.
+        expect(array(u8()).read(b(''), 0)).toStrictEqual([[], 0]);
+        expect(array(u8()).read(b('ff'), 1)).toStrictEqual([[], 1]);
+        expect(array(u8(), { size: u8() }).read(b(''), 0)).toStrictEqual([[], 0]);
+
+        // Fixed and remainder sizes are not affected.
+        expect(() => array(u8(), { size: 1 }).read(b(''), 0)).toThrow(SolanaError);
+        expect(array(u8(), { size: 'remainder' }).read(b(''), 0)).toStrictEqual([[], 0]);
+    });
+
+    it('can require the size prefix to be present', () => {
+        const strict = { requireSizePrefix: true } as const;
+
+        // Missing prefix.
+        expect(() => array(u8(), strict).read(b(''), 0)).toThrow(
+            new SolanaError(SOLANA_ERROR__CODECS__CANNOT_DECODE_EMPTY_BYTE_ARRAY, { codecDescription: 'u32' }),
+        );
+        expect(() => array(u8(), strict).read(b('ff'), 1)).toThrow(
+            new SolanaError(SOLANA_ERROR__CODECS__CANNOT_DECODE_EMPTY_BYTE_ARRAY, { codecDescription: 'u32' }),
+        );
+        expect(() => array(u8(), strict).read(b('0300'), 0)).toThrow(
+            new SolanaError(SOLANA_ERROR__CODECS__INVALID_BYTE_LENGTH, {
+                bytesLength: 2,
+                codecDescription: 'u32',
+                expected: 4,
+            }),
+        );
+        expect(() => array(u8(), { ...strict, size: u8() }).read(b(''), 0)).toThrow(
+            new SolanaError(SOLANA_ERROR__CODECS__CANNOT_DECODE_EMPTY_BYTE_ARRAY, { codecDescription: 'u8' }),
+        );
+
+        // Present prefix.
+        expect(array(u8(), strict).read(b('00000000'), 0)).toStrictEqual([[], 4]);
+        expect(array(u8(), strict).read(b('030000002a0102'), 0)).toStrictEqual([[42, 1, 2], 7]);
+        expect(array(u8(), strict).encode([42, 1, 2])).toStrictEqual(b('030000002a0102'));
+
+        // Fixed and remainder sizes are not affected.
+        expect(array(u8(), { ...strict, size: 0 }).read(b(''), 0)).toStrictEqual([[], 0]);
+        expect(array(u8(), { ...strict, size: 'remainder' }).read(b(''), 0)).toStrictEqual([[], 0]);
     });
 
     it('has the right sizes', () => {

--- a/packages/codecs-data-structures/src/__tests__/map-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/map-test.ts
@@ -1,7 +1,11 @@
 import { addCodecSizePrefix, fixCodecSize } from '@solana/codecs-core';
 import { getU8Codec, getU16Codec, getU32Codec, getU64Codec } from '@solana/codecs-numbers';
 import { getUtf8Codec } from '@solana/codecs-strings';
-import { SOLANA_ERROR__CODECS__INVALID_NUMBER_OF_ITEMS, SolanaError } from '@solana/errors';
+import {
+    SOLANA_ERROR__CODECS__CANNOT_DECODE_EMPTY_BYTE_ARRAY,
+    SOLANA_ERROR__CODECS__INVALID_NUMBER_OF_ITEMS,
+    SolanaError,
+} from '@solana/errors';
 
 import { getMapCodec } from '../map';
 import { b } from './__setup__';
@@ -122,6 +126,21 @@ describe('getMapCodec', () => {
         expect(mapU64.encode(new Map([[1, 2]]))).toStrictEqual(b('010200000000000000'));
         expect(mapU64.encode(new Map([[1, 2n]]))).toStrictEqual(b('010200000000000000'));
         expect(mapU64.read(b('010200000000000000'), 0)).toStrictEqual([new Map([[1, 2n]]), 9]);
+    });
+
+    it('decodes an exhausted byte array as an empty map by default', () => {
+        expect(map(u8(), u8()).read(b(''), 0)).toStrictEqual([new Map(), 0]);
+        expect(map(u8(), u8()).read(b('ff'), 1)).toStrictEqual([new Map(), 1]);
+    });
+
+    it('can require the size prefix to be present', () => {
+        const strict = { requireSizePrefix: true } as const;
+        expect(() => map(u8(), u8(), strict).read(b(''), 0)).toThrow(
+            new SolanaError(SOLANA_ERROR__CODECS__CANNOT_DECODE_EMPTY_BYTE_ARRAY, { codecDescription: 'u32' }),
+        );
+        expect(map(u8(), u8(), strict).read(b('00000000'), 0)).toStrictEqual([new Map(), 4]);
+        expect(map(u8(), u8(), strict).read(b('010000000102'), 0)).toStrictEqual([new Map([[1, 2]]), 6]);
+        expect(map(u8(), u8(), { ...strict, size: 'remainder' }).read(b(''), 0)).toStrictEqual([new Map(), 0]);
     });
 
     it('has the right sizes', () => {

--- a/packages/codecs-data-structures/src/__tests__/set-test.ts
+++ b/packages/codecs-data-structures/src/__tests__/set-test.ts
@@ -1,7 +1,11 @@
 import { addCodecSizePrefix, fixCodecSize } from '@solana/codecs-core';
 import { getU8Codec, getU16Codec, getU32Codec, getU64Codec } from '@solana/codecs-numbers';
 import { getUtf8Codec } from '@solana/codecs-strings';
-import { SOLANA_ERROR__CODECS__INVALID_NUMBER_OF_ITEMS, SolanaError } from '@solana/errors';
+import {
+    SOLANA_ERROR__CODECS__CANNOT_DECODE_EMPTY_BYTE_ARRAY,
+    SOLANA_ERROR__CODECS__INVALID_NUMBER_OF_ITEMS,
+    SolanaError,
+} from '@solana/errors';
 
 import { getSetCodec } from '../set';
 import { b } from './__setup__';
@@ -102,6 +106,21 @@ describe('getSetCodec', () => {
         expect(setU64.encode(new Set([2]))).toStrictEqual(b('0200000000000000'));
         expect(setU64.encode(new Set([2n]))).toStrictEqual(b('0200000000000000'));
         expect(setU64.read(b('0200000000000000'), 0)).toStrictEqual([new Set([2n]), 8]);
+    });
+
+    it('decodes an exhausted byte array as an empty set by default', () => {
+        expect(set(u8()).read(b(''), 0)).toStrictEqual([new Set(), 0]);
+        expect(set(u8()).read(b('ff'), 1)).toStrictEqual([new Set(), 1]);
+    });
+
+    it('can require the size prefix to be present', () => {
+        const strict = { requireSizePrefix: true } as const;
+        expect(() => set(u8(), strict).read(b(''), 0)).toThrow(
+            new SolanaError(SOLANA_ERROR__CODECS__CANNOT_DECODE_EMPTY_BYTE_ARRAY, { codecDescription: 'u32' }),
+        );
+        expect(set(u8(), strict).read(b('00000000'), 0)).toStrictEqual([new Set(), 4]);
+        expect(set(u8(), strict).read(b('020000002a01'), 0)).toStrictEqual([new Set([42, 1]), 6]);
+        expect(set(u8(), { ...strict, size: 'remainder' }).read(b(''), 0)).toStrictEqual([new Set(), 0]);
     });
 
     it('has the right sizes', () => {

--- a/packages/codecs-data-structures/src/array.ts
+++ b/packages/codecs-data-structures/src/array.ts
@@ -45,6 +45,19 @@ export type ArrayCodecConfig<TPrefix extends NumberCodec | NumberDecoder | Numbe
      */
     description?: string;
     /**
+     * Whether a size prefix must be present when decoding.
+     *
+     * By default, when the size is stored as a prefix and there are no bytes left to read,
+     * the decoder returns an empty array instead of failing. This allows new collections to be
+     * appended to existing data layouts without breaking the decoding of older data.
+     * Set this option to `true` to throw when the size prefix is missing.
+     *
+     * Only applies when the `size` option is a number codec.
+     *
+     * @defaultValue `false`
+     */
+    requireSizePrefix?: boolean;
+    /**
      * Specifies how the size of the array is determined.
      *
      * - A {@link NumberCodec}, {@link NumberDecoder}, or {@link NumberEncoder} stores a size prefix before encoding the array.
@@ -178,7 +191,7 @@ export function getArrayDecoder<TTo>(item: Decoder<TTo>, config: ArrayCodecConfi
         ...(fixedSize !== null ? { fixedSize } : { maxSize }),
         read: (bytes: ReadonlyUint8Array | Uint8Array, offset) => {
             const array: TTo[] = [];
-            if (typeof size === 'object' && offset >= bytes.length) {
+            if (typeof size === 'object' && !config.requireSizePrefix && offset >= bytes.length) {
                 return [array, offset];
             }
 
@@ -258,11 +271,25 @@ export function getArrayDecoder<TTo>(item: Decoder<TTo>, config: ArrayCodecConfi
  * //   └-- 3 items of 1 byte each. The size is inferred from the remainder of the bytes.
  * ```
  *
+ * @example
+ * Requiring the size prefix to be present when decoding.
+ * ```ts
+ * getArrayCodec(getU8Codec()).decode(new Uint8Array([]));
+ * // [] (an exhausted byte array decodes as an empty array by default).
+ *
+ * getArrayCodec(getU8Codec(), { requireSizePrefix: true }).decode(new Uint8Array([]));
+ * // Throws: the size prefix is missing.
+ * ```
+ *
  * @remarks
  * The size of the array can be controlled using the `size` option:
  * - A `Codec<number>` (e.g. `getU16Codec()`) stores a size prefix before the array.
  * - A `number` enforces a fixed number of elements.
  * - `"remainder"` uses all remaining bytes to infer the array length.
+ *
+ * When the size is stored as a prefix, decoding an exhausted byte array yields an empty array,
+ * which allows arrays to be appended to existing data layouts without breaking older data.
+ * Use the `requireSizePrefix` option to throw instead.
  *
  * Separate {@link getArrayEncoder} and {@link getArrayDecoder} functions are available.
  *

--- a/packages/codecs-data-structures/src/map.ts
+++ b/packages/codecs-data-structures/src/map.ts
@@ -31,6 +31,19 @@ import { getTupleDecoder, getTupleEncoder } from './tuple';
  */
 export type MapCodecConfig<TPrefix extends NumberCodec | NumberDecoder | NumberEncoder> = {
     /**
+     * Whether a size prefix must be present when decoding.
+     *
+     * By default, when the size is stored as a prefix and there are no bytes left to read,
+     * the decoder returns an empty map instead of failing. This allows new collections to be
+     * appended to existing data layouts without breaking the decoding of older data.
+     * Set this option to `true` to throw when the size prefix is missing.
+     *
+     * Only applies when the `size` option is a number codec.
+     *
+     * @defaultValue `false`
+     */
+    requireSizePrefix?: boolean;
+    /**
      * The size of the map.
      * @defaultValue u32 prefix.
      */

--- a/packages/codecs-data-structures/src/set.ts
+++ b/packages/codecs-data-structures/src/set.ts
@@ -30,6 +30,19 @@ import { ArrayLikeCodecSize, getArrayDecoder, getArrayEncoder } from './array';
  */
 export type SetCodecConfig<TPrefix extends NumberCodec | NumberDecoder | NumberEncoder> = {
     /**
+     * Whether a size prefix must be present when decoding.
+     *
+     * By default, when the size is stored as a prefix and there are no bytes left to read,
+     * the decoder returns an empty set instead of failing. This allows new collections to be
+     * appended to existing data layouts without breaking the decoding of older data.
+     * Set this option to `true` to throw when the size prefix is missing.
+     *
+     * Only applies when the `size` option is a number codec.
+     *
+     * @defaultValue `false`
+     */
+    requireSizePrefix?: boolean;
+    /**
      * The size encoding strategy for the set.
      * @defaultValue Uses a `u32` prefix.
      */


### PR DESCRIPTION
When a collection's size is stored as a prefix, decoding an exhausted byte array yields an empty collection instead of failing. That is a deliberate default: it lets a program append a `Vec` to an existing account layout and still decode accounts created before the change. It is also lenient in a way that some formats cannot accept: borsh, for instance, requires the length prefix to be present, so a truncated buffer must fail rather than decode to `[]`.

```ts
getArrayCodec(getU8Codec()).decode(new Uint8Array([])); // []
getArrayCodec(getU8Codec(), { requireSizePrefix: true }).decode(new Uint8Array([])); // Throws: missing size prefix.
```

This PR adds an opt-in `requireSizePrefix` option to the array, map and set codec configs. When set, the decoder no longer short-circuits on an exhausted byte array and the prefix codec's own byte-length assertion throws. Fixed and `"remainder"` sizes are unaffected, and the default is unchanged; the previously untested default is now covered explicitly.